### PR TITLE
Add Glaive conversation format support

### DIFF
--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -94,7 +94,7 @@ def load_guanaco(tokenizer, cfg):
 
 def load_glaive(tokenizer, cfg, ds_cfg: Optional[Dict[str, Any]] = None):
     conversation = (
-        ds_cfg["conversation"] if ds_cfg and "conversation" in ds_cfg else None
+        ds_cfg["conversation"] if ds_cfg and "conversation" in ds_cfg else "chatml_glaive"
     )
     return GlaiveShareGPTPromptTokenizingStrategy(
         ShareGPTPrompterV2(conversation=conversation),

--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -192,8 +192,8 @@ class GlaiveShareGPTPromptTokenizingStrategy(SimpleShareGPTPromptTokenizingStrat
     sharegpt strategy that remaps glaive data to sharegpt format
     """
 
-    def get_conversation_thread(self, row):
-        conversation = chatml_to_conversation(row)
+    def get_conversation_thread(self, prompt):
+        conversation = chatml_to_conversation(prompt)
         conversation = merge_consecutive_messages(conversation)
 
         return conversation

--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -6,7 +6,10 @@ from fastchat.conversation import Conversation, SeparatorStyle, register_conv_te
 
 from axolotl.prompt_tokenizers import ShareGPTPromptTokenizingStrategy
 from axolotl.prompters import ShareGPTPrompterV2
-from axolotl.utils.tokenization import chatml_to_conversation, merge_consecutive_messages
+from axolotl.utils.tokenization import (
+    chatml_to_conversation,
+    merge_consecutive_messages,
+)
 
 
 def register_chatml_template(system_message=None):
@@ -192,5 +195,5 @@ class GlaiveShareGPTPromptTokenizingStrategy(SimpleShareGPTPromptTokenizingStrat
     def get_conversation_thread(self, row):
         conversation = chatml_to_conversation(row)
         conversation = merge_consecutive_messages(conversation)
-        
+
         return conversation

--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -1,10 +1,12 @@
 """Module containing the SimpleShareGPTPromptTokenizingStrategy class"""
+
 from typing import Any, Dict, Optional
 
 from fastchat.conversation import Conversation, SeparatorStyle, register_conv_template
 
 from axolotl.prompt_tokenizers import ShareGPTPromptTokenizingStrategy
 from axolotl.prompters import ShareGPTPrompterV2
+from axolotl.utils.tokenization import chatml_to_conversation, merge_consecutive_messages
 
 
 def register_chatml_template(system_message=None):
@@ -15,6 +17,16 @@ def register_chatml_template(system_message=None):
             system_template="<|im_start|>system\n{system_message}",
             system_message=system_message,
             roles=["<|im_start|>user", "<|im_start|>assistant"],
+            sep_style=SeparatorStyle.CHATML,
+            sep="<|im_end|>",
+        )
+    )
+    register_conv_template(
+        Conversation(
+            name="chatml_glaive",
+            system_template="<|im_start|>system\n{system_message}",
+            system_message=system_message,
+            roles=["<|im_start|>user", "<|im_start|>assistant", "<|im_start|>tool"],
             sep_style=SeparatorStyle.CHATML,
             sep="<|im_end|>",
         )
@@ -71,6 +83,18 @@ def load_role(tokenizer, cfg):
 def load_guanaco(tokenizer, cfg):
     return GuanacoShareGPTPromptTokenizingStrategy(
         ShareGPTPrompterV2(),
+        tokenizer,
+        cfg.train_on_inputs,
+        cfg.sequence_len,
+    )
+
+
+def load_glaive(tokenizer, cfg, ds_cfg: Optional[Dict[str, Any]] = None):
+    conversation = (
+        ds_cfg["conversation"] if ds_cfg and "conversation" in ds_cfg else None
+    )
+    return GlaiveShareGPTPromptTokenizingStrategy(
+        ShareGPTPrompterV2(conversation=conversation),
         tokenizer,
         cfg.train_on_inputs,
         cfg.sequence_len,
@@ -158,3 +182,15 @@ class UltrachatShareGPTPromptTokenizingStrategy(SimpleShareGPTPromptTokenizingSt
             {"from": role_map[t["role"]], "value": t["content"]} for t in conversations
         ]
         return turns
+
+
+class GlaiveShareGPTPromptTokenizingStrategy(SimpleShareGPTPromptTokenizingStrategy):
+    """
+    sharegpt strategy that remaps glaive data to sharegpt format
+    """
+
+    def get_conversation_thread(self, row):
+        conversation = chatml_to_conversation(row)
+        conversation = merge_consecutive_messages(conversation)
+        
+        return conversation

--- a/src/axolotl/prompt_strategies/sharegpt.py
+++ b/src/axolotl/prompt_strategies/sharegpt.py
@@ -94,7 +94,9 @@ def load_guanaco(tokenizer, cfg):
 
 def load_glaive(tokenizer, cfg, ds_cfg: Optional[Dict[str, Any]] = None):
     conversation = (
-        ds_cfg["conversation"] if ds_cfg and "conversation" in ds_cfg else "chatml_glaive"
+        ds_cfg["conversation"]
+        if ds_cfg and "conversation" in ds_cfg
+        else "chatml_glaive"
     )
     return GlaiveShareGPTPromptTokenizingStrategy(
         ShareGPTPrompterV2(conversation=conversation),

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -360,11 +360,15 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                     LOG.warning(f"expected tuple, got {part}")
                     continue
 
-                user, assistant = conversation.roles
+                tool_role_label = None
+                if len(conversation.roles) == 3:
+                    user_role_label, assistant_role_label, tool_role_label = conversation.roles
+                else:
+                    user_role_label, assistant_role_label = conversation.roles
                 role, content = part
 
                 # Uses "in" because role contains extra characters
-                if user in role:
+                if user_role_label in role:
                     role = (
                         role.replace(role_remap[0]["from"], role_remap[0]["to"])
                         if role_remap
@@ -384,7 +388,7 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                     else:
                         # everything from this is masked out from the labels
                         labels = [IGNORE_TOKEN_ID] * len(res["input_ids"])
-                elif assistant in role:
+                elif assistant_role_label in role:
                     role = (
                         role.replace(role_remap[1]["from"], role_remap[1]["to"])
                         if role_remap
@@ -426,6 +430,8 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                     else:
                         # everything from this is masked out from the labels
                         labels = [IGNORE_TOKEN_ID] * len(res["input_ids"])
+                elif tool_role_label and tool_role_label in role:
+                    labels = [IGNORE_TOKEN_ID] * len(res["input_ids"])
                 else:
                     LOG.warning(f"unhandled role: {role}")
                     continue

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -362,7 +362,9 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
 
                 tool_role_label = None
                 if len(conversation.roles) == 3:
-                    user_role_label, assistant_role_label, tool_role_label = conversation.roles
+                    user_role_label, assistant_role_label, tool_role_label = (
+                        conversation.roles
+                    )
                 else:
                     user_role_label, assistant_role_label = conversation.roles
                 role, content = part

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -362,9 +362,11 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
 
                 tool_role_label = None
                 if len(conversation.roles) == 3:
-                    user_role_label, assistant_role_label, tool_role_label = (
-                        conversation.roles
-                    )
+                    (
+                        user_role_label,
+                        assistant_role_label,
+                        tool_role_label,
+                    ) = conversation.roles
                 else:
                     user_role_label, assistant_role_label = conversation.roles
                 role, content = part

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -267,7 +267,8 @@ class ShareGPTPrompter(Prompter):  # pylint: disable=too-few-public-methods
 
     role_key_human = "human"
     role_key_model = "gpt"
-    role_key_tool = "tool"
+    # Optional, only used for tool usage datasets.
+    role_key_tool = None
 
     def __init__(
         self,
@@ -275,6 +276,7 @@ class ShareGPTPrompter(Prompter):  # pylint: disable=too-few-public-methods
         conversation: Optional[Union[str, Conversation]] = None,
         role_key_human: Optional[str] = None,
         role_key_model: Optional[str] = None,
+        role_key_tool: Optional[str] = None,
     ):
         if conversation:
             if isinstance(conversation, Conversation):
@@ -287,6 +289,8 @@ class ShareGPTPrompter(Prompter):  # pylint: disable=too-few-public-methods
             self.role_key_human = role_key_human
         if role_key_model:
             self.role_key_model = role_key_model
+        if role_key_tool:
+            self.role_key_tool = role_key_tool
 
     def _build_result(self, source):
         if len(source) < 2:

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -267,6 +267,7 @@ class ShareGPTPrompter(Prompter):  # pylint: disable=too-few-public-methods
 
     role_key_human = "human"
     role_key_model = "gpt"
+    role_key_tool = "tool"
 
     def __init__(
         self,
@@ -303,6 +304,8 @@ class ShareGPTPrompter(Prompter):  # pylint: disable=too-few-public-methods
             source.pop(0)
 
         roles = {self.role_key_human: conv.roles[0], self.role_key_model: conv.roles[1]}
+        if self.role_key_tool:
+            roles[self.role_key_tool] = conv.roles[2]
 
         try:
             # Apply prompt templates

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -1,9 +1,9 @@
 """Module for tokenization utilities"""
 
-import re
-from typing import List, Dict
 
 import logging
+import re
+from typing import List, Dict
 
 from termcolor import colored
 

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -1,5 +1,7 @@
 """Module for tokenization utilities"""
 
+import re
+from typing import List, Dict
 
 import logging
 
@@ -36,3 +38,64 @@ def check_example_labels(example, tokenizer, text_only=False):
     LOG.info("\n\n\n")
 
     return " ".join(colored_tokens)
+
+
+GLAIVE_ROLES = ["USER", "ASSISTANT", "FUNCTION RESPONSE"]
+GLAIVE_TO_SHAREGPT_ROLE = {
+    "SYSTEM": "system",
+    "USER": "human",
+    "ASSISTANT": "gpt",
+    "FUNCTION RESPONSE": "tool",
+}
+GLAIVE_MSG_REGEX = re.compile(r"({}): ".format("|".join(GLAIVE_ROLES)))
+
+
+def chatml_to_conversation(row: Dict[str, str]) -> List[Dict[str, str]]:
+    """
+    Converts a ChatML formatted row to a list of messages in ShareGPT format.
+    Initially based off https://github.com/lilacai/lilac/blob/main/notebooks/GlaiveToShareGPT.ipynb.
+    """
+
+    system_prompt = row.get("system")
+    if system_prompt:
+        system_prompt = system_prompt.removeprefix("SYSTEM: ")
+
+    chat_str = row["chat"]
+    chat_msgs = [s.strip() for s in GLAIVE_MSG_REGEX.split(chat_str) if s]
+
+    chat_msg_dicts = [
+        {"from": GLAIVE_TO_SHAREGPT_ROLE[role], "value": value}
+        for role, value in zip(chat_msgs[::2], chat_msgs[1::2])
+    ]
+
+    if system_prompt:
+        chat_msg_dicts = [
+            {"from": GLAIVE_TO_SHAREGPT_ROLE["SYSTEM"], "value": system_prompt}
+        ] + chat_msg_dicts
+
+    return chat_msg_dicts
+
+
+def merge_consecutive_messages(messages):
+    """
+    Merge consecutive messages from the same sender into a single message.
+    This can be useful with datasets that contain multiple consecutive tool calls.
+    """
+
+    merged_messages = []
+    current_from = None
+    current_message = ""
+
+    for msg in messages:
+        if current_from == msg["from"]:
+            current_message += msg["value"]
+        else:
+            if current_from is not None:
+                merged_messages.append({"from": current_from, "value": current_message})
+            current_from = msg["from"]
+            current_message = msg["value"]
+
+    if current_from is not None:
+        merged_messages.append({"from": current_from, "value": current_message})
+
+    return merged_messages

--- a/src/axolotl/utils/tokenization.py
+++ b/src/axolotl/utils/tokenization.py
@@ -3,7 +3,7 @@
 
 import logging
 import re
-from typing import List, Dict
+from typing import Dict, List
 
 from termcolor import colored
 
@@ -47,7 +47,8 @@ GLAIVE_TO_SHAREGPT_ROLE = {
     "ASSISTANT": "gpt",
     "FUNCTION RESPONSE": "tool",
 }
-GLAIVE_MSG_REGEX = re.compile(r"({}): ".format("|".join(GLAIVE_ROLES)))
+
+GLAIVE_MSG_REGEX = re.compile(rf"({'|'.join(GLAIVE_ROLES)}): ")
 
 
 def chatml_to_conversation(row: Dict[str, str]) -> List[Dict[str, str]]:

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -1,4 +1,5 @@
 """Module for testing prompt tokenizers."""
+
 import json
 import logging
 import unittest
@@ -18,6 +19,7 @@ from axolotl.prompt_strategies.llama2_chat import (
     Llama2ChatPrompter,
     LLama2ChatTokenizingStrategy,
 )
+from axolotl.prompt_strategies.sharegpt import GlaiveShareGPTPromptTokenizingStrategy
 from axolotl.prompt_tokenizers import (
     AlpacaPromptTokenizingStrategy,
     ShareGPTPromptTokenizingStrategy,
@@ -264,6 +266,23 @@ class TestPromptTokenizationStrategies(unittest.TestCase):
         with self._caplog.at_level(logging.WARNING):
             res = strat.tokenize_prompt(conversation)
             idx = res["input_ids"].index(20255)  # assistant token
+            assert res["labels"][idx] == -100
+
+    def test_glaive_tool_label_ignore(self):
+        conversation = {
+            "system": "SYSTEM: This is a system prompt",
+            "chat": "USER: Can you book a flight for me from New York to London? ASSISTANT: I'm sorry, but I don't have the capability to book flights.  <|endoftext|>",
+        }
+        prompter = ShareGPTPrompterV2()
+        strat = GlaiveShareGPTPromptTokenizingStrategy(
+            prompter,
+            self.tokenizer,
+            False,
+            2048,
+        )
+        with self._caplog.at_level(logging.WARNING):
+            res = strat.tokenize_prompt(conversation)
+            idx = res["input_ids"].index(13566)  # assistant token
             assert res["labels"][idx] == -100
 
     def test_no_sys_prompt(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds support for the Glaive function calling dataset. This dataset has 2 columns, `system` and `chat`; and an additional `tool` role in the conversation. This role contains the output from a tool call.

In this PR we add support for the Glaive dataset, which we convert to the ShareGPT format; tool calls are masked, and consecutive tool calls are merged to one message.

## How has this been tested?

I SFT trained a TinyLlama lora with the config below. 

```
base_model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
model_type: LlamaForCausalLM
tokenizer_type: LlamaTokenizer
is_llama_derived_model: true

load_in_8bit: true
load_in_4bit: false
strict: false

datasets:
  - path: glaiveai/glaive-function-calling-v2
    type: sharegpt.load_glaive
    conversation: chatml_glaive
```