### PR TITLE
update to latest nccl in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG PYTORCH_VERSION="2.0.1"
 ENV PYTORCH_VERSION=$PYTORCH_VERSION
 
 RUN apt-get update && \
-    apt-get install -y vim curl
+    apt-get install -y vim curl nano libnccl2 libnccl-dev
 
 WORKDIR /workspace
 


### PR DESCRIPTION
mixtral seems to hang with current docker image. it's been reported that updating NCCL fixes the issue.