### PR TITLE
Add deepspeed installation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cd axolotl
 pip3 install packaging
 pip3 install -e .[flash-attn]
 pip3 install -U git+https://github.com/huggingface/peft.git
+pip3 install deepspeed
 
 # finetune lora
 accelerate launch -m axolotl.cli.train examples/openllama-3b/lora.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ scikit-learn==1.2.2
 pynvml
 art
 wandb
+deepspeed


### PR DESCRIPTION
The "Quickstart" section of the README did not include the installation of deepspeed. This is required when setting up a fresh instance of Axolotl. This change-set adds `pip3 install deepspeed` to installation instructions.

Details about this are discussed in https://github.com/OpenAccess-AI-Collective/axolotl/issues/598.