### PR TITLE
feat: add check for quantized model

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -32,8 +32,8 @@ def check_model_config(cfg: DictDefault, model_config: AutoConfig):
     quant_config_exists = hasattr(model_config, "quantization_config")
     quant_config_method_is_gptq = (
         quant_config_exists
-        and hasattr(model_config.quantization_config, "quant_method")
-        and model_config.quantization_config.quant_method == "gptq"
+        and "quant_method" in model_config.quantization_config
+        and model_config.quantization_config["quant_method"] == "gptq"
     )
 
     if cfg.gptq and not quant_config_method_is_gptq:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -38,6 +38,25 @@ def load_model_config(cfg):
         for key, val in cfg.model_config.items():
             setattr(model_config, key, val)
 
+    if (
+        hasattr(model_config, "quantization_config")
+        and model_config.quantization_config
+    ):
+        if not cfg.gptq:
+            raise ValueError(
+                "model_config.quantization_config is set but gptq is not. "
+                "Please use the gptq flag to train quantized model or point to a non-quantized model."
+            )
+
+        if (
+            hasattr(model_config.quantization_config, "quant_method")
+            and model_config.quantization_config.quant_method != "gptq"
+        ):
+            raise ValueError(
+                "model_config.quantization_config.quant_method is not set to gptq."
+                "Please make sure to point to a GPTQ model."
+            )
+
     return model_config
 
 


### PR DESCRIPTION
There was a case in discord when someone tried to train AWQ model using full finetune.

This adds check that when `quantization_config` is in the model's config to make sure gptq is set.

Inversely, it makes sure that when `gptq: true`, the quantization_config exists and GPTQ model.