### PR TITLE
[WandB] Push axolotl config to top level wandb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ When you include these tokens in your axolotl config, axolotl adds these tokens 
 ### Inference Playground
 
 Axolotl allows you to load your model in an interactive terminal playground for quick experimentation.
-The config file is the same config file used for training. 
+The config file is the same config file used for training.
 
 Pass the appropriate flag to the inference command, depending upon what kind of model was trained:
 

--- a/src/axolotl/utils/callbacks.py
+++ b/src/axolotl/utils/callbacks.py
@@ -569,7 +569,9 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 ) as temp_file:
                     copyfile(self.axolotl_config_path, temp_file.name)
                     wandb.save(temp_file.name)
-                LOG.info("The Axolotl config has been saved to the WandB run under files.")
+                LOG.info(
+                    "The Axolotl config has been saved to the WandB run under files."
+                )
             except (FileNotFoundError, ConnectionError) as err:
                 LOG.warning(f"Error while saving Axolotl config to WandB: {err}")
         return control

--- a/src/axolotl/utils/callbacks.py
+++ b/src/axolotl/utils/callbacks.py
@@ -563,9 +563,6 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
     ):
         if is_main_process():
             try:
-                artifact = wandb.Artifact(name="axolotl-config", type="config")
-                artifact.add_file(local_path=self.axolotl_config_path)
-                wandb.run.log_artifact(artifact)
                 # sync config to top level in run, cannot delete file right away because wandb schedules it to be synced even w/policy = 'now', so let OS delete it later.
                 with NamedTemporaryFile(
                     mode="w", delete=False, suffix=".yml", prefix="axolotl_config_"

--- a/src/axolotl/utils/callbacks.py
+++ b/src/axolotl/utils/callbacks.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Dict, List
-from tempfile import NamedTemporaryFile
 from shutil import copyfile
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Dict, List
 
 import evaluate
 import numpy as np
@@ -567,7 +567,9 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 artifact.add_file(local_path=self.axolotl_config_path)
                 wandb.run.log_artifact(artifact)
                 # sync config to top level in run, cannot delete file right away because wandb schedules it to be synced even w/policy = 'now', so let OS delete it later.
-                with NamedTemporaryFile(mode='w', delete=False, suffix='.yml', prefix='axolotl_config_') as temp_file:
+                with NamedTemporaryFile(
+                    mode="w", delete=False, suffix=".yml", prefix="axolotl_config_"
+                ) as temp_file:
                     copyfile(self.axolotl_config_path, temp_file.name)
                     wandb.save(temp_file.name)
                 LOG.info("Axolotl config has been saved to WandB as an artifact.")

--- a/src/axolotl/utils/callbacks.py
+++ b/src/axolotl/utils/callbacks.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 from typing import TYPE_CHECKING, Dict, List
+from tempfile import NamedTemporaryFile
+from shutil import copyfile
 
 import evaluate
 import numpy as np
@@ -564,6 +566,10 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 artifact = wandb.Artifact(name="axolotl-config", type="config")
                 artifact.add_file(local_path=self.axolotl_config_path)
                 wandb.run.log_artifact(artifact)
+                # sync config to top level in run, cannot delete file right away because wandb schedules it to be synced even w/policy = 'now', so let OS delete it later.
+                with NamedTemporaryFile(mode='w', delete=False, suffix='.yml', prefix='axolotl_config_') as temp_file:
+                    copyfile(self.axolotl_config_path, temp_file.name)
+                    wandb.save(temp_file.name)
                 LOG.info("Axolotl config has been saved to WandB as an artifact.")
             except (FileNotFoundError, ConnectionError) as err:
                 LOG.warning(f"Error while saving Axolotl config to WandB: {err}")

--- a/src/axolotl/utils/callbacks.py
+++ b/src/axolotl/utils/callbacks.py
@@ -569,7 +569,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 ) as temp_file:
                     copyfile(self.axolotl_config_path, temp_file.name)
                     wandb.save(temp_file.name)
-                LOG.info("Axolotl config has been saved to WandB as an artifact.")
+                LOG.info("The Axolotl config has been saved to the WandB run under files.")
             except (FileNotFoundError, ConnectionError) as err:
                 LOG.warning(f"Error while saving Axolotl config to WandB: {err}")
         return control


### PR DESCRIPTION
@teknium1 has told me that one annoying thing is finding the axolotl configs in wandb.  This really drives me insane too.  This PR pushes the config to the top level files under each experiment run in wandb (and also keeps it in artifacts).  

We copy the axolotl config into a new file called `axolotl_config_{tempfile_uid}.yml` so we do not collide with the existing `config.yml` that wandb itself pushes to the files.  

This is how it looks now (example is from [this run](https://wandb.ai/hamelsmu/axolotl-test/runs/ivyob1n1/))

![better_wandb](https://github.com/OpenAccess-AI-Collective/axolotl/assets/1483922/44d9f645-628c-4309-a326-96d7f645890b)
