### PR TITLE
Fix prompt assembly for llama

### DIFF
--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -88,7 +88,7 @@ def get_turns(  # pylint: disable=too-many-return-statements
             yield "", system_prompt
         else:
             yield "", "[INST] "
-        for i, (role, message) in enumerate(self.messages[1:]):
+        for i, (role, message) in enumerate(self.messages):
             if message:
                 yield role + " ", message + seps[i % 2]
             else:

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -86,8 +86,10 @@ def get_turns(  # pylint: disable=too-many-return-statements
         if self.system_message:
             if self.messages:
                 # For llama, the system message is incorporated into the first human instruction
-                system_prompt += self.messages[0][1]
-                self.messages.pop(0)
+                first_role, first_msg = self.messages[0]
+                if first_role == self.roles[0]:
+                    system_prompt += first_msg
+                    self.messages.pop(0)
             yield "", system_prompt
         for i, (role, message) in enumerate(self.messages):
             if message:

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -90,7 +90,10 @@ def get_turns(  # pylint: disable=too-many-return-statements
             yield "", "[INST] "
         for i, (role, message) in enumerate(self.messages):
             if message:
-                yield role + " ", message + seps[i % 2]
+                if i == 0:
+                    yield "", message + " "
+                else:
+                    yield role + " ", message + seps[i % 2]
             else:
                 yield role, ""
         return

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -85,15 +85,17 @@ def get_turns(  # pylint: disable=too-many-return-statements
     if self.sep_style == SeparatorStyle.LLAMA2:
         seps = [self.sep, self.sep2]
         if self.system_message:
+            if (
+                self.messages
+            ):  # For llama, the system message is incorporated into the first human instruction
+                system_prompt += self.messages[0][1]
+                self.messages.pop(0)
             yield "", system_prompt
         else:
             yield "", "[INST] "
         for i, (role, message) in enumerate(self.messages):
             if message:
-                if i == 0:
-                    yield "", message + " "
-                else:
-                    yield role + " ", message + seps[i % 2]
+                yield role + " ", message + seps[i % 2]
             else:
                 yield role, ""
         return

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -83,19 +83,19 @@ def get_turns(  # pylint: disable=too-many-return-statements
                 yield role + ":", ""
         return
     if self.sep_style == SeparatorStyle.LLAMA2:
-        seps = [self.sep, self.sep2]
         if self.system_message:
-            if (
-                self.messages
-            ):  # For llama, the system message is incorporated into the first human instruction
+            if self.messages:
+                # For llama, the system message is incorporated into the first human instruction
                 system_prompt += self.messages[0][1]
                 self.messages.pop(0)
             yield "", system_prompt
-        else:
-            yield "", "[INST] "
         for i, (role, message) in enumerate(self.messages):
             if message:
-                yield role + " ", message + seps[i % 2]
+                if (i % 2 == 0 and not self.system_message) or (
+                    i % 2 != 0 and self.system_message
+                ):
+                    role = "<s> " + role
+                yield role + " ", message
             else:
                 yield role, ""
         return

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -114,18 +114,8 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
                 in self._caplog.records[0].message
             )
 
-    def test_sharegpt_llama_missing_turns(self):
-        "Make sure there are no missing turns with the sharegpt/llama-2 format."
-
-        conversation = {
-            "conversations": [
-                {"from": "system", "value": "lorem"},
-                {"from": "gpt", "value": "ipsum"},
-                {"from": "human", "value": "abc"},
-                {"from": "human", "value": "123"},
-                {"from": "gpt", "value": "sit"},
-            ]
-        }
+    def test_sharegpt_llama(self):
+        "Make sure the sharegpt/llama is tokenized and formatted correctly."
         prompter = ShareGPTPrompterV2(conversation="llama-2")
         strat = ShareGPTPromptTokenizingStrategy(
             prompter,
@@ -134,12 +124,65 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
             2048,
         )
 
-        non_system_prompt = strat.tokenizer.decode(
-            strat.tokenize_prompt(conversation)["input_ids"]
-        )
-        for msg in conversation["conversations"]:
-            if msg["from"] != "system":
-                assert msg["value"] in non_system_prompt
+        def tokenize(conv):
+            return strat.tokenize_prompt(conv)["input_ids"]
+
+        def decode(ids):
+            return strat.tokenizer.decode(ids)
+
+        # Multi-turn conversations
+        multi_turn_conv = {
+            "conversations": [
+                {"from": "system", "value": "lorem"},
+                {"from": "human", "value": "abc"},
+                {"from": "gpt", "value": "ipsum"},
+                {"from": "human", "value": "123"},
+                {"from": "gpt", "value": "sit"},
+            ]
+        }
+        # fmt: off
+        mt_ids = tokenize(multi_turn_conv)
+        assert decode(mt_ids) == '<s> [INST] <<SYS>>\nlorem\n<</SYS>>\n\nabc [/INST] ipsum</s><s> [INST] 123 [/INST] sit</s>'
+        assert mt_ids == [1, 518, 25580, 29962, 3532, 14816, 29903, 6778, 13, 29880, 3668, 13, 29966, 829, 14816, 29903, 6778, 13, 13, 10736, 518, 29914, 25580, 29962, 23421, 2, 1, 518, 25580, 29962, 29871, 29896, 29906, 29941, 518, 29914, 25580, 29962, 7845, 2]
+
+        # Single-turn conversations
+        single_turn_conv = {
+            "conversations": [
+                {"from": "system", "value": "lorem"},
+                {"from": "human", "value": "abc"},
+                {"from": "gpt", "value": "ipsum"},
+            ]
+        }
+
+        st_ids = tokenize(single_turn_conv)
+        assert decode(st_ids) == '<s> [INST] <<SYS>>\nlorem\n<</SYS>>\n\nabc [/INST] ipsum</s>'
+        assert st_ids == [1, 518, 25580, 29962, 3532, 14816, 29903, 6778, 13, 29880, 3668, 13, 29966, 829, 14816, 29903, 6778, 13, 13, 10736, 518, 29914, 25580, 29962, 23421, 2]
+
+        # No system message, single-turn
+        no_sys_conv = {
+            "conversations": [
+                {"from": "human", "value": "abc"},
+                {"from": "gpt", "value": "ipsum"},
+            ]
+        }
+
+        ns_ids = tokenize(no_sys_conv)
+        assert decode(ns_ids) == '<s> [INST] abc [/INST] ipsum</s>'
+        assert ns_ids == [1, 518, 25580, 29962, 25638, 518, 29914, 25580, 29962, 23421, 2]
+
+        # No system message, multi-turn
+        no_sys_mt_conv = {
+            "conversations": [
+                {"from": "human", "value": "abc"},
+                {"from": "gpt", "value": "ipsum"},
+                {"from": "human", "value": "123"},
+                {"from": "gpt", "value": "sit"},
+            ]
+        }
+        ns_mt_ids = tokenize(no_sys_mt_conv)
+        assert decode(ns_mt_ids) == '<s> [INST] abc [/INST] ipsum</s><s> [INST] 123 [/INST] sit</s>'
+        assert ns_mt_ids == [1, 518, 25580, 29962, 25638, 518, 29914, 25580, 29962, 23421, 2, 1, 518, 25580, 29962, 29871, 29896, 29906, 29941, 518, 29914, 25580, 29962, 7845, 2]
+        # fmt: on
 
     def test_sharegpt_changes_roles(self):
         conversation = {

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -134,10 +134,12 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
             2048,
         )
 
-        non_system_prompt = strat.tokenizer.decode(strat.tokenize_prompt(conversation)['input_ids'])
-        for c in conversation['conversations']:
-            if c['from'] != 'system':
-                assert(c['value'] in non_system_prompt)
+        non_system_prompt = strat.tokenizer.decode(
+            strat.tokenize_prompt(conversation)["input_ids"]
+        )
+        for msg in conversation["conversations"]:
+            if msg["from"] != "system":
+                assert msg["value"] in non_system_prompt
 
     def test_sharegpt_changes_roles(self):
         conversation = {

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -115,7 +115,7 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
             )
 
     def test_sharegpt_llama_missing_turns(self):
-        "Make sure there are no missing turns when ussing sharegpt/llama-2"
+        "Make sure there are no missing turns with the sharegpt/llama-2 format."
 
         conversation = {
             "conversations": [

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -114,6 +114,31 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
                 in self._caplog.records[0].message
             )
 
+    def test_sharegpt_llama_missing_turns(self):
+        "Make sure there are no missing turns when ussing sharegpt/llama-2"
+
+        conversation = {
+            "conversations": [
+                {"from": "system", "value": "lorem"},
+                {"from": "gpt", "value": "ipsum"},
+                {"from": "human", "value": "abc"},
+                {"from": "human", "value": "123"},
+                {"from": "gpt", "value": "sit"},
+            ]
+        }
+        prompter = ShareGPTPrompterV2(conversation="llama-2")
+        strat = ShareGPTPromptTokenizingStrategy(
+            prompter,
+            self.tokenizer,
+            False,
+            2048,
+        )
+
+        non_system_prompt = strat.tokenizer.decode(strat.tokenize_prompt(conversation)['input_ids'])
+        for c in conversation['conversations']:
+            if c['from'] != 'system':
+                assert(c['value'] in non_system_prompt)
+
     def test_sharegpt_changes_roles(self):
         conversation = {
             "roles": ["USER", "CHARACTER"],


### PR DESCRIPTION
UPDATE:  I found many issues with the llama templating after fixing the omission of the human message.  I found the following issues:

- EOS/BOS being applied incorrectly in between turns
- System Message was incorrectly formatted with a `[INST]` where it wasn't supposed to be
- Proper handling of multi-turn
- etc.  

I added lots of tests for the following cases:

1. Multi turn
2. Single turn
3. Multi turn without system message
4. Single turn without system message

**For the tests,  I put a redundant decoded version of the string  so that you can see the prompt which will help with code review and understanding**