### PR TITLE
Preprocess dataset size fix

### DIFF
--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -25,6 +25,7 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
     # pylint: disable=duplicate-code
     print_axolotl_text_art()
     parsed_cfg = load_cfg(config, **kwargs)
+    parsed_cfg.is_preprocess = True
     check_accelerate_default_config()
     check_user_token()
     parser = transformers.HfArgumentParser((PreprocessCliArgs))

--- a/src/axolotl/datasets.py
+++ b/src/axolotl/datasets.py
@@ -57,6 +57,7 @@ class TokenizedPromptDataset(Dataset):
             num_proc=num_proc,
             remove_columns=features,
             load_from_cache_file=load_from_cache_file,
+            keep_in_memory=True,
             **map_kwargs,
         )
 

--- a/src/axolotl/datasets.py
+++ b/src/axolotl/datasets.py
@@ -31,13 +31,17 @@ class TokenizedPromptDataset(Dataset):
         prompt_tokenizer: PromptTokenizingStrategy,
         dataset: IterableDataset,
         process_count: Optional[int] = None,
+        load_from_cache_file: Optional[bool] = None,
         **kwargs,
     ):
         self.prompt_tokenizer = prompt_tokenizer
         self.process_count = process_count
-        super().__init__(self.process(dataset).data, **kwargs)
+        super().__init__(
+            self.process(dataset, load_from_cache_file=load_from_cache_file).data,
+            **kwargs,
+        )
 
-    def process(self, dataset):
+    def process(self, dataset, load_from_cache_file=None):
         features = dataset.features.keys()
         num_proc = (
             min(64, self.process_count)
@@ -52,6 +56,7 @@ class TokenizedPromptDataset(Dataset):
             self.prompt_tokenizer.tokenize_prompt,
             num_proc=num_proc,
             remove_columns=features,
+            load_from_cache_file=load_from_cache_file,
             **map_kwargs,
         )
 

--- a/src/axolotl/datasets.py
+++ b/src/axolotl/datasets.py
@@ -31,17 +31,16 @@ class TokenizedPromptDataset(Dataset):
         prompt_tokenizer: PromptTokenizingStrategy,
         dataset: IterableDataset,
         process_count: Optional[int] = None,
-        load_from_cache_file: Optional[bool] = None,
         **kwargs,
     ):
         self.prompt_tokenizer = prompt_tokenizer
         self.process_count = process_count
         super().__init__(
-            self.process(dataset, load_from_cache_file=load_from_cache_file).data,
+            self.process(dataset).data,
             **kwargs,
         )
 
-    def process(self, dataset, load_from_cache_file=None):
+    def process(self, dataset):
         features = dataset.features.keys()
         num_proc = (
             min(64, self.process_count)
@@ -56,7 +55,6 @@ class TokenizedPromptDataset(Dataset):
             self.prompt_tokenizer.tokenize_prompt,
             num_proc=num_proc,
             remove_columns=features,
-            load_from_cache_file=load_from_cache_file,
             keep_in_memory=True,
             **map_kwargs,
         )

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -597,7 +597,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
     elif ds_strategy := load(config_dataset.type, tokenizer, cfg, config_dataset):
         dataset_prompter = UnsupportedPrompter()
@@ -605,7 +604,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
     elif d_base_type == "alpaca":
         dataset_prompter = AlpacaPrompter(d_prompt_style)
@@ -619,7 +617,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "explainchoice":
@@ -634,7 +631,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "concisechoice":
@@ -649,7 +645,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "summarizetldr":
@@ -664,7 +659,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "jeopardy":
@@ -679,7 +673,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "oasst":
@@ -694,7 +687,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "gpteacher":
@@ -709,7 +701,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "reflection":
@@ -724,7 +715,6 @@ def get_dataset_wrapper(
             ds_strategy,
             dataset,
             process_count=cfg.dataset_processes,
-            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     else:

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -594,12 +594,18 @@ def get_dataset_wrapper(
         )
         dataset_prompter = UnsupportedPrompter()
         dataset_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
     elif ds_strategy := load(config_dataset.type, tokenizer, cfg, config_dataset):
         dataset_prompter = UnsupportedPrompter()
         dataset_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
     elif d_base_type == "alpaca":
         dataset_prompter = AlpacaPrompter(d_prompt_style)
@@ -610,7 +616,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "explainchoice":
@@ -622,7 +631,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "concisechoice":
@@ -634,7 +646,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "summarizetldr":
@@ -646,7 +661,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "jeopardy":
@@ -658,7 +676,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "oasst":
@@ -670,7 +691,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "gpteacher":
@@ -682,7 +706,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     elif d_base_type == "reflection":
@@ -694,7 +721,10 @@ def get_dataset_wrapper(
             cfg.sequence_len,
         )
         ds_wrapper = TokenizedPromptDataset(
-            ds_strategy, dataset, process_count=cfg.dataset_processes
+            ds_strategy,
+            dataset,
+            process_count=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_mistral_derived_model,
         )
         dataset_wrapper = ds_wrapper
     else:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -111,27 +111,39 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, tokenizer):
     with zero_first(is_main_process()):
         if cfg.group_by_length:
             train_dataset = train_dataset.map(
-                add_length, num_proc=cfg.dataset_processes
+                add_length,
+                num_proc=cfg.dataset_processes,
+                load_from_cache_file=not cfg.is_preprocess,
             )
 
         if cfg.sample_packing:
             train_dataset = train_dataset.map(
-                add_position_ids, num_proc=cfg.dataset_processes
+                add_position_ids,
+                num_proc=cfg.dataset_processes,
+                load_from_cache_file=not cfg.is_preprocess,
             )
             if cfg.eval_sample_packing is not False:
                 if eval_dataset:
                     eval_dataset = eval_dataset.map(
-                        add_position_ids, num_proc=cfg.dataset_processes
+                        add_position_ids,
+                        num_proc=cfg.dataset_processes,
+                        load_from_cache_file=not cfg.is_preprocess,
                     )
 
         if cfg.group_by_length or cfg.sample_packing:
             max_input_len = np.max(get_dataset_lengths(train_dataset))
             LOG.debug(f"max_input_len: {max_input_len}", main_process_only=True)
 
-        train_dataset = train_dataset.filter(drop_long, num_proc=cfg.dataset_processes)
+        train_dataset = train_dataset.filter(
+            drop_long,
+            num_proc=cfg.dataset_processes,
+            load_from_cache_file=not cfg.is_preprocess,
+        )
         if eval_dataset:
             eval_dataset = eval_dataset.filter(
-                drop_long, num_proc=cfg.dataset_processes
+                drop_long,
+                num_proc=cfg.dataset_processes,
+                load_from_cache_file=not cfg.is_preprocess,
             )
 
         # Phi doesn't want the attention_mask feature when training


### PR DESCRIPTION
# Description

This PR fixes the obscene disk usage when preprocessing datasets. this is mostly during the tokenization map step. By keeping this step completely in memory, it solves ALL the additional disk requirements (which is as much as 10x). Additionally, when running the `-m axolotl.cli.preprocess` sometimes it would rely on the cache, but since pre-processing is an explicit step, the expectation is that it should ignore the cache in most cases.
