### PR TITLE
Added quotes to the pip install -e command in the documentation to fix an incompatibility …

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git clone https://github.com/OpenAccess-AI-Collective/axolotl
 cd axolotl
 
 pip3 install packaging
-pip3 install -e .[flash-attn,deepspeed]
+pip3 install -e '.[flash-attn,deepspeed]'
 pip3 install -U git+https://github.com/huggingface/peft.git
 
 # finetune lora
@@ -122,7 +122,7 @@ accelerate launch -m axolotl.cli.inference examples/openllama-3b/lora.yml \
   3. Install axolotl along with python dependencies
         ```bash
         pip3 install packaging
-        pip3 install -e .[flash-attn,deepspeed]
+        pip3 install -e '.[flash-attn,deepspeed]'
         ```
 
 - LambdaLabs
@@ -158,7 +158,7 @@ accelerate launch -m axolotl.cli.inference examples/openllama-3b/lora.yml \
   cd axolotl
 
   pip3 install packaging
-  pip3 install -e .[flash-attn,deepspeed]
+  pip3 install -e '.[flash-attn,deepspeed]'
   pip3 install protobuf==3.20.3
   pip3 install -U --ignore-installed requests Pillow psutil scipy
   ```


### PR DESCRIPTION
…with shells that do glob expansion like zsh a more comprehensive description can be found at https://github.com/mu-editor/mu/issues/852