### PR TITLE
ensure merged model matches the training dtype

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -72,7 +72,7 @@ def do_merge_lora(
     LOG.info("running merge of LoRA with base model")
     model = model.merge_and_unload()
     if cfg.bf16:
-        model.to(dtype=torch.float16)
+        model.to(dtype=torch.bfloat16)
     else:
         model.to(dtype=torch.float16)
 

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -71,7 +71,10 @@ def do_merge_lora(
 
     LOG.info("running merge of LoRA with base model")
     model = model.merge_and_unload()
-    model.to(dtype=torch.float16)
+    if cfg.bf16:
+        model.to(dtype=torch.float16)
+    else:
+        model.to(dtype=torch.float16)
 
     if cfg.local_rank == 0:
         LOG.info(f"saving merged model to: {str(Path(cfg.output_dir) / 'merged')}")

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -71,10 +71,7 @@ def do_merge_lora(
 
     LOG.info("running merge of LoRA with base model")
     model = model.merge_and_unload()
-    if cfg.bf16:
-        model.to(dtype=torch.bfloat16)
-    else:
-        model.to(dtype=torch.float16)
+    model.to(dtype=cfg.torch_dtype)
 
     if cfg.local_rank == 0:
         LOG.info(f"saving merged model to: {str(Path(cfg.output_dir) / 'merged')}")


### PR DESCRIPTION
seems like all the lora merges are fp16. matching the training would open up bfloat16 support which should be better.