### PR TITLE
support for fp8

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -483,6 +483,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["fp16"] = (
             self.cfg.fp16 and not self.cfg.bf16
         ) or False
+        if self.cfg.fp8:
+            training_arguments_kwargs["fp16"] = False
+            training_arguments_kwargs["bf16"] = False
+
         training_arguments_kwargs["tf32"] = self.cfg.tf32
         training_arguments_kwargs["warmup_steps"] = warmup_steps
         training_arguments_kwargs["logging_steps"] = logging_steps

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -70,7 +70,9 @@ def normalize_config(cfg):
     else:
         torch.backends.cuda.matmul.allow_tf32 = cfg.tf32 or False
 
-    if cfg.bf16 or cfg.bfloat16:
+    if cfg.fp8:
+        cfg.torch_dtype = torch.bfloat16
+    elif cfg.bf16 or cfg.bfloat16:
         cfg.torch_dtype = torch.bfloat16
     elif cfg.load_in_8bit or cfg.fp16 or cfg.float16:
         cfg.torch_dtype = torch.float16

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -268,6 +268,8 @@ def setup_trainer(cfg, train_dataset, eval_dataset, model, tokenizer, total_num_
         setup_fsdp_envs(cfg)
     elif cfg.deepspeed:
         os.environ["ACCELERATE_USE_DEEPSPEED"] = "true"
+    if cfg.fp8:
+        os.environ["ACCELERATE_MIXED_PRECISION"] = "fp8"
 
     trainer_builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
     trainer_builder.train_dataset = train_dataset


### PR DESCRIPTION
can now train fp8 with `fp8: true`
- doesn't support sample packing
- doesn't work with deepspeed. this is due to how accelerate wraps the model w deepspeed first, so doesn't wrap it later for fp8 (we could probably manually wrap it beforehand)
- doesn't work with flash attention
- the model weights are still in bf16, as torch complains about missing storage when using torch.float8_e5m2
```
Traceback (most recent call last):                          
  File "/workspace/axolotl/src/axolotl/utils/models.py", line 250, in load_model
    model = LlamaForCausalLM.from_pretrained(               
  File "/root/miniconda3/envs/py3.10/lib/python3.10/site-packages/transformers/modeling_utils.py", line 3051, in from_pretrained
    dtype_orig = cls._set_default_torch_dtype(torch_dtype)
  File "/root/miniconda3/envs/py3.10/lib/python3.10/site-packages/transformers/modeling_utils.py", line 1222, in _set_default_torch_dtype
    torch.set_default_dtype(dtype)
  File "/root/miniconda3/envs/py3.10/lib/python3.10/site-packages/torch/__init__.py", line 661, in set_default_dtype
    _C._set_default_dtype(d)
TypeError: couldn't find storage object Float8_e5m2Storage
```