### PR TITLE
fixing prompt template of chatml by removal of linebreak

### DIFF
--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -13,7 +13,7 @@ register_conv_template(
         system_message="You are a helpful assistant.",
         roles=["<|im_start|>user", "<|im_start|>assistant"],
         sep_style=SeparatorStyle.CHATML,
-        sep="<|im_end|>\n",
+        sep="<|im_end|>",
     )
 )
 


### PR DESCRIPTION
reference to discord chat:
"""
hi <@208256080092856321> , went through the code step-by-step and found that there's an extra linebreak ('\n') in the separator of ChatML so the separator will end up having two linebreaks . You can see it here: https://github.com/OpenAccess-AI-Collective/axolotl/blob/a581e9f8f66e14c22ec914ee792dd4fe073e62f6/src/axolotl/prompt_strategies/sharegpt.py#L16  and https://github.com/OpenAccess-AI-Collective/axolotl/blob/a48dbf6561cc74c275a48070f397334a2c367dd5/src/axolotl/monkeypatch/fastchat_conversation_turns.py#L117 . A typical silent killer of prompt template for those not aware but the model is most probably robust enough to still reply coherently since it's just a linebreak.
"""