### PR TITLE
Fix backward compat for peft

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -140,11 +140,17 @@ def load_model(
             )
 
             replace_peft_model_with_int4_lora_model()
-        else:
-            from peft import prepare_model_for_kbit_training
     except Exception as err:
         logging.exception(err)
         raise err
+
+    try:
+        from peft import prepare_model_for_kbit_training
+    except ImportError:
+        # For backward compatibility
+        from peft import (
+            prepare_model_for_int8_training as prepare_model_for_kbit_training,
+        )
 
     model_kwargs = {}
     if cfg.adapter == "qlora" and cfg.load_in_4bit:


### PR DESCRIPTION
To allow backward compatibility. The previous PR might prevent older peft lib from working.