### PR TITLE
[bug-report template] Use yaml codeblock for config.yaml field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -59,6 +59,7 @@ body:
       label: Config yaml
       description: |
         Please attach the config yaml!
+      render: yaml
 
   - type: textarea
     id: possible-solution


### PR DESCRIPTION
The default bug report does not triple-backtick-yaml the config file, resulting in weird markdown formatting that is hard to read.
