### PR TITLE
don't use mask expansion for inference

### DIFF
--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -2,6 +2,7 @@ base_model: meta-llama/Llama-2-7b-hf
 base_model_config: meta-llama/Llama-2-7b-hf
 model_type: LlamaForCausalLM
 tokenizer_type: LlamaTokenizer
+is_llama_derived_model: true
 
 load_in_8bit: true
 load_in_4bit: false

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -2,6 +2,7 @@ base_model: meta-llama/Llama-2-7b-hf
 base_model_config: meta-llama/Llama-2-7b-hf
 model_type: LlamaForCausalLM
 tokenizer_type: LlamaTokenizer
+is_llama_derived_model: true
 
 load_in_8bit: false
 load_in_4bit: true

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -138,8 +138,10 @@ def load_model(
         LOG.info("patching with xpos rope")
         replace_llama_rope_with_xpos_rope()
 
-    if cfg.is_llama_derived_model and (
-        cfg.max_packed_sequence_len or cfg.sample_packing
+    if (
+        cfg.is_llama_derived_model
+        and (cfg.max_packed_sequence_len or cfg.sample_packing)
+        and not cfg.inference
     ):
         from axolotl.monkeypatch.llama_expand_mask import hijack_expand_mask
 


### PR DESCRIPTION
fixes this issue from discord where the mask expansion shouldn't happen during inference.

```
  File "/home/pi/miniforge3/lib/python3.10/site-packages/transformers/models/llama/modeling_llama.py", line 345, in forward
    raise ValueError(
ValueError: Attention mask should be of size (1, 1, 1, 44), but is torch.Size([1, 1, 44, 44])
```