### PR TITLE
Fix(preprocess): Use space delimiter for debug_text_only also

### DIFF
--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -31,8 +31,8 @@ def check_example_labels(example, tokenizer, text_only=False):
         )
         colored_tokens.append(colored_token)
 
-    delimiter = "" if text_only else " "
-    LOG.info(delimiter.join(colored_tokens))
+    output = " ".join(colored_tokens)
+    LOG.info(output)
     LOG.info("\n\n\n")
 
-    return " ".join(colored_tokens)
+    return output


### PR DESCRIPTION
@TheBloke , I couldn't find the corresponding PR that you mentioned in the earlier issue https://github.com/OpenAccess-AI-Collective/axolotl/pull/462 .

This PR will fix `debug_text_only` having outputs without space.

Before:
```
<s><|im_start|>system<0x0A>Youareahelpfulassistant.<|im_end|><0x0A><|im_start|>user<0x0A>LetXbeacompactconnected
```