### PR TITLE
Enable full (non-sharded) model saving with SHARDED_STATE_DICT

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -117,6 +117,10 @@ def train(
 
     LOG.info(f"Training Completed!!! Saving pre-trained model to {cfg.output_dir}")
 
+    if trainer.is_fsdp_enabled:
+        trainer.accelerator.state.fsdp_plugin.set_state_dict_type("FULL_STATE_DICT")
+        LOG.info("Set FSDP state dict type to FULL_STATE_DICT for saving.")
+
     if cfg.relora_steps:
         if cfg.adapter == "lora" and not (cfg.load_in_4bit or cfg.load_in_8bit):
             model = model.merge_and_unload()


### PR DESCRIPTION
Copied from [here](https://github.com/pacman100/DHS-LLM-Workshop/blob/95acb4b034136fd99cdeeb7d8eb5ef8ad28afa1f/chat_assistant/training/train.py#L199) and tested successfully.

Unfortunately I was not able to get `resume_from_checkpoint` working with SHARDED_STATE_DICT, Issue is [here](https://github.com/huggingface/transformers/issues/26186).