### PR TITLE
allow remote data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
     - path: https://some.url.com/yourdata.jsonl # Accepts folder with arrow/parquet or file path like above. Supports s3, gcs.
       ds_type: json # this is the default, see other options below.
   ```
-f
+
 - loading
   ```yaml
   load_in_4bit: true

--- a/README.md
+++ b/README.md
@@ -468,6 +468,12 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
   dataset:
     - path: s3://path_to_ds # Accepts folder with arrow/parquet or file path like above. Supports s3, gcs.
       ...
+
+  # loading from a public url
+  # The url must be a direct link to a file. The format is json (which includes jsonl) by default, unless you change the `ds_type` option.
+  dataset:
+    - path: https://some.url.com/yourdata.jsonl # Accepts folder with arrow/parquet or file path like above. Supports s3, gcs.
+      ds_type: json # this is the default, see other options below.
   ```
 
 - loading

--- a/README.md
+++ b/README.md
@@ -469,13 +469,15 @@ See [examples](examples) for quick start. It is recommended to duplicate and mod
     - path: s3://path_to_ds # Accepts folder with arrow/parquet or file path like above. Supports s3, gcs.
       ...
 
-  # loading from a public url
-  # The url must be a direct link to a file. The format is json (which includes jsonl) by default, unless you change the `ds_type` option.
+  # Loading Data From a Public URL
+  # - URLs must use HTTPS protocol for security reasons, not HTTP.
+  # - The URL should be a direct link to the file you wish to load.
+  # - The file format is `json` (which includes `jsonl`) by default. For different formats, adjust the `ds_type` option accordingly.
   dataset:
     - path: https://some.url.com/yourdata.jsonl # Accepts folder with arrow/parquet or file path like above. Supports s3, gcs.
       ds_type: json # this is the default, see other options below.
   ```
-
+f
 - loading
   ```yaml
   load_in_4bit: true

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -336,7 +336,7 @@ def load_tokenized_prepared_datasets(
                         split=None,
                         storage_options=storage_options,
                     )
-            elif config_dataset.path.startswith("http"):
+            elif config_dataset.path.startswith("https://"):
                 ds_type = get_ds_type(config_dataset)
                 ds = load_dataset(
                     ds_type,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -336,6 +336,16 @@ def load_tokenized_prepared_datasets(
                         split=None,
                         storage_options=storage_options,
                     )
+            elif config_dataset.path.startswith("http"):
+                ds_type = get_ds_type(config_dataset)
+                ds = load_dataset(
+                    ds_type,
+                    name=config_dataset.name,
+                    data_files=config_dataset.path,
+                    streaming=False,
+                    split=None,
+                    storage_options=storage_options,
+                )
             else:
                 if isinstance(config_dataset.data_files, str):
                     fp = hf_hub_download(


### PR DESCRIPTION
This ended up being pretty simple.  Added support for remote URL paths per discussion with @winglian - HF Datasets natively allow remote paths