### PR TITLE
configure nightly docker builds

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,10 +1,9 @@
-name: ci-cd
+name: docker-nightlies
 
 on:
-  push:
-    branches:
-      - "main"
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
 
 jobs:
   build-axolotl:
@@ -59,8 +58,7 @@ jobs:
           file: ./docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ steps.metadata.outputs.tags }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }}
-            ${{ (matrix.is_latest) && format('{0}-latest', steps.metadata.outputs.tags) || '' }}
+            ${{ steps.metadata.outputs.tags }}-${{ format('{0:yyyyMMdd}', github.event.repository.pushed_at) }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }}
           labels: ${{ steps.metadata.outputs.labels }}
 
   build-axolotl-cloud:
@@ -112,6 +110,5 @@ jobs:
           file: ./docker/Dockerfile-cloud
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-             ${{ steps.metadata.outputs.tags }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }}
-             ${{ (matrix.is_latest) && format('{0}-latest', steps.metadata.outputs.tags) || '' }}
+             ${{ steps.metadata.outputs.tags }}-${{ format('{0:yyyyMMdd}', github.event.repository.pushed_at) }}-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}${{ matrix.axolotl_extras != '' && '-' || '' }}${{ matrix.axolotl_extras }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,11 @@ jobs:
             python_version: "3.10"
             pytorch: 2.1.2
             num_gpus: 1
+          - cuda: 121
+            cuda_version: 12.1.0
+            python_version: "3.11"
+            pytorch: 2.2.1
+            num_gpus: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

This updates the bleeding edge docker image to use PyTorch 2.2.1. 

We also now build nightlies for the docker images tagged with the date.