### PR TITLE
[feat] add system_prompt and prompt_style for interface

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -90,9 +90,9 @@ def do_inference(
 ):
     model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
     prompter = cli_args.prompter
-    prompt_style = cli_args.prompt_style
-    system_prompt = cli_args.system_prompt
-    system_no_input_prompt = cli_args.system_no_input_prompt
+    prompt_style = cfg.prompt_style
+    system_prompt = cfg.system_prompt
+    system_no_input_prompt = cfg.system_no_input_prompt
     default_tokens = {"unk_token": "<unk>", "bos_token": "<s>", "eos_token": "</s>"}
 
     for token, symbol in default_tokens.items():
@@ -165,6 +165,9 @@ def do_inference_gradio(
 ):
     model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
     prompter = cli_args.prompter
+    prompt_style = cfg.prompt_style
+    system_prompt = cfg.system_prompt
+    system_no_input_prompt = cfg.system_no_input_prompt
     default_tokens = {"unk_token": "<unk>", "bos_token": "<s>", "eos_token": "</s>"}
 
     for token, symbol in default_tokens.items():
@@ -174,9 +177,8 @@ def do_inference_gradio(
 
     prompter_module = None
     if prompter:
-        prompter_module = getattr(
-            importlib.import_module("axolotl.prompters"), prompter
-        )
+        PrompterClass = getattr(importlib.import_module("axolotl.prompters"), prompter)
+        prompter_module = PrompterClass(prompt_style=prompt_style, system_prompt=system_prompt, system_no_input_prompt=system_no_input_prompt)
 
     if cfg.landmark_attention:
         from axolotl.monkeypatch.llama_landmark_attn import set_model_mem_id

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -90,6 +90,9 @@ def do_inference(
 ):
     model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
     prompter = cli_args.prompter
+    prompt_style = cli_args.prompt_style
+    system_prompt = cli_args.system_prompt
+    system_no_input_prompt = cli_args.system_no_input_prompt
     default_tokens = {"unk_token": "<unk>", "bos_token": "<s>", "eos_token": "</s>"}
 
     for token, symbol in default_tokens.items():
@@ -99,9 +102,8 @@ def do_inference(
 
     prompter_module = None
     if prompter:
-        prompter_module = getattr(
-            importlib.import_module("axolotl.prompters"), prompter
-        )
+        PrompterClass = getattr(importlib.import_module("axolotl.prompters"), prompter)
+        prompter_module = PrompterClass(prompt_style=prompt_style, system_prompt=system_prompt, system_no_input_prompt=system_no_input_prompt)
 
     if cfg.landmark_attention:
         from axolotl.monkeypatch.llama_landmark_attn import set_model_mem_id

--- a/src/axolotl/common/cli.py
+++ b/src/axolotl/common/cli.py
@@ -27,9 +27,6 @@ class TrainerCliArgs:
     merge_lora: bool = field(default=False)
     prompter: Optional[str] = field(default=None)
     shard: bool = field(default=False)
-    prompt_style: Optional[str] = field(default=None)
-    system_prompt: Optional[str] = field(default=None)
-    system_no_input_prompt: Optional[str] = field(default=None)
 
 
 @dataclass

--- a/src/axolotl/common/cli.py
+++ b/src/axolotl/common/cli.py
@@ -27,6 +27,9 @@ class TrainerCliArgs:
     merge_lora: bool = field(default=False)
     prompter: Optional[str] = field(default=None)
     shard: bool = field(default=False)
+    prompt_style: Optional[str] = field(default=None)
+    system_prompt: Optional[str] = field(default=None)
+    system_no_input_prompt: Optional[str] = field(default=None)
 
 
 @dataclass

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -40,7 +40,11 @@ class AlpacaPrompter(Prompter):
     turn_no_input_format: str
     prompt_style: Optional[PromptStyle] = None
 
-    def __init__(self, prompt_style=PromptStyle.INSTRUCT.value):
+    def __init__(self, prompt_style=PromptStyle.INSTRUCT.value, system_prompt=None, system_no_input_prompt=None):
+        if system_prompt is not None:
+            self.system_prompt = system_prompt
+        if system_no_input_prompt is not None:
+            self.system_no_input_prompt = system_no_input_prompt
         self.prompt_style = prompt_style if prompt_style else PromptStyle.INSTRUCT.value
         self.match_prompt_style()
 


### PR DESCRIPTION
Add three args:

> system_prompt
> system_no_input_prompt
> prompt_style

usage: 
`python -m axolotl.cli.inference examples/qlora.yml --prompter=AlpacaPrompter --system_prompt="" --system_no_input_prompt="" --prompt_style="chatml"  `

