### PR TITLE
improve vram use w gradient checkpointing

### DIFF
--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -160,6 +160,13 @@ def normalize_config(cfg):
     if isinstance(cfg.pretraining_dataset, dict):
         cfg.pretraining_dataset = [cfg.pretraining_dataset]
 
+    if (
+        cfg.gradient_checkpointing
+        and cfg.unfrozen_parameters is None
+        and cfg.gradient_checkpointing_kwargs is None
+    ):
+        cfg.gradient_checkpointing_kwargs = {"use_reentrant": True}
+
     log_gpu_memory_usage(LOG, "baseline", cfg.device)
 
 


### PR DESCRIPTION
# Description

transformers recommends the default for use_reentrant as gradient checkpointing kwargs to be false, as there can be issues when individual layers are frozen for full finetunes. however, this increases VRAM usage when set to false un-necessarily.