### PR TITLE
prevent cli functions from getting fired on import

### DIFF
--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -23,4 +23,5 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     do_inference(cfg=parsed_cfg, cli_args=parsed_cli_args)
 
 
-fire.Fire(do_cli)
+if __name__ == "__main__":
+    fire.Fire(do_cli)

--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -23,4 +23,5 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     do_merge_lora(cfg=parsed_cfg, cli_args=parsed_cli_args)
 
 
-fire.Fire(do_cli)
+if __name__ == "__main__":
+    fire.Fire(do_cli)

--- a/src/axolotl/cli/shard.py
+++ b/src/axolotl/cli/shard.py
@@ -38,4 +38,5 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     shard(cfg=parsed_cfg, cli_args=parsed_cli_args)
 
 
-fire.Fire(do_cli)
+if __name__ == "__main__":
+    fire.Fire(do_cli)

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -32,4 +32,5 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     train(cfg=parsed_cfg, cli_args=parsed_cli_args, dataset_meta=dataset_meta)
 
 
-fire.Fire(do_cli)
+if __name__ == "__main__":
+    fire.Fire(do_cli)


### PR DESCRIPTION
currently this is firing the clis for all the new functions when calling scripts/finetune.py