### PR TITLE
Support device_map=sequential & max_memory config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ sample_packing_eff_est:
 total_num_tokens:
 
 # Passed through to transformers when loading the model when launched without accelerate
+# Use `sequential` when training w/ model parallelism to limit memory
 device_map:
 # Defines the max memory usage per gpu on the system. Passed through to transformers when loading the model.
 max_memory:

--- a/README.md
+++ b/README.md
@@ -612,6 +612,11 @@ eval_sample_packing:
 sample_packing_eff_est:
 total_num_tokens:
 
+# Passed through to transformers when loading the model when launched without accelerate
+device_map:
+# Defines the max memory usage per gpu on the system. Passed through to transformers when loading the model.
+max_memory:
+
 # If you want to use 'lora' or 'qlora' or leave blank to train all parameters in original model
 adapter: lora
 # If you already have a lora model trained that you want to load, put that here.

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -27,7 +27,7 @@ def choose_device(cfg):
 
     cfg.device = get_device()
     if cfg.world_size == 1:
-        cfg.device_map = "auto"
+        cfg.device_map = cfg.device_map or "auto"
     else:
         if cfg.device.startswith("cuda"):
             cfg.device_map = {"": torch.cuda.current_device()}

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -216,6 +216,7 @@ def load_model(
     model_kwargs = {}
 
     model_kwargs["device_map"] = cfg.device_map
+    model_kwargs["max_memory"] = cfg.max_memory
     model_kwargs["torch_dtype"] = cfg.torch_dtype
 
     if cfg.model_revision:


### PR DESCRIPTION
In order to train a large model, I recently had to use the combination of `device_map=sequential` and `max_memory` in order to balance the memory usage per gpu (in model parallel) manually.

- `device_map=auto` should not be forced when a value has been specified in the config
- `max_memory` allows for setting memory limits per gpu and is most useful with `device_map=sequential`

This was the simplest way I found to implement supporting these two options.

cc @winglian 