### PR TITLE
include the suffix modified string in ascii art

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -46,7 +46,7 @@ def print_axolotl_text_art(suffix=None):
     ascii_text = "  axolotl"
     if suffix:
         ascii_text += f"  x  {suffix}"
-    ascii_art = text2art(" axolotl", font=font)
+    ascii_art = text2art(ascii_text, font=font)
 
     if is_main_process():
         print(ascii_art)


### PR DESCRIPTION
Previously the suffix was applied to modify the `ascii_text` string. `ascii_text` was however not added to the actual print statement.