### PR TITLE
Pin optimum package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ sentencepiece
 wandb
 einops
 xformers>=0.0.22
-optimum
+optimum==1.13.2
 hf_transfer
 colorama
 numba


### PR DESCRIPTION
With this, training gptq lora works again.

Without this, I get this error:

```
Traceback (most recent call last):
  File "/axolotl/src/axolotl/utils/models.py", line 306, in load_model
    model = AutoModelForCausalLM.from_pretrained(
  File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/auto_factory.py", line 565, in from_pretrained
    return model_class.from_pretrained(
  File "/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py", line 2713, in from_pretrained
    from optimum.gptq import GPTQQuantizer
  File "/usr/local/lib/python3.10/dist-packages/optimum/gptq/__init__.py", line 15, in <module>
    from .quantizer import GPTQQuantizer, load_quantized_model
  File "/usr/local/lib/python3.10/dist-packages/optimum/gptq/quantizer.py", line 44, in <module>
    if is_auto_gptq_available():
  File "/usr/local/lib/python3.10/dist-packages/optimum/utils/import_utils.py", line 116, in is_auto_gptq_available
    raise ImportError(
ImportError: Found an incompatible version of auto-gptq. Found version 0.4.2, but only version above 0.4.99 are supported

```