### PR TITLE
Mistral: Sliding Window Attention with Flash Attention and Sample Packing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     dependency_links=dependency_links,
     extras_require={
         "flash-attn": [
-            "flash-attn>=2.2.1",
+            "flash-attn>=2.3.0",
         ],
         "deepspeed": [
             "deepspeed",

--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -154,10 +154,10 @@ def flashattn_forward(
         and kv_seq_len > self.config.sliding_window
     )
 
-    # if use_sliding_windows:
-    #     window_size = (self.config.sliding_window, self.config.sliding_window)
-    # else:
-    window_size = (-1, -1)
+    if use_sliding_windows:
+        window_size = (self.config.sliding_window, self.config.sliding_window)
+    else:
+        window_size = (-1, -1)
 
     if past_key_value is not None:
         # Activate slicing cache only if the config has a value `sliding_windows` attribute

--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -16,6 +16,7 @@ from flash_attn.flash_attn_interface import (  # pylint: disable=ungrouped-impor
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.mistral.modeling_mistral import (
     MistralDecoderLayer as OriginalMistralDecoderLayer,
+    MistralAttention as OriginalMistralAttention
 )
 from transformers.models.mistral.modeling_mistral import apply_rotary_pos_emb, repeat_kv
 
@@ -41,6 +42,32 @@ def replace_mistral_attn_with_flash_attn(
             mistral_model_forward
         )
 
+def _make_sliding_window_causal_mask(
+    input_ids_shape: torch.Size,
+    dtype: torch.dtype,
+    device: torch.device,
+    past_key_values_length: int = 0,
+    sliding_window: int = 4096,
+):
+    """
+    Make causal mask used for sliding window attention
+    """
+    bsz, tgt_len = input_ids_shape
+
+    tensor = torch.full(
+        (tgt_len, tgt_len),
+        fill_value=1,
+        device=device,
+    )
+    mask = torch.tril(tensor, diagonal=0)
+    # make the mask banded to account for sliding window
+    # NOTE: HF implementation is wrong as of 14-10-2023 for torch.triu, needs +1
+    mask = torch.triu(mask, diagonal=-sliding_window + 1)
+    mask = torch.log(mask).to(dtype)
+
+    if past_key_values_length > 0:
+        mask = torch.cat([torch.zeros(tgt_len, past_key_values_length, dtype=dtype, device=device), mask], dim=-1)
+    return mask[None, None, :, :].expand(bsz, 1, tgt_len, tgt_len + past_key_values_length)
 
 # Disable the transformation of the attention mask in LlamaModel as the flash attention
 # requires the attention mask to be the same as the key_padding_mask
@@ -53,11 +80,21 @@ def _prepare_decoder_attention_mask(
     sliding_window,
 ):  # pylint: disable=unused-argument
     # [bsz, seq_len]
-    return attention_mask
+    sliding_window_mask = None
+    if input_shape[-1] > 1:
+        sliding_window_mask = _make_sliding_window_causal_mask(
+            input_shape,
+            inputs_embeds.dtype,
+            device=inputs_embeds.device,
+            past_key_values_length=past_key_values_length,
+            sliding_window=sliding_window,
+        )
+    
+    return attention_mask if sliding_window_mask is None else attention_mask + sliding_window_mask
 
 
 def flashattn_forward(
-    self,
+    self: OriginalMistralAttention,
     hidden_states: torch.Tensor,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
@@ -91,8 +128,35 @@ def flashattn_forward(
         query_states, key_states, cos, sin, position_ids
     )
 
+    use_sliding_windows = (
+        hasattr(self.config, "sliding_window") is not None
+        and kv_seq_len > self.config.sliding_window
+    )
+
+    if use_sliding_windows:
+        window_size = (self.config.sliding_window, self.config.sliding_window)
+    else:
+        window_size = (-1, -1)
+
     if past_key_value is not None:
-        # reuse k, v, self_attention
+        # Activate slicing cache only if the config has a value `sliding_windows` attribute
+        if hasattr(self.config, "sliding_window") and kv_seq_len > self.config.sliding_window:
+            slicing_tokens = kv_seq_len - self.config.sliding_window
+
+            past_key = past_key_value[0]
+            past_value = past_key_value[1]
+
+            past_key = past_key[:, :, slicing_tokens:, :].contiguous()
+            past_value = past_value[:, :, slicing_tokens:, :].contiguous()
+
+            if past_key.shape[-2] != self.config.sliding_window - 1:
+                raise ValueError(
+                    f"past key much have a shape of (`batch_size, num_heads, self.config.sliding_window-1, head_dim`), got"
+                    f" {past_key.shape}"
+                )
+
+            past_key_value = (past_key, past_value)
+        
         key_states = torch.cat([past_key_value[0], key_states], dim=2)
         value_states = torch.cat([past_key_value[1], value_states], dim=2)
 
@@ -120,7 +184,7 @@ def flashattn_forward(
         qkv = rearrange(qkv, "b s ... -> (b s) ...")
 
         output = flash_attn_varlen_qkvpacked_func(
-            qkv, cu_seqlens, max_seqlen, 0.0, softmax_scale=None, causal=True
+            qkv, cu_seqlens, max_seqlen, 0.0, softmax_scale=None, causal=True, window_size=window_size
         )
         output = rearrange(output, "(b s) ... -> b s ...", b=bsz)
     elif query_states.shape == key_states.shape:
@@ -146,6 +210,7 @@ def flashattn_forward(
             0.0,
             softmax_scale=None,
             causal=is_causal,
+            window_size=window_size
         )
         output = output_pad_fn(output_unpad)
     else:
@@ -157,6 +222,7 @@ def flashattn_forward(
                 query_states,
                 torch.stack([key_states, value_states], 2),
                 causal=is_causal,
+                window_size=window_size
             )
         else:
             (  # pylint: disable=unbalanced-tuple-unpacking
@@ -191,6 +257,7 @@ def flashattn_forward(
                 0.0,
                 softmax_scale=None,
                 causal=is_causal,
+                window_size=window_size
             )
             output = output_pad_fn(output_unpad)
 

--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -99,10 +99,7 @@ def _prepare_decoder_attention_mask(
 
     # NOTE: attention mask and sliding masks are only broadcastable in certain scenarios.
     # Without attention_mask.shape[0] == 1, error will trigger after eval loss but only when wandb is enabled.
-    if (
-        input_shape[-1] > 1
-        and attention_mask.shape[0] == 1
-    ):
+    if input_shape[-1] > 1 and attention_mask.shape[0] == 1:
         sliding_window_mask = _make_sliding_window_causal_mask(
             input_shape,
             inputs_embeds.dtype,

--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -99,7 +99,10 @@ def _prepare_decoder_attention_mask(
 
     # NOTE: attention mask and sliding masks are only broadcastable in certain scenarios.
     # Without attention_mask.shape[0] == 1, error will trigger after eval loss but only when wandb is enabled.
-    if attention_mask.shape[0] == 1:
+    if (
+        input_shape[-1] > 1
+        and attention_mask.shape[0] == 1
+    ):
         sliding_window_mask = _make_sliding_window_causal_mask(
             input_shape,
             inputs_embeds.dtype,

--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -101,10 +101,9 @@ def _prepare_decoder_attention_mask(
     # Without attention_mask.shape[0] == 1, error will trigger after eval loss but only when wandb is enabled.
     if input_shape[-1] > 1 and attention_mask.shape[0] == 1:
         sliding_window_mask = _make_sliding_window_causal_mask(
-            input_shape[0],
-            input_shape[1],
-            input_shape,
-            inputs_embeds.dtype,
+            bsz=input_shape[0],
+            tgt_len=input_shape[1],
+            dtype=inputs_embeds.dtype,
             device=inputs_embeds.device,
             past_key_values_length=past_key_values_length,
             sliding_window=sliding_window,


### PR DESCRIPTION
Main benefits of this PR:
- Loss is reduced 5x on long-context datasets due to passing `window_size` to Flash Attention.
- Memory usage is reduced by 3GB due to the usage of a sliding window mask.

<details>

<summary>Memory usage</summary>

Memory usage with SWA. The conclusion is that you save 3GB when using a sliding window mask.
- `_prepare_decoder_attention_mask` with `window_size=(4096, 4096)` parameter to flash attention.
    - PR, with sliding window mask: 4.851GB (+24.606GB cache, +0.781GB misc)
    - PR, without sliding window mask: 4.851GB (+27.778GB cache, +0.781GB misc)
- `_prepare_decoder_attention_mask` with `window_size=(-1, -1)` parameter to flash attention.
    - PR, with sliding window mask: 4.851GB (+24.606GB cache, +0.781GB misc)
    - Main, without sliding window mask: 4.851GB (+27.778GB cache, +0.781GB misc)

</details>

<details>

<summary>Long context (casperhansen/longalpaca_1k_test)</summary>

I test with a long context dataset, minimum 16k tokens and maximum 32k tokens. Minimum 48GB VRAM needed to run this.

Results after a few steps:

- PR: Loss starts at 1.9, goes down to 1.54 after 4 steps, 1.396 after 19 steps
- Main: Loss starts at 9.98, goes down to 9.11 after 4 steps

```
base_model: mistralai/Mistral-7B-v0.1
base_model_config: mistralai/Mistral-7B-v0.1
model_type: MistralForCausalLM
tokenizer_type: LlamaTokenizer
is_mistral_derived_model: true

load_in_8bit: false
load_in_4bit: true
strict: false

datasets:
  - path: casperhansen/longalpaca_1k_test
    type: alpaca
dataset_prepared_path: last_run_prepared
val_set_size: 0.01
output_dir: ./qlora-out

adapter: qlora
lora_model_dir:

sequence_len: 32768
sample_packing: true
pad_to_sequence_len: true

lora_r: 32
lora_alpha: 16
lora_dropout: 0.05
lora_target_linear: true
lora_fan_in_fan_out:
lora_target_modules:
  - gate_proj
  - down_proj
  - up_proj
  - q_proj
  - v_proj
  - k_proj
  - o_proj

wandb_mode: 
wandb_project: 
wandb_entity: 
wandb_watch: 
wandb_run_id: 
wandb_log_model:

gradient_accumulation_steps: 1
micro_batch_size: 1
num_epochs: 1
optimizer: adamw_bnb_8bit
lr_scheduler: cosine
learning_rate: 0.0002

train_on_inputs: false
group_by_length: false
bf16: true
fp16: false
tf32: false

gradient_checkpointing: true
early_stopping_patience:
resume_from_checkpoint:
local_rank:
logging_steps: 1
xformers_attention:
flash_attention: true

warmup_steps: 10
eval_steps: 20
eval_table_size: 5
eval_table_max_new_tokens: 128
save_steps:
debug:
deepspeed:
weight_decay: 0.0
fsdp:
fsdp_config:
special_tokens:
  bos_token: "<s>"
  eos_token: "</s>"
  unk_token: "<unk>"
```
</details>

<details>

<summary>Short context (mhenrichsen/alpaca_2k_test)</summary>

Loss on short-context datasets is tested to be the same.

Used default config in `examples/mistral/qlora.yml`.

![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/27340033/fa0b4f41-e49c-4ff8-a723-02881277d1e1)
![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/27340033/31d01993-6a6d-4ac8-83a1-bcc5804c3ccf)

</details>

Other notes:
- `attention_mask` and `sliding_window_mask` are not broadcastable in the first iteration after eval loss. However, this is only the case when `wandb` is enabled. This error is handled by `attention_mask.shape[0] != 1` so that it does not trigger.
- I tried to use [`_expand_mask`](https://github.com/younesbelkada/transformers/blob/c2869469cb2cb15ae608cf2529bf87ba2faadfc8/src/transformers/models/mistral/modeling_mistral.py#L97) and it did not work with Flash Attention. I tried other methods too, but same problem.