### PR TITLE
Cosine learning rate schedule - minimum learning rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ early_stopping_patience: 3
 # Specify a scheduler and kwargs to use with the optimizer
 lr_scheduler: # 'one_cycle' | 'log_sweep' | empty for cosine
 lr_scheduler_kwargs:
+cosine_min_lr_ratio: # decay lr to some percentage of the peak lr, e.g. cosine_min_lr_ratio=0.1 for 10% of peak lr
 
 # For one_cycle optim
 lr_div_factor: # Learning rate div factor

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -164,6 +164,10 @@ class AxolotlTrainer(Trainer):
                     num_training_steps=num_training_steps,
                 )
             elif self.args.lr_scheduler_type == "cosine" and self.args.cosine_min_lr_ratio is not None:
+                assert 0 <= self.args.cosine_min_lr_ratio <= 1.0, "cosine_min_lr_ratio must be between 0.0 and 1.0"
+                if self.args.deepspeed:
+                    LOG.warning("Using cosine scheduler with deepspeed. This may be ignored if a scheduler is set \
+                                in the deepspeed JSON")
                 self.lr_scheduler = get_cosine_schedule_with_min_lr(  # pylint: disable=attribute-defined-outside-init
                     optimizer,
                     num_warmup_steps=self.args.get_warmup_steps(num_training_steps),

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -38,7 +38,10 @@ from axolotl.utils.collators import (
     MambaDataCollator,
 )
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
-from axolotl.utils.schedulers import get_cosine_schedule_with_quadratic_warmup, get_cosine_schedule_with_min_lr
+from axolotl.utils.schedulers import (
+    get_cosine_schedule_with_min_lr,
+    get_cosine_schedule_with_quadratic_warmup,
+)
 
 try:
     import torch._dynamo  # pylint: disable=ungrouped-imports

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -38,7 +38,7 @@ from axolotl.utils.collators import (
     MambaDataCollator,
 )
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
-from axolotl.utils.schedulers import get_cosine_schedule_with_quadratic_warmup
+from axolotl.utils.schedulers import get_cosine_schedule_with_quadratic_warmup, get_cosine_schedule_with_min_lr
 
 try:
     import torch._dynamo  # pylint: disable=ungrouped-imports
@@ -120,6 +120,10 @@ class AxolotlTrainingArguments(TrainingArguments):
         default=None,
         metadata={"help": "prefetch_factor argument to the dataloader"},
     )
+    cosine_min_lr_ratio: Optional[float] = field(
+        default=None,
+        metadata={"help": "Minimum learning rate is min_lr_ratio * learning_rate"},
+    )
 
 
 class AxolotlTrainer(Trainer):
@@ -158,6 +162,13 @@ class AxolotlTrainer(Trainer):
                     optimizer,
                     num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                     num_training_steps=num_training_steps,
+                )
+            elif self.args.lr_scheduler_type == "cosine" and self.args.cosine_min_lr_ratio is not None:
+                self.lr_scheduler = get_cosine_schedule_with_min_lr(  # pylint: disable=attribute-defined-outside-init
+                    optimizer,
+                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
+                    num_training_steps=num_training_steps,
+                    min_lr_ratio=self.args.cosine_min_lr_ratio,
                 )
             else:
                 return super().create_scheduler(num_training_steps, optimizer)
@@ -745,6 +756,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["lr_scheduler_kwargs"] = (
             self.cfg.lr_scheduler_kwargs if self.cfg.lr_scheduler_kwargs else {}
         )
+        training_arguments_kwargs["cosine_min_lr_ratio"] = self.cfg.cosine_min_lr_ratio
         training_arguments_kwargs["weight_decay"] = (
             self.cfg.weight_decay if self.cfg.weight_decay is not None else 0.0
         )

--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -100,3 +100,44 @@ def get_cosine_schedule_with_quadratic_warmup(
         num_cycles=num_cycles,
     )
     return LambdaLR(optimizer, lr_lambda, last_epoch)
+
+
+def _get_cosine_schedule_with_min_lr_lambda(
+        current_step: int,
+        *,
+        num_warmup_steps: int,
+        num_training_steps: int,
+        min_lr_ratio: float
+):
+    # Warm up
+    if current_step < num_warmup_steps:
+        return float(current_step) / float(max(1, num_warmup_steps))
+    
+    # Cosine learning rate decay
+    progress = float(current_step - num_warmup_steps) / float(
+        max(1, num_training_steps - num_warmup_steps)
+    )
+    scaling = 0.5 * (1.0 + math.cos(math.pi * progress))
+    return (1 - min_lr_ratio) * scaling + min_lr_ratio
+
+
+def get_cosine_schedule_with_min_lr(
+    optimizer: Optimizer,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    min_lr_ratio: float = 0.0,
+):
+    """
+    Create a learning rate schedule which has:
+        - linear warmup from 0 -> `max_lr` over `num_warmup_steps`
+        - cosine learning rate annealing from `max_lr` -> `min_lr` over `num_training_steps`
+    """
+
+    lr_lambda = partial(
+        _get_cosine_schedule_with_min_lr_lambda,
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=num_training_steps,
+        min_lr_ratio=min_lr_ratio,
+    )
+    return LambdaLR(optimizer, lr_lambda)
+

--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -103,16 +103,16 @@ def get_cosine_schedule_with_quadratic_warmup(
 
 
 def _get_cosine_schedule_with_min_lr_lambda(
-        current_step: int,
-        *,
-        num_warmup_steps: int,
-        num_training_steps: int,
-        min_lr_ratio: float
+    current_step: int,
+    *,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    min_lr_ratio: float
 ):
     # Warm up
     if current_step < num_warmup_steps:
         return float(current_step) / float(max(1, num_warmup_steps))
-    
+
     # Cosine learning rate decay
     progress = float(current_step - num_warmup_steps) / float(
         max(1, num_training_steps - num_warmup_steps)
@@ -140,4 +140,3 @@ def get_cosine_schedule_with_min_lr(
         min_lr_ratio=min_lr_ratio,
     )
     return LambdaLR(optimizer, lr_lambda)
-


### PR DESCRIPTION
Regarding cosine learning rate decay, in the literature the learning rate is typically decayed to some percentage of the peak learning rate rather than decayed to 0 (e.g., Llama 2 decays the final learning rate down to 10% of the peak learning rate).

I am unsure if `axolotl` currently offers a straightforward way of setting the minimum learning rate when using cosine decay. Here is a simple implementation where the user simply needs to specify `cosine_min_lr_ratio` in the config file (e.g., `cosine_min_lr_ratio=0.1` decays the final learning rate down to 10% of the peak learning rate).

![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/9025103/c0d1053c-109e-4740-8084-0d4d97195cd5)
