### PR TITLE
tweak: improve base builder for smaller layers

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -13,16 +13,14 @@ ARG CUDA="118"
 
 ENV PYTHON_VERSION=$PYTHON_VERSION
 
-RUN apt-get update
-RUN apt-get install -y wget git build-essential ninja-build git-lfs libaio-dev && rm -rf /var/lib/apt/lists/*
-
-RUN wget \
+RUN apt-get update \
+    && apt-get install -y wget git build-essential ninja-build git-lfs libaio-dev && rm -rf /var/lib/apt/lists/*
+    && wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && mkdir /root/.conda \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh
-
-RUN conda create -n "py${PYTHON_VERSION}" python="${PYTHON_VERSION}"
+    && rm -f Miniconda3-latest-Linux-x86_64.sh \
+    && conda create -n "py${PYTHON_VERSION}" python="${PYTHON_VERSION}"
 
 ENV PATH="/root/miniconda3/envs/py${PYTHON_VERSION}/bin:${PATH}"
 


### PR DESCRIPTION
By merging layers we don't save the apt cache