### PR TITLE
Remove seq_len arg in rotary_emb

### DIFF
--- a/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
@@ -284,9 +284,7 @@ def flashattn_forward_with_s2attn(
     # [bsz, nh, q_len, hd]
     # pylint: disable=duplicate-code
 
-    cos, sin = self.rotary_emb(
-        value_states, position_ids=position_ids
-    )
+    cos, sin = self.rotary_emb(value_states, position_ids=position_ids)
     query_states, key_states = apply_rotary_pos_emb(
         query_states, key_states, cos, sin, position_ids
     )
@@ -432,9 +430,7 @@ def flashattn_forward(
     # [bsz, q_len, nh, hd]
     # [bsz, nh, q_len, hd]
 
-    cos, sin = self.rotary_emb(
-        value_states, position_ids=position_ids
-    )
+    cos, sin = self.rotary_emb(value_states, position_ids=position_ids)
     query_states, key_states = apply_rotary_pos_emb(
         query_states, key_states, cos, sin, position_ids
     )

--- a/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
@@ -284,11 +284,8 @@ def flashattn_forward_with_s2attn(
     # [bsz, nh, q_len, hd]
     # pylint: disable=duplicate-code
 
-    kv_seq_len = key_states.shape[-2]
-    if past_key_value is not None:
-        kv_seq_len += past_key_value[0].shape[-2]
     cos, sin = self.rotary_emb(
-        value_states, seq_len=kv_seq_len, position_ids=position_ids
+        value_states, position_ids=position_ids
     )
     query_states, key_states = apply_rotary_pos_emb(
         query_states, key_states, cos, sin, position_ids
@@ -435,12 +432,8 @@ def flashattn_forward(
     # [bsz, q_len, nh, hd]
     # [bsz, nh, q_len, hd]
 
-    kv_seq_len = key_states.shape[-2]
-    if past_key_value is not None:
-        kv_seq_len += past_key_value[0].shape[-2]
-
     cos, sin = self.rotary_emb(
-        value_states, seq_len=kv_seq_len, position_ids=position_ids
+        value_states, position_ids=position_ids
     )
     query_states, key_states = apply_rotary_pos_emb(
         query_states, key_states, cos, sin, position_ids

--- a/src/axolotl/monkeypatch/llama_attn_hijack_xformers.py
+++ b/src/axolotl/monkeypatch/llama_attn_hijack_xformers.py
@@ -80,11 +80,7 @@ def xformers_forward(
     # [bsz, q_len, nh, hd]
     # [bsz, nh, q_len, hd]
 
-    kv_seq_len = key_states.shape[-2]
-    if past_key_value is not None:
-        kv_seq_len += past_key_value[0].shape[-2]
-
-    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    cos, sin = self.rotary_emb(value_states)
     query_states, key_states = apply_rotary_pos_emb(
         query_states, key_states, cos, sin, position_ids
     )


### PR DESCRIPTION
Remove `seq_len` argument in `self.rotary_emb()` in the flash-attn and xformers patches. Solves #1423.

# Description

Issue #1423 mentioned that the error `TypeError: LlamaRotaryEmbedding.forward() got an unexpected keyword argument 'seq_len'` occurs when training Llama with flash-attention. I found that it only happens when the version of transformers is greater than 4.38. This error occurs because in transformers version 4.39, the `seq_len` argument in the `LlamaRotaryEmbedding.forward()` function was deprecated. You can see the change at https://github.com/huggingface/transformers/commit/ffe60fdcd60c17c3f216694160c2521da90f984c#diff-06392bad3b9e97be9ade60d4ac46f73b6809388f4d507c2ba1384ab872711c51.

In the file `axolotl/src/axolotl/monkeypatch/llama_attn_hijack_flash.py`, line 290 calls `LlamaRotaryEmbedding.forward()` with the argument `seq_len=kv_seq_len`, which is no longer supported in the updated version of transformers.

## Motivation and Context

This change solves issue #1423, allowing flash-attn to be enabled when training with Llama.

## How has this been tested?

The changes are small. I re-ran my training script after removing the `seq_len` related arguments and observed the same behavior as when downgrading transformers to version 4.38.