### PR TITLE
Fix: Save adapter for lora

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -228,11 +228,12 @@ def train(
     logging.info(
         f"Training Completed!!! Saving pre-trained model to {cfg.output_dir}"
     )
-    # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
-    trainer.save_model(cfg.output_dir)
     
     if cfg.adapter == 'lora':
         trainer.save_pretrained(cfg.output_dir)
+    else:
+        # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
+        trainer.save_model(cfg.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -229,11 +229,10 @@ def train(
         f"Training Completed!!! Saving pre-trained model to {cfg.output_dir}"
     )
     
-    if cfg.adapter == 'lora':
-        trainer.save_pretrained(cfg.output_dir)
-    else:
-        # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
-        trainer.save_model(cfg.output_dir)
+
+    # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
+    trainer.save_pretrained(cfg.output_dir)
+    # trainer.save_model(cfg.output_dir)  # TODO this may be needed for deepspeed to work? need to review another time
 
 
 if __name__ == "__main__":

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -230,6 +230,9 @@ def train(
     )
     # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
     trainer.save_model(cfg.output_dir)
+    
+    if cfg.adapter == 'lora':
+        trainer.save_pretrained(cfg.output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the latest commit, the code has changed to `save_model`. This would not save Loras. I added an extra check if it's training lora, to also `save_pretrained`.