### PR TITLE
Fix data loading for DPO and other formats like parquet.

### DIFF
--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -928,8 +928,12 @@ def load_prepare_dpo_datasets(cfg):
                     )
                     split_datasets.insert(i, ds)
             else:
+                ds_type = get_ds_type(ds_cfg)
                 ds = load_dataset(  # pylint: disable=invalid-name
-                    ds_cfg["path"],
+                    ds_type,
+                    name=ds_cfg["name"],
+                    data_files=ds_cfg["path"],
+                    streaming=False,
                     split=ds_cfg["split"],
                 )
                 split_datasets.insert(i, ds)


### PR DESCRIPTION
If you want to do DPO with a locale file at the moment it is only possible with jsonl files.
This enables it for more file formats like parquet.

fixes #1282