### PR TITLE
Add `lora_modules_to_save`

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -285,6 +285,7 @@ def load_lora(model, cfg):
         target_modules=cfg.lora_target_modules,
         lora_dropout=cfg.lora_dropout,
         fan_in_fan_out=cfg.lora_fan_in_fan_out,
+        modules_to_save=cfg.lora_modules_to_save if cfg.lora_modules_to_save else None,
         bias="none",
         task_type="CAUSAL_LM",
     )


### PR DESCRIPTION
Add the ability to target more modules within the model for lora training.

```
 - **modules_to_save** (`list` of `str`) -- The list of sub-module names to save when
        saving the model.
```