### PR TITLE
Set eval_sample_packing to false in mistral config.yaml

### DIFF
--- a/examples/mistral/config.yml
+++ b/examples/mistral/config.yml
@@ -17,6 +17,7 @@ output_dir: ./out
 sequence_len: 8192
 sample_packing: true
 pad_to_sequence_len: true
+eval_sample_packing: false
 
 wandb_project:
 wandb_entity:


### PR DESCRIPTION
Without `eval_sampling_packing` set to `false`, running `accelerate launch -m axolotl.cli.train examples/mistral/config.yml` returns the following error:

```
ValueError: eval dataset split is too small for sample_packing. You should set `eval_sample_packing: False`.
```