### PR TITLE
ADD: Raise warning for duplicated conversation types

### DIFF
--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -528,7 +528,7 @@ def validate_config(cfg):
     if cfg.datasets:
         for idx, ds_cfg in enumerate(cfg.datasets):
             if (
-                ds_cfg.type in ["ultra_apply_chatml", "toxic_apply_chatml","chatml.intel"]
+                ds_cfg.type in ["ultra_apply_chatml", "toxic_apply_chatml","chatml.intel","chatml.argilla"]
                 and ds_cfg.conversation
             ):
                 raise ValueError(

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -525,6 +525,16 @@ def validate_config(cfg):
     if cfg.fsdp and "bnb" in cfg.optimizer:
         raise ValueError(f"FSDP not compatible with {cfg.optimizer}")
 
+    if cfg.datasets:
+        for idx, ds_cfg in enumerate(cfg.datasets):
+            if (
+                ds_cfg.type in ["ultra_apply_chatml", "toxic_apply_chatml","chatml.intel"]
+                and ds_cfg.conversation
+            ):
+                raise ValueError(
+                    f"Your dataset type: {ds_cfg.path} has a built in datasets conversation method"
+                )
+
     # TODO
     # MPT 7b
     # https://github.com/facebookresearch/bitsandbytes/issues/25

--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -528,7 +528,13 @@ def validate_config(cfg):
     if cfg.datasets:
         for idx, ds_cfg in enumerate(cfg.datasets):
             if (
-                ds_cfg.type in ["ultra_apply_chatml", "toxic_apply_chatml","chatml.intel","chatml.argilla"]
+                ds_cfg.type
+                in [
+                    "ultra_apply_chatml",
+                    "toxic_apply_chatml",
+                    "chatml.intel",
+                    "chatml.argilla",
+                ]
                 and ds_cfg.conversation
             ):
                 raise ValueError(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -698,6 +698,24 @@ class ValidationTest(BaseValidation):
                 "set without any models being saved" in self._caplog.records[0].message
             )
 
+    def test_chat_model_tokenizer(self):
+        cfg = DictDefault(
+            {
+                "datasets": [
+                    {
+                        "path": "unalignment/toxic-dpo-v0.1",
+                        "type": "toxic_apply_chatml",
+                        "conversation": "chatml",
+                    }
+                ]
+            }
+        )
+        with pytest.raises(
+            ValueError,
+            match=r".*Your dataset type*",
+        ):
+            validate_config(cfg)
+
     def test_hub_model_id_save_value(self):
         cfg = DictDefault({"hub_model_id": "test", "saves_per_epoch": 4})
 


### PR DESCRIPTION
Rasise a warning if conversation is specified but already exists in the type for datasets.  This is for example the case for ultra_apply_chatml. 