### PR TITLE
bug-fix: account for gradient accumulation steps in !sample_packing_eff_est sample_packing case

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -224,6 +224,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                     data_loader_len
                     * cfg.num_epochs
                     / int(os.environ.get("WORLD_SIZE", 1))
+                    / (cfg.gradient_accumulation_steps or 1)
                 )
             )
 


### PR DESCRIPTION
This addresses issues e.g. with `warmup_ratio` becoming a multiple of the gradient accumulation steps.

See also #977.