### PR TITLE
Feat/custom chat template

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,8 @@ rl:
 chat_template: chatml
 # Changes the default system message
 default_system_message: You are a helpful assistant. Please give a long and detailed answer. # Currently only supports chatml.
+# A custom chat template in Jinja format. Will overwrite `chat_template` and `default_system_message`
+custom_chat_template: {% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>' + messages[-2]['role'] + '\n' }}{% endif %}
 # Axolotl attempts to save the dataset as an arrow after packing the data together so
 # subsequent training attempts load faster, relative path
 dataset_prepared_path: data/last_run_prepared

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ chat_template: chatml
 # Changes the default system message
 default_system_message: You are a helpful assistant. Please give a long and detailed answer. # Currently only supports chatml.
 # A custom chat template in Jinja format. Will overwrite `chat_template` and `default_system_message`
-custom_chat_template: {% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>' + messages[-2]['role'] + '\n' }}{% endif %}
+custom_chat_template: {% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>' + 'assistant' + '\n' }}{% endif %}
 # Axolotl attempts to save the dataset as an arrow after packing the data together so
 # subsequent training attempts load faster, relative path
 dataset_prepared_path: data/last_run_prepared

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ chat_template: chatml
 # Changes the default system message
 default_system_message: You are a helpful assistant. Please give a long and detailed answer. # Currently only supports chatml.
 # A custom chat template in Jinja format. Will overwrite `chat_template` and `default_system_message`
-custom_chat_template: {% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>' + 'assistant' + '\n' }}{% endif %}
+custom_chat_template: "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>' + 'assistant' + '\n' }}{% endif %}"
 # Axolotl attempts to save the dataset as an arrow after packing the data together so
 # subsequent training attempts load faster, relative path
 dataset_prepared_path: data/last_run_prepared

--- a/src/axolotl/utils/chat_templates.py
+++ b/src/axolotl/utils/chat_templates.py
@@ -4,12 +4,14 @@ These templates are used for formatting messages in a conversation.
 """
 
 
-def chat_templates(user_choice: str):
+def chat_templates(user_choice: str, user_custom_choice: str):
     """
     Finds the correct chat_template for the tokenizer_config.
+    Priority is given to `user_custom_choice` over `user_choice`.
 
     Args:
         user_choice (str): The user's choice of template.
+        user_custom_choice (str): The user's choice of a custom template.
 
     Returns:
         str: The chosen template string.
@@ -17,6 +19,9 @@ def chat_templates(user_choice: str):
     Raises:
         ValueError: If the user_choice is not found in the templates.
     """
+
+    if user_custom_choice:
+        return user_custom_choice
 
     templates = {
         "inst": "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token}}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}",  # I don't know what this one is called. Used by Mistral/Mixtral.

--- a/src/axolotl/utils/chat_templates.py
+++ b/src/axolotl/utils/chat_templates.py
@@ -4,14 +4,13 @@ These templates are used for formatting messages in a conversation.
 """
 
 
-def chat_templates(user_choice: str, user_custom_choice: str):
+def chat_templates(user_choice: str):
     """
     Finds the correct chat_template for the tokenizer_config.
     Priority is given to `user_custom_choice` over `user_choice`.
 
     Args:
         user_choice (str): The user's choice of template.
-        user_custom_choice (str): The user's choice of a custom template.
 
     Returns:
         str: The chosen template string.
@@ -19,9 +18,6 @@ def chat_templates(user_choice: str, user_custom_choice: str):
     Raises:
         ValueError: If the user_choice is not found in the templates.
     """
-
-    if user_custom_choice:
-        return user_custom_choice
 
     templates = {
         "inst": "{{ bos_token }}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token}}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}",  # I don't know what this one is called. Used by Mistral/Mixtral.

--- a/src/axolotl/utils/chat_templates.py
+++ b/src/axolotl/utils/chat_templates.py
@@ -7,7 +7,6 @@ These templates are used for formatting messages in a conversation.
 def chat_templates(user_choice: str):
     """
     Finds the correct chat_template for the tokenizer_config.
-    Priority is given to `user_custom_choice` over `user_choice`.
 
     Args:
         user_choice (str): The user's choice of template.

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -218,7 +218,9 @@ def load_tokenizer(cfg):
     LOG.debug(f"PAD: {tokenizer.pad_token_id} / {tokenizer.pad_token}")
     LOG.debug(f"UNK: {tokenizer.unk_token_id} / {tokenizer.unk_token}")
 
-    if cfg.chat_template:
+    if cfg.custom_chat_template:
+        tokenizer.chat_template = cfg.custom_chat_template
+    elif cfg.chat_template:
         chat_template_string = chat_templates(cfg.chat_template)
         if cfg.default_system_message and cfg.chat_template == "chatml":
             chat_template_string = chat_template_string.replace(
@@ -226,8 +228,6 @@ def load_tokenizer(cfg):
             )
 
         tokenizer.chat_template = chat_template_string
-    elif cfg.custom_chat_template:
-        tokenizer.chat_template = cfg.custom_chat_template
     else:
         LOG.info(
             "No Chat template selected. Consider adding a chat template for easier inference."

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -218,14 +218,16 @@ def load_tokenizer(cfg):
     LOG.debug(f"PAD: {tokenizer.pad_token_id} / {tokenizer.pad_token}")
     LOG.debug(f"UNK: {tokenizer.unk_token_id} / {tokenizer.unk_token}")
 
-    if cfg.chat_template:
-        chat_template_string = chat_templates(cfg.chat_template)
+    if cfg.chat_template or cfg.custom_chat_template:
+        chat_template_string = chat_templates(cfg.chat_template, cfg.custom_chat_template)
         if cfg.default_system_message and cfg.chat_template == "chatml":
             chat_template_string = chat_template_string.replace(
                 "You are a helpful assistant.", cfg.default_system_message
             )
 
         tokenizer.chat_template = chat_template_string
+    elif cfg.custom_chat_template:
+        tokenizer.chat_template = cfg.custom_chat_template
     else:
         LOG.info(
             "No Chat template selected. Consider adding a chat template for easier inference."

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -218,8 +218,8 @@ def load_tokenizer(cfg):
     LOG.debug(f"PAD: {tokenizer.pad_token_id} / {tokenizer.pad_token}")
     LOG.debug(f"UNK: {tokenizer.unk_token_id} / {tokenizer.unk_token}")
 
-    if cfg.chat_template or cfg.custom_chat_template:
-        chat_template_string = chat_templates(cfg.chat_template, cfg.custom_chat_template)
+    if cfg.chat_template:
+        chat_template_string = chat_templates(cfg.chat_template)
         if cfg.default_system_message and cfg.chat_template == "chatml":
             chat_template_string = chat_template_string.replace(
                 "You are a helpful assistant.", cfg.default_system_message


### PR DESCRIPTION
# Description

Adds a `custom_chat_template` parameter on the config that allows to set a custom chat template in Jinja format.

## Motivation and Context

It's convenient so those of use who use this won't need to edit the tokenizer config directly after the fine-tune has finished.

## How has this been tested?

I did not write any test cases for this. I tested it manually on my own environment and it does seem to work.