### PR TITLE
Collate missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,11 @@ val_set_size: 0.04
 dataset_shard_num:
 # Index of shard to use for whole dataset
 dataset_shard_idx:
+# At training time, collates certain features of the dataset if they are missing
+collate_missing_features:
+  # - labels # copy input_ids
+  # - position_ids # [0, 1, 2, ..., len(input_ids)-1]
+  # - attention_mask [1, 1, 1, ...] with same length as input_ids
 
 # The maximum length of an input to train with, this should typically be less than 2048
 # as most models have a token/context limit of 2048


### PR DESCRIPTION
Currently the `BatchSamplerDataCollatorForSeq2Seq` typically requires `input_ids`, `labels`, `attention_mask`, `position_ids`. For certain uses cases (e.g., datasets of type `completion`), the latter 3 are straightforwardly derived from `input_ids`. Therefore, saving to disk datasets with all 4 features can be redundant, and generally requires a lot more disk space (up to 5x).

The changes here implement a `MissingFeaturesCollator` together with the `collate_missing_features` config option. If `labels`, `attention_mask`, or `position_ids` are missing from the dataset, it replaces them with the following defaults:
  - labels: copy input_ids
  - position_ids: [0, 1, 2, ..., len(input_ids)-1]
  - attention_mask: [1, 1, 1, ...] with same length as input_ids

I've observed that eagerly filling these missing features does not lead to longer run-times.