### PR TITLE
Fix: lowercase `True` values in config

### DIFF
--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -19,8 +19,8 @@ adapter: qlora
 lora_model_dir:
 
 sequence_len: 8192
-sample_packing: True
-pad_to_sequence_len: True
+sample_packing: true
+pad_to_sequence_len: true
 
 lora_r: 32
 lora_alpha: 16

--- a/examples/pythia/lora.yml
+++ b/examples/pythia/lora.yml
@@ -28,8 +28,8 @@ num_epochs: 3
 learning_rate: 0.00001
 train_on_inputs: false
 group_by_length: false
-bf16: True
-tf32: True
+bf16: true
+tf32: true
 early_stopping_patience:
 resume_from_checkpoint:
 local_rank:


### PR DESCRIPTION
Corrected the Mistral example to use lowercase 'true' instead of 'True' since YAML is case-sensitive.