### PR TITLE
support user defined prompters, pretokenized datasets in config, local parquet, local arrow files

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ datasets:
   - path: vicgalle/alpaca-gpt4
   # The type of prompt to use for training. [alpaca, sharegpt, gpteacher, oasst, reflection]
     type: alpaca # format | format:<prompt_style> (chat/instruct) | <prompt_strategies>.load_<load_fn>
+    ds_type: # Optional[str] (json|arrow|parquet) defines the datatype when path is a file
     data_files: # path to source data files
     shards: # number of shards to split data into
     name: # name of dataset configuration to load

--- a/src/axolotl/prompt_strategies/__init__.py
+++ b/src/axolotl/prompt_strategies/__init__.py
@@ -3,7 +3,7 @@
 import importlib
 
 
-def load(strategy, tokenizer, cfg):
+def load(strategy, tokenizer, cfg, ds_cfg):
     try:
         load_fn = "load"
         if strategy.split(".")[-1].startswith("load_"):
@@ -11,6 +11,9 @@ def load(strategy, tokenizer, cfg):
             strategy = ".".join(strategy.split(".")[:-1])
         mod = importlib.import_module(f".{strategy}", "axolotl.prompt_strategies")
         func = getattr(mod, load_fn)
-        return func(tokenizer, cfg)
+        load_kwargs = {}
+        if strategy == "user_defined":
+            load_kwargs["ds_cfg"] = ds_cfg
+        return func(tokenizer, cfg, **load_kwargs)
     except Exception:  # pylint: disable=broad-exception-caught
         return None

--- a/src/axolotl/prompt_strategies/__init__.py
+++ b/src/axolotl/prompt_strategies/__init__.py
@@ -2,6 +2,8 @@
 
 import importlib
 
+from axolotl.prompt_strategies.user_defined import UserDefinedDatasetConfig
+
 
 def load(strategy, tokenizer, cfg, ds_cfg):
     try:
@@ -13,7 +15,7 @@ def load(strategy, tokenizer, cfg, ds_cfg):
         func = getattr(mod, load_fn)
         load_kwargs = {}
         if strategy == "user_defined":
-            load_kwargs["ds_cfg"] = ds_cfg
+            load_kwargs["ds_cfg"] = UserDefinedDatasetConfig(**ds_cfg)
         return func(tokenizer, cfg, **load_kwargs)
     except Exception:  # pylint: disable=broad-exception-caught
         return None

--- a/src/axolotl/prompt_strategies/alpaca_w_system.py
+++ b/src/axolotl/prompt_strategies/alpaca_w_system.py
@@ -57,6 +57,8 @@ class SystemDataPrompter(AlpacaPrompter):
     Alpaca Style Prompter that uses system prompts from the dataset
     """
 
+    system_format: str = "### System:\n{system}\n\n"
+
     def build_prompt_w_system(
         self,
         system: str,

--- a/src/axolotl/prompt_strategies/user_defined.py
+++ b/src/axolotl/prompt_strategies/user_defined.py
@@ -1,0 +1,67 @@
+"""
+User Defined prompts with configuration from the YML config
+"""
+
+from typing import Tuple
+
+from axolotl.prompt_strategies.alpaca_w_system import (
+    InstructionWSystemPromptTokenizingStrategy,
+    SystemDataPrompter,
+)
+
+
+class UserDefinedPromptTokenizationStrategy(InstructionWSystemPromptTokenizingStrategy):
+    """
+    Prompt Tokenization Strategy for user defined prompts
+    """
+
+
+class UserDefinedPrompter(SystemDataPrompter):
+    """
+    Prompter for user defined prompts
+    """
+
+
+def load(tokenizer, cfg, ds_cfg=None):
+    if not ds_cfg:
+        raise ValueError("Missing dataset prompt configuration")
+
+    system_prompt = ""
+    if ds_cfg["system_prompt"] and not ds_cfg["field_system"]:
+        system_prompt = ds_cfg["system_prompt"]
+
+    def parse_instruction_fields(
+        self, prompt  # pylint: disable=unused-argument
+    ) -> Tuple[str, str, str, str]:
+        return (
+            prompt[ds_cfg["field_instruction"]],
+            prompt[ds_cfg["field_input"]]
+            if ds_cfg["field_input"] and ds_cfg["field_input"] in prompt
+            else "",
+            prompt[ds_cfg["field_output"]],
+            prompt[ds_cfg["field_system"]]
+            if ds_cfg["field_system"] and ds_cfg["field_system"] in prompt
+            else system_prompt,
+        )
+
+    def match_prompt_style(self):
+        self.turn_format = ds_cfg["format"]
+        self.turn_no_input_format = (
+            ds_cfg["no_input_format"]
+            if "no_input_format" in ds_cfg
+            else ds_cfg["format"]
+        )
+        self.system_format = ds_cfg["system_format"]
+
+    prompter = UserDefinedPrompter()
+    prompter.match_prompt_style = match_prompt_style
+
+    strat = UserDefinedPromptTokenizationStrategy(
+        prompter,
+        tokenizer,
+        cfg.train_on_inputs,
+        cfg.sequence_len,
+    )
+
+    strat.parse_instruction_fields = parse_instruction_fields
+    return strat

--- a/src/axolotl/prompt_strategies/user_defined.py
+++ b/src/axolotl/prompt_strategies/user_defined.py
@@ -42,7 +42,7 @@ def load(tokenizer, cfg, ds_cfg: Optional[UserDefinedDatasetConfig] = None):
         raise ValueError("Missing dataset prompt configuration")
 
     system_prompt = ""
-    if ds_cfg.system_prompt and not ds_cfg.field_system:
+    if ds_cfg.system_prompt:
         system_prompt = ds_cfg.system_prompt
 
     def parse_instruction_fields(

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -63,12 +63,16 @@ class AlpacaPrompter:
         # returns the full prompt from instruction and optional input
         # if a label (=response, =output) is provided, it's also appended.
         if input:
-            res = self.system_format.format(
-                system=self.system_prompt
+            res = (
+                self.system_format.format(system=self.system_prompt)
+                if self.system_prompt
+                else ""
             ) + self.turn_format.format(instruction=instruction, input=input)
         else:
-            res = self.system_format.format(
-                system=self.system_no_input_prompt
+            res = (
+                self.system_format.format(system=self.system_no_input_prompt)
+                if self.system_prompt
+                else ""
             ) + self.turn_no_input_format.format(instruction=instruction)
         if output:
             res = f"{res}{output}"

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -26,7 +26,7 @@ class AlpacaPrompter:
 
     system_prompt = "Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\n\n"
     system_no_input_prompt = "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n"
-    system_format: str
+    system_format: str = "{system}"
     turn_format: str
     turn_no_input_format: str
     prompt_style: Optional[PromptStyle] = None
@@ -63,13 +63,13 @@ class AlpacaPrompter:
         # returns the full prompt from instruction and optional input
         # if a label (=response, =output) is provided, it's also appended.
         if input:
-            res = self.system_prompt + self.turn_format.format(
-                instruction=instruction, input=input
-            )
+            res = self.system_format.format(
+                system=self.system_prompt
+            ) + self.turn_format.format(instruction=instruction, input=input)
         else:
-            res = self.system_no_input_prompt + self.turn_no_input_format.format(
-                instruction=instruction
-            )
+            res = self.system_format.format(
+                system=self.system_no_input_prompt
+            ) + self.turn_no_input_format.format(instruction=instruction)
         if output:
             res = f"{res}{output}"
         yield res

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -164,20 +164,9 @@ def load_tokenized_prepared_datasets(
                     ds_type = "json"
                     if d.ds_type:
                         ds_type = d.ds_type
-                    elif d.data_files and (
-                        (
-                            isinstance(d.data_files, list)
-                            and ".parquet" in d.data_files[0]
-                        )
-                        or (
-                            isinstance(d.data_files, str) and ".parquet" in d.data_files
-                        )
-                    ):
+                    elif ".parquet" in d.path:
                         ds_type = "parquet"
-                    elif d.data_files and (
-                        (isinstance(d.data_files, list) and ".arrow" in d.data_files[0])
-                        or (isinstance(d.data_files, str) and ".arrow" in d.data_files)
-                    ):
+                    elif ".arrow" in d.path:
                         ds_type = "arrow"
                     ds = load_dataset(
                         ds_type,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -41,6 +41,7 @@ from axolotl.prompters import (
     ShareGPTPrompter,
     SummarizeTLDRPrompter,
 )
+from axolotl.utils.dict import DictDefault
 from axolotl.utils.distributed import is_main_process, zero_first
 from axolotl.utils.trainer import (
     calculate_total_num_steps,
@@ -221,8 +222,8 @@ def load_tokenized_prepared_datasets(
             ):
                 # dataset is already tokenized, just drop it straight in
                 datasets.append(ds)
-            elif isinstance(d.type, object):
-                ds_strategy = load("user_defined", tokenizer, cfg, d.type)
+            elif isinstance(d.type, DictDefault):
+                ds_strategy = load("user_defined", tokenizer, cfg, d.type.to_dict())
                 ds_wrapper = TokenizedPromptDataset(ds_strategy, ds)
                 datasets.append(ds_wrapper)
             elif ds_strategy := load(d.type, tokenizer, cfg, d):

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -164,9 +164,20 @@ def load_tokenized_prepared_datasets(
                     ds_type = "json"
                     if d.ds_type:
                         ds_type = d.ds_type
-                    elif d.data_files and ".parquet" in d.data_files[0]:
+                    elif d.data_files and (
+                        (
+                            isinstance(d.data_files, list)
+                            and ".parquet" in d.data_files[0]
+                        )
+                        or (
+                            isinstance(d.data_files, str) and ".parquet" in d.data_files
+                        )
+                    ):
                         ds_type = "parquet"
-                    elif d.data_files and ".arrow" in d.data_files[0]:
+                    elif d.data_files and (
+                        (isinstance(d.data_files, list) and ".arrow" in d.data_files[0])
+                        or (isinstance(d.data_files, str) and ".arrow" in d.data_files)
+                    ):
                         ds_type = "arrow"
                     ds = load_dataset(
                         ds_type,


### PR DESCRIPTION
for user defined prompters:
```yaml
datasets:
  - path: path/to/custom.jsonl
    type:
      system_prompt: "Below is a conversation between a user and a helpful assistant"
      field_instruction: question
      field_output: answer
      format: |-
        User: {instruction}
        Assistant:
```
the above would define a prompt strategy for a data file with features question and answer mapped to the instruction and output fields according to the format. The `{output}` is not necessary in the format as it is assumed to be appended at the end.

support for pretokenized datasets in the config is automatic as it checks for the input_ids, labels, and attention mask features on the dataset which would only exist on pretokenized dataset

support for parquet and arrow files is supported by either setting the `ds_type` option for a dataset, or automatically when a file under `data_files` has the suffix of `.arrow` or `.parquet`