### PR TITLE
Fix do_merge_lora raises an Exception in transformers v4.37.0

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -82,6 +82,7 @@ def do_merge_lora(
         model.to(dtype=cfg.torch_dtype)
     except RuntimeError:
         pass
+    model.generation_config.do_sample = True
 
     if cfg.local_rank == 0:
         LOG.info(f"saving merged model to: {str(Path(cfg.output_dir) / 'merged')}")


### PR DESCRIPTION
# Description

`transformers v4.37.0` introduced [this change](https://github.com/huggingface/transformers/commit/afc45b13ca40f56268e5f135aab2487377fc536b#diff-9bec72286f01bbca7bb467dd6b68abb7adb7d90e5d48bea08b8a4890cfc27157) which causes `do_merge_lora` to raise an exception because the model contains bad generation config, which shown on the stacktrace below.

```
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.10.10/lib/python3.10/site-packages/transformers/generation/configuration_utils.py", line 558, in save_pretrained
    raise ValueError(str([w.message for w in caught_warnings]))
ValueError: [UserWarning('`do_sample` is set to `False`. However, `temperature` is set to `0.9` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or u
nset `temperature`.'), UserWarning('`do_sample` is set to `False`. However, `top_p` is set to `0.6` -- this flag is only used in sample-based generation modes. You should set `do_sample=True`
or unset `top_p`.')]
```