### PR TITLE
fix packing for tokenizers that don't use a bos_token when the bos token and eos token are both the same

### DIFF
--- a/src/axolotl/datasets.py
+++ b/src/axolotl/datasets.py
@@ -132,8 +132,12 @@ class ConstantLengthDataset(IterableDataset):
                         attention_mask = example["attention_mask"]
                         labels = example["labels"]
                         if (
-                            buffer["input_ids"]
-                            and input_ids[0] == self.tokenizer.bos_token_id
+                            (
+                                buffer["input_ids"]
+                                and input_ids[0] == self.tokenizer.bos_token_id
+                            )
+                            or self.tokenizer.bos_token_id
+                            == self.tokenizer.eos_token_id
                         ):
                             attention_mask[0] = 0
 

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -34,3 +34,5 @@ def check_example_labels(example, tokenizer):
 
     logging.info(" ".join(colored_tokens))
     logging.info("\n\n\n")
+
+    print(" ".join(colored_tokens))

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -18,7 +18,7 @@ class TestGpt2Packing(unittest.TestCase):
 
     def setUp(self) -> None:
         # pylint: disable=duplicate-code
-        self.tokenizer = AutoTokenizer.from_pretrained("bigcode/starcoderplus")
+        self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
         self.tokenizer.add_special_tokens(
             {
                 "bos_token": "<|endoftext|>",
@@ -52,15 +52,10 @@ class TestGpt2Packing(unittest.TestCase):
         packed_dataset = Dataset.from_list(list(constant_len_dataset))
 
         example = packed_dataset[0]
-        from axolotl.utils.tokenization import check_example_labels
-
-        check_example_labels(example, self.tokenizer)
         # tokenizers where eos and bos tokens are the same, don't have a bos token
         next_eos_index = (
             example["input_ids"][1:].index(self.tokenizer.eos_token_id) + 1
         )  # add one since we sliced
-
-        print(example["input_ids"][next_eos_index + 1])
 
         assert example["input_ids"][next_eos_index] == self.tokenizer.eos_token_id
         assert example["attention_mask"][next_eos_index + 1] == 0
@@ -103,9 +98,6 @@ class TestLlamaPacking(unittest.TestCase):
         )
         packed_dataset = Dataset.from_list(list(constant_len_dataset))
         example = packed_dataset[0]
-        from axolotl.utils.tokenization import check_example_labels
-
-        check_example_labels(example, self.tokenizer)
         next_bos_index = (
             example["input_ids"][1:].index(self.tokenizer.bos_token_id) + 1
         )  # add one since we sliced


### PR DESCRIPTION
when packing with tokenizers such as gpt2, the tokenizer doesn't generate a bos token, so we need to reset the attention on the next token.