### PR TITLE
Add experimental install guide for ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Features:
   - [Conda/Pip venv](#condapip-venv)
   - [Cloud GPU](#cloud-gpu) - Latitude.sh, JarvisLabs, RunPod
   - [Bare Metal Cloud GPU](#bare-metal-cloud-gpu)
+  - [ROCm (Experimental)](#rocm-experimental)
   - [Windows](#windows)
   - [Mac](#mac)
   - [Google Colab](#google-colab)
@@ -250,6 +251,45 @@ Use a Deeplearning linux OS with cuda and pytorch installed. Then follow instruc
 Make sure to run the below to uninstall xla.
 ```bash
 pip uninstall -y torch_xla[tpu]
+```
+
+</details>
+
+#### ROCm (Experimental)
+
+<details>
+
+<summary>Click to Expand</summary>
+
+**Axolotl is *not* maintained for ROCm use.**
+
+This is an experimental setup guide for RDNA3 on ROCm 6.1 which has been tested by one person Ubuntu 22.04.4 with an RX 7900 XTX. *Your results may vary.*
+
+There is no Flash Attention support except on [MI200 & MI300 GPUs using the ROCm fork](https://github.com/ROCm/flash-attention), so will need to use `sdp_attention: true` if you wish to use sample packing during training.
+
+```bash
+# Initial setup for axolotl
+pip install packaging ninja
+pip install -e '.[deepspeed]'
+
+# Remove PyTorch, bitsandbytes, & xformers so we can replace them with ROCm versions (no xformers though)
+pip uninstall -y torch bitsandbytes xformers
+pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+
+# Setup the bitsandbytes fork by arlo-phoenix
+git clone https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git bitsandbytes
+cd bitsandbytes
+
+# Replace this with the correct folder name if you aren't on ROCm 6.1
+export ROCM_HOME=/opt/rocm-6.1.0
+
+# Replace this with the correct target if you aren't using an RDNA3 GPU
+make hip ROCM_TARGET=gfx1100
+pip install .
+
+# Completely optional; You can uninstall nvidia related packages to save space
+cd ..
+pip uninstall -y nvidia-cublas-cu11 nvidia-cuda-cupti-cu11 nvidia-cuda-nvrtc-cu11 nvidia-cuda-runtime-cu11 nvidia-cudnn-cu11 nvidia-cufft-cu11 nvidia-curand-cu11 nvidia-cusolver-cu11 nvidia-cusparse-cu11 nvidia-nccl-cu11 nvidia-nvtx-cu11
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ pip uninstall -y torch bitsandbytes xformers
 pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.0
 
 # Setup the bitsandbytes fork by arlo-phoenix
-git clone -b rocm https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git
+git clone -b rocm https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git bitsandbytes
 cd bitsandbytes
 
 # Replace this with the correct folder name if you aren't on ROCm 6.1

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ pip install -e '.[deepspeed]'
 
 # Remove PyTorch, bitsandbytes, & xformers so we can replace them with ROCm versions (no xformers though)
 pip uninstall -y torch bitsandbytes xformers
-pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+pip install torch --index-url https://download.pytorch.org/whl/rocm6.0
 
 # Setup the bitsandbytes fork by arlo-phoenix
 git clone -b rocm https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git bitsandbytes
@@ -289,7 +289,7 @@ pip install .
 
 # Completely optional; You can uninstall nvidia related packages to save space
 cd ..
-pip uninstall -y nvidia-cublas-cu11 nvidia-cuda-cupti-cu11 nvidia-cuda-nvrtc-cu11 nvidia-cuda-runtime-cu11 nvidia-cudnn-cu11 nvidia-cufft-cu11 nvidia-curand-cu11 nvidia-cusolver-cu11 nvidia-cusparse-cu11 nvidia-nccl-cu11 nvidia-nvtx-cu11
+pip uninstall -y nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvrtc-cu12 nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-curand-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 nvidia-nccl-cu12 nvidia-nvjitlink-cu12 nvidia-nvtx-cu12
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ pip uninstall -y torch bitsandbytes xformers
 pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.0
 
 # Setup the bitsandbytes fork by arlo-phoenix
-git clone https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git bitsandbytes
+git clone -b rocm https://github.com/arlo-phoenix/bitsandbytes-rocm-5.6.git
 cd bitsandbytes
 
 # Replace this with the correct folder name if you aren't on ROCm 6.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This adds a guide on how to install Axolotl for ROCm users.

Currently you need to install the packages included in `pip install -e '.[deepspeed]'` then uninstall `torch`, `xformers`, and `bitsandbytes`, so you can then install the ROCm versions of `torch` and `bitsandbytes`. The process is a definitely janky, since you install stuff you don't want just to uninstall it afterwards.

Installing the ROCm version of `torch` first to try to skip a step results in Axolotl failing to install, so the order this is in is necessary without changes to the `readme.txt` or `setup.py`.

Improvements could be made to this setup by preventing `torch`, `bitsandbytes`, and `xformers` from being installed by modifying `setup.py` to include `[amd]` and `[nvidia]` options. That way we would skip the *install-then-uninstall* step done before installing the packages required.

## Motivation and Context

I still see people on places like Reddit asking if it's possible yet to train AI stuff using AMD hardware. I want more people to know it's possible, although still experimental.

## How has this been tested?
Using my personal system; Ubuntu 22.04.4, using ROCm 6.1 with an RX 7900 XTX. I've been using Axolotl (and other PyTorch based AI tools like kohya_ss) this way for months on various version of PyTorch and ROCm without major issues.

The only time I've had issues was when ROCm 6.0.2 released and caused training to only output 0 loss after I upgraded. This might've just been an issue with how I upgraded.

## Screenshots (if appropriate)

## Types of changes

This only adds additions to the `README.md` file.

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
