### PR TITLE
Fix bug in dataset loading

### DIFF
--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -136,12 +136,25 @@ def load_tokenized_prepared_datasets(
                     use_auth_token=use_auth_token,
                 )
             else:
-                fp = []
-                for file in d.data_files:
-                    fp.append(hf_hub_download(
+                if isinstance(d.data_files, str):
+                    fp = hf_hub_download(
                         repo_id=d.path,
                         repo_type="dataset",
-                        filename=file,
+                        filename=d.data_files,
+                    )
+                elif isinstance(d.data_files, list):
+                    fp = []
+                    for file in d.data_files:
+                        fp.append(
+                            hf_hub_download(
+                                repo_id=d.path,
+                                repo_type="dataset",
+                                filename=file,
+                            )
+                        )
+                else:
+                    raise ValueError(
+                        "data_files must be either a string or list of strings"
                     )
                 ds = load_dataset(
                     "json", name=d.name, data_files=fp, streaming=False, split=None

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -136,11 +136,13 @@ def load_tokenized_prepared_datasets(
                     use_auth_token=use_auth_token,
                 )
             else:
-                fp = hf_hub_download(
-                    repo_id=d.path,
-                    repo_type="dataset",
-                    filename=d.data_files,
-                )
+                fp = []
+                for file in d.data_files:
+                    fp.append(hf_hub_download(
+                        repo_id=d.path,
+                        repo_type="dataset",
+                        filename=file,
+                    )
                 ds = load_dataset(
                     "json", name=d.name, data_files=fp, streaming=False, split=None
                 )


### PR DESCRIPTION
This fixes a bug when loading datasets. `d.data_files` is a list, so it cannot be directly passed to `hf_hub_download`, which only takes a single filename.