### PR TITLE
Remove lr scheduler in DeepSpeed config to avoid conflict

### DIFF
--- a/deepspeed/zero1.json
+++ b/deepspeed/zero1.json
@@ -24,16 +24,6 @@
       "weight_decay": "auto"
     }
   },
-  "scheduler": {
-    "type": "WarmupDecayLR",
-    "params": {
-      "warmup_min_lr": "auto",
-      "warmup_max_lr": "auto",
-      "warmup_num_steps": "auto",
-      "warmup_type": "linear",
-      "total_num_steps": "auto"
-    }
-  },
   "gradient_accumulation_steps": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",

--- a/deepspeed/zero2.json
+++ b/deepspeed/zero2.json
@@ -28,16 +28,6 @@
       "weight_decay": "auto"
     }
   },
-  "scheduler": {
-    "type": "WarmupDecayLR",
-    "params": {
-      "warmup_min_lr": "auto",
-      "warmup_max_lr": "auto",
-      "warmup_num_steps": "auto",
-      "warmup_type": "linear",
-      "total_num_steps": "auto"
-    }
-  },
   "gradient_accumulation_steps": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",

--- a/deepspeed/zero3.json
+++ b/deepspeed/zero3.json
@@ -32,16 +32,6 @@
       "weight_decay": "auto"
     }
   },
-  "scheduler": {
-    "type": "WarmupDecayLR",
-    "params": {
-      "warmup_min_lr": "auto",
-      "warmup_max_lr": "auto",
-      "warmup_num_steps": "auto",
-      "warmup_type": "linear",
-      "total_num_steps": "auto"
-    }
-  },
   "gradient_accumulation_steps": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",


### PR DESCRIPTION
This PR removed the following `schduler` in DeepSpeed config files.
```json
{
  "scheduler": {
    "type": "WarmupDecayLR",
    "params": {
      "warmup_min_lr": "auto",
      "warmup_max_lr": "auto",
      "warmup_num_steps": "auto",
      "warmup_type": "linear",
      "total_num_steps": "auto"
    }
}
```

The `scheduler` in DeepSpeed configurations is not necessary because the axolotl package defines its own learning rate scheduler (which is passed to the HuggingFace trainer). In fact, the DeepSpeed scheduler can sometimes cause conflicts. For instance, when lr_scheduler: constant_with_warmup is set in the training YAML file, the actual scheduler is overridden by DeepSpeed's `scheduler` (which is DeepSpeed's `WarmupDecayLR` instead of HuggingFace's `constant_with_warmup`). Removing `scheduler` from DeepSpeed configurations can resolve this issue.