### PR TITLE
don't pass rope_scaling kwarg if it's None

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -229,8 +229,12 @@ def load_model(
         elif cfg.is_llama_derived_model and not cfg.trust_remote_code:
             from transformers import LlamaForCausalLM
 
+            config_kwargs = {}
+            if cfg.rope_scaling:
+                config_kwargs["rope_scaling"] = cfg.rope_scaling
             config = LlamaConfig.from_pretrained(
-                base_model_config, rope_scaling=cfg.rope_scaling
+                base_model_config,
+                **config_kwargs,
             )
             model = LlamaForCausalLM.from_pretrained(
                 base_model,


### PR DESCRIPTION
If the base model already has rope_scaling enabled, then if rope_scaling is simply empty, then it unsets this in the config and you get increased loss when training.

I've tested this on multi-gpu and this fixes the loss so that is is on-par with a previous commit that works correctly before this was introduced.