### PR TITLE
don't resize embeddings if it's already large enough

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -291,7 +291,8 @@ def load_model(
         if cfg.resize_token_embeddings_to_32x
         else len(tokenizer)
     )
-    model.resize_token_embeddings(embeddings_len)
+    if model.get_input_embeddings().num_embeddings < embeddings_len:
+        model.resize_token_embeddings(embeddings_len)
 
     if (
         hasattr(model.config, "max_position_embeddings")

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -293,6 +293,8 @@ def load_model(
     )
     if model.get_input_embeddings().num_embeddings < embeddings_len:
         model.resize_token_embeddings(embeddings_len)
+    else:
+        model.tie_weights()
 
     if (
         hasattr(model.config, "max_position_embeddings")


### PR DESCRIPTION
for example, we don't actually need to resize phi b/c the embeddings size is already much larger than the tokenizer len

```python
>>> from transformers import AutoModelForCausalLM, AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained("microsoft/phi-1_5", trust_remote_code=True)
>>> len(tokenizer)
50295
>>> model = AutoModelForCausalLM.from_pretrained("microsoft/phi-1_5", trust_remote_code=True)
>>> model.get_input_embeddings().num_embeddings
51200
>>> 
```