### PR TITLE
Allow load_best_model_at_end to be configured for early stopping on custom evaluation datasets

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -883,16 +883,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 self.cfg.load_best_model_at_end is not False
                 or self.cfg.early_stopping_patience
             )
-            and
-                (
-                    (
-                        not self.cfg.test_datasets and self.cfg.val_set_size > 0
-                    )
-                    or
-                    (
-                        self.cfg.test_datasets and self.cfg.val_set_size == 0
-                    )
-                )
+            and (
+                (not self.cfg.test_datasets and self.cfg.val_set_size > 0)
+                or (self.cfg.test_datasets and self.cfg.val_set_size == 0)
+            )
             and self.cfg.save_steps
             and self.cfg.eval_steps
             and self.cfg.save_steps % self.cfg.eval_steps == 0

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -883,8 +883,16 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 self.cfg.load_best_model_at_end is not False
                 or self.cfg.early_stopping_patience
             )
-            and not self.cfg.test_datasets
-            and self.cfg.val_set_size > 0
+            and
+                (
+                    (
+                        not self.cfg.test_datasets and self.cfg.val_set_size > 0
+                    )
+                    or
+                    (
+                        self.cfg.test_datasets and self.cfg.val_set_size == 0
+                    )
+                )
             and self.cfg.save_steps
             and self.cfg.eval_steps
             and self.cfg.save_steps % self.cfg.eval_steps == 0


### PR DESCRIPTION
# Description

This change adds an additional clause when configuring the trainer to allow load_best_model_at_end to be set when using custom evaluation datasets (i.e. test_datasets is populated and val_set_size is to zero).

## Motivation and Context

When using a custom test dataset for evaluation was unable to set early_stopping_patience as load_best_model_at_end was never set on the training configuration. This change allows the early stopping callback to be configured in the trainer successful. 

## How has this been tested?

I have been using this successfully for various training runs for models.
