### PR TITLE
feature: better device mapping for large models

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,11 @@ tf32: true # require >=ampere
 bfloat16: true # require >=ampere
 float16: true
 
+# Limit the memory for all available GPUs to this amount (if an integer, expressed in gigabytes); default: unset
+gpu_memory_limit: 20GiB
+# Do the LoRA/PEFT loading on CPU -- this is required if the base model is so large it takes up most or all of the available GPU VRAM, e.g. during a model and LoRA merge
+lora_on_cpu: true
+
 # A list of one or more datasets to finetune the model with
 datasets:
   # HuggingFace dataset repo | s3://,gs:// path | "json" for local dataset, make sure to fill data_files

--- a/README.md
+++ b/README.md
@@ -1043,11 +1043,13 @@ Add below flag to train command above
 python3 -m axolotl.cli.merge_lora examples/your_config.yml --lora_model_dir="./completed-model"
 ```
 
-If you run out of CUDA memory, you can try to merge in system RAM with
+You may need to use the `gpu_memory_limit` and/or `lora_on_cpu` config options to avoid running out of memory. If you still run out of CUDA memory, you can try to merge in system RAM with
 
 ```bash
 CUDA_VISIBLE_DEVICES="" python3 -m axolotl.cli.merge_lora ...
 ```
+
+although this will be very slow, and using the config options above are recommended instead.
 
 ## Common Errors 🧰
 

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -71,7 +71,7 @@ def do_merge_lora(
     safe_serialization = cfg.save_safetensors is True
 
     LOG.info("running merge of LoRA with base model")
-    model = model.merge_and_unload()
+    model = model.merge_and_unload(progressbar=True)
     model.to(dtype=cfg.torch_dtype)
 
     if cfg.local_rank == 0:
@@ -79,6 +79,7 @@ def do_merge_lora(
         model.save_pretrained(
             str(Path(cfg.output_dir) / "merged"),
             safe_serialization=safe_serialization,
+            progressbar=True,
         )
         tokenizer.save_pretrained(str(Path(cfg.output_dir) / "merged"))
 

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -462,6 +462,11 @@ def validate_config(cfg):
             "lora_modules_to_save not properly set yet adding new tokens. Please add `embed_tokens` and `lm_head` to `lora_modules_to_save`."
         )
 
+    if cfg.max_memory is not None and cfg.gpu_memory_limit is not None:
+        raise ValueError(
+            "max_memory and gpu_memory_limit are mutually exclusive and cannot be used together."
+        )
+
     # TODO
     # MPT 7b
     # https://github.com/facebookresearch/bitsandbytes/issues/25

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -283,7 +283,7 @@ def load_model(
     max_memory = cfg.max_memory
     device_map = cfg.device_map
 
-    if cfg.gpu_memory_limit and max_memory is None:
+    if cfg.gpu_memory_limit:
         gpu_memory_limit = (
             str(cfg.gpu_memory_limit) + "GiB"
             if isinstance(cfg.gpu_memory_limit, int)

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -2,7 +2,7 @@
 import logging
 import math
 import os
-from typing import Optional, Tuple  # noqa: F401
+from typing import Any, Optional, Tuple  # noqa: F401
 
 import addict
 import bitsandbytes as bnb
@@ -685,10 +685,15 @@ def load_lora(model, cfg, inference=False):
 
     if cfg.lora_model_dir:
         LOG.debug("Loading pretained PEFT - LoRA")
+        model_kwargs: Any = {}
+        if cfg.lora_on_cpu:
+            model_kwargs["max_memory"] = {"cpu": "256GiB"}
+            model_kwargs["device_map"] = {"": "cpu"}
         model = PeftModel.from_pretrained(
             model,
             cfg.lora_model_dir,
             is_trainable=(not inference),
+            **model_kwargs,
         )
     else:
         model = get_peft_model(model, lora_config)

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -305,7 +305,7 @@ def load_model(
         device_map = infer_auto_device_map(
             model_canvas,
             max_memory=max_memory,
-            dtype="float16",  # TODO: may probably use bfloat16 and others here as well
+            dtype=cfg.torch_dtype,
         )
         # We can discard max_memory now as we have a device map set up for us
         max_memory = None

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -435,7 +435,6 @@ def load_model(
             model_kwargs["device"] = torch.cuda.current_device()
             del model_kwargs["torch_dtype"]
             del model_kwargs["device_map"]
-            del model_kwargs["max_memory"]
 
             model = MambaLMHeadModel.from_pretrained(
                 base_model,

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -284,23 +284,28 @@ def load_model(
     device_map = cfg.device_map
 
     if cfg.gpu_memory_limit and max_memory is None:
-        gpu_memory_limit = str(cfg.gpu_memory_limit) + "GiB" if isinstance(cfg.gpu_memory_limit, int) else cfg.gpu_memory_limit
+        gpu_memory_limit = (
+            str(cfg.gpu_memory_limit) + "GiB"
+            if isinstance(cfg.gpu_memory_limit, int)
+            else cfg.gpu_memory_limit
+        )
 
         max_memory = {}
         for i in range(torch.cuda.device_count()):
             max_memory[i] = gpu_memory_limit
-        max_memory["cpu"] = "256GiB" # something sufficiently large to fit anything
+        max_memory["cpu"] = "256GiB"  # something sufficiently large to fit anything
 
     if max_memory is not None:
         # Based on https://github.com/togethercomputer/OpenChatKit/blob/main/inference/bot.py
         from accelerate import infer_auto_device_map, init_empty_weights
+
         with init_empty_weights():
             model_canvas = AutoModelForCausalLM.from_config(model_config)
         model_canvas.tie_weights()
         device_map = infer_auto_device_map(
             model_canvas,
             max_memory=max_memory,
-            dtype='float16', # TODO: may probably use bfloat16 and others here as well
+            dtype="float16",  # TODO: may probably use bfloat16 and others here as well
         )
         # We can discard max_memory now as we have a device map set up for us
         max_memory = None

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -280,8 +280,32 @@ def load_model(
 
     model_kwargs = {}
 
-    model_kwargs["device_map"] = cfg.device_map
-    model_kwargs["max_memory"] = cfg.max_memory
+    max_memory = cfg.max_memory
+    device_map = cfg.device_map
+
+    if cfg.gpu_memory_limit and max_memory is None:
+        gpu_memory_limit = str(cfg.gpu_memory_limit) + "GiB" if isinstance(cfg.gpu_memory_limit, int) else cfg.gpu_memory_limit
+
+        max_memory = {}
+        for i in range(torch.cuda.device_count()):
+            max_memory[i] = gpu_memory_limit
+        max_memory["cpu"] = "256GiB" # something sufficiently large to fit anything
+
+    if max_memory is not None:
+        # Based on https://github.com/togethercomputer/OpenChatKit/blob/main/inference/bot.py
+        from accelerate import infer_auto_device_map, init_empty_weights
+        with init_empty_weights():
+            model_canvas = AutoModelForCausalLM.from_config(model_config)
+        model_canvas.tie_weights()
+        device_map = infer_auto_device_map(
+            model_canvas,
+            max_memory=max_memory,
+            dtype='float16', # TODO: may probably use bfloat16 and others here as well
+        )
+        # We can discard max_memory now as we have a device map set up for us
+        max_memory = None
+
+    model_kwargs["device_map"] = device_map
     model_kwargs["torch_dtype"] = cfg.torch_dtype
 
     if is_deepspeed_zero3_enabled():


### PR DESCRIPTION
When a model does not fit completely into the GPU (at 16-bits, if merging with a LoRA), a crash occurs, indicating we need an offload dir. If we hide the GPUs and do it purely in CPU, it works, but now we are not using the GPUs at all.

If we try to do offloading while using GPUs, accelerate ends up trying to offload types that are only supported on the GPUs, which results in the possibly infamous `NotImplementedError: Cannot copy out of meta tensor; no data!` error.

This pull requests  adds two new configuration options. One, `gpu_memory_limit` is a convenience option that can be used instead of manually setting the `max_memory` config. (For per-GPU maxes, you need to set it manually though.) It defaults to GBs if an integer, and is assumed to be a proper memory string otherwise (e.g. "`123MiB`").

The other, `lora_on_cpu` is a flag which if set will force the PeftModel loading part to be done purely on CPU end. This slows things down, but if the model is taking up too much of the GPU VRAM, the only alternative is to crash and/or buy more GPUs.

Main, attempting to merge a 34b codellama model with a lora, on a 24 GB A10G with 30GB RAM a,d 64GB swap:
```
[2023-12-06 06:20:36,148] [DEBUG] [axolotl.load_tokenizer:135] [PID:16542] [RANK:0] EOS: 2 / </s>
[2023-12-06 06:20:36,149] [DEBUG] [axolotl.load_tokenizer:136] [PID:16542] [RANK:0] BOS: 1 / <s>
[2023-12-06 06:20:36,149] [DEBUG] [axolotl.load_tokenizer:137] [PID:16542] [RANK:0] PAD: 2 / </s>
[2023-12-06 06:20:36,149] [DEBUG] [axolotl.load_tokenizer:138] [PID:16542] [RANK:0] UNK: 0 / <unk>
[2023-12-06 06:20:36,149] [INFO] [axolotl.common.cli.load_model_and_tokenizer:51] [PID:16542] [RANK:0] loading model and (optionally) peft_config...
[2023-12-06 06:20:36,150] [INFO] [axolotl.load_model:236] [PID:16542] [RANK:0] patching _expand_mask
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:02<00:00,  2.71it/s]
[2023-12-06 06:20:40,509] [INFO] [axolotl.load_model:425] [PID:16542] [RANK:0] GPU memory usage after model load: 17.622GB (+0.017GB cache, +1.173GB misc)
[2023-12-06 06:20:40,513] [INFO] [axolotl.load_model:460] [PID:16542] [RANK:0] converting modules to torch.bfloat16 for flash attention
[2023-12-06 06:20:40,516] [INFO] [axolotl.load_lora:562] [PID:16542] [RANK:0] found linear modules: ['gate_proj', 'q_proj', 'up_proj', 'down_proj', 'k_proj', 'v_proj', 'o_proj']
[2023-12-06 06:20:40,516] [DEBUG] [axolotl.load_lora:577] [PID:16542] [RANK:0] Loading pretained PEFT - LoRA
[2023-12-06 06:20:40,649] [WARNING] [auto_gptq.nn_modules.qlinear.qlinear_cuda.<module>:16] [PID:16542] CUDA extension not installed.
[2023-12-06 06:20:40,650] [WARNING] [auto_gptq.nn_modules.qlinear.qlinear_cuda_old.<module>:15] [PID:16542] CUDA extension not installed.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ec2-user/workspace/axolotl/src/axolotl/cli/merge_lora.py", line 27, in <module>
    fire.Fire(do_cli)
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/fire/core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/fire/core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/workspace/axolotl/src/axolotl/cli/merge_lora.py", line 23, in do_cli
    do_merge_lora(cfg=parsed_cfg, cli_args=parsed_cli_args)
  File "/home/ec2-user/workspace/axolotl/src/axolotl/cli/__init__.py", line 70, in do_merge_lora
    model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/workspace/axolotl/src/axolotl/common/cli.py", line 52, in load_model_and_tokenizer
    model, _ = load_model(cfg, tokenizer, inference=cli_args.inference)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/workspace/axolotl/src/axolotl/utils/models.py", line 468, in load_model
    model, lora_config = load_adapter(model, cfg, cfg.adapter)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/workspace/axolotl/src/axolotl/utils/models.py", line 503, in load_adapter
    return load_lora(model, cfg, inference=inference)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/workspace/axolotl/src/axolotl/utils/models.py", line 578, in load_lora
    model = PeftModel.from_pretrained(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/peft/peft_model.py", line 306, in from_pretrained
    model.load_adapter(model_id, adapter_name, is_trainable=is_trainable, **kwargs)
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/peft/peft_model.py", line 636, in load_adapter
    dispatch_model(
  File "/opt/conda/envs/ai/lib/python3.11/site-packages/accelerate/big_modeling.py", line 368, in dispatch_model
    raise ValueError(
ValueError: We need an `offload_dir` to dispatch this model according to this `device_map`, the following submodules need to be offloaded: base_model.model.model.layers.19, base_model.model.model.layers.20, base_model.model.model.layers.21, base_model.model.model.layers.22, base_model.model.model.layers.23, base_model.model.model.layers.24, base_model.model.model.layers.25, base_model.model.model.layers.26, base_model.model.model.layers.27, base_model.model.model.layers.28, base_model.model.model.layers.29, base_model.model.model.layers.30, base_model.model.model.layers.31, base_model.model.model.layers.32, base_model.model.model.layers.33, base_model.model.model.layers.34, base_model.model.model.layers.35, base_model.model.model.layers.36, base_model.model.model.layers.37, base_model.model.model.layers.38, base_model.model.model.layers.39, base_model.model.model.layers.40, base_model.model.model.layers.41, base_model.model.model.layers.42, base_model.model.model.layers.43, base_model.model.model.layers.44, base_model.model.model.layers.45, base_model.model.model.layers.46, base_model.model.model.layers.47, base_model.model.model.norm, base_model.model.lm_head.
```

This pull request, with
```
gpu_memory_limit: 20GiB
lora_on_cpu: true
```

```
[2023-12-06 04:46:08,700] [INFO] [axolotl.normalize_config:141] [PID:14824] [RANK:0] GPU memory usage baseline: 0.000GB (+0.456GB misc)
[2023-12-06 04:46:08,700] [INFO] [axolotl.common.cli.load_model_and_tokenizer:49] [PID:14824] [RANK:0] loading tokenizer... ./curr-model
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama.LlamaTokenizer'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thouroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565
[2023-12-06 04:46:08,853] [DEBUG] [axolotl.load_tokenizer:135] [PID:14824] [RANK:0] EOS: 2 / </s>
[2023-12-06 04:46:08,853] [DEBUG] [axolotl.load_tokenizer:136] [PID:14824] [RANK:0] BOS: 1 / <s>
[2023-12-06 04:46:08,853] [DEBUG] [axolotl.load_tokenizer:137] [PID:14824] [RANK:0] PAD: 2 / </s>
[2023-12-06 04:46:08,853] [DEBUG] [axolotl.load_tokenizer:138] [PID:14824] [RANK:0] UNK: 0 / <unk>
[2023-12-06 04:46:08,853] [INFO] [axolotl.common.cli.load_model_and_tokenizer:51] [PID:14824] [RANK:0] loading model and (optionally) peft_config...
[2023-12-06 04:46:08,854] [INFO] [axolotl.load_model:236] [PID:14824] [RANK:0] patching _expand_mask
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:04<00:00,  1.68it/s]
[2023-12-06 04:46:14,187] [INFO] [axolotl.load_model:444] [PID:14824] [RANK:0] GPU memory usage after model load: 19.528GB (+0.017GB cache, +1.173GB misc)
[2023-12-06 04:46:14,191] [INFO] [axolotl.load_model:479] [PID:14824] [RANK:0] converting modules to torch.bfloat16 for flash attention
[2023-12-06 04:46:14,194] [INFO] [axolotl.load_lora:581] [PID:14824] [RANK:0] found linear modules: ['v_proj', 'up_proj', 'down_proj', 'k_proj', 'o_proj', 'q_proj', 'gate_proj']
[2023-12-06 04:46:14,194] [DEBUG] [axolotl.load_lora:598] [PID:14824] [RANK:0] Loading pretained PEFT - LoRA
[2023-12-06 04:46:14,351] [WARNING] [auto_gptq.nn_modules.qlinear.qlinear_cuda.<module>:16] [PID:14824] CUDA extension not installed.
[2023-12-06 04:46:14,352] [WARNING] [auto_gptq.nn_modules.qlinear.qlinear_cuda_old.<module>:15] [PID:14824] CUDA extension not installed.
trainable params: 217,841,664 || all params: 33,961,811,968 || trainable%: 0.6414312175253134
[2023-12-06 04:46:29,104] [INFO] [axolotl.load_model:508] [PID:14824] [RANK:0] GPU memory usage after adapters: 0.000GB ()
[2023-12-06 04:46:29,106] [INFO] [axolotl.scripts.do_merge_lora:73] [PID:14824] [RANK:0] running merge of LoRA with base model
Unloading and merging model: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 678/678 [16:09<00:00,  1.43s/it]
[2023-12-06 05:02:38,873] [INFO] [axolotl.scripts.do_merge_lora:78] [PID:14824] [RANK:0] saving merged model to: qlora-out/merged
```

(V)RAM stats (from a previous run, so log times will differ):

Peak (V)RAM usage:
```
$ nvidia-smi; free -h
Wed Dec  6 05:04:49 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.85.12    Driver Version: 525.85.12    CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA A10G         On   | 00000000:00:1E.0 Off |                    0 |
|  0%   28C    P0    56W / 300W |  21590MiB / 23028MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A     14824      C   python                          21588MiB |
+-----------------------------------------------------------------------------+
              total        used        free      shared  buff/cache   available
Mem:            30G         30G        298M         13M        507M        339M
Swap:           63G         37G         26G
```

Post-run (V)RAM usage:
```
Wed Dec  6 05:38:29 2023       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.85.12    Driver Version: 525.85.12    CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA A10G         On   | 00000000:00:1E.0 Off |                    0 |
|  0%   28C    P0    60W / 300W |      0MiB / 23028MiB |    100%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
              total        used        free      shared  buff/cache   available
Mem:            30G        353M         29G        168K        998M         30G
Swap:           63G        110M         63G
```
