### PR TITLE
fix(model loading): warn when model revision is passed to gptq

### DIFF
--- a/src/axolotl/utils/validation.py
+++ b/src/axolotl/utils/validation.py
@@ -100,7 +100,8 @@ def validate_config(cfg):
     if cfg.gptq and cfg.model_revision:
         raise ValueError(
             "model_revision is not supported for GPTQ models. "
-            + "Please download the model from HuggingFace Hub manually for correct branch and point to its path."
+            + "Please download the model from HuggingFace Hub manually for correct branch, "
+            + "point to its path, and remove model_revision from the config."
         )
 
     # TODO

--- a/src/axolotl/utils/validation.py
+++ b/src/axolotl/utils/validation.py
@@ -97,6 +97,12 @@ def validate_config(cfg):
             "push_to_hub_model_id is deprecated. Please use hub_model_id instead."
         )
 
+    if cfg.gptq and cfg.model_revision:
+        raise ValueError(
+            "model_revision is not supported for GPTQ models. "
+            + "Please download the model from HuggingFace Hub manually for correct branch and point to its path."
+        )
+
     # TODO
     # MPT 7b
     # https://github.com/facebookresearch/bitsandbytes/issues/25


### PR DESCRIPTION
Adds a check if `model_revision` is passed when using gptq and depending on axolotl to download from HF.

I chose to raise an error instead of modifying upstream repo as I don't think that's preferred right now.