### PR TITLE
Added advanced DDP args

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,11 @@ fsdp_config:
 # Deepspeed config path
 deepspeed:
 
+# DDP Arguments
+ddp_timeout:
+ddp_bucket_cap_mb:
+ddp_broadcast_buffers:
+
 # Path to torch distx for optim 'adamw_anyprecision'
 torchdistx_path:
 

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ fsdp_config:
 # Deepspeed config path
 deepspeed:
 
-# DDP Arguments
+# Advanced DDP Arguments
 ddp_timeout:
 ddp_bucket_cap_mb:
 ddp_broadcast_buffers:

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ fsdp_config:
 # Deepspeed config path
 deepspeed:
 
-# DDP Arguments
+# Advanced DDP Arguments
 ddp_timeout:
 ddp_bucket_cap_mb:
 ddp_broadcast_buffers:

--- a/README.md
+++ b/README.md
@@ -607,6 +607,11 @@ fsdp_config:
 # Deepspeed config path
 deepspeed:
 
+# DDP Arguments
+ddp_timeout:
+ddp_bucket_cap_mb:
+ddp_broadcast_buffers:
+
 # Path to torch distx for optim 'adamw_anyprecision'
 torchdistx_path:
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -517,6 +517,15 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer, total_num_
             "steps" if cfg.save_steps else "epoch"
         )
 
+    # DDP Config
+    if cfg.ddp_timeout:
+        training_arguments_kwargs["ddp_timeout"]=cfg.ddp_timeout
+    #see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
+    if cfg.ddp_bucket_cap_mb:
+        training_arguments_kwargs["ddp_bucket_cap_mb"]=cfg.ddp_bucket_cap_mb
+    if cfg.ddp_broadcast_buffers:
+        training_arguments_kwargs["ddp_broadcast_buffers"]=cfg.ddp_broadcast_buffers
+
     training_args = AxolotlTrainingArguments(  # pylint: disable=unexpected-keyword-arg
         max_steps=total_num_steps if cfg.max_steps else -1,
         max_seq_length=cfg.sequence_len,

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -579,6 +579,15 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer, total_num_
         if cfg.bench_dataset:
             training_arguments_kwargs["bench_dataset"] = cfg.bench_dataset
 
+    # DDP Config
+    if cfg.ddp_timeout:
+        training_arguments_kwargs["ddp_timeout"]=cfg.ddp_timeout
+    #see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
+    if cfg.ddp_bucket_cap_mb:
+        training_arguments_kwargs["ddp_bucket_cap_mb"]=cfg.ddp_bucket_cap_mb
+    if cfg.ddp_broadcast_buffers:
+        training_arguments_kwargs["ddp_broadcast_buffers"]=cfg.ddp_broadcast_buffers
+
     training_args = AxolotlTrainingArguments(  # pylint: disable=unexpected-keyword-arg
         max_steps=total_num_steps if cfg.max_steps else -1,
         max_seq_length=cfg.sequence_len,

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -581,12 +581,12 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer, total_num_
 
     # DDP Config
     if cfg.ddp_timeout:
-        training_arguments_kwargs["ddp_timeout"]=cfg.ddp_timeout
-    #see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
+        training_arguments_kwargs["ddp_timeout"] = cfg.ddp_timeout
+    # see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
     if cfg.ddp_bucket_cap_mb:
-        training_arguments_kwargs["ddp_bucket_cap_mb"]=cfg.ddp_bucket_cap_mb
-    if cfg.ddp_broadcast_buffers:
-        training_arguments_kwargs["ddp_broadcast_buffers"]=cfg.ddp_broadcast_buffers
+        training_arguments_kwargs["ddp_bucket_cap_mb"] = cfg.ddp_bucket_cap_mb
+    if cfg.ddp_broadcast_buffers is not None:
+        training_arguments_kwargs["ddp_broadcast_buffers"] = cfg.ddp_broadcast_buffers
 
     training_args = AxolotlTrainingArguments(  # pylint: disable=unexpected-keyword-arg
         max_steps=total_num_steps if cfg.max_steps else -1,

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -519,12 +519,12 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer, total_num_
 
     # DDP Config
     if cfg.ddp_timeout:
-        training_arguments_kwargs["ddp_timeout"]=cfg.ddp_timeout
-    #see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
+        training_arguments_kwargs["ddp_timeout"] = cfg.ddp_timeout
+    # see https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html
     if cfg.ddp_bucket_cap_mb:
-        training_arguments_kwargs["ddp_bucket_cap_mb"]=cfg.ddp_bucket_cap_mb
-    if cfg.ddp_broadcast_buffers:
-        training_arguments_kwargs["ddp_broadcast_buffers"]=cfg.ddp_broadcast_buffers
+        training_arguments_kwargs["ddp_bucket_cap_mb"] = cfg.ddp_bucket_cap_mb
+    if cfg.ddp_broadcast_buffers is not None:
+        training_arguments_kwargs["ddp_broadcast_buffers"] = cfg.ddp_broadcast_buffers
 
     training_args = AxolotlTrainingArguments(  # pylint: disable=unexpected-keyword-arg
         max_steps=total_num_steps if cfg.max_steps else -1,


### PR DESCRIPTION
Is there any reason to not have ddp args accessible? 

Should only be necessary for special cases (and thus no neet to add to examples), but these are crucial for debugging my hanging issues (#494) and timeout is also important e.g. increasing for long-running evals that only run on process 0 and decreasing for debugging...