### PR TITLE
fix: revert local dir dataset load

### DIFF
--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -242,7 +242,14 @@ def load_tokenized_prepared_datasets(
             local_path = Path(config_dataset.path)
             if local_path.exists():
                 if local_path.is_dir():
-                    ds = load_from_disk(config_dataset.path)
+                    # TODO dirs with arrow or parquet files could be loaded with `load_from_disk`
+                    ds = load_dataset(
+                        config_dataset.path,
+                        name=config_dataset.name,
+                        data_files=config_dataset.data_files,
+                        streaming=False,
+                        split=None,
+                    )
                 elif local_path.is_file():
                     ds_type = get_ds_type(config_dataset)
 


### PR DESCRIPTION
@gordicaleksa This PR reverts the change that breaks path pointing to local directory of files.

In the meantime, could you also provide the config that you use? I think it can be loaded in a different existing way also.