### PR TITLE
fix(model): apply gate fp32 only for mixtral

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -676,7 +676,7 @@ def load_model(
     if not cfg.fsdp:
         # FSDP doesn't like mixed Float and BFloat16
         for name, module in model.named_modules():
-            if "norm" in name or (model_config.model_type == "mixtral" and "gate" in name):
+            if "norm" in name or name == "gate":
                 module.to(torch.float32)
             if model_config.model_type == "btlm":
                 # don't upcast lm_head for btlm

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -676,7 +676,7 @@ def load_model(
     if not cfg.fsdp:
         # FSDP doesn't like mixed Float and BFloat16
         for name, module in model.named_modules():
-            if any(m in name for m in ["norm", "gate"]):
+            if "norm" in name or (model_config.model_type == "mixtral" and "gate" in name):
                 module.to(torch.float32)
             if model_config.model_type == "btlm":
                 # don't upcast lm_head for btlm

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -676,7 +676,7 @@ def load_model(
     if not cfg.fsdp:
         # FSDP doesn't like mixed Float and BFloat16
         for name, module in model.named_modules():
-            if "norm" in name or name == "gate":
+            if "norm" in name or name.endswith(".gate"):
                 module.to(torch.float32)
             if model_config.model_type == "btlm":
                 # don't upcast lm_head for btlm


### PR DESCRIPTION
Gate was accidentally moved to fp32 for non-mixtral models.

This has been discovered by Nafnlaus on discord: https://discord.com/channels/1104757954588196865/1104757955204743201/1202445059438542899

# Description

Details on negative effect: https://discord.com/channels/1104757954588196865/1104757955204743201/1202287752486604853

Worse eval loss.

## Social Handles (Optional)

His discord handle is `@nafnlaus00`. Github: @enn-nafnlaus
