### PR TITLE
FEAT: add tagging support to axolotl

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -291,7 +291,7 @@ class AxolotlTrainer(Trainer):
         #     return (loss, outputs) if return_outputs else loss
         return super().compute_loss(model, inputs, return_outputs=return_outputs)
 
-    def _sanitze_kwargs_for_tagging(tag_names, kwargs=None):
+    def _sanitize_kwargs_for_tagging(self, tag_names, kwargs=None):
         if isinstance(tag_names, str):
             tag_names = [tag_names]
 
@@ -312,7 +312,7 @@ class AxolotlTrainer(Trainer):
         Overwrite the `push_to_hub` method in order to force-add the tags when pushing the
         model on the Hub. Please refer to `~transformers.Trainer.push_to_hub` for more details.
         """
-        kwargs = self._sanitze_kwargs_for_tagging(
+        kwargs = self._sanitize_kwargs_for_tagging(
             tag_names=self.tag_names, kwargs=kwargs
         )
 

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -9,10 +9,9 @@ import math
 import sys
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 from typing import Optional
-from functools import wraps
 
 import torch
 import transformers
@@ -306,14 +305,16 @@ class AxolotlTrainer(Trainer):
                 kwargs["tags"] = tag_names
 
         return kwargs
-        
+
     @wraps(Trainer.push_to_hub)
     def push_to_hub(self, *args, **kwargs) -> str:
         """
         Overwrite the `push_to_hub` method in order to force-add the tags when pushing the
         model on the Hub. Please refer to `~transformers.Trainer.push_to_hub` for more details.
         """
-        kwargs = self._sanitze_kwargs_for_tagging(tag_names=self.tag_names, kwargs=kwargs)
+        kwargs = self._sanitze_kwargs_for_tagging(
+            tag_names=self.tag_names, kwargs=kwargs
+        )
 
         return super().push_to_hub(*args, **kwargs)
 
@@ -322,6 +323,7 @@ class AxolotlMambaTrainer(AxolotlTrainer):
     """
     Mamba specific trainer to handle loss calculation
     """
+
     tag_names = ["axolotl", "mamba"]
 
     def compute_loss(
@@ -349,6 +351,7 @@ class OneCycleLRSchedulerTrainer(AxolotlTrainer):
     """
     Trainer subclass that uses the OneCycleLR scheduler
     """
+
     tag_names = ["axolotl", "onecycle"]
 
     def __init__(self, *args, **kwargs):
@@ -379,6 +382,7 @@ class ReLoRATrainer(AxolotlTrainer):
     """
     Trainer subclass that uses the OneCycleLR scheduler
     """
+
     tag_names = ["axolotl", "relora"]
 
     def __init__(self, *args, **kwargs):

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 from typing import Optional
+from functools import wraps
 
 import torch
 import transformers
@@ -120,6 +121,7 @@ class AxolotlTrainer(Trainer):
     """
 
     args = None  # type: AxolotlTrainingArguments
+    tag_names = ["axolotl"]
 
     def __init__(self, *args, num_epochs=1, bench_data_collator=None, **kwargs):
         self.num_epochs = num_epochs
@@ -290,11 +292,37 @@ class AxolotlTrainer(Trainer):
         #     return (loss, outputs) if return_outputs else loss
         return super().compute_loss(model, inputs, return_outputs=return_outputs)
 
+    def _sanitze_kwargs_for_tagging(tag_names, kwargs=None):
+        if isinstance(tag_names, str):
+            tag_names = [tag_names]
+
+        if kwargs is not None:
+            if "tags" not in kwargs:
+                kwargs["tags"] = tag_names
+            elif "tags" in kwargs and isinstance(kwargs["tags"], list):
+                kwargs["tags"].extend(tag_names)
+            elif "tags" in kwargs and isinstance(kwargs["tags"], str):
+                tag_names.append(kwargs["tags"])
+                kwargs["tags"] = tag_names
+
+        return kwargs
+        
+    @wraps(Trainer.push_to_hub)
+    def push_to_hub(self, *args, **kwargs) -> str:
+        """
+        Overwrite the `push_to_hub` method in order to force-add the tags when pushing the
+        model on the Hub. Please refer to `~transformers.Trainer.push_to_hub` for more details.
+        """
+        kwargs = self._sanitze_kwargs_for_tagging(tag_names=self.tag_names, kwargs=kwargs)
+
+        return super().push_to_hub(*args, **kwargs)
+
 
 class AxolotlMambaTrainer(AxolotlTrainer):
     """
     Mamba specific trainer to handle loss calculation
     """
+    tag_names = ["axolotl", "mamba"]
 
     def compute_loss(
         self,
@@ -321,6 +349,7 @@ class OneCycleLRSchedulerTrainer(AxolotlTrainer):
     """
     Trainer subclass that uses the OneCycleLR scheduler
     """
+    tag_names = ["axolotl", "onecycle"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -350,6 +379,7 @@ class ReLoRATrainer(AxolotlTrainer):
     """
     Trainer subclass that uses the OneCycleLR scheduler
     """
+    tag_names = ["axolotl", "relora"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Hi there,

I would like to introduce a feature request to axolotl; automatic tagging when users push the trained model on the Hub. That way, you can easily filter on 🤗 Hub models that has been trained with axolotl with a simple filter: https://huggingface.co/models?other=axolotl&sort=created 

Similar feature as: https://github.com/huggingface/trl/pull/1133 that we added in TRL library

cc @winglian 