### PR TITLE
Standardize system prompt format for AlpacaPrompter (instruct case)

### DIFF
--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -51,7 +51,7 @@ class AlpacaPrompter(Prompter):
             self.turn_no_input_format = (
                 "### Instruction:\n{instruction}\n\n### Response:\n"
             )
-            self.system_format = "### System:\n{system}\n\n"
+            self.system_format = "{system}\n\n"
         if self.prompt_style == PromptStyle.CHAT.value:
             self.turn_format = "USER: {instruction}\n{input}\nASSISTANT:"
             self.turn_no_input_format = "USER: {instruction}\nASSISTANT:"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I changed system prompt format for prompt template of Alpaca Prompter: removed `###System\n` before system message, so it aligns with commonly used Alpaca template.

## Motivation and Context

After a short discussion of some problems related to Alpaca template, we found out, that in axolotl implementation system prompt starts with ### System, which is however not a standard way to to this. Link to discussion message - [link](https://discord.com/channels/1104757954588196865/1111279858136383509/1199755122956304546) 

Link to an example of commonly used alpaca prompt template in alpaca-lora repo - [link](https://github.com/tloen/alpaca-lora/blob/main/templates/README.md#example-template)

This change might save a lot of time for beginners that are not aware of this unconventional prompt change that was implemented in axolotl. 

## How has this been tested?

This change shoud not influence framework functionality, it just adjusts prompt template. 