### PR TITLE
Set `gradient_clipping` to `auto` in DeepSpeed configs

### DIFF
--- a/deepspeed_configs/zero1.json
+++ b/deepspeed_configs/zero1.json
@@ -16,6 +16,7 @@
     "min_loss_scale": 1
   },
   "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",
   "wall_clock_breakdown": false

--- a/deepspeed_configs/zero2.json
+++ b/deepspeed_configs/zero2.json
@@ -20,6 +20,7 @@
     "min_loss_scale": 1
   },
   "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",
   "wall_clock_breakdown": false

--- a/deepspeed_configs/zero3.json
+++ b/deepspeed_configs/zero3.json
@@ -24,6 +24,7 @@
     "min_loss_scale": 1
   },
   "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",
   "wall_clock_breakdown": false

--- a/deepspeed_configs/zero3_bf16.json
+++ b/deepspeed_configs/zero3_bf16.json
@@ -24,6 +24,7 @@
     "min_loss_scale": 1
   },
   "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",
   "wall_clock_breakdown": false


### PR DESCRIPTION
Without this setting, DeepSpeed would not use the `max_grad_norm` value set in the yaml file.
# Description
By adding this `"gradient_clipping": "auto",` to all the json config files.

## How has this been tested?
I tested 6 cases.

| json    |  yaml  |
| ------ | ------- |
| none   |   10 |
| none   |  0.3 |
| "auto" |  10 |
| "auto" |  0.3 |
|   10     |  0.3 |
|    0.3  |  0.3 |

The result was, if these values are different, DeepSpeed outputs an error. Setting "auto" resolved the error.
If DeepSpeed json files do not have `"gradient_clipping": "auto",`, setting some values in the yaml file did not make any differences.