### PR TITLE
Make model compilation failure a warning only

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -82,7 +82,10 @@ def train(
 
     if torch.__version__ >= "2" and sys.platform != "win32":
         LOG.info("Compiling torch model")
-        model = torch.compile(model)
+        try:
+            model = torch.compile(model)
+        except RuntimeError as ex:
+            LOG.warning("An error was raised by PyTorch when performing compile operation. This warning can be ignored if model compilation is not required: '%s'", str(ex))
 
     # go ahead and presave, so we have the adapter config available to inspect
     if peft_config:

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -85,7 +85,10 @@ def train(
         try:
             model = torch.compile(model)
         except RuntimeError as ex:
-            LOG.warning("An error was raised by PyTorch when performing compile operation. This warning can be ignored if model compilation is not required: '%s'", str(ex))
+            LOG.warning(
+                "An error was raised by PyTorch when performing compile operation. This warning can be ignored if model compilation is not required: '%s'",
+                str(ex),
+            )
 
     # go ahead and presave, so we have the adapter config available to inspect
     if peft_config:


### PR DESCRIPTION
A small update that will output a warning when model compilation fails instead of halting training.

## Background

While testing on (unsupported) Python 3.11 + Torch 2.0.1  the following error is raised:

```text
[2023-09-06 11:16:32,019] [INFO] [axolotl.train.train:84] [PID:9554] Compiling torch model
Traceback (most recent call last):
  File "/workspace/axolotl/scripts/finetune.py", line 278, in <module>
    fire.Fire(do_cli)
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/fire/core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/fire/core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/axolotl/scripts/finetune.py", line 274, in do_cli
    train(cfg=parsed_cfg, cli_args=parsed_cli_args, dataset_meta=dataset_meta)
  File "/workspace/axolotl/src/axolotl/train.py", line 85, in train
    model = torch.compile(model)
            ^^^^^^^^^^^^^^^^^^^^
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/torch/__init__.py", line 1444, in compile
    return torch._dynamo.optimize(backend=backend, nopython=fullgraph, dynamic=dynamic, disable=disable)(model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 457, in optimize
    check_if_dynamo_supported()
  File "/opt/resonance_ai/venv/lib/python3.11/site-packages/torch/_dynamo/eval_frame.py", line 413, in check_if_dynamo_supported
    raise RuntimeError("Python 3.11+ not yet supported for torch.compile")
RuntimeError: Python 3.11+ not yet supported for torch.compile
```

Since model compilation may not be required this change seems reasonable to increase compatibility.
