### PR TITLE
override device_map if the model is gptq-based

### DIFF
--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -39,6 +39,11 @@ def choose_device(cfg):
     accelerate_vars = [var for var in os.environ if var.startswith("ACCELERATE_USE_")]
     if accelerate_vars:
         cfg.device_map = None
+    
+    # Override the device_map if the model we are trying to train is gptq-based"
+    # Otherwise training will not work
+    if cfg.gptq:
+        cfg.device_map="auto"
 
 
 def normalize_config(cfg):

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -39,7 +39,7 @@ def choose_device(cfg):
     accelerate_vars = [var for var in os.environ if var.startswith("ACCELERATE_USE_")]
     if accelerate_vars:
         cfg.device_map = None
-    
+
     # Override the device_map if the model we are trying to train is gptq-based"
     # Otherwise training will not work
     if cfg.gptq:

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -43,7 +43,7 @@ def choose_device(cfg):
     # Override the device_map if the model we are trying to train is gptq-based"
     # Otherwise training will not work
     if cfg.gptq:
-        cfg.device_map="auto"
+        cfg.device_map = "auto"
 
 
 def normalize_config(cfg):


### PR DESCRIPTION
Override `device_map` in config if the model is GPTQ-based.

This solves #599, which wasn't entirely addressed by #609.

After this PR, example `gptq-lora.yml` trains correctly.

Finetuning with 2xRTX3090 works too, but I'm not really sure on how it will perform on custom accelerate configs.