### PR TITLE
Get qlora mistral-7b fine tuning working on a single 4090

### DIFF
--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -43,7 +43,7 @@ wandb_run_id:
 wandb_log_model:
 
 gradient_accumulation_steps: 4
-micro_batch_size: 4
+micro_batch_size: 2
 num_epochs: 1
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine


### PR DESCRIPTION
Sets micro_batch_size from 4 to 2 in the `mistral/qlora.yml` example. With this change, qlora fine tuning of mistral-7b fits on a single 4090, per https://twitter.com/Teknium1/status/1709750388528939473.

I tried a few different values of `micro_batch_size` and `gradient_accumulation_steps`, as suggested by the readme, but I'm not an expert so please advise if there's a better way to do this.

![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/264658/978199a8-f1e6-49b8-85b3-6db952f84bb0)
![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/264658/776df8e1-e886-447e-be62-136f636e231b)
![Screenshot from 2023-10-09 17-15-49](https://github.com/OpenAccess-AI-Collective/axolotl/assets/264658/717cbee2-9726-432c-9430-9efbe7c5b390)
