### PR TITLE
Install from git url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Get started with Axolotl in just a few steps! This quickstart guide will walk yo
 
 `pip3 install "axolotl[flash-attn,deepspeed] @ git+https://github.com/OpenAccess-AI-Collective/axolotl"`
 
-
 ### For developers
 ```bash
 git clone https://github.com/OpenAccess-AI-Collective/axolotl

--- a/README.md
+++ b/README.md
@@ -85,13 +85,20 @@ Get started with Axolotl in just a few steps! This quickstart guide will walk yo
 
 **Requirements**: Python >=3.9 and Pytorch >=2.0.
 
+`pip3 install "axolotl[flash-attn,deepspeed] @ git+https://github.com/OpenAccess-AI-Collective/axolotl"`
+
+
+### For developers
 ```bash
 git clone https://github.com/OpenAccess-AI-Collective/axolotl
 cd axolotl
 
 pip3 install packaging
 pip3 install -e '.[flash-attn,deepspeed]'
+```
 
+### Usage
+```bash
 # finetune lora
 accelerate launch -m axolotl.cli.train examples/openllama-3b/lora.yml
 


### PR DESCRIPTION
I'm working on https://llm-efficiency-challenge.github.io/ and evaluating a bunch of submissions where axolotl is quite popular

Problem is since you don't have a pypy package people are resorting to cloning or copying your whole repo over, this is some new syntax that's a bit more convenient and if you need help setting up nightly binaries on github actions please lmk. I'm not sure most people using a library should be doing editable installs