### PR TITLE
load the tokenizer seperately from the model

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -5,7 +5,7 @@ import random
 import signal
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Dict, Any, Union
 
 import fire
 import torch
@@ -117,6 +117,10 @@ def choose_config(path: Path):
     return chosen_file
 
 
+def check_not_in(list1: List[str], list2: Union[Dict[str, Any], List[str]]) -> bool:
+    return not any(el in list2 for el in list1)
+
+
 def train(
     config: Path = Path("configs/"),
     prepare_ds_only: bool = False,
@@ -169,7 +173,7 @@ def train(
         cfg
     )
 
-    if "inference" not in kwargs and "shard" not in kwargs:  # don't need to load dataset for these
+    if check_not_in(["inference", "shard", "merge_lora"], kwargs):  # don't need to load dataset for these
         train_dataset, eval_dataset = load_prepare_datasets(
             tokenizer, cfg, DEFAULT_DATASET_PREPARED_PATH
         )

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -46,7 +46,7 @@ def load_tokenizer(
     else:
         tokenizer = AutoTokenizer.from_pretrained(
             base_model_config,
-            trust_remote_code=True if cfg.trust_remote_code is True else False,
+            trust_remote_code=cfg.trust_remote_code or False,
         )
 
     logging.debug(f"EOS: {tokenizer.eos_token_id} / {tokenizer.eos_token}")

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -41,7 +41,7 @@ def load_tokenizer(
     if tokenizer_type:
         tokenizer = getattr(transformers, tokenizer_type).from_pretrained(
             base_model_config,
-            trust_remote_code=True if cfg.trust_remote_code is True else False,
+            trust_remote_code=cfg.trust_remote_code or False,
         )
     else:
         tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
loading the tokenizer separately allows us to only load the tokenizer and prepare the dataset without the slow step of loading ht model. We can also skip loading the dataset for inference or shard cases
fixes #59

