### PR TITLE
BUG FIX: lock pytorch version in colab example

### DIFF
--- a/examples/colab-notebooks/colab-axolotl-example.ipynb
+++ b/examples/colab-notebooks/colab-axolotl-example.ipynb
@@ -43,6 +43,7 @@
       },
       "outputs": [],
       "source": [
+        "!pip install torch==\"2.1.2\"\n",
         "!pip install -e git+https://github.com/OpenAccess-AI-Collective/axolotl#egg=axolotl\n",
         "!pip install flash-attn==\"2.5.0\"\n",
         "!pip install deepspeed==\"0.13.1\""


### PR DESCRIPTION
Fix pytorch version in colab example. 