### PR TITLE
Turn on sample_packing for Gemma training

### DIFF
--- a/examples/gemma/qlora.yml
+++ b/examples/gemma/qlora.yml
@@ -21,7 +21,8 @@ lora_dropout: 0.05
 lora_target_linear: true
 
 sequence_len: 4096
-sample_packing: false
+sample_packing: true
+eval_sample_packing: false
 pad_to_sequence_len: true
 
 wandb_project:


### PR DESCRIPTION
In last commit, sample_packing was entirely turned off #1405 
However, only `eval_sample_packing` must be kept false here.