### PR TITLE
improve handling of the prepared ds path and other cfg defaults

### DIFF
--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -14,6 +14,7 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     # pylint: disable=duplicate-code
     print_axolotl_text_art()
     parsed_cfg = load_cfg(config, **kwargs)
+    parsed_cfg.sample_packing = False
     parser = transformers.HfArgumentParser((TrainerCliArgs))
     parsed_cli_args, _ = parser.parse_args_into_dataclasses(
         return_remaining_strings=True

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -1,10 +1,12 @@
 """
 CLI to run training on a model
 """
+import logging
 from pathlib import Path
 
 import fire
 import transformers
+from colorama import Fore
 
 from axolotl.cli import (
     check_accelerate_default_config,
@@ -14,7 +16,10 @@ from axolotl.cli import (
     print_axolotl_text_art,
 )
 from axolotl.common.cli import TrainerCliArgs
+from axolotl.common.const import DEFAULT_DATASET_PREPARED_PATH
 from axolotl.train import train
+
+LOG = logging.getLogger("axolotl.cli.train")
 
 
 def do_cli(config: Path = Path("examples/"), **kwargs):
@@ -27,6 +32,14 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     parsed_cli_args, _ = parser.parse_args_into_dataclasses(
         return_remaining_strings=True
     )
+    if parsed_cli_args.prepare_ds_only and not parsed_cfg.dataset_prepared_path:
+        msg = (
+            Fore.RED
+            + "--prepare_ds_only called without dataset_prepared_path set."
+            + Fore.RESET
+        )
+        LOG.warning(msg)
+        parsed_cfg.dataset_prepared_path = DEFAULT_DATASET_PREPARED_PATH
 
     dataset_meta = load_datasets(cfg=parsed_cfg, cli_args=parsed_cli_args)
     if parsed_cli_args.prepare_ds_only:

--- a/src/axolotl/common/const.py
+++ b/src/axolotl/common/const.py
@@ -1,0 +1,5 @@
+"""
+Various shared constants
+"""
+
+DEFAULT_DATASET_PREPARED_PATH = "last_run_prepared"

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -16,6 +16,7 @@ from datasets import (
 from huggingface_hub import hf_hub_download
 from transformers import PreTrainedTokenizerBase
 
+from axolotl.common.const import DEFAULT_DATASET_PREPARED_PATH
 from axolotl.datasets import ConstantLengthDataset, TokenizedPromptDataset
 from axolotl.prompt_strategies import load
 from axolotl.prompt_tokenizers import (
@@ -44,7 +45,6 @@ from axolotl.utils.trainer import (
 )
 
 LOG = logging.getLogger("axolotl")
-DEFAULT_DATASET_PREPARED_PATH = "last_run_prepared"
 
 
 def md5(to_hash: str, encoding: str = "utf-8") -> str:
@@ -357,7 +357,7 @@ def load_tokenized_prepared_datasets(
         if len(datasets) > 1:
             LOG.info("shuffle merged datasets")
             dataset = dataset.shuffle(seed=seed)
-        if cfg.local_rank == 0 and cfg.dataset_prepared_path:
+        if cfg.local_rank == 0:
             LOG.info(f"Saving merged prepared dataset to disk... {prepared_ds_path}")
             dataset.save_to_disk(prepared_ds_path)
             if cfg.push_dataset_to_hub:


### PR DESCRIPTION
Defaults to saving the prepared dataset, even if it's not going to be used unless explicitly called
warns in red when calling prepare_ds_only without a prepared dataset path set
disable sample packing when doing inference