### PR TITLE
add python 3.11 to the matrix for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9", "3.10"]
+        python_version: ["3.9", "3.10", "3.11"]
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
we're not building any docker images yet with 3.11, but it's good to have the tests as a sanity check for python 3.11 when we're ready to support it. This way we can fix possible issues iteratively rather than needing to do a possible refactor later.