### PR TITLE
Flash attn hotfix

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -319,6 +319,7 @@ def load_model(
                 model_config._attn_implementation = (  # pylint: disable=protected-access
                     "flash_attention_2"
                 )
+                model_kwargs["use_flash_attention_2"] = True
         else:
             if model_config.model_type == "mixtral":
                 model_config._attn_implementation = (  # pylint: disable=protected-access

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -319,11 +319,14 @@ def load_model(
                 model_config._attn_implementation = (  # pylint: disable=protected-access
                     "flash_attention_2"
                 )
-                model_kwargs["use_flash_attention_2"] = True
         else:
             if model_config.model_type == "mixtral":
                 model_config._attn_implementation = (  # pylint: disable=protected-access
                     "flash_attention_2"
+                )
+            else:
+                model_config._attn_implementation = (  # pylint: disable=protected-access
+                    "eager"
                 )
 
     try:


### PR DESCRIPTION
transformers 4.36.0 changed to using SDPA for attention when flash attention isn't used. This breaks all of our monkey patches. This fix forces it to use the old attention modules.