### PR TITLE
workaround so training doesn't hang when packed dataloader batches aren't even

### DIFF
--- a/src/axolotl/utils/dataloader.py
+++ b/src/axolotl/utils/dataloader.py
@@ -243,6 +243,18 @@ class MultipackDistributedDataloader:
             len_remaining -= 1
             if not len_remaining:
                 return
+        # yield a no-op for cases where we don't have any data left to pack
+        for i in range(0, len_remaining):
+            yield self.collate_fn(
+                [
+                    {
+                        "input_ids": [0],
+                        "labels": [0],
+                        "attention_mask": [True],
+                        "position_ids": [0],
+                    }
+                ]
+            )
 
     def _len_est(self):
         lengths_sum = np.sum(self.lengths)

--- a/src/axolotl/utils/dataloader.py
+++ b/src/axolotl/utils/dataloader.py
@@ -249,7 +249,7 @@ class MultipackDistributedDataloader:
                 [
                     {
                         "input_ids": [0],
-                        "labels": [0],
+                        "labels": [-100],
                         "attention_mask": [True],
                         "position_ids": [0],
                     }


### PR DESCRIPTION
Due to the way the dataloader gets distributed random samples from the sampler, each process gets the same # of tokens, but due to randomness, some processes end up with smaller total rows in the packed dataset. This causes the trainer to hang when it gets to that step since there is no data for that GPU. This workaround just asks it to train against a single token, but we don't label anything, so there is no additional accumulated loss for this. 

The train losses are lower when this workaround is tested. This is attributed to the fewer number of tokens in the batch available that we count towards the loss, since the cross entropy loss is summed to get the train loss.

<img width="1747" alt="Screenshot 2023-08-23 at 1 12 37 AM" src="https://github.com/OpenAccess-AI-Collective/axolotl/assets/381258/c71b062d-daba-4557-b412-c4217b948471">

