### PR TITLE
Fix pydantic configuration for the max_memory input

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -511,7 +511,9 @@ class AxolotlInputConfig(
 
     neftune_noise_alpha: Optional[float] = None
 
-    max_memory: Optional[Dict[Union[int, Literal['cpu','disk']],Union[int, str]]] = None
+    max_memory: Optional[
+        Dict[Union[int, Literal["cpu", "disk"]], Union[int, str]]
+    ] = None
     gpu_memory_limit: Optional[Union[int, str]] = None
 
     chat_template: Optional[Union[Literal["chatml", "inst"], ChatTemplate]] = None

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -511,7 +511,7 @@ class AxolotlInputConfig(
 
     neftune_noise_alpha: Optional[float] = None
 
-    max_memory: Optional[Union[int, str]] = None
+    max_memory: Optional[Dict[Union[int, Literal['cpu','disk']],Union[int, str]]] = None
     gpu_memory_limit: Optional[Union[int, str]] = None
 
     chat_template: Optional[Union[Literal["chatml", "inst"], ChatTemplate]] = None


### PR DESCRIPTION
A change to the Pydantic configuration to support max_memory being a dictionary

# Description

Changes the pydantic verification to allow max_memory to be a dictionary, with both elements in the dictionary in each entry able to be either a string or an integer.

## Motivation and Context

Unable to set memory allowances for card independently following the pydantic implementation.

## How has this been tested?

Ran through several tests of most of hte options to ensure that dictionaries are now correctly accepted and non-dictionaries are not

## Types of changes

Loading configuration

## Social Handles (Optional)

Discord: david78901