### PR TITLE
Fix: Higher vram usage for mistral and sample_packing

### DIFF
--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -36,10 +36,10 @@ lora_target_modules:
   - k_proj
   - o_proj
 
-wandb_project: 
-wandb_entity: 
+wandb_project:
+wandb_entity:
 wandb_watch:
-wandb_run_id: 
+wandb_run_id:
 wandb_log_model:
 
 gradient_accumulation_steps: 4

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -81,7 +81,7 @@ def load_tokenizer(cfg):
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-    # Mistral's FA requires left padding
+    # Mistral's official FA implementation requires left padding
     if cfg.is_mistral_derived_model and cfg.flash_attention and not cfg.sample_packing:
         tokenizer.padding_side = "left"
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -81,7 +81,8 @@ def load_tokenizer(cfg):
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-    if cfg.is_mistral_derived_model:
+    # Mistral's FA requires left padding
+    if cfg.is_mistral_derived_model and cfg.flash_attention and not cfg.sample_packing:
         tokenizer.padding_side = "left"
 
     if cfg.special_tokens:


### PR DESCRIPTION
Since Mistral's FA requires tokenizer left padding, we only apply this for that specific scenario now.