### PR TITLE
set fp16 to false if bf16, update bf16: auto in example YAMLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,8 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
   ```yaml
   load_in_4bit: true
   load_in_8bit: true
-  bf16: true # require >=ampere
-  fp16: true
+  bf16: auto # require >=ampere, auto will detect if your GPU supports this and choose automatically.
+  fp16: # unset this value to use fp16 when bf16 is auto detected. set to false if you want to fallback to fp32
   tf32: true # require >=ampere
   bfloat16: true # require >=ampere, use instead of bf16 when you don't want AMP (automatic mixed precision)
   float16: true # use instead of fp16 when you don't want AMP

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
   load_in_4bit: true
   load_in_8bit: true
   bf16: auto # require >=ampere, auto will detect if your GPU supports this and choose automatically.
-  fp16: # unset this value to use fp16 when bf16 is auto detected. set to false if you want to fallback to fp32
+  fp16: # leave empty to use fp16 when bf16 is 'auto'. set to false if you want to fallback to fp32
   tf32: true # require >=ampere
   bfloat16: true # require >=ampere, use instead of bf16 when you don't want AMP (automatic mixed precision)
   float16: true # use instead of fp16 when you don't want AMP

--- a/examples/cerebras/btlm-ft.yml
+++ b/examples/cerebras/btlm-ft.yml
@@ -54,7 +54,7 @@ learning_rate: 0.000085
 train_on_inputs: true
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 
 gradient_checkpointing: false

--- a/examples/cerebras/btlm-ft.yml
+++ b/examples/cerebras/btlm-ft.yml
@@ -53,7 +53,7 @@ lr_quadratic_warmup: true
 learning_rate: 0.000085
 train_on_inputs: true
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 

--- a/examples/cerebras/qlora.yml
+++ b/examples/cerebras/qlora.yml
@@ -36,7 +36,7 @@ lr_scheduler: cosine
 learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 gradient_checkpointing: true

--- a/examples/cerebras/qlora.yml
+++ b/examples/cerebras/qlora.yml
@@ -37,7 +37,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 gradient_checkpointing: true
 early_stopping_patience:

--- a/examples/code-llama/13b/lora.yml
+++ b/examples/code-llama/13b/lora.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/13b/lora.yml
+++ b/examples/code-llama/13b/lora.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/code-llama/13b/qlora.yml
+++ b/examples/code-llama/13b/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/13b/qlora.yml
+++ b/examples/code-llama/13b/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/code-llama/34b/lora.yml
+++ b/examples/code-llama/34b/lora.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/34b/lora.yml
+++ b/examples/code-llama/34b/lora.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/code-llama/34b/qlora.yml
+++ b/examples/code-llama/34b/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/34b/qlora.yml
+++ b/examples/code-llama/34b/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/code-llama/7b/lora.yml
+++ b/examples/code-llama/7b/lora.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/7b/lora.yml
+++ b/examples/code-llama/7b/lora.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/code-llama/7b/qlora.yml
+++ b/examples/code-llama/7b/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/code-llama/7b/qlora.yml
+++ b/examples/code-llama/7b/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/falcon/config-7b-lora.yml
+++ b/examples/falcon/config-7b-lora.yml
@@ -38,7 +38,7 @@ lr_scheduler: cosine
 learning_rate: 0.00003
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 gradient_checkpointing: true

--- a/examples/falcon/config-7b-lora.yml
+++ b/examples/falcon/config-7b-lora.yml
@@ -39,7 +39,7 @@ learning_rate: 0.00003
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 gradient_checkpointing: true
 early_stopping_patience:

--- a/examples/falcon/config-7b-qlora.yml
+++ b/examples/falcon/config-7b-qlora.yml
@@ -65,7 +65,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 gradient_checkpointing: true
 # stop training after this many evaluation losses have increased in a row

--- a/examples/falcon/config-7b-qlora.yml
+++ b/examples/falcon/config-7b-qlora.yml
@@ -64,7 +64,7 @@ lr_scheduler: cosine
 learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 gradient_checkpointing: true

--- a/examples/falcon/config-7b.yml
+++ b/examples/falcon/config-7b.yml
@@ -38,7 +38,7 @@ lr_scheduler: cosine
 learning_rate: 0.00003
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 gradient_checkpointing: true

--- a/examples/falcon/config-7b.yml
+++ b/examples/falcon/config-7b.yml
@@ -39,7 +39,7 @@ learning_rate: 0.00003
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 gradient_checkpointing: true
 early_stopping_patience:

--- a/examples/gptj/qlora.yml
+++ b/examples/gptj/qlora.yml
@@ -34,7 +34,7 @@ learning_rate: 0.0001
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 gradient_checkpointing: true
 early_stopping_patience:

--- a/examples/gptj/qlora.yml
+++ b/examples/gptj/qlora.yml
@@ -33,7 +33,7 @@ lr_scheduler: cosine
 learning_rate: 0.0001
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 gradient_checkpointing: true

--- a/examples/jeopardy-bot/config.yml
+++ b/examples/jeopardy-bot/config.yml
@@ -31,7 +31,7 @@ lr_scheduler: cosine
 learning_rate: 0.00003
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 tf32: true
 early_stopping_patience:
 resume_from_checkpoint:

--- a/examples/llama-2/fft_optimized.yml
+++ b/examples/llama-2/fft_optimized.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/fft_optimized.yml
+++ b/examples/llama-2/fft_optimized.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/llama-2/relora.yml
+++ b/examples/llama-2/relora.yml
@@ -47,7 +47,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/llama-2/relora.yml
+++ b/examples/llama-2/relora.yml
@@ -48,7 +48,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mamba/config.yml
+++ b/examples/mamba/config.yml
@@ -34,7 +34,7 @@ learning_rate: 5e-5
 train_on_inputs: false
 group_by_length: true
 
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 

--- a/examples/mamba/config.yml
+++ b/examples/mamba/config.yml
@@ -35,7 +35,7 @@ train_on_inputs: false
 group_by_length: true
 
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 
 gradient_checkpointing: false

--- a/examples/mistral/config.yml
+++ b/examples/mistral/config.yml
@@ -35,7 +35,7 @@ learning_rate: 0.000005
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/config.yml
+++ b/examples/mistral/config.yml
@@ -34,7 +34,7 @@ learning_rate: 0.000005
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/mistral/mixtral.yml
+++ b/examples/mistral/mixtral.yml
@@ -64,7 +64,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/mixtral.yml
+++ b/examples/mistral/mixtral.yml
@@ -63,7 +63,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -51,7 +51,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -50,7 +50,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/mpt-7b/config.yml
+++ b/examples/mpt-7b/config.yml
@@ -33,7 +33,7 @@ lr_scheduler: cosine
 learning_rate: 0.0000002
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 tf32: true
 early_stopping_patience:
 resume_from_checkpoint:

--- a/examples/phi/phi-ft.yml
+++ b/examples/phi/phi-ft.yml
@@ -46,7 +46,7 @@ learning_rate: 0.000003
 
 train_on_inputs: false
 group_by_length: true
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 

--- a/examples/phi/phi-ft.yml
+++ b/examples/phi/phi-ft.yml
@@ -47,7 +47,7 @@ learning_rate: 0.000003
 train_on_inputs: false
 group_by_length: true
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 
 gradient_checkpointing:

--- a/examples/phi/phi-qlora.yml
+++ b/examples/phi/phi-qlora.yml
@@ -46,7 +46,7 @@ learning_rate: 0.000003
 
 train_on_inputs: false
 group_by_length: true
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 

--- a/examples/phi/phi-qlora.yml
+++ b/examples/phi/phi-qlora.yml
@@ -47,7 +47,7 @@ learning_rate: 0.000003
 train_on_inputs: false
 group_by_length: true
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 
 gradient_checkpointing:

--- a/examples/phi/phi2-ft.yml
+++ b/examples/phi/phi2-ft.yml
@@ -48,7 +48,7 @@ learning_rate: 1e-5
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: true
 

--- a/examples/phi/phi2-ft.yml
+++ b/examples/phi/phi2-ft.yml
@@ -49,7 +49,7 @@ learning_rate: 1e-5
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/pythia/lora.yml
+++ b/examples/pythia/lora.yml
@@ -27,7 +27,7 @@ num_epochs: 4
 learning_rate: 0.00001
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 tf32: true
 early_stopping_patience:
 resume_from_checkpoint:

--- a/examples/qwen/lora.yml
+++ b/examples/qwen/lora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: false

--- a/examples/qwen/lora.yml
+++ b/examples/qwen/lora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/qwen/qlora.yml
+++ b/examples/qwen/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: false

--- a/examples/qwen/qlora.yml
+++ b/examples/qwen/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/redpajama/config-3b.yml
+++ b/examples/redpajama/config-3b.yml
@@ -34,7 +34,7 @@ lr_scheduler: cosine
 learning_rate: 0.0000002
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 tf32: true
 early_stopping_patience:
 resume_from_checkpoint:

--- a/examples/replit-3b/config-lora.yml
+++ b/examples/replit-3b/config-lora.yml
@@ -33,7 +33,7 @@ lr_scheduler:
 learning_rate: 0.00001
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 tf32: true
 gradient_checkpointing:
 early_stopping_patience:

--- a/examples/tiny-llama/lora.yml
+++ b/examples/tiny-llama/lora.yml
@@ -42,7 +42,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/tiny-llama/lora.yml
+++ b/examples/tiny-llama/lora.yml
@@ -41,7 +41,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/tiny-llama/pretrain.yml
+++ b/examples/tiny-llama/pretrain.yml
@@ -35,7 +35,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/tiny-llama/pretrain.yml
+++ b/examples/tiny-llama/pretrain.yml
@@ -34,7 +34,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/tiny-llama/qlora.yml
+++ b/examples/tiny-llama/qlora.yml
@@ -44,7 +44,7 @@ learning_rate: 0.0002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/tiny-llama/qlora.yml
+++ b/examples/tiny-llama/qlora.yml
@@ -43,7 +43,7 @@ learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 

--- a/examples/xgen-7b/xgen-7b-8k-qlora.yml
+++ b/examples/xgen-7b/xgen-7b-8k-qlora.yml
@@ -62,7 +62,7 @@ lr_scheduler: cosine
 learning_rate: 0.00002
 train_on_inputs: false
 group_by_length: false
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 gradient_checkpointing: true

--- a/examples/xgen-7b/xgen-7b-8k-qlora.yml
+++ b/examples/xgen-7b/xgen-7b-8k-qlora.yml
@@ -63,7 +63,7 @@ learning_rate: 0.00002
 train_on_inputs: false
 group_by_length: false
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 gradient_checkpointing: true
 # stop training after this many evaluation losses have increased in a row

--- a/examples/yi-34B-chat/qlora.yml
+++ b/examples/yi-34B-chat/qlora.yml
@@ -8,7 +8,7 @@ load_in_4bit: true
 strict: false
 sequence_len: 1024
 bf16: auto
-fp16: false
+fp16:
 tf32: false
 flash_attention: true
 special_tokens:

--- a/examples/yi-34B-chat/qlora.yml
+++ b/examples/yi-34B-chat/qlora.yml
@@ -7,7 +7,7 @@ load_in_8bit: false
 load_in_4bit: true
 strict: false
 sequence_len: 1024
-bf16: true
+bf16: auto
 fp16: false
 tf32: false
 flash_attention: true

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -68,6 +68,8 @@ def normalize_config(cfg):
         else:
             LOG.debug("bf16 support not detected, disabling for this configuration.")
             cfg.bf16 = False
+            if cfg.fp16 is None:
+                cfg.fp16 = True
 
     if cfg.device == "mps":
         cfg.load_in_8bit = False

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -77,6 +77,8 @@ def normalize_config(cfg):
         cfg.bf16 = False
     else:
         torch.backends.cuda.matmul.allow_tf32 = cfg.tf32 or False
+        if cfg.bf16:
+            cfg.fp16 = False
 
     if cfg.bf16 or cfg.bfloat16:
         cfg.torch_dtype = torch.bfloat16

--- a/tests/test_normalize_config.py
+++ b/tests/test_normalize_config.py
@@ -84,8 +84,10 @@ class NormalizeConfigTestCase(unittest.TestCase):
     def test_bf16_auto_setter_not_available(self, mock_bf16_avail):
         cfg = self._get_base_cfg()
         cfg.bf16 = "auto"
+        cfg.fp16 = None
         mock_bf16_avail.return_value = False
 
         normalize_config(cfg)
 
         self.assertFalse(cfg.bf16)
+        self.assertTrue(cfg.fp16)

--- a/tests/test_normalize_config.py
+++ b/tests/test_normalize_config.py
@@ -91,3 +91,15 @@ class NormalizeConfigTestCase(unittest.TestCase):
 
         self.assertFalse(cfg.bf16)
         self.assertTrue(cfg.fp16)
+
+    @patch("axolotl.utils.config.is_torch_bf16_gpu_available")
+    def test_bf16_disables_fp16(self, mock_bf16_avail):
+        cfg = self._get_base_cfg()
+        cfg.bf16 = True
+        cfg.fp16 = False
+        mock_bf16_avail.return_value = True
+
+        normalize_config(cfg)
+
+        self.assertTrue(cfg.bf16)
+        self.assertFalse(cfg.fp16)

--- a/tests/test_normalize_config.py
+++ b/tests/test_normalize_config.py
@@ -78,6 +78,7 @@ class NormalizeConfigTestCase(unittest.TestCase):
         normalize_config(cfg)
 
         self.assertTrue(cfg.bf16)
+        self.assertFalse(cfg.fp16)
 
     @patch("axolotl.utils.config.is_torch_bf16_gpu_available")
     def test_bf16_auto_setter_not_available(self, mock_bf16_avail):


### PR DESCRIPTION
#1116 enables `bf16: auto` support, which should simplify whether an end user needs to think about using bf16 for their particular GPU. This updates all the example yaml files to use this.