### PR TITLE
Respect sliding_window=None

### DIFF
--- a/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/mistral_attn_hijack_flash.py
@@ -94,7 +94,7 @@ def _prepare_decoder_attention_mask(
     sliding_window,
 ):  # pylint: disable=unused-argument
     # [bsz, seq_len]
-    if attention_mask is None:
+    if attention_mask is None or sliding_window is None:
         return attention_mask
 
     # NOTE: attention mask and sliding masks are only broadcastable in certain scenarios.
@@ -151,7 +151,7 @@ def flashattn_forward(
     )
 
     use_sliding_windows = (
-        hasattr(self.config, "sliding_window") is not None
+        getattr(self.config, "sliding_window") is not None
         and kv_seq_len > self.config.sliding_window
     )
 


### PR DESCRIPTION
# Description

Fixes sliding_window=None for Mistral and enabled fine tuning of Mistral instruct v0.2 as intended

## Motivation and Context

https://github.com/OpenAccess-AI-Collective/axolotl/issues/1213

## How has this been tested?

I run a train with sliding_window: null in the config

## Social Handles (Optional)

dreamgen on Discord
https://twitter.com/DreamGenAI

