### PR TITLE
Switch to parallel FFD bin packing algorithm (closes #1492)

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -182,10 +182,14 @@ pad_to_sequence_len:
 sample_packing:
 # Set to 'false' if getting errors during eval with sample_packing on.
 eval_sample_packing:
-# Increasing the following values helps with packing, but usually only a bit (<%1.)
-# The number of samples each process considers during packing.
-sample_packing_group_size: 25000
-# The number of samples which can be packed into one bin.
+# You can set these packing optimizations AFTER starting a training at least once.
+# The trainer will provide recommended values for these values.
+sample_packing_eff_est:
+total_num_tokens:
+# Increasing the following values helps with packing, but usually only slightly (<%1.)
+# The number of samples packed at a time.
+sample_packing_group_size: 100000
+# The number of samples which can be packed into one sequence. Increase if using a large sequence_len with many short samples.
 sample_packing_bin_size: 200
 
 # Passed through to transformers when loading the model when launched without accelerate

--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -182,10 +182,11 @@ pad_to_sequence_len:
 sample_packing:
 # Set to 'false' if getting errors during eval with sample_packing on.
 eval_sample_packing:
-# You can set these packing optimizations AFTER starting a training at least once.
-# The trainer will provide recommended values for these values.
-sample_packing_eff_est:
-total_num_tokens:
+# Increasing the following values helps with packing, but usually only a bit (<%1.)
+# The number of samples each process considers during packing.
+sample_packing_group_size: 25000
+# The number of samples which can be packed into one bin.
+sample_packing_bin_size: 200
 
 # Passed through to transformers when loading the model when launched without accelerate
 # Use `sequential` when training w/ model parallelism to limit memory

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -119,6 +119,10 @@ class AxolotlTrainingArguments(TrainingArguments):
         default=None,
         metadata={"help": "Use sample packing for efficient evals."},
     )
+    sample_packing_efficiency: float = field(
+        default=1.0,
+        metadata={"help": "Sample packing efficiency for calculating batch length."},
+    )
     sample_packing_bin_size: int = field(
         default=200,
         metadata={
@@ -126,7 +130,7 @@ class AxolotlTrainingArguments(TrainingArguments):
         },
     )
     sample_packing_group_size: int = field(
-        default=25000,
+        default=100000,
         metadata={
             "help": "The number of samples to group together for packing. Increase for better packing."
         },
@@ -1240,9 +1244,9 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs[
             "multipack_real_batches"
         ] = not self.cfg.flash_attention
-        training_arguments_kwargs[
-            "eval_sample_packing"
-        ] = bool(self.cfg.eval_sample_packing)
+        training_arguments_kwargs["eval_sample_packing"] = bool(
+            self.cfg.eval_sample_packing
+        )
         if self.cfg.sample_packing_bin_size is not None:
             training_arguments_kwargs[
                 "sample_packing_bin_size"
@@ -1251,6 +1255,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             training_arguments_kwargs[
                 "sample_packing_group_size"
             ] = self.cfg.sample_packing_group_size
+        if self.cfg.sample_packing_eff_est:
+            training_arguments_kwargs[
+                "sample_packing_efficiency"
+            ] = self.cfg.sample_packing_eff_est
 
         if self.cfg.relora_steps:
             training_arguments_kwargs["relora_steps"] = self.cfg.relora_steps

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -24,16 +24,15 @@ class DeprecatedParameters(BaseModel):
     max_packed_sequence_len: Optional[int] = None
     rope_scaling: Optional[Any] = None
     noisy_embedding_alpha: Optional[float] = None
+    sample_packing_eff_est: Optional[float] = None
 
     @field_validator("max_packed_sequence_len")
-    @classmethod
     def validate_max_packed_sequence_len(cls, max_packed_sequence_len):
         if max_packed_sequence_len:
             raise DeprecationWarning("`max_packed_sequence_len` is no longer supported")
         return max_packed_sequence_len
 
     @field_validator("rope_scaling")
-    @classmethod
     def validate_rope_scaling(cls, rope_scaling):
         if rope_scaling:
             raise DeprecationWarning(
@@ -42,11 +41,16 @@ class DeprecatedParameters(BaseModel):
         return rope_scaling
 
     @field_validator("noisy_embedding_alpha")
-    @classmethod
     def validate_noisy_embedding_alpha(cls, noisy_embedding_alpha):
         if noisy_embedding_alpha:
             LOG.warning("noisy_embedding_alpha is deprecated, use neftune_noise_alpha")
         return noisy_embedding_alpha
+
+    @field_validator("sample_packing_eff_est")
+    def validate_sample_packing_eff_est(cls, sample_packing_eff_est):
+        if sample_packing_eff_est:
+            LOG.warning("sample_packing_eff_est is deprecated and no longer necessary")
+        return sample_packing_eff_est
 
 
 class RemappedParameters(BaseModel):

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -24,15 +24,16 @@ class DeprecatedParameters(BaseModel):
     max_packed_sequence_len: Optional[int] = None
     rope_scaling: Optional[Any] = None
     noisy_embedding_alpha: Optional[float] = None
-    sample_packing_eff_est: Optional[float] = None
 
     @field_validator("max_packed_sequence_len")
+    @classmethod
     def validate_max_packed_sequence_len(cls, max_packed_sequence_len):
         if max_packed_sequence_len:
             raise DeprecationWarning("`max_packed_sequence_len` is no longer supported")
         return max_packed_sequence_len
 
     @field_validator("rope_scaling")
+    @classmethod
     def validate_rope_scaling(cls, rope_scaling):
         if rope_scaling:
             raise DeprecationWarning(
@@ -41,16 +42,11 @@ class DeprecatedParameters(BaseModel):
         return rope_scaling
 
     @field_validator("noisy_embedding_alpha")
+    @classmethod
     def validate_noisy_embedding_alpha(cls, noisy_embedding_alpha):
         if noisy_embedding_alpha:
             LOG.warning("noisy_embedding_alpha is deprecated, use neftune_noise_alpha")
         return noisy_embedding_alpha
-
-    @field_validator("sample_packing_eff_est")
-    def validate_sample_packing_eff_est(cls, sample_packing_eff_est):
-        if sample_packing_eff_est:
-            LOG.warning("sample_packing_eff_est is deprecated and no longer necessary")
-        return sample_packing_eff_est
 
 
 class RemappedParameters(BaseModel):

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -150,6 +150,8 @@ def wrap_pretraining_dataset(
             max_seq_length=max_tokens,
             batch_size=batch_size,
             multipack_attn=cfg.pretrain_multipack_attn,
+            group_size=cfg.sample_packing_group_size,
+            bin_size=cfg.sample_packing_bin_size,
         )
         # set this to 1 so downstream data_loader doesn't try to increase the batch again
         cfg.micro_batch_size = 1
@@ -189,6 +191,8 @@ def encode_packed_pretraining(
     max_seq_length: int = 2048,
     batch_size: int = 4,
     multipack_attn: Optional[bool] = False,
+    group_size: int = 100000,
+    bin_size: int = 200,
 ) -> Dict[str, List]:
     # pylint: disable=duplicate-code
     # tokenize all the examples
@@ -206,6 +210,9 @@ def encode_packed_pretraining(
         lengths=get_dataset_lengths(train_dataset),
         batch_size=1,
         batch_max_len=batch_size * max_seq_length,
+        group_size=group_size,
+        bin_size=bin_size,
+        drop_last=True,
     )
 
     chunked_data = defaultdict(list)

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -202,11 +202,10 @@ def encode_packed_pretraining(
     )
 
     sampler = MultipackBatchSampler(
-        RandomSampler(train_dataset),
-        batch_size=1,
-        drop_last=True,
-        batch_max_len=batch_size * max_seq_length,
+        sampler=RandomSampler(train_dataset),
         lengths=get_dataset_lengths(train_dataset),
+        batch_size=1,
+        batch_max_len=batch_size * max_seq_length,
     )
 
     chunked_data = defaultdict(list)

--- a/src/axolotl/utils/distributed.py
+++ b/src/axolotl/utils/distributed.py
@@ -36,16 +36,27 @@ def barrier():
 
 def is_main_process():
     """
-    Check if the current process is the main process.
-    If not in distributed mode, always return True.
+    Return whether the current process is on the main rank.
     """
-    if not is_distributed():
-        return True
-    return dist.get_rank() == 0
+    return get_rank() == 0
 
 
 def get_world_size():
+    """
+    Return world size (1 if not distributed.)
+    """
+    if not is_distributed():
+        return 1
     return int(os.getenv("WORLD_SIZE", "1"))
+
+
+def get_rank():
+    """
+    Return rank (0 if not distributed.)
+    """
+    if not is_distributed():
+        return 0
+    return dist.get_rank()
 
 
 @contextmanager

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -1,202 +1,119 @@
-# pylint: skip-file
 """
 Multipack Batch Sampler
 """
 import logging
-import math
-import os
-from typing import Any, Iterable, List, Union
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import cpu_count
 
 import numba
 import numpy as np
-from torch.utils.data import BatchSampler, Sampler
+from torch.utils.data import BatchSampler
 
 LOG = logging.getLogger("axolotl.utils.samplers.multipack")
 
 
+# First-fit-decreasing bin packing.
 @numba.njit
-def ffd_check(a: np.ndarray, c: int, n: int):
-    # First-fit-decreasing bin packing
-    # Check if a[] could fit in n bins with capacity c
-    # https://en.wikipedia.org/wiki/First-fit-decreasing_bin_packing
+def pack_group(items, group_offset, bin_capacity, max_items_per_bin):
+    idxs = np.argsort(items)[::-1]
+    sorted_items = items[idxs]
+    num_bins = len(items)
+    bins = np.full(num_bins, bin_capacity, dtype=np.int32)
+    bin_counts = np.zeros(num_bins, dtype=np.int32)
+    group_packing = np.full((num_bins, max_items_per_bin), -1, dtype=np.int32)
 
-    a = np.sort(a)[::-1]
-    bins = np.full((n,), c, dtype=a.dtype)
-    for size in a:
-        not_found = True
-        for idx in range(n):
-            if bins[idx] >= size:
-                bins[idx] -= size
-                not_found = False
+    for idx in range(len(sorted_items)):
+        item = sorted_items[idx]
+        global_idx = idxs[idx] + group_offset
+
+        placed = False
+        for i in range(num_bins):
+            if bins[i] >= item and bin_counts[i] < max_items_per_bin:
+                bins[i] -= item
+                group_packing[i, bin_counts[i]] = global_idx
+                bin_counts[i] += 1
+                placed = True
                 break
 
-        if not_found:
-            return False
+        if not placed:
+            raise ValueError(
+                f"Item could not be packed. Try increasing cfg.sample_packing_bin_size ({max_items_per_bin})."
+            )
 
-    return True
-
-
-@numba.njit
-def ffd_with_result(a: np.ndarray, c: int, start_index: int):
-    # First-fit-decreasing bin packing (with result return)
-
-    indices = np.argsort(a)[::-1]
-    a = a[indices]
-
-    bins: List[Any] = []
-    bins_result: List[Any] = []
-    for a_id, size in enumerate(a):
-        add_new = True
-        for idx in range(len(bins)):
-            if bins[idx] >= size:
-                bins[idx] -= size
-                bins_result[idx].append(indices[a_id] + start_index)
-                add_new = False
-                break
-
-        if add_new:
-            bins.append(c - size)
-            bins_result.append([indices[a_id] + start_index])
-
-    return bins_result
+    return group_packing
 
 
-@numba.njit
-def allocate(
-    lengths: np.ndarray, lengths_cumsum: np.ndarray, rank: int, c: int, n: int
-):
-    # Dynamic batch allocator, similar to Multifit
-    # https://en.wikipedia.org/wiki/Multifit_algorithm
-    # ~99.5% efficiency on OpenChat training set (12 * 2048 ctx len)
+def pack(items, bin_capacity, group_size, max_items_per_bin):
+    items = np.array(items, dtype=np.int32)
+    num_items = len(items)
+    num_processes = max(1, min(num_items // group_size, cpu_count()))
+    tasks = [
+        (items[i : i + group_size], i, bin_capacity, max_items_per_bin)
+        for i in range(0, num_items, group_size)
+    ]
 
-    s = 0
-    start_index = 0
-    result = []
+    packed_bins = []
+    with ProcessPoolExecutor(max_workers=num_processes) as executor:
+        for group_packing in executor.map(pack_group, *zip(*tasks)):
+            for bin_pack in group_packing:
+                filtered_pack = bin_pack[bin_pack != -1]
+                if filtered_pack.size > 0:
+                    packed_bins.append(filtered_pack.tolist())
 
-    while True:
-        # binary search [l, r)
-        left = 1
-        right = 1 + np.searchsorted(lengths_cumsum[start_index:], s + c * n, "right")
-
-        while right - left > 1:
-            mid = (left + right) // 2
-            if ffd_check(lengths[start_index : start_index + mid], c, n):
-                left = mid
-            else:
-                right = mid
-
-        # use length l
-        batch = ffd_with_result(
-            lengths[start_index : start_index + left], c, start_index
-        )
-        assert len(batch) <= n
-        if len(batch) < n:
-            break
-
-        start_index += left
-        s = lengths_cumsum[start_index - 1]
-
-        # add local rank
-        result.append(batch[rank])
-
-    return result, s, len(result) * c * n
+    return packed_bins
 
 
 class MultipackBatchSampler(BatchSampler):
-    """
-    Batch Sampler class for multipack
-    """
-
     def __init__(
         self,
-        sampler: Union[Sampler[int], Iterable[int]],
-        batch_size: int,
-        drop_last: bool,
-        batch_max_len: int,
-        lengths: np.ndarray,
-        packing_efficiency_estimate: float = 1.0,
+        sampler,
+        lengths,
+        batch_max_len,
+        batch_size,
+        group_size,
+        bin_size,
+        shuffle=False,
     ):
-        super().__init__(sampler, batch_size, drop_last)
-        self.batch_size = batch_size
+        self.sampler = sampler
+        self.sample_idxs = np.arange(len(sampler))
+        self.lengths = (
+            lengths if isinstance(lengths, np.ndarray) else np.array(lengths)
+        )
         self.batch_max_len = batch_max_len
-        self.lengths: np.ndarray = lengths
-        self.packing_efficiency_estimate = packing_efficiency_estimate or 1.0
+        self.batch_size = batch_size
+        self.group_size = group_size
+        self.bin_size = bin_size
+        self.shuffle = shuffle
+        self._batches = None
 
-        assert isinstance(self.lengths, np.ndarray)
+    def _pack_batches(self):
+        # Shuffle indices if necessary.
+        idxs = np.copy(self.sample_idxs)
+        if self.shuffle:
+            np.random.shuffle(idxs)
 
-        self.epoch = 0
-
-        # statistics
-        self.eff_total_used = 0
-        self.eff_total_slots = 0
-
-    def set_epoch(self, epoch: int):
-        self.epoch = epoch
-
-    def generate_batches(self, set_stats=False):
-        indices = [idx for idx in self.sampler]
-
-        lengths = self.lengths[indices]
-        lengths_cumsum = np.cumsum(lengths)
-
-        batches, total_used, total_slots = allocate(
-            lengths=lengths,
-            lengths_cumsum=lengths_cumsum,
-            rank=0,
-            c=self.batch_max_len,
-            n=1,
+        # Repack based on shuffled indices.
+        shuffled_lengths = self.lengths[idxs]
+        pack_idxs = pack(
+            shuffled_lengths, self.batch_max_len, self.group_size, self.bin_size
         )
 
-        batches = [
-            [
-                [indices[b_idx] for b_idx in batch]
-                for batch in batches[i : i + self.batch_size]
-            ]
-            for i in range(0, len(batches), self.batch_size)
+        # Wrap packs into batches.
+        batch_idxs = [
+            pack_idxs[i : i + self.batch_size]
+            for i in range(0, len(pack_idxs), self.batch_size)
         ]
 
-        # statistics
-        if set_stats:
-            self.eff_total_used += total_used
-            self.eff_total_slots += total_slots
-
-        return batches
+        return batch_idxs
 
     def __iter__(self):
-        batches = self.generate_batches(set_stats=True)
-        return iter(batches)
+        if self.shuffle or self._batches is None:
+            self._batches = self._pack_batches()
 
-    def num_batches(self):
-        batches = self.generate_batches(set_stats=True)
-        return len(batches)
-
-    def efficiency(self):
-        return self.eff_total_used / self.eff_total_slots
+        return iter(self._batches)
 
     def __len__(self):
-        self.num_batches()
-        return self._len_est()
+        if self._batches is None:
+            self._batches = self._pack_batches()
 
-    def _len_est(self):
-        world_size = int(os.getenv("WORLD_SIZE", "1"))
-        lengths_sum = np.sum(self.lengths)
-        lengths_sum_per_device = lengths_sum // world_size
-        LOG.info(
-            f"packing_efficiency_estimate: {self.packing_efficiency_estimate} "
-            f"total_num_tokens per device: {lengths_sum_per_device}"
-        )
-
-        # shave off 1% + 1 for dealing with variance in packing from random sampler to sampler
-        return max(
-            0,
-            (
-                world_size
-                * math.floor(
-                    0.99
-                    * lengths_sum_per_device
-                    / self.packing_efficiency_estimate
-                    // (self.batch_max_len * self.batch_size)
-                )
-                - 1
-            ),
-        )
+        return len(self._batches)

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -222,37 +222,76 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         # we have to drop anything longer then sequence len otherwise
         # flash attention with position ids fails
 
-        if cfg.flash_attention:
-            batch_size = 1
-            batch_max_len = cfg.micro_batch_size * cfg.sequence_len
-        else:
-            batch_size = cfg.micro_batch_size
-            batch_max_len = cfg.sequence_len
-
-        # Estimate steps by packing with reasonable values.
-        sampler = MultipackBatchSampler(
-            sampler=RandomSampler(train_dataset),
-            batch_size=batch_size,
-            batch_max_len=batch_max_len,
-            lengths=get_dataset_lengths(train_dataset),
-            group_size=100000,
-            bin_size=200,
-        )
-
-        data_loader = DataLoader(
-            train_dataset.remove_columns(["length"]),
-            batch_sampler=sampler,
-        )
-        data_loader_len = len(data_loader) // cfg.batch_size
-        LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
-
-        total_num_steps = int(
-            math.floor(
-                data_loader_len
+        if cfg.sample_packing_eff_est:
+            total_num_steps = (
+                # match count to len est in dataloader
+                (
+                    math.floor(
+                        0.99
+                        * cfg.total_num_tokens
+                        / cfg.sample_packing_eff_est
+                        / cfg.sequence_len
+                        // cfg.batch_size
+                        // int(os.environ.get("WORLD_SIZE", 1))
+                    )
+                    - 1
+                )
                 * cfg.num_epochs
-                / int(os.environ.get("WORLD_SIZE", 1))
             )
-        )
+            LOG.debug(
+                f"total_num_tokens: {cfg.total_num_tokens:_}, total_num_steps: {total_num_steps:_}",
+                main_process_only=True,
+            )
+        else:
+            if cfg.flash_attention:
+                batch_size = 1
+                batch_max_len = cfg.micro_batch_size * cfg.sequence_len
+            else:
+                batch_size = cfg.micro_batch_size
+                batch_max_len = cfg.sequence_len
+            sampler = MultipackBatchSampler(
+                sampler=RandomSampler(train_dataset),
+                lengths=get_dataset_lengths(train_dataset),
+                batch_size=batch_size,
+                batch_max_len=batch_max_len,
+                group_size=cfg.sample_packing_group_size,
+                bin_size=cfg.sample_packing_bin_size,
+                drop_last=True,
+            )
+
+            data_loader = DataLoader(
+                train_dataset.remove_columns(["length"]),
+                batch_sampler=sampler,
+            )
+            data_loader_len = len(data_loader) // cfg.batch_size
+            LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
+            # FIXME: is there a bug here somewhere? the total num steps depends
+            # on the agreed on value for sample_packing_eff_est
+            total_num_steps = int(
+                math.floor(
+                    data_loader_len
+                    * cfg.num_epochs
+                    / int(os.environ.get("WORLD_SIZE", 1))
+                )
+            )
+
+            def calc_sample_packing_eff_est(estimates: List[float]):
+                LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
+                return max(estimates)
+
+            sample_packing_actual_eff_all = reduce_and_broadcast(
+                lambda: sampler.efficiency,
+                calc_sample_packing_eff_est,
+            )
+            sample_packing_eff_est = (
+                math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
+            )
+            if update:
+                cfg.sample_packing_eff_est = sample_packing_eff_est
+            LOG.debug(
+                f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
+                main_process_only=True,
+            )
     else:
         total_num_steps = int(
             math.ceil(

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -222,75 +222,37 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         # we have to drop anything longer then sequence len otherwise
         # flash attention with position ids fails
 
-        if cfg.sample_packing_eff_est:
-            total_num_steps = (
-                # match count to len est in dataloader
-                (
-                    math.floor(
-                        0.99
-                        * cfg.total_num_tokens
-                        / cfg.sample_packing_eff_est
-                        / cfg.sequence_len
-                        // cfg.batch_size
-                        // int(os.environ.get("WORLD_SIZE", 1))
-                    )
-                    - 1
-                )
-                * cfg.num_epochs
-            )
-            LOG.debug(
-                f"total_num_tokens: {cfg.total_num_tokens:_}, total_num_steps: {total_num_steps:_}",
-                main_process_only=True,
-            )
+        if cfg.flash_attention:
+            batch_size = 1
+            batch_max_len = cfg.micro_batch_size * cfg.sequence_len
         else:
-            if cfg.flash_attention:
-                batch_size = 1
-                batch_max_len = cfg.micro_batch_size * cfg.sequence_len
-            else:
-                batch_size = cfg.micro_batch_size
-                batch_max_len = cfg.sequence_len
-            sampler = MultipackBatchSampler(
-                sampler=RandomSampler(train_dataset),
-                batch_size=batch_size,
-                drop_last=True,
-                batch_max_len=batch_max_len,
-                lengths=get_dataset_lengths(train_dataset),
-            )
+            batch_size = cfg.micro_batch_size
+            batch_max_len = cfg.sequence_len
 
-            data_loader = DataLoader(
-                train_dataset.remove_columns(["length"]),
-                batch_sampler=sampler,
-            )
-            data_loader_len = len(data_loader) // cfg.batch_size
-            actual_eff = sampler.efficiency()
-            LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
-            # FIXME: is there a bug here somewhere? the total num steps depends
-            # on the agreed on value for sample_packing_eff_est
-            total_num_steps = int(
-                math.floor(
-                    data_loader_len
-                    * cfg.num_epochs
-                    / int(os.environ.get("WORLD_SIZE", 1))
-                )
-            )
+        # Estimate steps by packing with reasonable values.
+        sampler = MultipackBatchSampler(
+            sampler=RandomSampler(train_dataset),
+            batch_size=batch_size,
+            batch_max_len=batch_max_len,
+            lengths=get_dataset_lengths(train_dataset),
+            group_size=100000,
+            bin_size=200,
+        )
 
-            def calc_sample_packing_eff_est(estimates: List[float]):
-                LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
-                return max(estimates)
+        data_loader = DataLoader(
+            train_dataset.remove_columns(["length"]),
+            batch_sampler=sampler,
+        )
+        data_loader_len = len(data_loader) // cfg.batch_size
+        LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
 
-            sample_packing_actual_eff_all = reduce_and_broadcast(
-                lambda: actual_eff,
-                calc_sample_packing_eff_est,
+        total_num_steps = int(
+            math.floor(
+                data_loader_len
+                * cfg.num_epochs
+                / int(os.environ.get("WORLD_SIZE", 1))
             )
-            sample_packing_eff_est = (
-                math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
-            )
-            if update:
-                cfg.sample_packing_eff_est = sample_packing_eff_est
-            LOG.debug(
-                f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
-                main_process_only=True,
-            )
+        )
     else:
         total_num_steps = int(
             math.ceil(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Replace the existing sample packing algorithm with a parallel implementation of first-fit-decreasing.

## Motivation and Context

I noticed [recently](https://github.com/OpenAccess-AI-Collective/axolotl/issues/1492) that we could get denser sample packing with a different algorithm. Looking into it more, FFD performs just as well and is much faster than the heuristic I had 😅.

We can run FFD in parallel without losing much performance by packing samples in groups rather than all at once. On an i9-14900k, it takes 2.2s to pack 1M samples with 99.7% efficiency (current `multipack.py` is 91.7% in 0.32s.)

I removed the length estimates around packing in favor of just counting the batches, but let me know if I should add that back in. Two new config options are added: `sample_packing_group_size` controls the the number of samples packed by each process, and `sample_packing_bin_size` sets the number of samples that can be placed in one pack (may need to be increased for large context lengths.)

## How has this been tested?

Tests have been updated to verify that packing is correct. Training appears to run the same, just with fewer steps.

It seems reasonable that sorting the items in FFD would interfere with shuffling between epochs, but I haven't been able to find any evidence of that being the case. Testing against a few [similarity metrics](https://gist.github.com/dsesclei/1b63e782045fed52c93c1dc55657dfd2) shows that even when we do the packing at once in one group, shuffling still generates a mostly new set of packs.

## Screenshots

Some performance checks below for 1M items. 

![group_size_vs_excess](https://github.com/OpenAccess-AI-Collective/axolotl/assets/801452/f935e214-0b63-4231-ac80-8a21f0d9102f)
![bin_size_vs_excess](https://github.com/OpenAccess-AI-Collective/axolotl/assets/801452/fdf2bb6e-4c06-41ca-82cc-b9cb865fb296)