### PR TITLE
streaming multipack for pretraining dataset

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -20,7 +20,6 @@ jobs:
             python_version: "3.10"
             pytorch: 2.0.1
             axolotl_extras:
-            is_latest: true
           - cuda: 121
             cuda_version: 12.1.0
             python_version: "3.10"

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -36,7 +36,7 @@ jobs:
           images: winglian/axolotl
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and export to Docker
+      - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -48,8 +48,7 @@ jobs:
           file: ./docker/Dockerfile
           tags: |
             ${{ steps.metadata.outputs.tags }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }}
-            ${{ (matrix.is_latest) && format('{0}-latest', steps.metadata.outputs.tags) || '' }}
           labels: ${{ steps.metadata.outputs.labels }}
-      - name: Unit Tests
+      - name: Unit Tests w docker image
         run: |
           docker run --rm ${{ steps.metadata.outputs.tags }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }} pytest --ignore=tests/e2e/ /workspace/axolotl/tests/

--- a/examples/tiny-llama/pretrain.yml
+++ b/examples/tiny-llama/pretrain.yml
@@ -1,0 +1,56 @@
+base_model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+
+model_type: LlamaForCausalLM
+tokenizer_type: LlamaTokenizer
+is_llama_derived_model: true
+
+load_in_8bit: false
+load_in_4bit: false
+strict: false
+
+max_steps: 200
+pretraining_dataset: c4
+dataset_prepared_path:
+val_set_size: 0.0
+output_dir: ./model-out
+
+sequence_len: 2048
+sample_packing: true
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 4
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+train_on_inputs: false
+group_by_length: false
+bf16: true
+fp16: false
+tf32: false
+
+gradient_checkpointing: true
+early_stopping_patience:
+resume_from_checkpoint:
+local_rank:
+logging_steps: 1
+xformers_attention:
+flash_attention: true
+
+warmup_steps: 10
+evals_per_epoch: 
+eval_table_size:
+saves_per_epoch: 1
+debug:
+deepspeed:
+weight_decay: 0.0
+fsdp:
+fsdp_config:
+special_tokens:

--- a/examples/tiny-llama/pretrain.yml
+++ b/examples/tiny-llama/pretrain.yml
@@ -9,7 +9,9 @@ load_in_4bit: false
 strict: false
 
 max_steps: 200
-pretraining_dataset: c4
+pretraining_dataset:
+  path: c4
+  name: en
 dataset_prepared_path:
 val_set_size: 0.0
 output_dir: ./model-out
@@ -45,7 +47,7 @@ xformers_attention:
 flash_attention: true
 
 warmup_steps: 10
-evals_per_epoch: 
+evals_per_epoch:
 eval_table_size:
 saves_per_epoch: 1
 debug:

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -5,7 +5,6 @@ import logging
 from pathlib import Path
 
 import fire
-import torch
 import transformers
 
 from axolotl.cli import (
@@ -20,7 +19,6 @@ from axolotl.common.cli import TrainerCliArgs
 from axolotl.train import train
 
 LOG = logging.getLogger("axolotl.cli.train")
-# torch.set_printoptions(threshold=10000)
 
 
 def do_cli(config: Path = Path("examples/"), **kwargs):

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 
 import fire
+import torch
 import transformers
 
 from axolotl.cli import (
@@ -19,6 +20,7 @@ from axolotl.common.cli import TrainerCliArgs
 from axolotl.train import train
 
 LOG = logging.getLogger("axolotl.cli.train")
+# torch.set_printoptions(threshold=10000)
 
 
 def do_cli(config: Path = Path("examples/"), **kwargs):

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -60,6 +60,12 @@ class AxolotlTrainingArguments(TrainingArguments):
         default=False,
         metadata={"help": "Use quadratic warmup for cosine scheduling."},
     )
+    pretraining: bool = field(
+        default=False,
+        metadata={
+            "help": "Indicates to trainer whether we are doing continued pretraining."
+        },
+    )
     sample_packing: bool = field(
         default=False,
         metadata={"help": "Use sample packing for efficient training."},
@@ -157,7 +163,7 @@ class AxolotlTrainer(Trainer):
         return self.lr_scheduler
 
     def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
-        if self.args.sample_packing and False:
+        if self.args.sample_packing and not self.args.pretraining:
             return MultipackBatchSampler(
                 RandomSampler(self.train_dataset),
                 self.args.train_batch_size,
@@ -193,7 +199,7 @@ class AxolotlTrainer(Trainer):
         return super()._get_eval_sampler(eval_dataset)
 
     def get_train_dataloader(self) -> DataLoader:
-        if self.args.sample_packing and False:
+        if self.args.sample_packing and not self.args.pretraining:
             train_dataset = self.train_dataset
             train_dataset = train_dataset.remove_columns(["length"])
             data_collator = self.data_collator
@@ -768,6 +774,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             training_arguments_kwargs
         )
         training_arguments_kwargs["model_type"] = self.cfg.model_config_type
+        training_arguments_kwargs["pretraining"] = bool(self.cfg.pretraining_dataset)
 
         if self.cfg.neftune_noise_alpha is not None:
             training_arguments_kwargs[

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -157,7 +157,7 @@ class AxolotlTrainer(Trainer):
         return self.lr_scheduler
 
     def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
-        if self.args.sample_packing:
+        if self.args.sample_packing and False:
             return MultipackBatchSampler(
                 RandomSampler(self.train_dataset),
                 self.args.train_batch_size,
@@ -193,7 +193,7 @@ class AxolotlTrainer(Trainer):
         return super()._get_eval_sampler(eval_dataset)
 
     def get_train_dataloader(self) -> DataLoader:
-        if self.args.sample_packing:
+        if self.args.sample_packing and False:
             train_dataset = self.train_dataset
             train_dataset = train_dataset.remove_columns(["length"])
             data_collator = self.data_collator
@@ -808,7 +808,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             train_dataset=self.train_dataset,
             eval_dataset=self.eval_dataset,
             args=training_args,
-            data_collator=self.build_collator(**data_collator_kwargs),
+            # data_collator=self.build_collator(**data_collator_kwargs),
             bench_data_collator=transformers.DataCollatorForSeq2Seq(
                 self.tokenizer,
                 return_tensors="pt",

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -815,7 +815,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             train_dataset=self.train_dataset,
             eval_dataset=self.eval_dataset,
             args=training_args,
-            # data_collator=self.build_collator(**data_collator_kwargs),
+            data_collator=self.build_collator(training_args, **data_collator_kwargs),
             bench_data_collator=transformers.DataCollatorForSeq2Seq(
                 self.tokenizer,
                 return_tensors="pt",
@@ -836,7 +836,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
 
         return trainer
 
-    def build_collator(self, **kwargs):
+    def build_collator(self, training_args: AxolotlTrainingArguments, **kwargs):
+        if training_args.pretraining:
+            return None
+
         if self.cfg.model_config_type == "mamba":
             return MambaDataCollator(tokenizer=self.tokenizer)
 

--- a/src/axolotl/utils/collators.py
+++ b/src/axolotl/utils/collators.py
@@ -178,3 +178,29 @@ class MambaDataCollator:
             "input_ids": input_ids,
             "labels": labels,
         }
+
+@dataclass
+class PretrainingBatchSamplerDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
+    """
+    Collator for multipack specific to the using the BatchSampler
+    """
+
+    def __call__(self, features, return_tensors=None):
+        chunked_data = {}
+        for feature in features.keys():
+            if feature == "length":
+                continue
+            if feature == "attention_mask":
+                arrays = [
+                    (1) * np.array(item)
+                    for item in features[feature]
+                ]
+                chunked_data[feature] = np.concatenate(arrays)
+            else:
+                arrays = [
+                    np.array(item) for item in features[feature]
+                ]
+                chunked_data[feature] = np.concatenate(arrays)
+        features = [chunked_data]
+        return super().__call__(features, return_tensors=return_tensors)
+

--- a/src/axolotl/utils/collators.py
+++ b/src/axolotl/utils/collators.py
@@ -179,6 +179,7 @@ class MambaDataCollator:
             "labels": labels,
         }
 
+
 @dataclass
 class PretrainingBatchSamplerDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
     """
@@ -191,16 +192,10 @@ class PretrainingBatchSamplerDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             if feature == "length":
                 continue
             if feature == "attention_mask":
-                arrays = [
-                    (1) * np.array(item)
-                    for item in features[feature]
-                ]
+                arrays = [(1) * np.array(item) for item in features[feature]]
                 chunked_data[feature] = np.concatenate(arrays)
             else:
-                arrays = [
-                    np.array(item) for item in features[feature]
-                ]
+                arrays = [np.array(item) for item in features[feature]]
                 chunked_data[feature] = np.concatenate(arrays)
         features = [chunked_data]
         return super().__call__(features, return_tensors=return_tensors)
-

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -822,7 +822,10 @@ def encode_pretraining(
 def load_pretraining_dataset(path, tokenizer, cfg, name=None, max_tokens=2048, seed=42):
     if cfg.sample_packing:
         collate_fn = PretrainingBatchSamplerDataCollatorForSeq2Seq(
-            tokenizer, return_tensors="pt", padding=True, pad_to_multiple_of=max_tokens
+            tokenizer,
+            return_tensors="pt",
+            padding=True,
+            pad_to_multiple_of=max_tokens * cfg.micro_batch_size,
         )
         encode = functools.partial(
             encode_packed_pretraining,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -71,9 +71,9 @@ def prepare_dataset(cfg, tokenizer):
     else:
         path = cfg.pretraining_dataset
         name = None
-        if isinstance(dict, cfg.pretraining_dataset):
-            path = cfg.pretraining_dataset.path
-            name = cfg.pretraining_dataset.name
+        if isinstance(cfg.pretraining_dataset, dict):
+            path = cfg.pretraining_dataset["path"]
+            name = cfg.pretraining_dataset["name"]
 
         train_dataset = load_pretraining_dataset(
             path,

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -143,6 +143,16 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, tokenizer):
     return train_dataset, eval_dataset
 
 
+def process_pretraining_datasets_for_packing(train_dataset, sequence_len):
+    drop_long = partial(drop_long_seq, sequence_len=sequence_len)
+
+    train_dataset = train_dataset.filter(drop_long)
+    train_dataset = train_dataset.map(
+        add_position_ids,
+    )
+    return train_dataset
+
+
 def calculate_total_num_steps(cfg, train_dataset, update=True):
     if not cfg.total_num_tokens:
         total_num_tokens = np.sum(

--- a/tests/test_packed_pretraining.py
+++ b/tests/test_packed_pretraining.py
@@ -1,13 +1,13 @@
 """Module for testing streaming dataset sequence packing"""
-import math
 import unittest
 from functools import partial
 
+import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
 
-from axolotl.utils.collators import DataCollatorForSeq2Seq
+from axolotl.utils.collators import PretrainingBatchSamplerDataCollatorForSeq2Seq
 from axolotl.utils.data import encode_packed_pretraining
 
 
@@ -19,21 +19,9 @@ class TestPacking(unittest.TestCase):
     def setUp(self) -> None:
         # pylint: disable=duplicate-code
         self.tokenizer = AutoTokenizer.from_pretrained("huggyllama/llama-7b")
-        self.tokenizer.add_special_tokens(
-            {
-                "bos_token": "<s>",
-                "eos_token": "</s>",
-                "unk_token": "<unk>",
-                "pad_token": "[PAD]",
-            }
-        )
-        self.max_seq_length = 8192
-        self.batch_size = 6
-        self.sample_packing_efficiency = 1
-        self.data_collator_kwargs = {
-            "padding": True,
-            "pad_to_multiple_of": 64 * math.ceil(self.max_seq_length / 64),
-        }
+        self.tokenizer.pad_token = "</s>"
+        self.max_seq_length = 2048
+        self.batch_size = 2
 
     def test_packing_stream_dataset(self):
         # pylint: disable=duplicate-code
@@ -43,11 +31,19 @@ class TestPacking(unittest.TestCase):
             streaming=True,
         )["train"]
 
+        collate_fn = PretrainingBatchSamplerDataCollatorForSeq2Seq(
+            self.tokenizer,
+            return_tensors="pt",
+            padding=True,
+            pad_to_multiple_of=self.max_seq_length,
+        )
+
         encode = partial(
             encode_packed_pretraining,
             self.tokenizer,
+            collate_fn,
             max_seq_length=self.max_seq_length,
-            sample_packing_efficiency=self.sample_packing_efficiency,
+            batch_size=self.batch_size,
         )
 
         dataset = dataset.map(
@@ -57,28 +53,27 @@ class TestPacking(unittest.TestCase):
             remove_columns=dataset.features.keys(),
         )
 
-        data_collator_fn = DataCollatorForSeq2Seq(
-            self.tokenizer,
-            return_tensors="pt",
-            **self.data_collator_kwargs,
-        )
-
         trainer_loader = DataLoader(
             dataset,
-            batch_size=self.batch_size,
-            collate_fn=data_collator_fn,
+            batch_size=1,
+            collate_fn=None,
             drop_last=True,
         )
         idx = 0
         for data in trainer_loader:
             if idx > 10:
                 break
-            assert data["input_ids"].shape == (self.batch_size, self.max_seq_length)
-            assert data["position_ids"].shape == (self.batch_size, self.max_seq_length)
-            assert data["labels"].shape == (self.batch_size, self.max_seq_length)
-            assert data["attention_mask"].shape == (
-                self.batch_size,
-                self.max_seq_length,
+            assert data["input_ids"].shape == torch.Size(
+                [1, self.batch_size * self.max_seq_length]
+            )
+            assert data["position_ids"].shape == torch.Size(
+                [1, self.batch_size * self.max_seq_length]
+            )
+            assert data["labels"].shape == torch.Size(
+                [1, self.batch_size * self.max_seq_length]
+            )
+            assert data["attention_mask"].shape == torch.Size(
+                [1, self.batch_size * self.max_seq_length]
             )
             idx += 1
 

--- a/tests/test_packed_pretraining.py
+++ b/tests/test_packed_pretraining.py
@@ -1,0 +1,87 @@
+"""Module for testing streaming dataset sequence packing"""
+import math
+import unittest
+from functools import partial
+
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer
+
+from axolotl.utils.collators import DataCollatorForSeq2Seq
+from axolotl.utils.data import encode_packed_pretraining
+
+
+class TestPacking(unittest.TestCase):
+    """
+    Test class for packing streaming dataset sequences
+    """
+
+    def setUp(self) -> None:
+        # pylint: disable=duplicate-code
+        self.tokenizer = AutoTokenizer.from_pretrained("huggyllama/llama-7b")
+        self.tokenizer.add_special_tokens(
+            {
+                "bos_token": "<s>",
+                "eos_token": "</s>",
+                "unk_token": "<unk>",
+                "pad_token": "[PAD]",
+            }
+        )
+        self.max_seq_length = 8192
+        self.batch_size = 6
+        self.sample_packing_efficiency = 1
+        self.data_collator_kwargs = {
+            "padding": True,
+            "pad_to_multiple_of": 64 * math.ceil(self.max_seq_length / 64),
+        }
+
+    def test_packing_stream_dataset(self):
+        # pylint: disable=duplicate-code
+        dataset = load_dataset(
+            "c4",
+            "en",
+            streaming=True,
+        )["train"]
+
+        encode = partial(
+            encode_packed_pretraining,
+            self.tokenizer,
+            max_seq_length=self.max_seq_length,
+            sample_packing_efficiency=self.sample_packing_efficiency,
+        )
+
+        dataset = dataset.map(
+            encode,
+            batched=True,
+            input_columns="text",
+            remove_columns=dataset.features.keys(),
+        )
+
+        data_collator_fn = DataCollatorForSeq2Seq(
+            self.tokenizer,
+            return_tensors="pt",
+            **self.data_collator_kwargs,
+        )
+
+        trainer_loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            collate_fn=data_collator_fn,
+            drop_last=True,
+        )
+        idx = 0
+        for data in trainer_loader:
+            if idx > 10:
+                break
+            assert data["input_ids"].shape == (self.batch_size, self.max_seq_length)
+            assert data["position_ids"].shape == (self.batch_size, self.max_seq_length)
+            assert data["labels"].shape == (self.batch_size, self.max_seq_length)
+            assert data["attention_mask"].shape == (
+                self.batch_size,
+                self.max_seq_length,
+            )
+            idx += 1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces support for multipacking in streaming pretraining datasets.
Due to the immense size of these datasets, traditional methods of loading them entirely into memory are not feasible. 
The proposed solution aims to enhance efficiency and scalability.

need guide for making config.
this multipack does not use BatchSamplerDataCollatorForSeq2Seq, only use DataCollatorForSeq2Seq due to huggingface dataset map function.
