### PR TITLE
fix for local variable 'LlamaForCausalLM' referenced before assignment

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -90,6 +90,7 @@ def load_model(
     Load a model from a base model and a model type.
     """
 
+    global LlamaForCausalLM  # pylint: disable=global-statement
     # TODO refactor as a kwarg
     load_in_8bit = cfg.load_in_8bit
     cfg.is_llama_derived_model = "llama" in base_model or (


### PR DESCRIPTION
fixes a bug where a new reference to `LlamaForCausalLM` causes it to no longer be a global inside the function.