### PR TITLE
Don't disable existing loggers when configuring axolotl logging

### DIFF
--- a/src/axolotl/logging_config.py
+++ b/src/axolotl/logging_config.py
@@ -30,6 +30,7 @@ class ColorfulFormatter(Formatter):
 
 DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
     "version": 1,
+    "disable_existing_loggers": False,
     "formatters": {
         "simple": {
             "format": "[%(asctime)s] [%(levelname)s] [%(name)s.%(funcName)s:%(lineno)d] [PID:%(process)d] %(message)s",


### PR DESCRIPTION
`logging.dictConfig` by default disables any existing loggers configured before that point. I am trying to use axolotl as a library and do some of my things around it. As such I have some third-party loggers that I would not like to get disabled.

