### PR TITLE
Clean Up LorA Merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,10 +1036,10 @@ Please use `--sample_packing False` if you have it on and receive the error simi
 
 ### Merge LORA to base
 
-Add below flag to train command above
+The following command will merge your LORA adapater with your base model.  You can optionally pass the argument `--lora_model_dir` to specify the directory where your LORA adapter was saved, otherwhise, this will be inferred from `output_dir` in your axolotl config file.  The merged model is saved in the sub-directory `{lora_model_dir}/merged`.
 
 ```bash
-python3 -m axolotl.cli.merge_lora examples/your_config.yml --lora_model_dir="./completed-model"
+python3 -m axolotl.cli.merge_lora your_config.yml --lora_model_dir="./completed-model"
 ```
 
 If you run out of CUDA memory, you can try to merge in system RAM with

--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -25,8 +25,15 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
         load_in_8bit=False,
         load_in_4bit=False,
         flash_attention=False,
-        **kwargs
+        **kwargs,
     )
+
+    if not parsed_cfg.lora_model_dir and parsed_cfg.output_dir:
+        parsed_cfg.lora_model_dir = parsed_cfg.output_dir
+    if not Path(parsed_cfg.lora_model_dir).exists():
+        raise ValueError(
+            f"Target directory for merge: `{parsed_cfg.lora_model_dir}` does not exist."
+        )
 
     do_merge_lora(cfg=parsed_cfg, cli_args=parsed_cli_args)
 


### PR DESCRIPTION
This PR does the following things:

1.  Added some docs as suggested by @NanoCode012 
2.  Makes the merge do the sensible default thing and read from your config's `output_dir` if `--lora_model_dir` is not provided.

