### PR TITLE
feature: add overlap_len option to completion strategy

### DIFF
--- a/src/axolotl/prompt_strategies/completion.py
+++ b/src/axolotl/prompt_strategies/completion.py
@@ -53,7 +53,8 @@ class CompletionPromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
             full_prompt = self._build_full_prompt(instruction, None, None)
             tokenized_full_prompt = self._tokenize(full_prompt)
             steps = self.sequence_len - self.overlap_len
-            if steps < 1: raise ValueError("Sequence length must be greater than overlap length")
+            if steps < 1:
+                raise ValueError("Sequence length must be greater than overlap length")
 
             for key, val in tokenized_full_prompt.items():
                 for i in range(0, len(val), steps):

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -96,7 +96,7 @@ def load_tokenized_prepared_datasets(
                 str(cfg.sequence_len)
                 + "@"
                 + "|".join(
-                    sorted([f"{d.path}:{d.type}:{d.shards}" for d in cfg.datasets])
+                    sorted([f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}" for d in cfg.datasets])
                 )
                 + "|"
                 + tokenizer_name
@@ -395,7 +395,7 @@ def load_prepare_datasets(
                     + str(max_packed_sequence_len)
                     + seed
                     + "|".join(
-                        sorted([f"{d.path}:{d.type}:{d.shards}" for d in cfg.datasets])
+                        sorted([f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}" for d in cfg.datasets])
                     )
                     + "|"
                     + tokenizer_name

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -96,7 +96,12 @@ def load_tokenized_prepared_datasets(
                 str(cfg.sequence_len)
                 + "@"
                 + "|".join(
-                    sorted([f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}" for d in cfg.datasets])
+                    sorted(
+                        [
+                            f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}"
+                            for d in cfg.datasets
+                        ]
+                    )
                 )
                 + "|"
                 + tokenizer_name
@@ -395,7 +400,12 @@ def load_prepare_datasets(
                     + str(max_packed_sequence_len)
                     + seed
                     + "|".join(
-                        sorted([f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}" for d in cfg.datasets])
+                        sorted(
+                            [
+                                f"{d.path}:{d.type}:{d.shards}:{d.overlap_len}"
+                                for d in cfg.datasets
+                            ]
+                        )
                     )
                     + "|"
                     + tokenizer_name


### PR DESCRIPTION
This is useful with smaller datasets, where the default to split the data into context size length chunks (thus only showing each part of the data a single time).

This PR only adds support to the completion prompt strategy, as that's the only one I've used so far.