### PR TITLE
Alternative sample_packing implementation

### DIFF
--- a/src/axolotl/utils/dataloader.py
+++ b/src/axolotl/utils/dataloader.py
@@ -185,8 +185,7 @@ class MultipackDistributedDataloader:
             lengths=lengths,
             lengths_cumsum=lengths_cumsum,
             rank=self.rank,
-            # c=self.batch_max_length,
-            c=self.seq_max_length * self.sample_packing_seq_len_multiplier,
+            c=self.batch_max_length,
             n=self.num_replicas,
         )
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -391,7 +391,10 @@ def calculate_total_num_steps(cfg, train_dataset, tokenizer):
                 ),
                 packing_efficiency_estimate=cfg.sample_packing_eff_est,
                 sample_packing_seq_len_multiplier=cfg.micro_batch_size,
-                num_replicas=0,  # should calc eff for all
+                num_replicas=int(
+                    os.environ.get("WORLD_SIZE", 1)
+                ),  # should calc eff for all?
+                rank=0,
             )
             data_loader_len = data_loader.len_w_stats()
             actual_eff = data_loader.efficiency()


### PR DESCRIPTION
I dont want to merge in the current state, just open a draft PR to make people aware of this (and probably someone with better programming skills than me can implement a `real` solution).

The current implementation of `sample_packing` causes the training to hang when `micro_batch_size`>1  (and sometimes even with mbs=1) - see issue #494 for a detailed report.

This implementation is closer to the original Openchat implementation and doesn't use the distributed sampler. The advantage is that packing is more efficient (the algorithm knows the whole dataset) and estimated regarding num_steps are better. The disadvantage is that every process has to load the whole dataset - for very large datasets probably not an option.

Detailed sweep with my real-world dataset (which im unfortunately not allowed to share); consisting of comparatively many long examples:
[WAND Report](https://api.wandb.ai/links/jan-harries/jyib3z7m).

A *good* solution would probably use some modified BatchSampler, so that accelerate would be able to either distribute the batches from one central process or to all nodes as a whole, depending on the dataset (see [here](https://github.com/huggingface/accelerate/blob/7befe580c2393b0a3d75a8aa75af79b8e57f84a4/src/accelerate/data_loader.py) ). 

Another solution could be to selectively ignore the buffers causing the hanging during gradient accumulation (using [this](https://github.com/pytorch/pytorch/blob/7ec439206853ec1a7ba74cfeeaa15d45d30475cc/torch/nn/parallel/distributed.py#L2149) but here Im out of my depth). 

Unfortunately I don't have the time + skills to implement a clean/good solution for this currently - just dropping here so it´s  not lost, if Im the only one with this problem happy to have the PR closed ;). 