### PR TITLE
feature: add aligned samples for completion prompt strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ tokenizer_legacy:
 # resize the model embeddings when new tokens are added to multiples of 32
 # this is reported to improve training speed on some models
 resize_token_embeddings_to_32x:
+# Whether to use left or right padding, defaults to right
+tokenizer_padding_side: right
 
 # used to identify which the model is based on
 is_falcon_derived_model:

--- a/examples/xgen-7b/xgen-7b-8k-qlora.yml
+++ b/examples/xgen-7b/xgen-7b-8k-qlora.yml
@@ -5,6 +5,8 @@ base_model_config: Salesforce/xgen-7b-8k-base
 trust_remote_code: true
 model_type: AutoModelForCausalLM
 tokenizer_type: AutoTokenizer
+# use left padding for aligned completion samples
+tokenizer_paddding_side: left
 load_in_8bit: false
 # enable 4bit for QLoRA
 load_in_4bit: true

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -45,6 +45,8 @@ def load_tokenizer(cfg):
     if cfg.tokenizer_legacy is not None:
         # True is the default w/ https://github.com/huggingface/transformers/pull/25224
         tokenizer_kwargs["legacy"] = cfg.tokenizer_legacy
+    if cfg.tokenizer_padding_side is not None:
+        tokenizer_kwargs["padding_side"] = cfg.tokenizer_padding_side
 
     tokenizer_cls = AutoTokenizer
     if cfg.tokenizer_type:


### PR DESCRIPTION
By default, data will be chopped into samples, with the last sample being right-padded to fill up the context. This will often result in last-samples-of-a-text that have a short text followed by a bunch of pads. While this is fine from a training perspective, it is far more common in real life to encounter a completion task where you are given a very short amount of the *starting text*. This PR flips the padding side, when possible, so that the very first sample begins with padding tokens, followed by the starting text, and the remaining samples are then perfectly aligned with the sequence length so that no more padding is required.

In other words, we end up with filled up context sizes for all samples except the first ones in each input, which now looks like

```[PAD] [PAD] [PAD] ... [PAD] Once upon a time, there was a```

whereas we would normally end up with filled up context sizes for all except the last one in each input, which looks like

```happily ever after.[PAD] [PAD] [PAD] ...[PAD] [PAD] [PAD]```

I should note that this approach would most likely benefit instruction format prompt strategies as well, with the caveat that it at minimum gets to the Response part.