### PR TITLE
Dockerfile: add deepspeed-kernels dependency for deepspeed>=0.12.0

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -27,7 +27,7 @@ ENV PATH="/root/miniconda3/envs/py${PYTHON_VERSION}/bin:${PATH}"
 WORKDIR /workspace
 
 RUN python3 -m pip install --upgrade pip && pip3 install packaging && \
-    python3 -m pip install --no-cache-dir -U torch==${PYTORCH_VERSION}+cu${CUDA} --extra-index-url https://download.pytorch.org/whl/cu$CUDA
+    python3 -m pip install --no-cache-dir -U torch==${PYTORCH_VERSION}+cu${CUDA} deepspeed-kernels --extra-index-url https://download.pytorch.org/whl/cu$CUDA
 
 FROM base-builder AS deepspeed-builder
 


### PR DESCRIPTION
# Description

Dockerfile-base: add deepspeed-kernels dependency for deepspeed

## Motivation and Context

Deepspeed update to  0.12.x breaks building of docker image. With the following log output:

```text
 > [deepspeed-builder 2/2] RUN git clone https://github.com/microsoft/DeepSpeed.git &&     cd DeepSpeed &&     MAX_CONCURRENCY=8 DS_BUILD_SPARSE_ATTN=0 DS_BUILD_OPS=1 DS_BUILD_EVOFORMER_ATTN=0 python3 setup.py bdist_wheel:
32.02  [WARNING]  cpu_lion attempted to use `py-cpuinfo` but failed (exception type: <class 'UnboundLocalError'>, local variable 'get_cpu_info' referenced before assignment), falling back to `lscpu` to get this information.
32.02  [WARNING]  cpu_lion attempted to use `py-cpuinfo` but failed (exception type: <class 'UnboundLocalError'>, local variable 'get_cpu_info' referenced before assignment), falling back to `lscpu` to get this information.
32.02  [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
32.02  [WARNING]  Filtered compute capabilities ['7.0', '7.5']
32.02     ext_modules.append(builder.builder())
32.02   File "/workspace/DeepSpeed/op_builder/builder.py", line 633, in builder
32.02     extra_link_args=self.strip_empty_entries(self.extra_ldflags()))
32.02   File "/workspace/DeepSpeed/op_builder/inference_cutlass_builder.py", line 71, in extra_ldflags
32.02     import dskernels
32.02 ModuleNotFoundError: No module named 'dskernels'
```

See also previous pull request #821 