### PR TITLE
bug-fix: take gradient accumulation steps into account when calculating total_num_steps

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -253,6 +253,12 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 / cfg.batch_size
             )
         )
+    if cfg.gradient_checkpointing:
+        # Divide total num steps by the gradient accumulation steps (rounded up)
+        total_num_steps = int(
+            (total_num_steps + cfg.gradient_accumulation_steps - 1)
+            / cfg.gradient_accumulation_steps
+        )
     LOG.debug(f"total_num_steps: {total_num_steps}", main_process_only=True)
     return total_num_steps
 


### PR DESCRIPTION
This becomes an issue e.g. when setting `warmup_ratio`, as it will become the multiple of the expected value and the gradient accumulation steps.