### PR TITLE
Vram fix attempt

### DIFF
--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -90,11 +90,6 @@ def prepare_dataset(cfg, tokenizer):
         eval_dataset = None
         return train_dataset, eval_dataset, cfg.max_steps, prompters
 
-    with zero_first(is_main_process()):
-        train_dataset, eval_dataset = process_datasets_for_packing(
-            cfg, train_dataset, eval_dataset, tokenizer
-        )
-
     if eval_dataset and cfg.sample_packing and cfg.eval_sample_packing is not False:
         total_eval_steps = calculate_total_num_steps(cfg, eval_dataset, update=False)
         if total_eval_steps == 0:
@@ -388,6 +383,8 @@ def load_tokenized_prepared_datasets(
         if len(datasets) > 1:
             LOG.info("shuffle merged datasets")
             dataset = dataset.shuffle(seed=seed)
+
+        dataset, _ = process_datasets_for_packing(cfg, dataset, None, tokenizer)
 
         if cfg.local_rank == 0:
             LOG.info(f"Saving merged prepared dataset to disk... {prepared_ds_path}")

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -90,6 +90,11 @@ def prepare_dataset(cfg, tokenizer):
         eval_dataset = None
         return train_dataset, eval_dataset, cfg.max_steps, prompters
 
+    with zero_first(is_main_process()):
+        train_dataset, eval_dataset = process_datasets_for_packing(
+            cfg, train_dataset, eval_dataset, tokenizer
+        )
+
     if eval_dataset and cfg.sample_packing and cfg.eval_sample_packing is not False:
         total_eval_steps = calculate_total_num_steps(cfg, eval_dataset, update=False)
         if total_eval_steps == 0:
@@ -162,7 +167,7 @@ def load_tokenized_prepared_datasets(
         LOG.info("Loading raw datasets...")
         if not cfg.is_preprocess:
             LOG.warning(
-                "Processing datasets during training can lead to VRAM instability. Please pre-process your dataset"
+                "Processing datasets during training can lead to VRAM instability. Please pre-process your dataset."
             )
 
         if cfg.seed:
@@ -383,8 +388,6 @@ def load_tokenized_prepared_datasets(
         if len(datasets) > 1:
             LOG.info("shuffle merged datasets")
             dataset = dataset.shuffle(seed=seed)
-
-        dataset, _ = process_datasets_for_packing(cfg, dataset, None, tokenizer)
 
         if cfg.local_rank == 0:
             LOG.info(f"Saving merged prepared dataset to disk... {prepared_ds_path}")

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -116,17 +116,11 @@ def load_tokenized_prepared_datasets(
             (
                 str(cfg.sequence_len)
                 + "@"
-                + str(int(cfg.sample_packing))
+                + str(cfg.sample_packing)
                 + "@"
-                + str(
-                    int(
-                        -1
-                        if (cfg.eval_sample_packing is None)
-                        else cfg.eval_sample_packing
-                    )
-                )
+                + str(cfg.eval_sample_packing)
                 + "@"
-                + str(int(cfg.group_by_length))
+                + str(cfg.group_by_length)
                 + "@"
                 + "|".join(
                     sorted(

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -116,6 +116,18 @@ def load_tokenized_prepared_datasets(
             (
                 str(cfg.sequence_len)
                 + "@"
+                + str(int(cfg.sample_packing))
+                + "@"
+                + str(
+                    int(
+                        -1
+                        if cfg.eval_sample_packing is None
+                        else cfg.eval_sample_packing
+                    )
+                )
+                + "@"
+                + str(int(cfg.group_by_length))
+                + "@"
                 + "|".join(
                     sorted(
                         [

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -121,7 +121,7 @@ def load_tokenized_prepared_datasets(
                 + str(
                     int(
                         -1
-                        if cfg.eval_sample_packing is None
+                        if (cfg.eval_sample_packing is None)
                         else cfg.eval_sample_packing
                     )
                 )

--- a/src/axolotl/utils/samplers/utils.py
+++ b/src/axolotl/utils/samplers/utils.py
@@ -7,11 +7,11 @@ import numpy as np
 def get_dataset_lengths(dataset):
     if "length" in dataset.data.column_names:
         lengths = np.array(dataset.data.column("length"))
+    elif "position_ids" in dataset.data.column_names:
+        position_ids = dataset.data.column("position_ids")
+        lengths = np.array([x[-1] + 1 for x in position_ids])
     else:
-        lengths = (
-            dataset.data.column("position_ids")
-            .to_pandas()
-            .apply(lambda x: x[-1] + 1)
-            .values
-        )
+        input_ids = dataset.data.column("input_ids")
+        lengths = np.vectorize(len)(np.array(input_ids, dtype=object))
+        return lengths
     return lengths

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -112,6 +112,18 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, tokenizer):
         if cfg.is_preprocess:
             max_input_len = np.max(get_dataset_lengths(train_dataset))
             LOG.debug(f"max_input_len: {max_input_len}", main_process_only=True)
+
+        # Phi doesn't want the attention_mask feature when training
+        if (
+            "CodeGenTokenizer" in tokenizer.__class__.__name__
+            or (cfg.is_mistral_derived_model and cfg.flash_attention)
+            or cfg.model_config_type == "mamba"
+        ):
+            LOG.info("dropping attention_mask column")
+            train_dataset = train_dataset.remove_columns("attention_mask")
+            if eval_dataset:
+                eval_dataset = eval_dataset.remove_columns("attention_mask")
+
         train_dataset = train_dataset.filter(
             drop_long,
             num_proc=cfg.dataset_processes,
@@ -144,17 +156,6 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, tokenizer):
                         num_proc=cfg.dataset_processes,
                         load_from_cache_file=not cfg.is_preprocess,
                     )
-
-        # Phi doesn't want the attention_mask feature when training
-        if (
-            "CodeGenTokenizer" in tokenizer.__class__.__name__
-            or (cfg.is_mistral_derived_model and cfg.flash_attention)
-            or cfg.model_config_type == "mamba"
-        ):
-            LOG.info("dropping attention_mask column")
-            train_dataset = train_dataset.remove_columns("attention_mask")
-            if eval_dataset:
-                eval_dataset = eval_dataset.remove_columns("attention_mask")
 
     return train_dataset, eval_dataset
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -110,11 +110,8 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, tokenizer):
     drop_long = partial(drop_long_seq, sequence_len=cfg.sequence_len)
     with zero_first(is_main_process()):
         if cfg.is_preprocess:
-            try:
-                max_input_len = np.max(get_dataset_lengths(train_dataset))
-                LOG.debug(f"max_input_len: {max_input_len}", main_process_only=True)
-            except RuntimeError:
-                pass
+            max_input_len = np.max(get_dataset_lengths(train_dataset))
+            LOG.debug(f"max_input_len: {max_input_len}", main_process_only=True)
         train_dataset = train_dataset.filter(
             drop_long,
             num_proc=cfg.dataset_processes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
more permanently fixes issues from #1127 dealing with VRAM instability. reverts an ordering change stemming from #1066 that was causing VRAM spikes during training. Updated dataset len calculations to use numpy instead of pandas since pandas can use the GPU and added a fallback calculation so we can still call it before dropping rows longer than the max length.

~~reverted order of calling `process_datasets_for_packing` from #1141 which can cause issues when changing max sequence length and needing to re-preprocess the datasets.~~

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
