### PR TITLE
Debug tokenization output: Add ability to output text only (no tokens), and/or specify num samples to see

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -246,9 +246,9 @@ def load_datasets(
         LOG.info("check_dataset_labels...")
         check_dataset_labels(
             train_dataset.select(
-                [random.randrange(0, len(train_dataset) - 1) for _ in range(5)]  # nosec
+                [random.randrange(0, len(train_dataset) - 1) for _ in range(cli_args.debug_num_examples)]  # nosec
             ),
-            tokenizer,
+            tokenizer, num_examples=cli_args.num_examples, text_only=cli_args.debug_text_only
         )
 
     return TrainDatasetMeta(

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -246,9 +246,14 @@ def load_datasets(
         LOG.info("check_dataset_labels...")
         check_dataset_labels(
             train_dataset.select(
-                [random.randrange(0, len(train_dataset) - 1) for _ in range(cli_args.debug_num_examples)]  # nosec
+                [
+                    random.randrange(0, len(train_dataset) - 1)
+                    for _ in range(cli_args.debug_num_examples)
+                ]  # nosec
             ),
-            tokenizer, num_examples=cli_args.debug_num_examples, text_only=cli_args.debug_text_only
+            tokenizer,
+            num_examples=cli_args.debug_num_examples,
+            text_only=cli_args.debug_text_only,
         )
 
     return TrainDatasetMeta(

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -248,7 +248,7 @@ def load_datasets(
             train_dataset.select(
                 [random.randrange(0, len(train_dataset) - 1) for _ in range(cli_args.debug_num_examples)]  # nosec
             ),
-            tokenizer, num_examples=cli_args.num_examples, text_only=cli_args.debug_text_only
+            tokenizer, num_examples=cli_args.debug_num_examples, text_only=cli_args.debug_text_only
         )
 
     return TrainDatasetMeta(

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -247,9 +247,9 @@ def load_datasets(
         check_dataset_labels(
             train_dataset.select(
                 [
-                    random.randrange(0, len(train_dataset) - 1)
+                    random.randrange(0, len(train_dataset) - 1)  # nosec
                     for _ in range(cli_args.debug_num_examples)
-                ]  # nosec
+                ]
             ),
             tokenizer,
             num_examples=cli_args.debug_num_examples,

--- a/src/axolotl/common/cli.py
+++ b/src/axolotl/common/cli.py
@@ -29,6 +29,7 @@ class TrainerCliArgs:
     prompter: Optional[str] = field(default=None)
     shard: bool = field(default=False)
 
+
 def load_model_and_tokenizer(
     *,
     cfg: DictDefault,

--- a/src/axolotl/common/cli.py
+++ b/src/axolotl/common/cli.py
@@ -21,12 +21,13 @@ class TrainerCliArgs:
     """
 
     debug: bool = field(default=False)
+    debug_text_only: bool = field(default=False)
+    debug_num_examples: int = field(default=5)
     inference: bool = field(default=False)
     merge_lora: bool = field(default=False)
     prepare_ds_only: bool = field(default=False)
     prompter: Optional[str] = field(default=None)
     shard: bool = field(default=False)
-
 
 def load_model_and_tokenizer(
     *,

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -29,9 +29,11 @@ def check_example_labels(example, tokenizer, text_only=False):
         decoded_input_token = tokenizer.decode(input_id)
         # Choose the color based on whether the label has the ignore value or not
         color = "red" if label_id == -100 else ("yellow" if label_id == 0 else "green")
-        colored_token = colored(decoded_input_token, color) + (not text_only and colored(
-            f"({label_id}, {mask}, {input_id})", "white"
-        ) or '')
+        colored_token = colored(decoded_input_token, color) + (
+            not text_only
+            and colored(f"({label_id}, {mask}, {input_id})", "white")
+            or ""
+        )
         colored_tokens.append(colored_token)
 
     LOG.info(" ".join(colored_tokens))

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -8,13 +8,13 @@ from termcolor import colored
 LOG = logging.getLogger("axolotl")
 
 
-def check_dataset_labels(dataset, tokenizer):
+def check_dataset_labels(dataset, tokenizer, num_examples=5, text_only=False):
     # the dataset is already shuffled, so let's just check the first 5 elements
-    for idx in range(5):
-        check_example_labels(dataset[idx], tokenizer)
+    for idx in range(num_examples):
+        check_example_labels(dataset[idx], tokenizer, text_only=text_only)
 
 
-def check_example_labels(example, tokenizer):
+def check_example_labels(example, tokenizer, text_only=False):
     # Get the input_ids, labels, and attention_mask from the dataset
     input_ids = example["input_ids"]
     labels = example["labels"]
@@ -29,9 +29,9 @@ def check_example_labels(example, tokenizer):
         decoded_input_token = tokenizer.decode(input_id)
         # Choose the color based on whether the label has the ignore value or not
         color = "red" if label_id == -100 else ("yellow" if label_id == 0 else "green")
-        colored_token = colored(decoded_input_token, color) + colored(
+        colored_token = colored(decoded_input_token, color) + (not text_only and colored(
             f"({label_id}, {mask}, {input_id})", "white"
-        )
+        ) or '')
         colored_tokens.append(colored_token)
 
     LOG.info(" ".join(colored_tokens))


### PR DESCRIPTION
Added two new CLI arguments to `scripts/finetune.py`:
- `--debug_text_only` (default: False) - if true, the debug output will not output token information, only the decoded text
- `--debug_num_examples` (default: 5) - allows specifying how many samples will be displayed.

Rationale: 

I regularly use `--prepare_ds_only --debug` as a way of confirming changes in my prompt strategy code, eg confirming that my prompt template is correct, and that the dataset is being processed in the way I intended.

However I find it quite hard to follow the text when tokens are printed alongside the text.  Disabling token output makes the output far easier to use for this purpose.  The text is still chunked into tokens, so the user can see when words are split into multiple tokens.

It's similarly sometimes useful to see more than 5 samples, especially when looking for output that may not occur in every sample.

