### PR TITLE
Fix Deepspeed Zero3 Config

### DIFF
--- a/deepspeed/zero3.json
+++ b/deepspeed/zero3.json
@@ -1,14 +1,5 @@
-{
   "zero_optimization": {
     "stage": 3,
-    "offload_optimizer": {
-      "device": "cpu",
-      "pin_memory": true
-    },
-    "offload_param": {
-      "device": "cpu",
-      "pin_memory": true
-    },
     "overlap_comm": true,
     "contiguous_gradients": true,
     "sub_group_size": 0,
@@ -41,12 +32,12 @@
     }
   },
   "scheduler": {
-    "type": "WarmupLR",
+    "type": "WarmupDecayLR",
     "params": {
       "warmup_min_lr": "auto",
       "warmup_max_lr": "auto",
       "warmup_num_steps": "auto",
-      "warmup_type": "linear"
+      "decay_style": "linear"
     }
   },
   "gradient_accumulation_steps": "auto",

--- a/deepspeed/zero3.json
+++ b/deepspeed/zero3.json
@@ -1,3 +1,4 @@
+{
   "zero_optimization": {
     "stage": 3,
     "overlap_comm": true,
@@ -37,7 +38,8 @@
       "warmup_min_lr": "auto",
       "warmup_max_lr": "auto",
       "warmup_num_steps": "auto",
-      "decay_style": "linear"
+      "warmup_type": "linear",
+      "total_num_steps": "auto"
     }
   },
   "gradient_accumulation_steps": "auto",


### PR DESCRIPTION
Update DS Zero 3 conf to not use CPU Offload (because it dramatically slows things down, just reduce batchsize unless you cant fit bs 1) and replace LR Scheduler with a properly decaying one - with constant LR scheduler, it will cause loss to increase after each epoch

Compare dark pink (decaying LR Schedule) with all others, including blue, which used constant LR Schedule (the default in this conf)
<img width="516" alt="image" src="https://github.com/OpenAccess-AI-Collective/axolotl/assets/127238744/128a298a-50c2-4c62-b736-c61df550b50f">
