### PR TITLE
DBRX Model Support

### DIFF
--- a/deepspeed_configs/zero3_bf16_cpuoffload_all.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_all.json
@@ -1,4 +1,6 @@
 {
+  "zero_force_ds_cpu_optimizer": false,
+  "zero_allow_untested_optimizer": true,
   "zero_optimization": {
     "stage": 3,
     "offload_optimizer": {

--- a/deepspeed_configs/zero3_bf16_cpuoffload_params.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_params.json
@@ -1,4 +1,6 @@
 {
+  "zero_force_ds_cpu_optimizer": false,
+  "zero_allow_untested_optimizer": true,
   "zero_optimization": {
     "stage": 3,
     "offload_param": {

--- a/examples/dbrx/16bit-lora.yaml
+++ b/examples/dbrx/16bit-lora.yaml
@@ -1,31 +1,20 @@
-base_model: NousResearch/Llama-2-7b-hf
-model_type: LlamaForCausalLM
-tokenizer_type: LlamaTokenizer
+base_model: LnL-AI/dbrx-base-converted
+trust_remote_code: true
 
 load_in_8bit: false
-load_in_4bit: true
+load_in_4bit: false
 strict: false
 
 datasets:
-  - path: yahma/alpaca-cleaned
+  - path: tatsu-lab/alpaca
     type: alpaca
 dataset_prepared_path: last_run_prepared
-val_set_size: 0.05
-output_dir: ./qlora-out
-
-adapter: qlora
-lora_model_dir:
+val_set_size: 0.0
+output_dir: ./out
 
 sequence_len: 512
 sample_packing: false
-pad_to_sequence_len: true
-
-lora_r: 32
-lora_alpha: 16
-lora_dropout: 0.05
-lora_target_modules:
-lora_target_linear: true
-lora_fan_in_fan_out:
+pad_to_sequence_len: false
 
 wandb_project:
 wandb_entity:
@@ -33,12 +22,26 @@ wandb_watch:
 wandb_name:
 wandb_log_model:
 
-gradient_accumulation_steps: 4
-micro_batch_size: 4
-num_epochs: 4
-optimizer: adamw_torch
+adapter: lora
+lora_model_dir:
+lora_r: 8
+lora_alpha: 16
+lora_dropout: 0.05
+# w1, w2, & v1 will hang the trainer
+lora_target_modules:
+  - Wqkv # attn
+  - out_proj # attn
+  - layer # router
+#  - w1
+#  - w2
+#  - v1
+
+gradient_accumulation_steps: 1
+micro_batch_size: 1
+num_epochs: 1
+optimizer: paged_adamw_8bit
 lr_scheduler: cosine
-learning_rate: 0.00001
+learning_rate: 0.0002
 
 train_on_inputs: false
 group_by_length: false
@@ -48,7 +51,7 @@ tf32: false
 
 gradient_checkpointing: true
 gradient_checkpointing_kwargs:
-  use_reentrant: true
+  use_reentrant: false
 early_stopping_patience:
 resume_from_checkpoint:
 local_rank:
@@ -57,11 +60,9 @@ xformers_attention:
 flash_attention: true
 
 warmup_steps: 10
-evals_per_epoch: 4
-eval_table_size:
+evals_per_epoch:
 saves_per_epoch: 1
 debug:
-deepspeed:
 weight_decay: 0.0
 fsdp:
   - full_shard
@@ -69,10 +70,9 @@ fsdp:
 fsdp_config:
   fsdp_limit_all_gathers: true
   fsdp_sync_module_states: true
-  fsdp_offload_params: true
+  fsdp_offload_params: false
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: true
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
-  fsdp_transformer_layer_cls_to_wrap: LlamaDecoderLayer
+  fsdp_transformer_layer_cls_to_wrap: DbrxBlock
   fsdp_state_dict_type: SHARDED_STATE_DICT
-special_tokens:

--- a/examples/dbrx/16bit-lora.yaml
+++ b/examples/dbrx/16bit-lora.yaml
@@ -1,4 +1,4 @@
-base_model: LnL-AI/dbrx-base-converted
+base_model: LnL-AI/dbrx-base-converted-v2
 trust_remote_code: true
 
 load_in_8bit: false
@@ -29,7 +29,9 @@ lora_alpha: 16
 lora_dropout: 0.05
 # w1, w2, & v1 will hang the trainer
 lora_target_modules:
-  - Wqkv # attn
+  - q_proj # attn
+  - k_proj # attn
+  - v_proj # attn
   - out_proj # attn
   - layer # router
 #  - w1

--- a/examples/dbrx/16bit-lora.yaml
+++ b/examples/dbrx/16bit-lora.yaml
@@ -77,5 +77,5 @@ fsdp_config:
   fsdp_cpu_ram_efficient_loading: true
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_transformer_layer_cls_to_wrap: DbrxBlock
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_activation_checkpointing: true

--- a/examples/dbrx/8bit-lora.yaml
+++ b/examples/dbrx/8bit-lora.yaml
@@ -1,7 +1,7 @@
 base_model: LnL-AI/dbrx-base-converted-v2
 trust_remote_code: true
 
-load_in_8bit: false
+load_in_8bit: true
 load_in_4bit: false
 strict: false
 

--- a/examples/dbrx/8bit-lora.yaml
+++ b/examples/dbrx/8bit-lora.yaml
@@ -77,5 +77,5 @@ fsdp_config:
   fsdp_cpu_ram_efficient_loading: true
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_transformer_layer_cls_to_wrap: DbrxBlock
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_activation_checkpointing: true

--- a/examples/dbrx/README.md
+++ b/examples/dbrx/README.md
@@ -16,7 +16,7 @@ The high memory usage seen w/ FSDP is due to FSDP not supporting 8bit optimizers
 - 16-bit LoRA w/ FSDP
   - ✅ w/o CPU Offload - 8x80GB uses ~80GiB/gpu
   - ❌ w/ CPU Offload - `paged_adamw_8bit` optimizer errors from being on cpu
-- ❓ 8-bit LoRA w/ FSDP - WIP, need to handle loading 8-bit quantized weights
+- ✅ 8-bit LoRA w/ FSDP
 - ❌ 4-bit QLoRA w/ FSDP - errors w/: `Error an illegal memory access was encountered at line 90 in file /src/csrc/ops.cu`
 - ✅ bf16 full finetune w/ FSDP, freezing all but first 8 layers (8x80GB uses ~78GiB/gpu)
 

--- a/examples/dbrx/README.md
+++ b/examples/dbrx/README.md
@@ -1,18 +1,25 @@
 # DBRX MoE
 
-Currently, for LoRA, only the `Wqkv`, `out_proj` and `layer` Linear layers are trainable.
+Currently, for LoRA, only the `q_proj`, `k_proj`, `v_proj` `out_proj` and `layer` Linear layers are trainable.
 
 We are using the "converted" base models based on [this issue](https://huggingface.co/databricks/dbrx-instruct/discussions/10)
 where the Experts are fused as an `nn.Parameter` rather than a `nn.Linear` layer. However, the implementation
 is still a bit buggy and attempting to train a LoRA adapter over those `w1`, `w2` and `v1` layers
 results in the trainer hanging.
 
-We recommend using the [`LnL-AI/dbrx-base-converted`](https://huggingface.co/LnL-AI/dbrx-base-converted) model as your base model for the time being.
+We recommend using the [`LnL-AI/dbrx-base-converted-v2`](https://huggingface.co/LnL-AI/dbrx-base-converted-v2) model as your base model for the time being.
 
+### FSDP
+The high memory usage seen w/ FSDP is due to FSDP not supporting 8bit optimizers.
 
 - 16-bit LoRA w/ FSDP
-  - ✅ w/o CPU Offload - 8x80GB uses ~62GiB/gpu
+  - ✅ w/o CPU Offload - 8x80GB uses ~80GiB/gpu
   - ❌ w/ CPU Offload - `paged_adamw_8bit` optimizer errors from being on cpu
 - ❓ 8-bit LoRA w/ FSDP - WIP, need to handle loading 8-bit quantized weights
 - ❌ 4-bit QLoRA w/ FSDP - errors w/: `Error an illegal memory access was encountered at line 90 in file /src/csrc/ops.cu`
 - ✅ bf16 full finetune w/ FSDP, freezing all but first 8 layers (8x80GB uses ~78GiB/gpu)
+
+
+### Deepspeed
+
+WIP

--- a/examples/dbrx/README.md
+++ b/examples/dbrx/README.md
@@ -1,0 +1,18 @@
+# DBRX MoE
+
+Currently, for LoRA, only the `Wqkv`, `out_proj` and `layer` Linear layers are trainable.
+
+We are using the "converted" base models based on [this issue](https://huggingface.co/databricks/dbrx-instruct/discussions/10)
+where the Experts are fused as an `nn.Parameter` rather than a `nn.Linear` layer. However, the implementation
+is still a bit buggy and attempting to train a LoRA adapter over those `w1`, `w2` and `v1` layers
+results in the trainer hanging.
+
+We recommend using the [`LnL-AI/dbrx-base-converted`](https://huggingface.co/LnL-AI/dbrx-base-converted) model as your base model for the time being.
+
+
+- 16-bit LoRA w/ FSDP
+  - ✅ w/o CPU Offload - 8x80GB uses ~62GiB/gpu
+  - ❌ w/ CPU Offload - `paged_adamw_8bit` optimizer errors from being on cpu
+- ❓ 8-bit LoRA w/ FSDP - WIP, need to handle loading 8-bit quantized weights
+- ❌ 4-bit QLoRA w/ FSDP - errors w/: `Error an illegal memory access was encountered at line 90 in file /src/csrc/ops.cu`
+- ✅ bf16 full finetune w/ FSDP, freezing all but first 8 layers (8x80GB uses ~78GiB/gpu)

--- a/examples/dbrx/README.md
+++ b/examples/dbrx/README.md
@@ -7,9 +7,10 @@ where the Experts are fused as an `nn.Parameter` rather than a `nn.Linear` layer
 is still a bit buggy and attempting to train a LoRA adapter over those `w1`, `w2` and `v1` layers
 results in the trainer hanging.
 
-We recommend using the [`LnL-AI/dbrx-base-converted-v2`](https://huggingface.co/LnL-AI/dbrx-base-converted-v2) model as your base model for the time being.
 
 ### FSDP
+We've tested using the [`LnL-AI/dbrx-base-converted-v2`](https://huggingface.co/LnL-AI/dbrx-base-converted-v2) model as the base model for FSDP.
+
 The high memory usage seen w/ FSDP is due to FSDP not supporting 8bit optimizers.
 
 - 16-bit LoRA w/ FSDP

--- a/examples/dbrx/fft-ds-zero3.yaml
+++ b/examples/dbrx/fft-ds-zero3.yaml
@@ -1,0 +1,56 @@
+base_model: LnL-AI/dbrx-base-converted-v2
+trust_remote_code: true
+
+load_in_8bit: false
+load_in_4bit: false
+strict: false
+
+datasets:
+  - path: tatsu-lab/alpaca
+    type: alpaca
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.0
+output_dir: ./out
+
+sequence_len: 512
+sample_packing: false
+pad_to_sequence_len: false
+
+unfrozen_parameters:
+  - transformer.blocks.[0-7].
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 1
+micro_batch_size: 1
+num_epochs: 1
+optimizer: paged_adamw_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+train_on_inputs: false
+group_by_length: false
+bf16: auto
+fp16:
+tf32: false
+
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+early_stopping_patience:
+resume_from_checkpoint:
+local_rank:
+logging_steps: 1
+xformers_attention:
+flash_attention: true
+
+warmup_steps: 10
+evals_per_epoch:
+saves_per_epoch: 1
+debug:
+weight_decay: 0.0
+deepspeed: deepspeed_configs/zero3_bf16.json

--- a/examples/llama-2/qlora-fsdp.yml
+++ b/examples/llama-2/qlora-fsdp.yml
@@ -74,5 +74,5 @@ fsdp_config:
   fsdp_cpu_ram_efficient_loading: true
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_transformer_layer_cls_to_wrap: LlamaDecoderLayer
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
 special_tokens:

--- a/examples/mistral/bigstral-ds-zero3.yaml
+++ b/examples/mistral/bigstral-ds-zero3.yaml
@@ -1,0 +1,63 @@
+base_model: mistral-community/Mixtral-8x22B-v0.1
+model_type: AutoModelForCausalLM
+tokenizer_type: LlamaTokenizer
+trust_remote_code: true
+
+load_in_8bit: false
+load_in_4bit: false
+strict: false
+
+unfrozen_parameters:
+  - ^lm_head.weight$
+  - ^model.embed_tokens.weight$
+  - model.layers.4[4-9]+.block_sparse_moe.gate
+  - model.layers.4[4-9]+.block_sparse_moe.experts
+  - model.layers.5[0-5]+.block_sparse_moe.gate
+  - model.layers.5[0-5]+.block_sparse_moe.experts
+
+model_config:
+  output_router_logits: true
+
+datasets:
+  - path: tatsu-lab/alpaca
+    type: alpaca
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.05
+output_dir: ./out
+
+sequence_len: 2048
+sample_packing: true
+pad_to_sequence_len: true
+
+gradient_accumulation_steps: 1
+micro_batch_size: 1
+num_epochs: 3
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 0.0001
+
+train_on_inputs: false
+group_by_length: false
+bf16: auto
+fp16:
+tf32: false
+
+gradient_checkpointing: true
+early_stopping_patience:
+resume_from_checkpoint:
+local_rank:
+logging_steps: 1
+xformers_attention:
+flash_attention: true
+
+save_total_limit: 1
+save_steps:
+debug:
+deepspeed: deepspeed_configs/zero3_bf16_cpuoffload_params.json
+weight_decay: 0.0
+fsdp:
+fsdp_config:
+special_tokens:
+  eos_token: "<|im_end|>"
+tokens:
+  - "<|im_start|>"

--- a/examples/mistral/mistral-qlora-fsdp.yml
+++ b/examples/mistral/mistral-qlora-fsdp.yml
@@ -77,6 +77,6 @@ fsdp_config:
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: false
   fsdp_transformer_layer_cls_to_wrap: MistralDecoderLayer
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
 special_tokens:

--- a/examples/mistral/mistral-qlora-fsdp.yml
+++ b/examples/mistral/mistral-qlora-fsdp.yml
@@ -75,8 +75,8 @@ fsdp_config:
   fsdp_sync_module_states: true
   fsdp_offload_params: false
   fsdp_use_orig_params: false
-  fsdp_cpu_ram_efficient_loading: true
-  fsdp_transformer_layer_cls_to_wrap: MixtralSparseMoeBlock
+  fsdp_cpu_ram_efficient_loading: false
+  fsdp_transformer_layer_cls_to_wrap: MistralDecoderLayer
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
 special_tokens:

--- a/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
+++ b/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
@@ -1,7 +1,6 @@
-base_model: mistralai/Mixtral-8x7B-v0.1
+base_model: mistral-community/Mixtral-8x22B-v0.1
 model_type: AutoModelForCausalLM
 tokenizer_type: LlamaTokenizer
-trust_remote_code: true
 
 load_in_8bit: false
 load_in_4bit: true

--- a/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
+++ b/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
@@ -76,6 +76,6 @@ fsdp_config:
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: true
   fsdp_transformer_layer_cls_to_wrap: MixtralSparseMoeBlock
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
 special_tokens:

--- a/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
+++ b/examples/mistral/mixtral-8x22b-qlora-fsdp.yml
@@ -38,7 +38,7 @@ wandb_log_model:
 gradient_accumulation_steps: 4
 micro_batch_size: 2
 num_epochs: 1
-optimizer: paged_adamw_8bit
+optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0002
 
@@ -72,7 +72,7 @@ fsdp:
 fsdp_config:
   fsdp_limit_all_gathers: true
   fsdp_sync_module_states: true
-  fsdp_offload_params: false
+  fsdp_offload_params: true
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: true
   fsdp_transformer_layer_cls_to_wrap: MixtralSparseMoeBlock

--- a/examples/mistral/mixtral-qlora-fsdp.yml
+++ b/examples/mistral/mixtral-qlora-fsdp.yml
@@ -39,7 +39,7 @@ wandb_log_model:
 gradient_accumulation_steps: 4
 micro_batch_size: 2
 num_epochs: 1
-optimizer: paged_adamw_8bit
+optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0002
 
@@ -73,10 +73,13 @@ fsdp:
 fsdp_config:
   fsdp_limit_all_gathers: true
   fsdp_sync_module_states: true
-  fsdp_offload_params: false
+  fsdp_offload_params: true
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: true
   fsdp_transformer_layer_cls_to_wrap: MixtralSparseMoeBlock
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_sharding_strategy: FULL_SHARD
+  fsdp_forward_prefetch: false
+  fsdp_backward_prefetch: BACKWARD_PRE
 special_tokens:

--- a/examples/mistral/mixtral-qlora-fsdp.yml
+++ b/examples/mistral/mixtral-qlora-fsdp.yml
@@ -77,7 +77,7 @@ fsdp_config:
   fsdp_use_orig_params: false
   fsdp_cpu_ram_efficient_loading: true
   fsdp_transformer_layer_cls_to_wrap: MixtralSparseMoeBlock
-  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_state_dict_type: FULL_STATE_DICT
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_sharding_strategy: FULL_SHARD
   fsdp_forward_prefetch: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ gcsfs
 
 trl @ git+https://github.com/huggingface/trl.git@0ee349dcd43b0f4b3169449f16751c38ac4a609f
 zstandard==0.22.0
+fastcore

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -918,10 +918,6 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         ):
             callbacks.append(SaveBetterTransformerModelCallback())
 
-        if self.cfg.use_wandb:
-            callbacks.append(
-                SaveAxolotlConfigtoWandBCallback(self.cfg.axolotl_config_path)
-            )
         if self.cfg.use_mlflow and is_mlflow_available():
             from axolotl.utils.callbacks.mlflow_ import (
                 SaveAxolotlConfigtoMlflowCallback,

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 import transformers.modelcard
+from accelerate import Accelerator
 from accelerate.logging import get_logger
 from datasets import Dataset
 from peft import PeftModel
@@ -81,6 +82,8 @@ def train(
     if cfg.adapter:
         msg += " and peft_config..."
     LOG.debug(msg)
+    # we wait unitl the last possible moment to setup Accelerator
+    Accelerator()
     model, peft_config = load_model(cfg, tokenizer, inference=cli_args.inference)
     model.generation_config.do_sample = True
 

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -259,6 +259,7 @@ class ModelInputConfig(BaseModel):
 
     base_model: str
     base_model_config: Optional[str] = None
+    cls_model_config: Optional[str] = None
     tokenizer_config: Optional[str] = None
     tokenizer_use_fast: Optional[bool] = None
     tokenizer_legacy: Optional[bool] = None

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -972,9 +972,16 @@ class AxolotlInputConfig(
 
     @model_validator(mode="before")
     @classmethod
-    def check_fsdp_w_8bit_optimizer(cls, data):
-        if data.get("fsdp") and "bnb" in data.get("optimizer", ""):
-            raise ValueError(f"FSDP not compatible with {data.get('optimizer')}")
+    def check_fsdp_offload_w_8bit_optimizer(cls, data):
+        if (
+            data.get("fsdp")
+            and "8bit" in data.get("optimizer", "")
+            and data.get("fsdp_config")
+            and data["fsdp_config"].get("fsdp_offload_params")
+        ):
+            raise ValueError(
+                f"FSDP Offload not compatible with {data.get('optimizer')}"
+            )
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/distributed.py
+++ b/src/axolotl/utils/distributed.py
@@ -4,27 +4,25 @@ utility helpers for distributed checks
 import os
 import pickle  # nosec
 from contextlib import contextmanager
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
-from accelerate import Accelerator
+from accelerate import PartialState
 
-accelerate = None  # pylint: disable=invalid-name
-
-
-def load_accelerate():
-    global accelerate  # pylint: disable=global-statement
-    accelerate = Accelerator()
+distributed_state = None  # pylint: disable=invalid-name
 
 
 def is_distributed():
     """
     Check if distributed training is initialized.
     """
-    global accelerate  # pylint: disable=global-statement
-    if not accelerate:
-        accelerate = Accelerator()
-    return dist.is_available() and dist.is_initialized()
+    global distributed_state  # pylint: disable=global-statement
+    if not distributed_state:
+        timeout = int(os.environ.get("AXOLOTL_NCCL_TIMEOUT", 1800))
+        distributed_state = PartialState(timeout=timedelta(seconds=timeout))
+
+    return distributed_state.use_distributed and distributed_state.initialized
 
 
 def barrier():

--- a/src/axolotl/utils/model_shard_quant.py
+++ b/src/axolotl/utils/model_shard_quant.py
@@ -1,0 +1,261 @@
+"""
+module to handle loading model on cpu/meta device for FSDP
+"""
+import os
+import time
+from typing import List, Optional, Type, Union
+
+import safetensors
+import torch
+from accelerate import init_empty_weights
+from bitsandbytes.nn import Linear4bit, Params4bit
+from fastcore.parallel import parallel
+from torch import Tensor, nn
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME, hub
+
+
+def _replace_linear(
+    model: nn.Module,
+    linear_replacement: Type[nn.Module],
+    quant_config: Union[dict, None] = None,
+    skip_modules=None,
+    **kwargs,
+):
+    """
+    Replace linear modules with a new Linear module.
+    Parameters:
+        model (`torch.nn.Module`):
+            Input model or `torch.nn.Module` as the function is run recursively.
+        linear_replacement (`torch.nn.Module`):
+            The linear module that replaces the old one. Only expects standard arguments.
+            If other arguments need to be passed, use a lambda.
+        skip_modules (`List[str]`, *optional*, defaults to `lm_head`):
+            List of modules names not to convert. Defaults to `lm_head`.
+    """
+    if skip_modules is None:
+        skip_modules = ["lm_head"]
+    for name, module in model.named_children():
+        if len(list(module.children())) > 0:
+            _replace_linear(
+                module, linear_replacement, quant_config, skip_modules, **kwargs
+            )
+
+        if isinstance(module, torch.nn.Linear) and name not in skip_modules:
+            if issubclass(linear_replacement, Linear4bit):
+                model._modules[  # pylint: disable=protected-access
+                    name
+                ] = linear_replacement(
+                    module.in_features,
+                    module.out_features,
+                    module.bias is not None,
+                    **kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported linear replacement: {type(linear_replacement)}"
+                )
+    return model
+
+
+def load_and_quantize(
+    module: nn.Module,
+    name: str,
+    value: Tensor,
+    device: torch.device = None,
+    dtype: torch.dtype = None,
+    skip_names: Optional[List[str]] = None,
+    to_cpu: bool = False,
+    to_meta: bool = False,
+    verbose: bool = False,
+    quant_method: str = "bnb",
+):
+    """
+    Loads `value` tensor into submodule of `module`, optionally skipping `skip_names` and converting to `dtype`.
+
+    Quantizes `Params4bit` on `device` then places on "cpu" if to_cpu=True or "meta" if to_meta=True.
+    """
+
+    if not skip_names:
+        skip_names = []
+
+    def place_on_device(value):
+        if to_meta:
+            device = "meta"
+        elif to_cpu:
+            device = "cpu"
+        return value.to(device=device, dtype=dtype)
+
+    if any(skip_name in name for skip_name in skip_names):
+        if verbose:
+            print(f"Skipping {name} because it is in skip_names")
+        return
+
+    module_key, _, value_key = name.rpartition(".")
+    try:
+        submodule = module.get_submodule(module_key)
+    except AttributeError as exc:
+        print(f"Module {module_key} not found:\n{exc}")
+        return
+
+    try:
+        if quant_method == "bnb":
+            param = submodule.get_parameter(value_key)
+            if isinstance(param, Params4bit):
+                # With `sync_module_states=True`, a meta device Params4bit needs to be the same
+                # shape as the quantized Params4bit with an initialized quant_state. However,
+                # FSDP only syncs parameters and buffers, so the quant_state isn't copied. This
+                # workaround quantizes Params4bit to initialize quant_state on all ranks, then
+                # replaces Params4bit's data with a meta tensor to free memory on non-rank 0.
+                value = type(param)(
+                    value.to(device=device, dtype=dtype).data, **param.__dict__
+                ).cuda(device)
+                if to_meta:
+                    value = type(param)(value.data.to("meta"), **value.__dict__)
+                elif to_cpu:
+                    value = type(param)(value.data.to("cpu"), **value.__dict__)
+            else:
+                value = type(param)(place_on_device(value).data)
+
+    except AttributeError:
+        # it's a buffer
+        value = place_on_device(value)
+
+    setattr(submodule, value_key, value)
+
+
+def n_loading_workers(quant_method: str, param_count: float):
+    devprops = torch.cuda.get_device_properties(torch.cuda.current_device())
+    left = int(os.cpu_count() / torch.cuda.device_count())
+    model_params_b = 70
+    right = int(
+        (4 if quant_method == "hqq" else 8)
+        * (devprops.total_memory / 1e9 / 40)
+        * (model_params_b / (param_count / 1e9))
+    )
+    return min(left, right)
+
+
+def load_sharded_model(
+    model_name,
+    model_config,
+    cfg,
+    torch_dtype=torch.bfloat16,
+    low_memory=True,
+):
+    if (low_memory and cfg.local_rank == 0) or not low_memory:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            use_cache=False,
+            torch_dtype=torch.float32,
+            _attn_implementation=model_config._attn_implementation,  # pylint: disable=protected-access
+            trust_remote_code=cfg.trust_remote_code,
+        )
+        dtype = torch.bfloat16 if cfg.bf16 else None
+        model.to(dtype=dtype, device="cpu" if low_memory else cfg.local_rank)
+    else:
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(
+                model_config,
+                torch_dtype=torch_dtype,
+                trust_remote_code=cfg.trust_remote_code,
+            )
+        if cfg.bf16:
+            model.to(torch.bfloat16)
+    return model
+
+
+def load_sharded_model_quant(
+    model_name,
+    model_config,
+    cfg,
+    compute_dtype=torch.bfloat16,
+    quant_storage=torch.float32,
+    low_memory=True,
+    verbose=False,
+    loading_workers=2,
+):
+    with init_empty_weights():
+        model = AutoModelForCausalLM.from_config(
+            model_config,
+            trust_remote_code=cfg.trust_remote_code,
+        )
+        if hasattr(model, "transformer"):
+            model.transformer = _replace_linear(
+                model.transformer,
+                Linear4bit,
+                compute_dtype=compute_dtype,
+                quant_type="nf4",
+                quant_storage=quant_storage,
+            )
+        else:
+            # this is the more common case with HF transformers
+            model.model = _replace_linear(
+                model.model,
+                Linear4bit,
+                compute_dtype=compute_dtype,
+                quant_type="nf4",
+                quant_storage=quant_storage,
+            )
+    model.is_loaded_in_4bit = True
+
+    # Grab the safetensors files that hold the weights
+    try:
+        idx = hub.cached_file(model_name, SAFE_WEIGHTS_INDEX_NAME)
+        files, _ = hub.get_checkpoint_shard_files(model_name, idx)
+    except OSError:
+        try:
+            # This means the model doesn't have a model.safetensors.index.json because it is not sharded
+            files = []
+            files.append(hub.cached_file(model_name, SAFE_WEIGHTS_NAME))
+        except OSError as exc:
+            # This means the model probably doesn't have a safetensors file
+            raise exc
+
+    # Load in the weights, using our custom load_and_quantize method which quantizes Params4bit on the fly
+    # and then places each layer on CPU or meta if using low_memory to minimize GPU memory usage
+    def load_and_quantize_parallel(name_param, model, **kwargs):
+        name, param = name_param
+        load_and_quantize(model, name, param, **kwargs)
+
+    quant_method = "bnb"
+    param_count = sum((p.numel() for n, p in model.named_parameters()))
+
+    n_workers = (
+        n_loading_workers(quant_method, param_count)
+        if loading_workers == -1
+        else loading_workers
+    )
+    if cfg.local_rank == 0 and verbose:
+        print(f"Using n_workers: {n_workers} for loading")
+
+    start = time.time()
+    for filename in tqdm(
+        files,
+        desc="Loading & Quantizing Model Shards",
+        disable=cfg.local_rank != 0,
+        position=0,
+    ):
+        weights = safetensors.torch.load_file(filename)
+        parallel(
+            load_and_quantize_parallel,
+            iter(weights.items()),
+            n_workers=n_workers,
+            threadpool=True,
+            model=model,
+            dtype=quant_storage,
+            device=cfg.local_rank,
+            skip_names=[],
+            to_cpu=(low_memory and cfg.local_rank == 0),
+            to_meta=(low_memory and cfg.local_rank != 0),
+            verbose=verbose,
+            quant_method=quant_method,
+        )
+
+    if cfg.local_rank == 0 and verbose:
+        print(f"Loaded model weights in {time.time()-start:.3f} seconds")
+    # cleanup any extra memory usage from parallel loading
+    torch.cuda.empty_cache()
+
+    return model

--- a/src/axolotl/utils/model_shard_quant.py
+++ b/src/axolotl/utils/model_shard_quant.py
@@ -152,7 +152,7 @@ def load_sharded_model(
             _attn_implementation=model_config._attn_implementation,  # pylint: disable=protected-access
             trust_remote_code=cfg.trust_remote_code,
         )
-        dtype = torch.bfloat16 if cfg.bf16 else None
+        dtype = torch_dtype if not cfg.float32 else None
         model.to(dtype=dtype, device="cpu" if low_memory else cfg.local_rank)
     else:
         with init_empty_weights():
@@ -161,8 +161,6 @@ def load_sharded_model(
                 torch_dtype=torch_dtype,
                 trust_remote_code=cfg.trust_remote_code,
             )
-        if cfg.bf16:
-            model.to(torch.bfloat16)
     return model
 
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -528,6 +528,7 @@ def load_model(
                 base_model,
                 model_config,
                 cfg,
+                torch_dtype=cfg.torch_dtype,
             )
             skip_move_to_device = True
         elif qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -71,7 +71,7 @@ def get_module_class_from_name(module, name):
         if module_class is not None:
             return module_class
 
-    raise ValueError(f"module class {name} not found in {module.__class__.__name__}")
+    return None
 
 
 def check_model_config(cfg: DictDefault, model_config: Union[AutoConfig, DictDefault]):

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -561,10 +561,12 @@ def load_model(
             )
             skip_move_to_device = True
         elif qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:
+            quant_storage = cfg.torch_dtype
             model = load_sharded_model_quant(
                 base_model,
                 model_config,
                 cfg,
+                quant_storage=quant_storage,
             )
             skip_move_to_device = True
         elif (

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -653,14 +653,17 @@ def load_model(
                     **model_kwargs,
                 )
             else:
+                if qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:
+                    skip_move_to_device = True
+                    if "device_map" in model_kwargs:
+                        del model_kwargs["device_map"]
+
                 model = AutoModelForCausalLM.from_pretrained(
                     base_model,
                     config=model_config,
                     trust_remote_code=cfg.trust_remote_code or False,
                     **model_kwargs,
                 )
-                if qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:
-                    skip_move_to_device = True
     except Exception as err:  # pylint: disable=broad-exception-caught
         LOG.exception(err)
         raise err

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -484,7 +484,7 @@ def load_model(
             "bnb_4bit_quant_type": "nf4",
             "bnb_4bit_quant_storage": torch.bfloat16,
         }
-        if not cfg.deepspeed:
+        if cfg.model_config_type in ["jamba", "qwen2_moe"] and not cfg.deepspeed:
             # for some reason, this causes the loss to be off by an order of magnitude
             # but deepspeed needs this still in bfloat16
             bnb_config["bnb_4bit_quant_storage"] = torch.float32

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -560,7 +560,11 @@ def load_model(
                 torch_dtype=cfg.torch_dtype,
             )
             skip_move_to_device = True
-        elif qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:
+        elif (
+            qlora_fsdp
+            and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading
+            and cfg.model_config_type == "dbrx"
+        ):
             quant_storage = cfg.torch_dtype
             model = load_sharded_model_quant(
                 base_model,
@@ -655,6 +659,8 @@ def load_model(
                     trust_remote_code=cfg.trust_remote_code or False,
                     **model_kwargs,
                 )
+                if qlora_fsdp and cfg.fsdp_config.fsdp_cpu_ram_efficient_loading:
+                    skip_move_to_device = True
     except Exception as err:  # pylint: disable=broad-exception-caught
         LOG.exception(err)
         raise err

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -306,6 +306,8 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
 
 def setup_fsdp_envs(cfg):
     os.environ["ACCELERATE_USE_FSDP"] = "true"
+    if cfg.fsdp_config.fsdp_activation_checkpointing:
+        os.environ["FSDP_ACTIVATION_CHECKPOINTING"] = "true"
     if cfg.fsdp_config.fsdp_offload_params:
         os.environ["FSDP_OFFLOAD_PARAMS"] = "true"
     if cfg.fsdp_config.fsdp_sync_module_states:


### PR DESCRIPTION
# DBRX MoE

 Currently, for LoRA, only the `q_proj`, `k_proj`, `v_proj` `out_proj` and `layer` Linear layers are trainable.

 We are using the "converted" base models based on [this issue](https://huggingface.co/databricks/dbrx-instruct/discussions/10)
 where the Experts are fused as an `nn.Parameter` rather than a `nn.Linear` layer. However, the implementation
 is still a bit buggy and attempting to train a LoRA adapter over those `w1`, `w2` and `v1` layers
 results in the trainer hanging.


 ### FSDP
 We've tested using the [`LnL-AI/dbrx-base-converted-v2`](https://huggingface.co/LnL-AI/dbrx-base-converted-v2) model as the base model for FSDP.

 The high memory usage seen w/ FSDP is due to FSDP not supporting 8bit optimizers.

 - 16-bit LoRA w/ FSDP
   - ✅ w/o CPU Offload - 8x80GB uses ~80GiB/gpu
   - ❌ w/ CPU Offload - `paged_adamw_8bit` optimizer errors from being on cpu
 - ✅ 8-bit LoRA w/ FSDP
 - ❌ 4-bit QLoRA w/ FSDP - errors w/: `Error an illegal memory access was encountered at line 90 in file /src/csrc/ops.cu`
 - ✅ bf16 full finetune w/ FSDP, freezing all but first 8 layers (8x80GB uses ~78GiB/gpu)


 ### Deepspeed

 WIP