### PR TITLE
Fix crash when running without CUDA

### DIFF
--- a/src/axolotl/utils/bench.py
+++ b/src/axolotl/utils/bench.py
@@ -28,6 +28,9 @@ def gpu_memory_usage_smi(device=0):
 
 
 def log_gpu_memory_usage(log, msg, device):
+    if not torch.cuda.is_available():
+        return (0, 0, 0)
+
     usage, cache, misc = gpu_memory_usage_all(device)
     extras = []
     if cache > 0:


### PR DESCRIPTION
`log_gpu_memory_usage` was failing hard when running with `CUDA_VISIBLE_DEVICES=""`, preventing doing things like merging adapters on the CPU. This simply skips the GPU memory logging when cuda is not available.