### PR TITLE
Disable caching on `--disable_caching` in CLI

### DIFF
--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -32,8 +32,11 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     parsed_cli_args, remaining_args = parser.parse_args_into_dataclasses(
         return_remaining_strings=True
     )
-    
-    if remaining_args.get("disable_caching") is not None and remaining_args["disable_caching"]:
+
+    if (
+        remaining_args.get("disable_caching") is not None
+        and remaining_args["disable_caching"]
+    ):
         disable_caching()
     if not parsed_cfg.dataset_prepared_path:
         msg = (

--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import fire
 import transformers
 from colorama import Fore
+from datasets import disable_caching
 
 from axolotl.cli import (
     check_accelerate_default_config,
@@ -28,9 +29,12 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     check_accelerate_default_config()
     check_user_token()
     parser = transformers.HfArgumentParser((PreprocessCliArgs))
-    parsed_cli_args, _ = parser.parse_args_into_dataclasses(
+    parsed_cli_args, remaining_args = parser.parse_args_into_dataclasses(
         return_remaining_strings=True
     )
+    
+    if remaining_args.get("disable_caching") is not None and remaining_args["disable_caching"]:
+        disable_caching()
     if not parsed_cfg.dataset_prepared_path:
         msg = (
             Fore.RED

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -3,10 +3,10 @@ CLI to run training on a model
 """
 import logging
 from pathlib import Path
-from datasets import disable_caching
 
 import fire
 import transformers
+from datasets import disable_caching
 
 from axolotl.cli import (
     check_accelerate_default_config,
@@ -33,7 +33,10 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
         return_remaining_strings=True
     )
 
-    if remaining_args.get("disable_caching") is not None and remaining_args["disable_caching"]:
+    if (
+        remaining_args.get("disable_caching") is not None
+        and remaining_args["disable_caching"]
+    ):
         disable_caching()
     if parsed_cfg.rl:
         dataset_meta = load_rl_datasets(cfg=parsed_cfg, cli_args=parsed_cli_args)

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -3,6 +3,7 @@ CLI to run training on a model
 """
 import logging
 from pathlib import Path
+from datasets import disable_caching
 
 import fire
 import transformers
@@ -28,9 +29,12 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     check_accelerate_default_config()
     check_user_token()
     parser = transformers.HfArgumentParser((TrainerCliArgs))
-    parsed_cli_args, _ = parser.parse_args_into_dataclasses(
+    parsed_cli_args, remaining_args = parser.parse_args_into_dataclasses(
         return_remaining_strings=True
     )
+
+    if remaining_args.get("disable_caching") is not None and remaining_args["disable_caching"]:
+        disable_caching()
     if parsed_cfg.rl:
         dataset_meta = load_rl_datasets(cfg=parsed_cfg, cli_args=parsed_cli_args)
     else:


### PR DESCRIPTION
The idea is that we can reduce disk space used by disable the caching of datasets. 10GB blows up to over 500GB of disk space taken up by the filtering/preprocessing.