### PR TITLE
fix(config): passing gradient_checkpoint_kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ group_by_length: false
 gradient_checkpointing: false
 # additional kwargs to pass to the trainer for gradient checkpointing
 # gradient_checkpointing_kwargs:
-#   use_reentrant: false
+#   use_reentrant: true
 
 # Stop training after this many evaluation losses have increased in a row
 # https://huggingface.co/transformers/v4.2.2/_modules/transformers/trainer_callback.html#EarlyStoppingCallback

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -837,10 +837,6 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 training_arguments_kwargs[
                     "gradient_checkpointing_kwargs"
                 ] = self.cfg.gradient_checkpointing_kwargs
-            else:
-                training_arguments_kwargs["gradient_checkpointing_kwargs"] = {
-                    "use_reentrant": False
-                }
         if self.cfg.fsdp:
             training_arguments_kwargs["fsdp"] = self.cfg.fsdp
             if self.cfg.fsdp_config:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -888,7 +888,7 @@ def load_model(
 
     if cfg.adapter in ["lora", "qlora"]:
         if cfg.gradient_checkpointing:
-            model.gradient_checkpointing_enable()
+            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=cfg.gradient_checkpointing_kwargs)
         if (
             cfg.load_in_8bit or cfg.load_in_4bit
         ) and not skip_prepare_model_for_kbit_training:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -888,7 +888,9 @@ def load_model(
 
     if cfg.adapter in ["lora", "qlora"]:
         if cfg.gradient_checkpointing:
-            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=cfg.gradient_checkpointing_kwargs)
+            model.gradient_checkpointing_enable(
+                gradient_checkpointing_kwargs=cfg.gradient_checkpointing_kwargs
+            )
         if (
             cfg.load_in_8bit or cfg.load_in_4bit
         ) and not skip_prepare_model_for_kbit_training:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

According to https://github.com/huggingface/transformers/issues/28339 , setting it to `False` increases VRAM. My quick testing shows ~1GB increase at lowest settings.

Furthermore, the default in transformers and torch is going to be `True` https://github.com/huggingface/transformers/issues/29638#issuecomment-1995034098

Finally, removing the default to False in trainer_building to clean old configs. I see that this kwarg is now set in https://github.com/OpenAccess-AI-Collective/axolotl/blob/a914cb37dc455a3fd0368e3a0898867f25b3a6c9/src/axolotl/utils/config/__init__.py#L170-L176

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
