### PR TITLE
Fix `use_mlflow` to be bool instead of str

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -315,7 +315,7 @@ class ModelOutputConfig(BaseModel):
 class MLFlowConfig(BaseModel):
     """mlflow configuration subset"""
 
-    use_mlflow: Optional[str] = None
+    use_mlflow: Optional[bool] = None
     mlflow_tracking_uri: Optional[str] = None
     mlflow_experiment_name: Optional[str] = None
     hf_mlflow_log_artifacts: Optional[bool] = None


### PR DESCRIPTION
This started causing validation errors with the new pydantic validations