### PR TITLE
fix device map

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -47,10 +47,11 @@ def choose_device(cfg):
             return "cpu"
 
     cfg.device = get_device()
-    if cfg.device == "cuda":
-        cfg.device_map = {"": cfg.local_rank}
-    else:
-        cfg.device_map = {"": cfg.device}
+    if cfg.device_map != "auto":
+        if cfg.device.startswith("cuda"):
+            cfg.device_map = {"": cfg.local_rank}
+        else:
+            cfg.device_map = {"": cfg.device}
 
 
 def get_multi_line_input() -> Optional[str]:


### PR DESCRIPTION
causes the device to be `{'':'cuda:0'}`. symptom is failure to train with this error:
```
ValueError: You can't train a model that has been loaded in 8-bit precision on a different device than the one you're training on. Make sure you loaded the model on the corr
ect device using for example `device_map={'':torch.cuda.current_device()}you're training on. Make sure you loaded the model on the correct device using for example `device_m
ap={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}                                                                                             
```
