### PR TITLE
Pin flash-attn to 2.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     dependency_links=dependency_links,
     extras_require={
         "flash-attn": [
-            "flash-attn>=2.3.0",
+            "flash-attn==2.3.3",
         ],
         "deepspeed": [
             "deepspeed",


### PR DESCRIPTION
Resolves #911 in the case where the user installs using:

```
pip install -e .[flash-attn]
```