### PR TITLE
Update sharegpt.py

### DIFF
--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -12,8 +12,8 @@ register_conv_template(
         system_template="<|im_start|>system\n{system_message}",
         system_message="You are a helpful assistant.",
         roles=["<|im_start|>user", "<|im_start|>assistant"],
-        sep_style=SeparatorStyle.CHATML,
         sep="<|im_end|>",
+        stop_str="<|im_end|>"
     )
 )
 


### PR DESCRIPTION
Modified register_conv_template to resolves the double EOS token issue at the end of prompts when using Chatml template with shareGPT.py. 

This issue was further discussed in the following issue:
https://github.com/OpenAccess-AI-Collective/axolotl/pull/922#issuecomment-1845887417

