### PR TITLE
clone in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN pip3 install --force-reinstall "peft @ git+https://github.com/huggingface/pe
             "accelerate @ git+https://github.com/huggingface/accelerate.git@main" \
             "transformers @ git+https://github.com/huggingface/transformers.git@main"
 
-RUN git clone https://github.com/OpenAccess-AI-Collective/axolotl.git
+RUN git clone --depth=1 https://github.com/OpenAccess-AI-Collective/axolotl.git
 # If AXOLOTL_EXTRAS is set, append it in brackets
 RUN cd axolotl && \
     if [ "$AXOLOTL_EXTRAS" != "" ] ; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,7 @@ RUN pip3 install --force-reinstall "peft @ git+https://github.com/huggingface/pe
             "accelerate @ git+https://github.com/huggingface/accelerate.git@main" \
             "transformers @ git+https://github.com/huggingface/transformers.git@main"
 
-RUN mkdir axolotl
-COPY . axolotl/
+RUN git clone https://github.com/OpenAccess-AI-Collective/axolotl.git
 # If AXOLOTL_EXTRAS is set, append it in brackets
 RUN cd axolotl && \
     if [ "$AXOLOTL_EXTRAS" != "" ] ; then \


### PR DESCRIPTION
there are issues with doing a git pull from the image. this clones axolotl rather than copying. 

the tradeoff is that the version of axolotl in the image is on main, not whatever branch the ci is running from (can be problematic in dev, but nothing we have in ci uses anything branch specific