### PR TITLE
add git environment variables to compose: avoid checkout failure erro…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,11 @@ services:
       - ~/.cache/huggingface/:/root/.cache/huggingface/
     # set environment variables
     environment:
+      # Set environment variables
+      - GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME}
+      - GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL}
+      - GIT_COMMITTER_NAME=${GIT_COMMITTER_NAME}
+      - GIT_COMMITTER_EMAIL=${GIT_COMMITTER_EMAIL}
       - WANDB_API_KEY=${WANDB_API_KEY}
     deploy:
       resources:


### PR DESCRIPTION
Hey,

Very small PR here. I ran into a repeated failure of git to checkout on building the docker image locally:

> 3720.4   fatal: unable to access 'https://github.com/huggingface/peft.git/': Failed to connect to github.com port 443 after 130313 ms: Connection timed out
3721.3   fatal: unable to checkout working tree
3721.3   warning: Clone succeeded, but checkout failed.
3721.3   You can inspect what was checked out with 'git status'
3721.3   and retry with 'git restore --source=HEAD :/'
3721.3 
3721.3   error: subprocess-exited-with-error
3721.3   
3721.3   × git clone --filter=blob:none --quiet https://github.com/huggingface/peft.git /tmp/pip-install-q72dqxi2/peft_91993db74c3f4fd4939038403b087a96 did not run successfully.
3721.3   │ exit code: 128
3721.3   ╰─> See above for output.

Configuring the local git credentials solves this problem for me (see [this stackoverflow](https://stackoverflow.com/a/17228373) - apparently this is an issue that can crop up when checking out long commit names). This can be done by just propagating environment variables into the provided `docker-compose.yaml`.