### PR TITLE
fix pretraining_ on odd datasets

### DIFF
--- a/src/axolotl/prompt_strategies/pretrain.py
+++ b/src/axolotl/prompt_strategies/pretrain.py
@@ -20,10 +20,11 @@ class PretrainTokenizationStrategy(PromptTokenizingStrategy):
     def supports_batched(self):
         return True
 
-    def __init__(self, *args, max_length=None, **kwargs):
+    def __init__(self, *args, max_length=None, text_column="text", **kwargs):
         super().__init__(*args, **kwargs)
         if max_length:
             self.max_length = max_length
+        self.text_column = text_column
 
     def _tokenize(
         self, prompt: str, add_eos_token: bool = True, strip_bos_token: bool = False
@@ -44,7 +45,7 @@ class PretrainTokenizationStrategy(PromptTokenizingStrategy):
         return res
 
     def tokenize_prompt(self, prompt):
-        return self._tokenize(prompt["text"])
+        return self._tokenize(prompt[self.text_column])
 
 
 def load(tokenizer, cfg):
@@ -53,6 +54,7 @@ def load(tokenizer, cfg):
         tokenizer,
         cfg.train_on_inputs,
         cfg.sequence_len,
+        text_column=cfg.pretraining_dataset[0].get("text_column", None),
         max_length=cfg.sequence_len * 64,
     )
     return strat

--- a/src/axolotl/prompt_strategies/pretrain.py
+++ b/src/axolotl/prompt_strategies/pretrain.py
@@ -54,7 +54,7 @@ def load(tokenizer, cfg):
         tokenizer,
         cfg.train_on_inputs,
         cfg.sequence_len,
-        text_column=cfg.pretraining_dataset[0].get("text_column", None),
+        text_column=cfg.pretraining_dataset[0]["text_column"] or "text",
         max_length=cfg.sequence_len * 64,
     )
     return strat

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -61,7 +61,7 @@ class RemappedParameters(BaseModel):
 class PretrainingDataset(BaseModel):
     """pretraining dataset configuration subset"""
 
-    config: Optional[str] = "default"
+    name: Optional[str] = None
     path: Optional[str] = None
     split: Optional[str] = "train"
     text_column: Optional[str] = "text"

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -64,6 +64,7 @@ class PretrainingDataset(BaseModel):
     path: Optional[str] = None
     split: Optional[str] = "train"
     text_column: Optional[str] = "text"
+    type: Optional[str] = "pretrain"
 
 
 class UserDefinedPrompterType(BaseModel):

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -61,6 +61,7 @@ class RemappedParameters(BaseModel):
 class PretrainingDataset(BaseModel):
     """pretraining dataset configuration subset"""
 
+    config: Optional[str] = "default"
     path: Optional[str] = None
     split: Optional[str] = "train"
     text_column: Optional[str] = "text"

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -62,6 +62,8 @@ class PretrainingDataset(BaseModel):
     """pretraining dataset configuration subset"""
 
     path: Optional[str] = None
+    split: Optional[str] = "train"
+    text_column: Optional[str] = "text"
 
 
 class UserDefinedPrompterType(BaseModel):
@@ -430,7 +432,7 @@ class AxolotlInputConfig(
     dataset_shard_idx: Optional[int] = None
 
     pretraining_dataset: Optional[  # type: ignore
-        conlist(Union[SFTDataset, PretrainingDataset], min_length=1)
+        conlist(Union[PretrainingDataset, SFTDataset], min_length=1)
     ] = Field(
         default=None, metadata={"help": {"streaming dataset to use for pretraining"}}
     )

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -82,6 +82,7 @@ def prepare_dataset(cfg, tokenizer):
                 )
     else:
         path = cfg.pretraining_dataset
+        config = "default"
         split = "train"
         name = None
         if isinstance(cfg.pretraining_dataset, list) and isinstance(
@@ -89,6 +90,8 @@ def prepare_dataset(cfg, tokenizer):
         ):
             path = cfg.pretraining_dataset[0]["path"]
             name = cfg.pretraining_dataset[0]["name"]
+            if "config" in cfg.pretraining_dataset[0]:
+              config = cfg.pretraining_dataset[0]["config"]
             if "split" in cfg.pretraining_dataset[0]:
               split = cfg.pretraining_dataset[0]["split"]
 
@@ -101,7 +104,7 @@ def prepare_dataset(cfg, tokenizer):
         )
 
         train_dataset = wrap_pretraining_dataset(
-            load_dataset(path, streaming=True, split=split, name=name),
+            load_dataset(path, config, streaming=True, split=split, name=name),
             tokenizer,
             cfg,
             ds_wrapper_partial,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -82,12 +82,15 @@ def prepare_dataset(cfg, tokenizer):
                 )
     else:
         path = cfg.pretraining_dataset
+        split = "train"
         name = None
         if isinstance(cfg.pretraining_dataset, list) and isinstance(
             cfg.pretraining_dataset[0], dict
         ):
             path = cfg.pretraining_dataset[0]["path"]
             name = cfg.pretraining_dataset[0]["name"]
+            if "split" in cfg.pretraining_dataset[0]:
+              split = cfg.pretraining_dataset[0]["split"]
 
         ds_wrapper_partial = functools.partial(
             get_dataset_wrapper,
@@ -98,7 +101,7 @@ def prepare_dataset(cfg, tokenizer):
         )
 
         train_dataset = wrap_pretraining_dataset(
-            load_dataset(path, streaming=True, split="train", name=name),
+            load_dataset(path, streaming=True, split=split, name=name),
             tokenizer,
             cfg,
             ds_wrapper_partial,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -82,7 +82,6 @@ def prepare_dataset(cfg, tokenizer):
                 )
     else:
         path = cfg.pretraining_dataset
-        config = "default"
         split = "train"
         name = None
         if isinstance(cfg.pretraining_dataset, list) and isinstance(
@@ -90,8 +89,6 @@ def prepare_dataset(cfg, tokenizer):
         ):
             path = cfg.pretraining_dataset[0]["path"]
             name = cfg.pretraining_dataset[0]["name"]
-            if "config" in cfg.pretraining_dataset[0]:
-              config = cfg.pretraining_dataset[0]["config"]
             if "split" in cfg.pretraining_dataset[0]:
               split = cfg.pretraining_dataset[0]["split"]
 
@@ -104,7 +101,7 @@ def prepare_dataset(cfg, tokenizer):
         )
 
         train_dataset = wrap_pretraining_dataset(
-            load_dataset(path, config, streaming=True, split=split, name=name),
+            load_dataset(path, streaming=True, split=split, name=name),
             tokenizer,
             cfg,
             ds_wrapper_partial,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -90,7 +90,7 @@ def prepare_dataset(cfg, tokenizer):
             path = cfg.pretraining_dataset[0]["path"]
             name = cfg.pretraining_dataset[0]["name"]
             if "split" in cfg.pretraining_dataset[0]:
-              split = cfg.pretraining_dataset[0]["split"]
+                split = cfg.pretraining_dataset[0]["split"]
 
         ds_wrapper_partial = functools.partial(
             get_dataset_wrapper,
@@ -839,11 +839,11 @@ def wrap_pretraining_dataset(
     # this is empty during streaming/pretraining
     remove_columns = []
     if dataset.features is None:
-      for first_row in dataset:
-        remove_columns = first_row.keys()
-        break
+        for first_row in dataset:
+            remove_columns = first_row.keys()
+            break
     else:
-      remove_columns = dataset.features.keys()
+        remove_columns = dataset.features.keys()
 
     dataset = dataset.map(
         encode,

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -834,14 +834,19 @@ def wrap_pretraining_dataset(
     else:
         LOG.debug("NOT shuffling merged pretraining datasets")
 
+    # remove all the existing columns after mapping since they end up having
+    # a different length than the encoded/tokenized column
+    # this is empty during streaming/pretraining
+    remove_columns = []
+    if dataset.features is not None:
+      remove_columns = dataset.features.keys()
+
     dataset = dataset.map(
         encode,
         batched=True,
         batch_size=buffer_size,
         # input_columns="text",
-        # remove all the existing columns after mapping since they end up having
-        # a different length than the encoded/tokenized column
-        remove_columns=dataset.features.keys(),
+        remove_columns=remove_columns,
     )
     return dataset
 

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -838,7 +838,11 @@ def wrap_pretraining_dataset(
     # a different length than the encoded/tokenized column
     # this is empty during streaming/pretraining
     remove_columns = []
-    if dataset.features is not None:
+    if dataset.features is None:
+      for first_row in dataset:
+        remove_columns = first_row.keys()
+        break
+    else:
       remove_columns = dataset.features.keys()
 
     dataset = dataset.map(


### PR DESCRIPTION
# Description

I'm interested in using axolotl to pretrain and then finetune on a dataset which I have on HF.

1. Fixes an issue I experienced because the training script expects pretraining to have a split named "train" and single column named "text". I propose adding `split` and `name` to the `PretrainingDataset` parser and a new `text_column` field.

2. The `load_dataset(path, streaming=True)` used in pretraining currently returns `features: None` or `features: Unknown`, so I propose retrieving the first record to get column names (this is later passed to `remove_columns`).

As an alternative config change, I could see using `SFTDataset` and removing the separate `PretrainingDataset` type

## How has this been tested?

Output YAML, ran training script in CoLab notebook

Sample dataset with one column named "Comment"
```yaml
pretraining_dataset:
  - path: urkopa/comments-lv
    split: train
    text_column: Comment
    type: pretrain
```

My dataset where each split has a different schema so I need to specify split and name
```yaml
pretraining_dataset:
  - path: monsoon-nlp/greenbeing-proteins
    split: pretraining
    text_column: sequence
    name: pretraining
    type: pretrain
```