### PR TITLE
new llama-2 default settings

### DIFF
--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -49,7 +49,7 @@ early_stopping_patience:
 resume_from_checkpoint:
 local_rank:
 logging_steps: 1
-xformers_attention: 
+xformers_attention:
 flash_attention: true
 
 warmup_steps: 10

--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -16,6 +16,7 @@ output_dir: ./lora-out
 
 sequence_len: 4096
 max_packed_sequence_len: 4096
+sample_packing: true
 
 adapter: lora
 lora_model_dir:
@@ -48,8 +49,8 @@ early_stopping_patience:
 resume_from_checkpoint:
 local_rank:
 logging_steps: 1
-xformers_attention: true
-flash_attention:
+xformers_attention: 
+flash_attention: true
 
 warmup_steps: 10
 eval_steps: 20
@@ -63,4 +64,3 @@ special_tokens:
   bos_token: "<s>"
   eos_token: "</s>"
   unk_token: "<unk>"
-  pad_token: "<pad>"

--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -15,7 +15,6 @@ val_set_size: 0.01
 output_dir: ./lora-out
 
 sequence_len: 4096
-max_packed_sequence_len: 4096
 sample_packing: true
 
 adapter: lora

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -19,6 +19,8 @@ lora_model_dir:
 
 sequence_len: 4096
 max_packed_sequence_len: 4096
+sample_packing: true
+
 lora_r: 32
 lora_alpha: 16
 lora_dropout: 0.05
@@ -49,8 +51,8 @@ early_stopping_patience:
 resume_from_checkpoint:
 local_rank:
 logging_steps: 1
-xformers_attention: true
-flash_attention:
+xformers_attention: 
+flash_attention: true
 
 warmup_steps: 10
 eval_steps: 20
@@ -64,4 +66,3 @@ special_tokens:
   bos_token: "<s>"
   eos_token: "</s>"
   unk_token: "<unk>"
-  pad_token: "<pad>"

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -18,7 +18,6 @@ adapter: qlora
 lora_model_dir:
 
 sequence_len: 4096
-max_packed_sequence_len: 4096
 sample_packing: true
 
 lora_r: 32

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -51,7 +51,7 @@ early_stopping_patience:
 resume_from_checkpoint:
 local_rank:
 logging_steps: 1
-xformers_attention: 
+xformers_attention:
 flash_attention: true
 
 warmup_steps: 10


### PR DESCRIPTION
- Removing <pad> tokens as it causes issues at inference
- adding sample_packing
- defaulting to flash_attention instead of xformers