### PR TITLE
Add data streaming support through `mosaic-streaming`

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,20 @@ tokens: # these are delimiters
 
 When you include these tokens in your axolotl config, axolotl adds these tokens to the tokenizer's vocabulary.
 
+#### Streaming dataset
+
+Use [mosaicml-streaming](https://github.com/mosaicml/streaming?tab=readme-ov-file#quick-start) to prepare your dataset for streaming the data. This allows for using "infinite" data sets. Just add `streaming: true` to your `datasets` entry:
+
+```
+datasets:
+    - ds_type: json
+      path: s3://my-bucket/datasets-path/
+      type: completion
+      streaming: true
+```
+
+Ensure that you have uploaded the dataset according to [mosaicml-streaming](https://github.com/mosaicml/streaming?tab=readme-ov-file#quick-start)'s format beforehand.
+
 ### Inference Playground
 
 Axolotl allows you to load your model in an interactive terminal playground for quick experimentation.

--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -90,6 +90,7 @@ datasets:
     shards: # Optional[int] number of shards to split data into
     name: # Optional[str] name of dataset configuration to load
     train_on_split: train # Optional[str] name of dataset split to load from
+    streaming: null # Optional[bool] whether to use `mosaicml-streaming`'s capabilities or not.
 
     # Optional[str] fastchat conversation type, only used with type: sharegpt
     conversation: # Options (see Conversation 'name'): https://github.com/lm-sys/FastChat/blob/main/fastchat/conversation.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ art
 fschat==0.2.36
 gradio==3.50.2
 tensorboard
+mosaicml-streaming
 
 mamba-ssm==1.2.0.post1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ art
 fschat==0.2.36
 gradio==3.50.2
 tensorboard
-mosaicml-streaming
+mosaicml-streaming==0.7.5
 
 mamba-ssm==1.2.0.post1
 

--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,5 @@ setup(
         "galore": [
             "galore_torch",
         ],
-        "mosaicml-streaming": [
-            "mosaicml-streaming",
-        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,8 @@ setup(
         "galore": [
             "galore_torch",
         ],
+        "mosaicml-streaming": [
+            "mosaicml-streaming",
+        ],
     },
 )

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -96,6 +96,7 @@ class SFTDataset(BaseModel):
     data_files: Optional[Union[str, List[str]]] = None
     name: Optional[str] = None
     ds_type: Optional[str] = None
+    streaming: Optional[bool] = None
     train_on_split: Optional[str] = None
 
     field: Optional[str] = None

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -66,9 +66,10 @@ def load_streaming_dataset(config_dataset):
     - ds (datasets.Dataset): A Hugging Face dataset object that streams data from the specified remote location.
     """
     # These imports are local due to the optionality of `mosaicml-streaming`.
-    from streaming import StreamingDataset
-    from datasets import Features, Value, Dataset
     from functools import partial
+
+    from datasets import Features, Value
+    from streaming import StreamingDataset
 
     # Initialize the `StreamingDataset` with configurations.
     streaming_dataset = StreamingDataset(
@@ -86,7 +87,7 @@ def load_streaming_dataset(config_dataset):
     #
     # This is necessary because downstream functions use a different interface
     # than `StreamingDataset` (e.g. the `features` attribute).
-    ds = Dataset.from_generator(
+    ds = Dataset.from_generator(  # pylint: disable=invalid-name
         generator=partial(generator_from_streaming_dataset, streaming_dataset),
         features=features,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR adds support for (non-volatile) memory efficient training through [StreamingDataset](https://github.com/mosaicml/streaming/blob/3ba93010ce86cba1dc4d51ab9977c8cbbbbfb2c9/streaming/base/dataset.py#L165).

## Motivation and Context

Context: https://github.com/OpenAccess-AI-Collective/axolotl/issues/585 .

## How has this been tested?

I have tested this through `docker` on a VM.

I'm open to ideas as to how this should be added. Does the repo support an `s3` bucket for instance?