### PR TITLE
clear the dataset cache on explicit pre-tokenization

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -219,7 +219,11 @@ def load_datasets(
 ) -> TrainDatasetMeta:
     tokenizer = load_tokenizer(cfg)
 
-    train_dataset, eval_dataset, total_num_steps = prepare_dataset(cfg, tokenizer)
+    skip_cache = cli_args.prepare_ds_only
+
+    train_dataset, eval_dataset, total_num_steps = prepare_dataset(
+        cfg, tokenizer, skip_cache=skip_cache
+    )
 
     if cli_args.debug or cfg.debug:
         LOG.info("check_dataset_labels...")

--- a/src/axolotl/cli/prepare_ds.py
+++ b/src/axolotl/cli/prepare_ds.py
@@ -1,0 +1,33 @@
+"""
+CLI to prepare the datasets for training
+"""
+from pathlib import Path
+
+import fire
+import transformers
+
+from axolotl.cli import (
+    check_accelerate_default_config,
+    load_cfg,
+    load_datasets,
+    print_axolotl_text_art,
+)
+from axolotl.common.cli import TrainerCliArgs
+
+
+def do_cli(config: Path = Path("examples/"), **kwargs):
+    # pylint: disable=duplicate-code
+    print_axolotl_text_art()
+    check_accelerate_default_config()
+    parser = transformers.HfArgumentParser((TrainerCliArgs))
+    parsed_cli_args, _ = parser.parse_args_into_dataclasses(
+        return_remaining_strings=True
+    )
+    parsed_cli_args.prepare_ds_only = True
+    parsed_cfg = load_cfg(config, **kwargs)
+
+    load_datasets(cfg=parsed_cfg, cli_args=parsed_cli_args)
+
+
+if __name__ == "__main__":
+    fire.Fire(do_cli)


### PR DESCRIPTION
TheBloke reported that when experimenting with custom prompt strategies, the transformed dataset gets cached and has to be manually cleared. This will clear it automatically when `--prepare_ds_only` option is set.