### PR TITLE
Fix typo `bloat16` -> `bfloat16`

### DIFF
--- a/src/axolotl/utils/config.py
+++ b/src/axolotl/utils/config.py
@@ -322,7 +322,7 @@ def validate_config(cfg):
             LOG.warning("BetterTransformers probably doesn't work with PEFT adapters")
         if cfg.fp16 or cfg.bf16:
             raise ValueError("AMP is not supported with BetterTransformer")
-        if cfg.float16 is not True and cfg.bloat16 is not True:
+        if cfg.float16 is not True and cfg.bfloat16 is not True:
             LOG.warning(
                 "You should probably set bfloat16 or float16 to true to "
                 "load the model in float16 for BetterTransformers"


### PR DESCRIPTION
Just noticed something while trying to grep all cfg attributes