### PR TITLE
Fix(doc): Clarify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ strict:
 
 Run
 ```bash
-accelerate launch scripts/finetune.py configs/your_config.yml
+accelerate launch scripts/finetune.py your_config.yml
 ```
 
 #### Multi-GPU


### PR DESCRIPTION
Removes the top `configs` directory as it wasn't used anymore.