### PR TITLE
fix: remove excessive newlines in system prompt(s) for alpaca

### DIFF
--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -33,8 +33,8 @@ class AlpacaPrompter(Prompter):
     Base class for alpaca prompters
     """
 
-    system_prompt = "Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\n\n"
-    system_no_input_prompt = "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n"
+    system_prompt = "Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request."
+    system_no_input_prompt = "Below is an instruction that describes a task. Write a response that appropriately completes the request."
     system_format: str = "{system}"
     turn_format: str
     turn_no_input_format: str


### PR DESCRIPTION
Main, with `type: alpaca`:
```
 ### System:
Below is an instruction that describes a task. Write a response that appropriately completes the request.



### Instruction:
a task

### Response:
 a response
```

This PR:
```
 ### System:
Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction:
a task

### Response:
 a response
```

Note: there may be other prompt styles that are still doing 4 newlines. I don't want to touch something without testing it.