### PR TITLE
Pass `deepspeed` and `fsdp` as `None` explicitly when merging adapters to allow custom device_map

### DIFF
--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -25,6 +25,8 @@ def do_cli(config: Path = Path("examples/"), **kwargs):
         load_in_8bit=False,
         load_in_4bit=False,
         flash_attention=False,
+        deepspeed=None,
+        fsdp=None,
         **kwargs,
     )
 


### PR DESCRIPTION
I wanted to merge my adapters using multiple gpus in a not so large main memory scenarios, so I tried passing `device_map=auto`

but if we have deepspeed or fsdp set in config yaml, then the axolotl sets `ACCELERATE_USE_*` in env
https://github.com/OpenAccess-AI-Collective/axolotl/blob/5294653a2d353066600cbc66bb06f7c63c87147b/src/axolotl/utils/trainer.py#L428-L432

which later down resets the `device_map` value back to None 
https://github.com/OpenAccess-AI-Collective/axolotl/blob/5294653a2d353066600cbc66bb06f7c63c87147b/src/axolotl/utils/config/__init__.py#L46-L48

kinda self sabotaging - forcing me to merge adapters on cpu

I am not adding a default device_map, so people can choose what they want - just making sure it will be respected
