### PR TITLE
Add support for offline mode with HF_HUB_OFFLINE envvar

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -365,6 +365,11 @@ def check_accelerate_default_config():
 
 
 def check_user_token():
+    # Skip check if HF_HUB_OFFLINE is set to True
+    if os.getenv('HF_HUB_OFFLINE') == '1':
+        LOG.info("Skipping HuggingFace token verification because HF_HUB_OFFLINE is set to True. Only local files will be used.")
+        return True
+    
     # Verify if token is valid
     api = HfApi()
     try:

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -371,7 +371,7 @@ def check_user_token():
             "Skipping HuggingFace token verification because HF_HUB_OFFLINE is set to True. Only local files will be used."
         )
         return True
-    
+
     # Verify if token is valid
     api = HfApi()
     try:

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -366,8 +366,10 @@ def check_accelerate_default_config():
 
 def check_user_token():
     # Skip check if HF_HUB_OFFLINE is set to True
-    if os.getenv('HF_HUB_OFFLINE') == '1':
-        LOG.info("Skipping HuggingFace token verification because HF_HUB_OFFLINE is set to True. Only local files will be used.")
+    if os.getenv("HF_HUB_OFFLINE") == "1":
+        LOG.info(
+            "Skipping HuggingFace token verification because HF_HUB_OFFLINE is set to True. Only local files will be used."
+        )
         return True
     
     # Verify if token is valid


### PR DESCRIPTION
# Added User Token Verification in HuggingFace API

# Description
<!--- Describe your changes in detail -->
Added an additional check to `check_user_token` that verifies the user's HuggingFace token. The function checks if the `HF_HUB_OFFLINE` environment variable is set to '1'. If so, it skips the verification and only local files will be used. 

## Motivation and Context

This change lets users skip token validation if they are in an offline system (e.g., HPC).

## How has this been tested?
This change has been tested by running the function with different environment variables and tokens. The function correctly identifies whether the token is valid or not.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Social Handles (Optional)

@jameshwade on Twitter and Discord