### PR TITLE
Support for additional_special_tokens

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,6 +161,8 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
+
+    additional_special_tokens = cfg.special_tokens.pop('additional_special_tokens')
     if cfg.special_tokens:
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
         for k, val in cfg.special_tokens.items():
@@ -211,6 +213,21 @@ def load_tokenizer(cfg):
                 AddedToken(token, rstrip=False, lstrip=False, normalized=False)
                 for token in cfg.tokens
             ]
+        )
+
+    # Additional special tokens are a List, and need to be treated differently than regular special
+    # tokens. We add them after we have called `add_tokens` in case these additional special tokens
+    # are new tokens.
+    #
+    # Usage:
+    #
+    # ```py
+    # special_tokens:
+    #   additional_special_tokens: ["<|im_start|>", "<|im_end|>"]
+    # ```
+    if additional_special_tokens is not None:
+        tokenizer.add_special_tokens(
+            {"additional_special_tokens": additional_special_tokens}
         )
 
     LOG.debug(f"EOS: {tokenizer.eos_token_id} / {tokenizer.eos_token}")

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,7 +161,6 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
-
     additional_special_tokens = cfg.special_tokens.pop('additional_special_tokens')
     if cfg.special_tokens:
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -232,10 +232,7 @@ def load_tokenizer(cfg):
             if len(tokenizer.encode(token)) > 1:
                 LOG.warning(f"missing {token} in cfg.tokens, adding to vocabulary.")
                 tokenizer.add_tokens(
-                    [
-                        AddedToken(token, rstrip=False, lstrip=False, normalized=False)
-                        for token in cfg.tokens
-                    ]
+                    [AddedToken(token, rstrip=False, lstrip=False, normalized=False)]
                 )
         tokenizer.add_special_tokens(
             {"additional_special_tokens": additional_special_tokens}

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,10 +161,11 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
-    additional_special_tokens = cfg.special_tokens.pop(
-        "additional_special_tokens", None
-    )
+    additional_special_tokens = None
     if cfg.special_tokens:
+        additional_special_tokens = cfg.special_tokens.pop(
+            "additional_special_tokens", None
+        )
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
         for k, val in cfg.special_tokens.items():
             # check if new special token is not already in tokenizer and

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,7 +161,9 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
-    additional_special_tokens = cfg.special_tokens.pop("additional_special_tokens", None)
+    additional_special_tokens = cfg.special_tokens.pop(
+        "additional_special_tokens", None
+    )
     if cfg.special_tokens:
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
         for k, val in cfg.special_tokens.items():

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -163,17 +163,18 @@ def load_tokenizer(cfg):
 
     additional_special_tokens = None
     if cfg.special_tokens:
-        additional_special_tokens = cfg.special_tokens.pop(
+        special_tokens = cfg.special_tokens.to_dict()
+        additional_special_tokens = special_tokens.pop(
             "additional_special_tokens", None
         )
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
-        for k, val in cfg.special_tokens.items():
+        for k, val in special_tokens.items():
             # check if new special token is not already in tokenizer and
             # is adapter training to make sure lora_modules_to_save is set
             # pylint: disable=too-many-boolean-expressions
             if (
                 (getattr(tokenizer, k) is None or getattr(tokenizer, k) != val)
-                and (len(tokenizer.encode(val)) > 1)
+                and (len(tokenizer.encode(val, add_special_tokens=False)) > 2)
                 and cfg.adapter
                 and (
                     not cfg.lora_modules_to_save
@@ -229,7 +230,7 @@ def load_tokenizer(cfg):
     # ```
     if additional_special_tokens is not None:
         for token in additional_special_tokens:
-            if len(tokenizer.encode(token)) > 1:
+            if len(tokenizer.encode(token, add_special_tokens=False)) > 2:
                 LOG.warning(f"missing {token} in cfg.tokens, adding to vocabulary.")
                 tokenizer.add_tokens(
                     [AddedToken(token, rstrip=False, lstrip=False, normalized=False)]

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -228,6 +228,15 @@ def load_tokenizer(cfg):
     #   additional_special_tokens: ["<|im_start|>", "<|im_end|>"]
     # ```
     if additional_special_tokens is not None:
+        for token in additional_special_tokens:
+            if len(tokenizer.encode(token)) > 1:
+                LOG.warning(f"missing {token} in cfg.tokens, adding to vocabulary.")
+                tokenizer.add_tokens(
+                    [
+                        AddedToken(token, rstrip=False, lstrip=False, normalized=False)
+                        for token in cfg.tokens
+                    ]
+                )
         tokenizer.add_special_tokens(
             {"additional_special_tokens": additional_special_tokens}
         )

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,7 +161,7 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
-    additional_special_tokens = cfg.special_tokens.pop('additional_special_tokens')
+    additional_special_tokens = cfg.special_tokens.pop("additional_special_tokens")
     if cfg.special_tokens:
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
         for k, val in cfg.special_tokens.items():

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -161,7 +161,7 @@ def load_tokenizer(cfg):
             if getattr(tokenizer, attr_name) is None:
                 setattr(tokenizer, attr_name, "<|endoftext|>")
 
-    additional_special_tokens = cfg.special_tokens.pop("additional_special_tokens")
+    additional_special_tokens = cfg.special_tokens.pop("additional_special_tokens", None)
     if cfg.special_tokens:
         lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
         for k, val in cfg.special_tokens.items():

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -229,12 +229,6 @@ def load_tokenizer(cfg):
     #   additional_special_tokens: ["<|im_start|>", "<|im_end|>"]
     # ```
     if additional_special_tokens is not None:
-        for token in additional_special_tokens:
-            if len(tokenizer.encode(token, add_special_tokens=False)) > 2:
-                LOG.warning(f"missing {token} in cfg.tokens, adding to vocabulary.")
-                tokenizer.add_tokens(
-                    [AddedToken(token, rstrip=False, lstrip=False, normalized=False)]
-                )
         tokenizer.add_special_tokens(
             {"additional_special_tokens": additional_special_tokens}
         )

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -76,6 +76,11 @@ class TestTokenizers(unittest.TestCase):
         )
         tokenizer = load_tokenizer(cfg)
         self.assertEqual(tokenizer("<|im_start|>user")["input_ids"], [1, 32000, 1404])
+        self.assertEqual(len(tokenizer), 32001)
+
+        # ensure reloading the tokenizer again from cfg results in same vocab length
+        tokenizer = load_tokenizer(cfg)
+        self.assertEqual(len(tokenizer), 32001)
 
 
 if __name__ == "__main__":

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -67,6 +67,16 @@ class TestTokenizers(unittest.TestCase):
         )
         load_tokenizer(cfg)
 
+    def test_add_additional_special_tokens(self):
+        cfg = DictDefault(
+            {
+                "tokenizer_config": "huggyllama/llama-7b",
+                "special_tokens": {"additional_special_tokens": ["<|im_start|>"]},
+            }
+        )
+        tokenizer = load_tokenizer(cfg)
+        self.assertEqual(tokenizer("<|im_start|>user")["input_ids"], [1, 32000, 1404])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description

This lets users specify "additional_special_tokens" of key of the `add_special_tokens` method.

## Motivation and Context

Special tokens are treated different by the tokenizer, ensuring that they are never broken down. This is important for some use cases, like ChatML.

Consider Yi-200K, which has `<|im_start|>` and `<|im_end|>` in its vocabulary already. They are, however not marked as special in the base variant. This means that:

```py
from transformers import AutoTokenizer, AutoModelForCausalLM

tokenizer = AutoTokenizer.from_pretrained(
    "01-ai/Yi-34B-200K"
)

tokens = tokenizer("<|im_start|>system\nX<|im_end|>")
```

Results in:

```txt
{'input_ids': [59666, 59705, 622, 59593, 5858, 46826, 10707, 144, 59733,
```

However, adding these tokens as special:

```py
tokenizer.add_special_tokens(
    {"additional_special_tokens": ["<|im_start|>", "<|im_end|>"]}
)
```

Fixes the issue:

```
{'input_ids': [6, 10707, 144, 59733, 7], 'attention_mask': [1, 1, 1, 1, 1]}
```

This change will let users handle these cases correctly.

## How has this been tested?

I ran a training for 1 step after adding this to my config:

```yaml
special_tokens:
  additional_special_tokens: ["<|im_start|>", "<|im_end|>"]
```

Without this, it's likely that many ChatML models are in-fact semi broken, because it's common practice to add `<|im_start|>` and `<|im_end|>` like this:

```yaml
special_tokens:
  eos_token: "<|im_end|>"
tokens:
  - "<|im_start|>"
```

This means that the tokenizer might incorrectly tokenize `<|im_start|>` strings.

## Social Handles (Optional)

dreamgen on discord
https://twitter.com/DreamGenAI
