### PR TITLE
Error msg for sharegpt if conv has less than 2 msg

### DIFF
--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -312,7 +312,9 @@ class ShareGPTPrompter:  # pylint: disable=too-few-public-methods
         if len(source) < 2:
             # If there isn't a back and forth conversation, ignore it
             # also happens on the data splitting leaving empty conversations
-            raise IndexError
+            raise IndexError(
+                f"A conversation entry has less than 2 messages :\n{source}"
+            )
 
         conv = self._conversation.copy()
         roles = {"human": conv.roles[0], "gpt": conv.roles[1]}


### PR DESCRIPTION
We could also add to the next error few lines below but I never encountered this error so I'm unsure on how to properly warn about it.

except IndexError as err:
            # sometimes there is a bing or system chat
            raise err