### PR TITLE
Add datasets to model card

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ When you include these tokens in your axolotl config, axolotl adds these tokens 
 ### Inference Playground
 
 Axolotl allows you to load your model in an interactive terminal playground for quick experimentation.
-The config file is the same config file used for training. 
+The config file is the same config file used for training.
 
 Pass the appropriate flag to the inference command, depending upon what kind of model was trained:
 

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -183,7 +183,7 @@ def train(
     if not cfg.hub_model_id:
         trainer.create_model_card(
             model_name=cfg.output_dir.lstrip("./"),
-            dataset_tags=list(map(lambda d: d['path'], cfg['datasets']))
+            dataset_tags=list(map(lambda d: d["path"], cfg["datasets"]))
         )
 
     return model, tokenizer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -183,7 +183,7 @@ def train(
     if not cfg.hub_model_id:
         trainer.create_model_card(
             model_name=cfg.output_dir.lstrip("./"),
-            dataset_tags=[d['path'] for d in cfg['datasets'] if not Path(d['path']).is_dir()],
+            dataset_tags=[d["path"] for d in cfg["datasets"] if not Path(d["path"]).is_dir()],
         )
 
     return model, tokenizer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -183,7 +183,9 @@ def train(
     if not cfg.hub_model_id:
         trainer.create_model_card(
             model_name=cfg.output_dir.lstrip("./"),
-            dataset_tags=[d["path"] for d in cfg["datasets"] if not Path(d["path"]).is_dir()],
+            dataset_tags=[
+                d["path"] for d in cfg["datasets"] if not Path(d["path"]).is_dir()
+            ],
         )
 
     return model, tokenizer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -183,7 +183,7 @@ def train(
     if not cfg.hub_model_id:
         trainer.create_model_card(
             model_name=cfg.output_dir.lstrip("./"),
-            dataset_tags=list(map(lambda d: d["path"], cfg["datasets"])),
+            dataset_tags=[d['path'] for d in cfg['datasets'] if not Path(d['path']).is_dir()],
         )
 
     return model, tokenizer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -181,7 +181,10 @@ def train(
         model.save_pretrained(cfg.output_dir, safe_serialization=safe_serialization)
 
     if not cfg.hub_model_id:
-        trainer.create_model_card(model_name=cfg.output_dir.lstrip("./"))
+        trainer.create_model_card(
+            model_name=cfg.output_dir.lstrip("./"),
+            dataset_tags=list(map(lambda d: d['path'], cfg['datasets']))
+        )
 
     return model, tokenizer
 

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -183,7 +183,7 @@ def train(
     if not cfg.hub_model_id:
         trainer.create_model_card(
             model_name=cfg.output_dir.lstrip("./"),
-            dataset_tags=list(map(lambda d: d["path"], cfg["datasets"]))
+            dataset_tags=list(map(lambda d: d["path"], cfg["datasets"])),
         )
 
     return model, tokenizer


### PR DESCRIPTION
In the spirit of #1004 and #1005, this automatically adds a "datasets" object to the model card through the "dataset_tags" attribute. 

The reason we use dataset_tags and not dataset comes from [here](https://github.com/huggingface/transformers/blob/3cefac1d974db5e2825a0cb2b842883a628be7a0/src/transformers/modelcard.py#L465C70-L465C82)

Datasets are from model card if they are local directories, using the same method as in https://github.com/OpenAccess-AI-Collective/axolotl/blob/dec66d7c53a2de6cf74911faf9c1ad1f7f0fff14/src/axolotl/utils/data.py#L244

Running @hamelsmu tiny-mistral config from [here](https://huggingface.co/hamel/axolotl-test) we get the following model card:

```
---
library_name: peft
tags:
- generated_from_trainer
datasets:
- mhenrichsen/alpaca_2k_test
base_model: openaccess-ai-collective/tiny-mistral
model-index:
- name: temp_dir
  results: []
---