### PR TITLE
fix HF model card upload for PEFT models

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -182,6 +182,9 @@ def train(
 
     if not cfg.hub_model_id:
         trainer.create_model_card(model_name=cfg.output_dir.lstrip("./"))
+    elif cfg.hub_model_id:
+        # defensively push to the hub to ensure the model card is updated
+        trainer.push_to_hub()
 
     return model, tokenizer
 


### PR DESCRIPTION
Discussed this with @winglian on Discord.  I tested this for both PEFT and non-PEFT models, and it fixes the issue of the model card not getting updated.