### PR TITLE
Feat: Set matmul tf32=True when tf32 passed

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -183,6 +183,9 @@ def train(
             cfg.fp16 = True
         cfg.bf16 = False
 
+    if cfg.tf32:
+        torch.backends.cuda.matmul.allow_tf32 = True
+
     # load the tokenizer first
     tokenizer_config = cfg.tokenizer_config or cfg.base_model_config
     logging.info(f"loading tokenizer... {tokenizer_config}")


### PR DESCRIPTION
Closes https://github.com/OpenAccess-AI-Collective/axolotl/issues/145

To be aware: 
- Pytorch keeps this `False` by default. https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices following this RFC https://github.com/pytorch/pytorch/issues/67384
- Huggingface recommends it as nvidia has shown small differences https://huggingface.co/docs/transformers/perf_train_gpu_one#tf32