### PR TITLE
Fix `total_num_steps`

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -330,7 +330,6 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                         / cfg.sample_packing_eff_est
                         / cfg.sequence_len
                         // cfg.batch_size
-                        // int(os.environ.get("WORLD_SIZE", 1))
                     )
                     - 1
                 )
@@ -368,7 +367,6 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 math.floor(
                     data_loader_len
                     * cfg.num_epochs
-                    / int(os.environ.get("WORLD_SIZE", 1))
                 )
             )
 
@@ -394,7 +392,6 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             math.ceil(
                 len(train_dataset)
                 * cfg.num_epochs
-                / int(os.environ.get("WORLD_SIZE", 1))
                 / cfg.batch_size
             )
         )

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -358,17 +358,14 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 train_dataset.remove_columns(["length"]),
                 batch_sampler=sampler,
             )
-            data_loader_len = len(data_loader) // (cfg.world_size * cfg.gradient_accumulation_steps)
+            data_loader_len = len(data_loader) // (
+                cfg.world_size * cfg.gradient_accumulation_steps
+            )
             actual_eff = sampler.efficiency()
             LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
             # FIXME: is there a bug here somewhere? the total num steps depends
             # on the agreed on value for sample_packing_eff_est
-            total_num_steps = int(
-                math.floor(
-                    data_loader_len
-                    * cfg.num_epochs
-                )
-            )
+            total_num_steps = int(math.floor(data_loader_len * cfg.num_epochs))
 
             def calc_sample_packing_eff_est(estimates: List[float]):
                 LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
@@ -389,11 +386,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             )
     else:
         total_num_steps = int(
-            math.ceil(
-                len(train_dataset)
-                * cfg.num_epochs
-                / cfg.batch_size
-            )
+            math.ceil(len(train_dataset) * cfg.num_epochs / cfg.batch_size)
         )
     LOG.debug(f"total_num_steps: {total_num_steps}", main_process_only=True)
     return total_num_steps

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -358,7 +358,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 train_dataset.remove_columns(["length"]),
                 batch_sampler=sampler,
             )
-            data_loader_len = len(data_loader) // cfg.batch_size
+            data_loader_len = len(data_loader) // (cfg.world_size * cfg.gradient_accumulation_steps)
             actual_eff = sampler.efficiency()
             LOG.debug(f"data_loader_len: {data_loader_len}", main_process_only=True)
             # FIXME: is there a bug here somewhere? the total num steps depends


### PR DESCRIPTION
Hi @winglian 👋,

Thank you for your excellent work!

I'm not entirely sure if I understand the `calculate_total_num_steps` function correctly.

Considering that `cfg.batch_size` already represents the effective batch size (per_device_batch_size * gradient_accumulation_steps * world_size) at this point, as seen in the following snippet of `normalize_config` function, it seems unnecessary to divide by `world_size` again when calculating `total_num_steps`.

https://github.com/OpenAccess-AI-Collective/axolotl/blob/68601ec6ad1cc0e8cb855376586e6eef6a8aa270/src/axolotl/utils/config/__init__.py#L73-L75

~~If confirmed, this implies that the model is trained on only 1/N of the desired steps when utilizing N GPUs with the current version.~~