### PR TITLE
fix(tokenize): fix list index out of range by swapping dataset

### DIFF
--- a/examples/falcon/config-7b-lora.yml
+++ b/examples/falcon/config-7b-lora.yml
@@ -9,8 +9,8 @@ gptq: false
 strict: false
 push_dataset_to_hub:
 datasets:
-  - path: teknium/GPT4-LLM-Cleaned
-    type: alpaca:chat
+  - path: mhenrichsen/alpaca_2k_test
+    type: alpaca
 dataset_prepared_path: last_run_prepared
 val_set_size: 0.01
 adapter: lora

--- a/examples/falcon/config-7b.yml
+++ b/examples/falcon/config-7b.yml
@@ -9,8 +9,8 @@ gptq: false
 strict: false
 push_dataset_to_hub:
 datasets:
-  - path: teknium/GPT4-LLM-Cleaned
-    type: alpaca:chat
+  - path: mhenrichsen/alpaca_2k_test
+    type: alpaca
 dataset_prepared_path: last_run_prepared
 val_set_size: 0.01
 adapter:

--- a/examples/pythia/lora.yml
+++ b/examples/pythia/lora.yml
@@ -2,7 +2,7 @@ base_model: EleutherAI/pythia-1.4b-deduped
 base_model_config: EleutherAI/pythia-1.4b-deduped
 load_in_8bit: true
 datasets:
-  - path: teknium/GPT4-LLM-Cleaned
+  - path: mhenrichsen/alpaca_2k_test
     type: alpaca
 dataset_prepared_path: last_run_prepared
 val_set_size: 0.05


### PR DESCRIPTION
Fix #314 . 

This is only a workaround. The other workaround is to point to the exact file path, but I find this solution a bit cleaner.

It's still unclear on why this problem exists for falcon+pythia, but ok for llama.