### PR TITLE
Update ChatTemplate enum to include alpaca and gemma

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -128,6 +128,7 @@ class RLType(str, Enum):
 
 class ChatTemplate(str, Enum):
     """Chat templates configuration subset"""
+
     alpaca = "alpaca"  # pylint: disable=invalid-name
     chatml = "chatml"  # pylint: disable=invalid-name
     inst = "inst"  # pylint: disable=invalid-name

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -128,9 +128,10 @@ class RLType(str, Enum):
 
 class ChatTemplate(str, Enum):
     """Chat templates configuration subset"""
-
+    alpaca = "alpaca"  # pylint: disable=invalid-name
     chatml = "chatml"  # pylint: disable=invalid-name
     inst = "inst"  # pylint: disable=invalid-name
+    gemma = "gemma"  # pylint: disable=invalid-name
 
 
 class LoftQConfig(BaseModel):
@@ -518,7 +519,7 @@ class AxolotlInputConfig(
     ] = None
     gpu_memory_limit: Optional[Union[int, str]] = None
 
-    chat_template: Optional[Union[Literal["chatml", "inst"], ChatTemplate]] = None
+    chat_template: Optional[ChatTemplate] = None
     default_system_message: Optional[str] = None
 
     # INTERNALS - document for now, generally not set externally


### PR DESCRIPTION
Was going through internals and trying gemma format but pydantic validation wouldn't let it pass
Not sure if we want to expose `alpaca`