### PR TITLE
Add support for Gemma chat template

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ scipy
 scikit-learn==1.2.2
 pynvml
 art
-fschat @ git+https://github.com/lm-sys/FastChat.git@main
+fschat @ git+https://github.com/lm-sys/FastChat.git@5095615810cf613dba7f27dd155f571fcff976d8
 gradio==3.50.2
 tensorboard
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ scipy
 scikit-learn==1.2.2
 pynvml
 art
-fschat==0.2.36
+fschat @ git+https://github.com/lm-sys/FastChat.git@main
 gradio==3.50.2
 tensorboard
 

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -123,6 +123,14 @@ def get_turns(  # pylint: disable=too-many-return-statements
             else:
                 yield role, ""
         return
+    if self.sep_style == SeparatorStyle.GEMMA:
+        if self.system_message:
+            raise ValueError("Gemma chat template does not support system messages")
+        for i, (role, message) in enumerate(self.messages):
+            prefix = "<bos>" if i == 0 else ""
+            message_str = message if message else ""
+            yield prefix + "<start_of_turn>" + role + "\n", message_str + "<end_of_turn>\n"
+        return
     if self.sep_style == SeparatorStyle.CHATGLM:
         # source: https://huggingface.co/THUDM/chatglm-6b/blob/1d240ba371910e9282298d4592532d7f0f3e9f3e/modeling_chatglm.py#L1302-L1308
         # source2: https://huggingface.co/THUDM/chatglm2-6b/blob/e186c891cf64310ac66ef10a87e6635fa6c2a579/modeling_chatglm.py#L926


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Supports Gemma chat template for SFT. Currently, when users specify `type=gemma` in their YAML file. e.g.,

```
base_model: google/gemma-2b-it
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

datasets:
  - path: HuggingFaceH4/ultrachat_200k
    conversation: gemma
    type: sharegpt.load_ultrachat
    split: "train_sft"
    train_on_split: "train_sft"
```

errors will occur, as the current version of axolotl doesn't support Gemma chat template as there is no `if self.sep_style == SeparatorStyle.GEMMA` in [fastchat_conversation_turns.py](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/src/axolotl/monkeypatch/fastchat_conversation_turns.py)

<!--- Describe your changes in detail -->



I added the following lines to fastchat_conversation_turns.py
```
    if self.sep_style == SeparatorStyle.GEMMA:
        if self.system_message:
            raise ValueError("Gemma chat template does not support system messages")
        for i, (role, message) in enumerate(self.messages):
            prefix = "<bos>" if i == 0 else ""
            message_str = message if message else ""
            yield prefix + "<start_of_turn>" + role + "\n", message_str + "<end_of_turn>\n"
        return
```
which will generate texts matching [Gemma-instruct's chat template](https://huggingface.co/google/gemma-1.1-7b-it#chat-template). 

Besides, the FastChat latest version 0.2.36 doesn't support Gemma chat template, so I updated the `requirements.txt` to install the up-to-date FastChat from GitHub. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested it with 

```
base_model: google/gemma-2b-it
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

datasets:
  - path: HuggingFaceH4/ultrachat_200k
    conversation: gemma
    type: sharegpt.load_ultrachat
    split: "train_sft"
    train_on_split: "train_sft"
```

and it worked well.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
