### PR TITLE
Separate AutoGPTQ dep to `pip install -e .[auto-gptq]`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/
-auto-gptq==0.5.1
 packaging
 peft==0.7.0
 transformers @ git+https://github.com/huggingface/transformers.git@3cefac1d974db5e2825a0cb2b842883a628be7a0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/
 packaging
 peft==0.7.0
 transformers @ git+https://github.com/huggingface/transformers.git@3cefac1d974db5e2825a0cb2b842883a628be7a0

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ setup(
         "mamba-ssm": [
             "mamba-ssm==1.0.1",
         ],
-        "autogptq": [
-            "auto-gptq==0.5.1 --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/",
+        "auto-gptq": [
+            "auto-gptq==0.5.1",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,8 @@ setup(
         "mamba-ssm": [
             "mamba-ssm==1.0.1",
         ],
+        "autogptq": [
+            "auto-gptq==0.5.1 --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/",
+        ],
     },
 )


### PR DESCRIPTION
This fixes the following issue:
1. You already have the correct version of `torch` installed with CUDA dependencies and everything.
2. You install axolotl with `pip install -e .`
3. The AutoGPTQ installation proceeds to
    - redownload torch
    - redownload CUDA dependencies

This issue causes bloating of the environment and longer build times. So, I have separated this dependency as it's frankly not needed for 99% of training runs.