### PR TITLE
pin model_revision for phi2

### DIFF
--- a/examples/phi/phi2-ft.yml
+++ b/examples/phi/phi2-ft.yml
@@ -1,4 +1,5 @@
 base_model: microsoft/phi-2
+model_revision:  834565c  # pin model repo to the previous architecture
 model_type: AutoModelForCausalLM
 tokenizer_type: AutoTokenizer
 trust_remote_code: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Microsoft silently updated the underlying model architecture and weights for phi2 which isn't compatible with our flash attention patches for sample packing. This PR simply pins the model revision in the example yaml to the previous arch revision.
