### PR TITLE
Fix: Cannot tokenize with bf16 and on cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ accelerate launch -m axolotl.cli.train your_config.yml
 
 You can optionally pre-tokenize dataset with the following before finetuning:
 ```bash
-CUDA_VISIBLE_DEVICES="" accelerate launch -m axolotl.cli.train your_config.yml --prepare_ds_only
+CUDA_VISIBLE_DEVICES=0 accelerate launch -m axolotl.cli.train your_config.yml --prepare_ds_only
 ```
 
 ##### Config


### PR DESCRIPTION
When running with CPU and bf16 on, you would get `ValueError: bf16 requested, but AMP is not supported on this GPU. Requires Ampere series or above.`