### PR TITLE
workaround for transformers bug requireing do_sample for saveing pretrained

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -63,6 +63,8 @@ def train(
         msg += " and peft_config..."
     LOG.debug(msg)
     model, peft_config = load_model(cfg, tokenizer, inference=cli_args.inference)
+    model.generation_config.do_sample = True
+
     model_ref = None
     if cfg.rl:
         if cfg.adapter and not cfg.rl_adapter_ref_model:


### PR DESCRIPTION
# Description

similar to #1184, this needs to be set for training to since saving the trained model hits the same issue