### PR TITLE
Clarify custom format example

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,13 @@ Have dataset(s) in one of the following format (JSONL recommended):
 
 #### How to add custom prompts
 
-If you want an input/output type of format, you can define a custom prompt in your YAML:
+For a dataset that is preprocessed for instruction purposes:
+
+```json
+{"instruction": "...", "output": "..."}
+```
+
+You can use this example in your YAML config:
 
 ```yaml
 datasets:
@@ -305,19 +311,8 @@ datasets:
     type:
       system_prompt: ""
       field_system: system
-      field_instruction: instruction
-      field_output: output
-      format: "### Instruction: \n{instruction}\n### Output: \n"
-      no_input_format: "### Instruction: \n{instruction}\n### Output: \n"
-```
-
-When you print this, it corresponds to the following. Notice the empty newline where generation output starts from:
-
-```
-### Instruction:
-{instruction}
-### Output:
-
+      format: "[INST] {instruction} [/INST]"
+      no_input_format: "[INST] {instruction} [/INST]"
 ```
 
 #### How to use your custom pretokenized dataset

--- a/README.md
+++ b/README.md
@@ -297,24 +297,28 @@ Have dataset(s) in one of the following format (JSONL recommended):
 
 #### How to add custom prompts
 
-Using yaml. Example:
+If you want an input/output type of format, you can define a custom prompt in your YAML:
+
 ```yaml
 datasets:
   - path: repo
     type:
       system_prompt: ""
-      no_input_format: |-
-        User: {instruction}<|end_of_turn|>
-        Assistant:
-      format: |-
-        User: {instruction}
-        {input}<|end_of_turn|>
-        Assistant:
+      field_system: system
+      field_instruction: instruction
+      field_output: output
+      format: "### Instruction: \n{instruction}\n### Output: \n"
+      no_input_format: "### Instruction: \n{instruction}\n### Output: \n"
 ```
 
-Using file:
-1. Add your method to a file in [prompt_strategies](src/axolotl/prompt_strategies). Please see other files as example.
-2. Use your custom file name as the dataset type `<prompt_strategies_file>.load_<load_fn>`.
+When you print this, it corresponds to the following. Notice the empty newline where generation output starts from:
+
+```
+### Instruction:
+{instruction}
+### Output:
+
+```
 
 #### How to use your custom pretokenized dataset
 


### PR DESCRIPTION
The current README seems a bit unclear on specifying a custom prompt format. In this PR, I modify the example to show a common scenario where you want a generation pair of `prompt/completion`.

I get rid of the YAML formatting of `|-` as it can quickly lead to unexpected behavior. One should just use a string, although it looks less fancy, it will be easier to ensure correctness.

```
    type:
      system_prompt: ""
      field_system: system
      format: "[INST] {instruction} [/INST]"
      no_input_format: "[INST] {instruction} [/INST]"
```

There are other more complicated formats that I choose to omit as you are better off using something that is not error-prone, especially when you are already using a custom dataset. Here is one example with Alpaca instruct, perhaps this can be included somewhere else in the docs:

```
    type:
      system_prompt: ""
      field_system: system
      format: "\n### Instruction: \n{instruction}\n### Output: \n"
      no_input_format: "\n### Instruction: \n{instruction}\n### Output: \n"

```