### PR TITLE
Update FAQS.md

### DIFF
--- a/FAQS.md
+++ b/FAQS.md
@@ -2,3 +2,6 @@
 
 - Can you train StableLM with this? Yes, but only with a single GPU atm. Multi GPU support is coming soon! Just waiting on this [PR](https://github.com/huggingface/transformers/pull/22874)
 - Will this work with Deepspeed? That's still a WIP, but setting `export ACCELERATE_USE_DEEPSPEED=true` should work in some cases
+- Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c
+/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.  This could lead to a segmentation fault at exit. 
+<br>Try reinstalling bitsandbytes and transformers from source</br>

--- a/FAQS.md
+++ b/FAQS.md
@@ -3,5 +3,5 @@
 - Can you train StableLM with this? Yes, but only with a single GPU atm. Multi GPU support is coming soon! Just waiting on this [PR](https://github.com/huggingface/transformers/pull/22874)
 - Will this work with Deepspeed? That's still a WIP, but setting `export ACCELERATE_USE_DEEPSPEED=true` should work in some cases
 - ```Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c```
-```/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.```  
+`/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.`
 This could lead to a segmentation fault at exit. Try reinstalling bitsandbytes and transformers from source.

--- a/FAQS.md
+++ b/FAQS.md
@@ -2,6 +2,6 @@
 
 - Can you train StableLM with this? Yes, but only with a single GPU atm. Multi GPU support is coming soon! Just waiting on this [PR](https://github.com/huggingface/transformers/pull/22874)
 - Will this work with Deepspeed? That's still a WIP, but setting `export ACCELERATE_USE_DEEPSPEED=true` should work in some cases
-- ```Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c```
+- `Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c`
 `/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.`
 This could lead to a segmentation fault at exit. Try reinstalling bitsandbytes and transformers from source.

--- a/FAQS.md
+++ b/FAQS.md
@@ -2,6 +2,6 @@
 
 - Can you train StableLM with this? Yes, but only with a single GPU atm. Multi GPU support is coming soon! Just waiting on this [PR](https://github.com/huggingface/transformers/pull/22874)
 - Will this work with Deepspeed? That's still a WIP, but setting `export ACCELERATE_USE_DEEPSPEED=true` should work in some cases
-- Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c
-/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.  This could lead to a segmentation fault at exit. 
-<br>Try reinstalling bitsandbytes and transformers from source</br>
+- ```Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c```
+```/arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.```  
+This could lead to a segmentation fault at exit. Try reinstalling bitsandbytes and transformers from source.


### PR DESCRIPTION
Updated FAQS.md with the following statement

Error invalid argument at line 359 in file /workspace/bitsandbytes/csrc/pythonInterface.c /arrow/cpp/src/arrow/filesystem/s3fs.cc:2598:  arrow::fs::FinalizeS3 was not called even though S3 was initialized.  This could lead to a segmentation fault at exit

try reinstalling bitsandbytes and transformers from source