### PR TITLE
catch ConnectionError when checking dataset from HuggingFace

### DIFF
--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -158,7 +158,7 @@ def load_tokenized_prepared_datasets(
                     token=use_auth_token,
                 )
                 ds_from_hub = True
-            except FileNotFoundError:
+            except (FileNotFoundError, ConnectionError):
                 pass
 
             # prefer local dataset, even if hub exists


### PR DESCRIPTION
When using axolotl in HPC environments, commonly without access to the internet, HF_DATASETS_OFFLINE enviroment variable need to be set. This causes data loading, even for a JSON file, to throw an uncatched error and impeding the training run to begin.

This addition catches `ConnectionError` and continues treating it as if it was a `FileNotFoundError`, checking for local files next.

You can test the difference just by adding `HF_DATASETS_OFFLINE=1` to the training command. The run must use a local JSON file.