### PR TITLE
Feat: Add torch to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sentencepiece
 wandb
 einops
 xformers
+torch


### PR DESCRIPTION
Error with `pip install -e .` in new venv due to missing torch.