### PR TITLE
add lion-pytorch optimizer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def parse_requirements():
                 or "flash-attention" in line
                 or "deepspeed" in line
                 or "mamba-ssm" in line
+                or "lion-pytorch" in line
             )
             if line.startswith("--extra-index-url"):
                 # Handle custom index URLs
@@ -84,6 +85,9 @@ setup(
         ],
         "mlflow": [
             "mlflow",
+        ],
+        "lion-pytorch": [
+            "lion-pytorch==0.1.2",
         ],
     },
 )

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -263,7 +263,7 @@ class HyperparametersConfig(BaseModel):
 
     learning_rate: Union[str, float]
     weight_decay: Optional[float] = None
-    optimizer: Optional[OptimizerNames] = None
+    optimizer: Optional[Union[OptimizerNames, Literal["lion_pytorch"]]] = None
     torchdistx_path: Optional[str] = None
     lr_scheduler: Optional[SchedulerType] = None
     lr_scheduler_kwargs: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
Not sure if there is any point in merging this but bitsandbytes is not supported on some devices (namely MPS), so I added a torch only lion optimizer.
My tests have been disappointing, I didn't see any difference when using it instead of adamw_torch.

At least this can serve as a reference on how to add optimizers not natively supported by hf's transformers.