### PR TITLE
Fix(model): Linear detected and added to target module with rope linear

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -507,7 +507,7 @@ def find_all_linear_names(model):
     cls = (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt, torch.nn.Linear, QuantLinear)
     lora_module_names = set()
     for name, module in model.named_modules():
-        if isinstance(module, cls) or "Linear" in module.__class__.__name__:
+        if isinstance(module, cls):
             names = name.split(".")
             lora_module_names.add(names[0] if len(names) == 1 else names[-1])
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -507,7 +507,11 @@ def find_all_linear_names(model):
     cls = (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt, torch.nn.Linear, QuantLinear)
     lora_module_names = set()
     for name, module in model.named_modules():
-        if isinstance(module, cls):
+        if (
+            isinstance(module, cls)
+            or "Linear" in module.__class__.__name__
+            and module.__class__.__name__ not in ("LlamaLinearScalingRotaryEmbedding",)
+        ):
             names = name.split(".")
             lora_module_names.add(names[0] if len(names) == 1 else names[-1])
 


### PR DESCRIPTION
Discussion: https://discord.com/channels/1104757954588196865/1110594519226925137/1163762312247787570

> ValueError: Target module LlamaLinearScalingRotaryEmbedding() is not supported. Currently, only the following modules are supported: torch.nn.Linear, torch.nn.Embedding, torch.nn.Conv2d, transformers.pytorch_utils.Conv1D


when lora + `rope_scaling: linear`. dynamic is ok.

This condition check must've included the linear layer from the name.

Alternative solution: add blacklist for this module.

Note: I'm not sure if by removing this would affect any current run, but the linear layers listed in `cls` seems to be inclusive.