### PR TITLE
Enable or disable bf16 support based on availability

### DIFF
--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -61,6 +61,14 @@ def normalize_config(cfg):
         cfg.device_map = {"": int(os.environ.get("LOCAL_RANK", 0))}
         cfg.batch_size = cfg.batch_size * cfg.world_size
 
+    if cfg.bf16 == "auto":
+        if is_torch_bf16_gpu_available():
+            LOG.info("bf16 support detected, enabling for this configuration.")
+            cfg.bf16 = True
+        else:
+            LOG.info("bf16 support not detected, disabling for this configuration.")
+            cfg.bf16 = False
+
     if cfg.device == "mps":
         cfg.load_in_8bit = False
         cfg.tf32 = False

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -63,10 +63,10 @@ def normalize_config(cfg):
 
     if cfg.bf16 == "auto":
         if is_torch_bf16_gpu_available():
-            LOG.info("bf16 support detected, enabling for this configuration.")
+            LOG.debug("bf16 support detected, enabling for this configuration.")
             cfg.bf16 = True
         else:
-            LOG.info("bf16 support not detected, disabling for this configuration.")
+            LOG.debug("bf16 support not detected, disabling for this configuration.")
             cfg.bf16 = False
 
     if cfg.device == "mps":

--- a/tests/test_normalize_config.py
+++ b/tests/test_normalize_config.py
@@ -2,6 +2,7 @@
 Test classes for checking functionality of the cfg normalization
 """
 import unittest
+from unittest.mock import patch
 
 from axolotl.utils.config import normalize_cfg_datasets, normalize_config
 from axolotl.utils.dict import DictDefault
@@ -67,3 +68,23 @@ class NormalizeConfigTestCase(unittest.TestCase):
 
         assert cfg.datasets[0].conversation == "vicuna_v1.1"
         assert cfg.datasets[1].conversation == "chatml"
+
+    @patch("axolotl.utils.config.is_torch_bf16_gpu_available")
+    def test_bf16_auto_setter_available(self, mock_bf16_avail):
+        cfg = self._get_base_cfg()
+        cfg.bf16 = "auto"
+        mock_bf16_avail.return_value = True
+
+        normalize_config(cfg)
+
+        self.assertTrue(cfg.bf16)
+
+    @patch("axolotl.utils.config.is_torch_bf16_gpu_available")
+    def test_bf16_auto_setter_not_available(self, mock_bf16_avail):
+        cfg = self._get_base_cfg()
+        cfg.bf16 = "auto"
+        mock_bf16_avail.return_value = False
+
+        normalize_config(cfg)
+
+        self.assertFalse(cfg.bf16)


### PR DESCRIPTION
Issue #1090 

Added support for `auto` in bf16 setting of config-files. Now sets bf16 to True/False depending on GPU-support if `bf16: auto`.