### PR TITLE
support for datasets with multiple names

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,15 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
       name: enron_emails
       type: completion # format from earlier
 
+  # huggingface repo with multiple named configurations/subsets
+  datasets:
+    - path: bigcode/commitpackft
+      name:
+        - ruby
+        - python
+        - typescript
+      type: ... # unimplemented custom format
+
   # local
   datasets:
     - path: data.jsonl # or json

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -134,8 +134,17 @@ def load_tokenized_prepared_datasets(
             seed = 42
 
         datasets = []
+
+        def for_d_in_datasets(dataset_configs):
+            for dataset in dataset_configs:
+                if dataset.name and isinstance(dataset.name, list):
+                    for name in dataset.name:
+                        yield DictDefault({**dataset, "name": name})
+                else:
+                    yield dataset
+
         # pylint: disable=invalid-name
-        for d in cfg.datasets:
+        for d in for_d_in_datasets(cfg.datasets):
             ds: Union[Dataset, DatasetDict] = None
             ds_from_hub = False
             try:


### PR DESCRIPTION
some datasets like https://huggingface.co/datasets/bigcode/commitpackft have 100+ named parts. normally, handling that would require adding multiple blocks like:
```
datasets:
  - path: bigcode/commitpackft
    name: python
    type: ...
  - path: bigcode/commitpackft
    name: ruby
    type: ...
  - path: bigcode/commitpackft
    name: typescript
    type: ...
etc...
```

This PR let's us at least simplify this to 
```
datasets:
  - path: bigcode/commitpackft
    name: 
      - ruby
      - python
      - typescript
    type: ...
```
