### PR TITLE
fix: handles AutoTokenizer from untrusted source

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -167,7 +167,7 @@ def load_model(
             else:
                 tokenizer = getattr(transformers, tokenizer_type).from_pretrained(model)
         except:
-            tokenizer = AutoTokenizer.from_pretrained(base_model_config)
+            tokenizer = AutoTokenizer.from_pretrained(base_model_config, trust_remote_code=True if cfg.trust_remote_code is True else False)
 
     logging.debug(f"EOS: {tokenizer.eos_token_id} / {tokenizer.eos_token}")
     logging.debug(f"BOS: {tokenizer.bos_token_id} / {tokenizer.bos_token}")


### PR DESCRIPTION
Set `trust_remote_code` param depending of `cfg.trust_remote_code` when calling `AutoTokenizer.from_pretrained`.

Prevents the following error:
```sh
Loading SOME_NAME requires you to execute the configuration file in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
```