### PR TITLE
Update tinyllama lora.yml to fix eval packing issue

### DIFF
--- a/examples/tiny-llama/lora.yml
+++ b/examples/tiny-llama/lora.yml
@@ -15,6 +15,7 @@ output_dir: ./lora-out
 
 sequence_len: 4096
 sample_packing: true
+eval_sample_packing: false
 pad_to_sequence_len: true
 
 adapter: lora


### PR DESCRIPTION
Disables evaluation set sample packing for the TinyLlama Lora config. Without this setting, it raises a 

```
ValueError: eval dataset split is too small for sample_packing. You should set `eval_sample_packing: False`. 
Traceback (most recent call last):
```

# Description

Adds:

`eval_sample_packing: false`

## Motivation and Context

Fixes an error with the default config

## How has this been tested?

Ran it with the setting, and it then worked fine (see screenshot below)

## Screenshots (if appropriate)

<img width="881" alt="Screenshot 2024-03-05 at 10 47 53 AM" src="https://github.com/OpenAccess-AI-Collective/axolotl/assets/5618407/6740f52e-81ca-4d2c-b4d8-67f87abe9a9a">


## Social Handles (Optional)

@rasbt (on Twitter)