### PR TITLE
Allow any origin to access the Jupyter Lab server in the docker image.

### DIFF
--- a/scripts/cloud-entrypoint.sh
+++ b/scripts/cloud-entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 if [ "$JUPYTER_DISABLE" != "1" ]; then
     # Run Jupyter Lab in the background
-    jupyter lab --allow-root --ip 0.0.0.0 &
+    jupyter lab --allow-root --ip 0.0.0.0 --ServerApp.allow_origin='*' &
 fi
 
 # Execute the passed arguments (CMD)


### PR DESCRIPTION
Prevents blocking kernel connection cross origin request on runpod deployment.

# Description

After opening Jupyter Lab in the browser, without this change, it is unable to connect to the kernel.

## Motivation and Context

You can't use Jupyter Lab if you can't connect to the kernel.

## How has this been tested?

I tested the command manually from the terminal on my deployed runpod. It shouldn't affect other areas of the code.

## Screenshots (if appropriate)

<img width="1231" alt="image" src="https://github.com/OpenAccess-AI-Collective/axolotl/assets/35749/0bbb2e40-2746-4990-94c0-86330d016591">

## Types of changes

Dockerfile

## Social Handles (Optional)

twitter: @mattflo
discord: m4ttfl0
