### PR TITLE
Fix save typo

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -236,7 +236,7 @@ def train(
     logging.info(f"Training Completed!!! Saving pre-trained model to {cfg.output_dir}")
 
     # TODO do we need this fix? https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading
-    trainer.save_pretrained(cfg.output_dir)
+    model.save_pretrained(cfg.output_dir)
     # trainer.save_model(cfg.output_dir)  # TODO this may be needed for deepspeed to work? need to review another time
 
 


### PR DESCRIPTION
Following https://github.com/OpenAccess-AI-Collective/axolotl/pull/23#issuecomment-1543802250, I made a mistake to use `trainer` instead of `model`.

Ref: https://github.com/huggingface/transformers/issues/14828