### PR TITLE
Update SaveAxolotlConfigtoWandBCallback to use artifact instead of save

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -748,7 +748,9 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                     mode="w", delete=False, suffix=".yml", prefix="axolotl_config_"
                 ) as temp_file:
                     copyfile(self.axolotl_config_path, temp_file.name)
-                    wandb.save(temp_file.name)
+                    at = wandb.Artifact(f"config-{wandb.run.id}", type="axolotl-config")
+                    at.add_file(temp_file.name)
+                    wandb.log_artifact(at)
                 LOG.info(
                     "The Axolotl config has been saved to the WandB run under files."
                 )

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -751,6 +751,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                     at = wandb.Artifact(f"config-{wandb.run.id}", type="axolotl-config")
                     at.add_file(temp_file.name)
                     wandb.log_artifact(at)
+                    wandb.save(temp_file.name)
                 LOG.info(
                     "The Axolotl config has been saved to the WandB run under files."
                 )

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -748,9 +748,11 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                     mode="w", delete=False, suffix=".yml", prefix="axolotl_config_"
                 ) as temp_file:
                     copyfile(self.axolotl_config_path, temp_file.name)
-                    at = wandb.Artifact(f"config-{wandb.run.id}", type="axolotl-config")
-                    at.add_file(temp_file.name)
-                    wandb.log_artifact(at)
+                    artifact = wandb.Artifact(
+                        f"config-{wandb.run.id}", type="axolotl-config"
+                    )
+                    artifact.add_file(temp_file.name)
+                    wandb.log_artifact(artifact)
                     wandb.save(temp_file.name)
                 LOG.info(
                     "The Axolotl config has been saved to the WandB run under files."


### PR DESCRIPTION
Removing the use `wandb.save` in favor of `wandb.artifact`