### PR TITLE
Pass weakref to model in the SIGINT handler to free up model post train function

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -3,6 +3,7 @@
 import os
 import signal
 import sys
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -126,15 +127,18 @@ def train(
 
     # In case we want to stop early with ctrl+c, this is a nice to have to save the pretrained model
     if cfg.local_rank == 0:
-
-        def terminate_handler(_, __, model):
-            if cfg.flash_optimum and BetterTransformer:
-                model = BetterTransformer.reverse(model)
-            model.save_pretrained(cfg.output_dir, safe_serialization=safe_serialization)
+        
+        def terminate_handler(_, __, model_weakref):
+            if model_weakref() is not None:
+                _model = model_weakref()
+                if cfg.flash_optimum and BetterTransformer:
+                    _model = BetterTransformer.reverse(_model)
+                _model.save_pretrained(cfg.output_dir, safe_serialization=safe_serialization)
             sys.exit(0)
 
+        _model_weakref = weakref.ref(model)
         signal.signal(
-            signal.SIGINT, lambda signum, frame: terminate_handler(signum, frame, model)
+            signal.SIGINT, lambda signum, frame: terminate_handler(signum, frame, _model_weakref)
         )
 
     badge_markdown = """[<img src="https://raw.githubusercontent.com/OpenAccess-AI-Collective/axolotl/main/image/axolotl-badge-web.png" alt="Built with Axolotl" width="200" height="32"/>](https://github.com/OpenAccess-AI-Collective/axolotl)"""

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -133,12 +133,15 @@ def train(
                 _model = model_weakref()
                 if cfg.flash_optimum and BetterTransformer:
                     _model = BetterTransformer.reverse(_model)
-                _model.save_pretrained(cfg.output_dir, safe_serialization=safe_serialization)
+                _model.save_pretrained(
+                    cfg.output_dir, safe_serialization=safe_serialization
+                )
             sys.exit(0)
 
         _model_weakref = weakref.ref(model)
         signal.signal(
-            signal.SIGINT, lambda signum, frame: terminate_handler(signum, frame, _model_weakref)
+            signal.SIGINT, 
+            lambda signum, frame: terminate_handler(signum, frame, _model_weakref)
         )
 
     badge_markdown = """[<img src="https://raw.githubusercontent.com/OpenAccess-AI-Collective/axolotl/main/image/axolotl-badge-web.png" alt="Built with Axolotl" width="200" height="32"/>](https://github.com/OpenAccess-AI-Collective/axolotl)"""

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -127,7 +127,7 @@ def train(
 
     # In case we want to stop early with ctrl+c, this is a nice to have to save the pretrained model
     if cfg.local_rank == 0:
-        
+
         def terminate_handler(_, __, model_weakref):
             if model_weakref() is not None:
                 _model = model_weakref()
@@ -140,8 +140,8 @@ def train(
 
         _model_weakref = weakref.ref(model)
         signal.signal(
-            signal.SIGINT, 
-            lambda signum, frame: terminate_handler(signum, frame, _model_weakref)
+            signal.SIGINT,
+            lambda signum, frame: terminate_handler(signum, frame, _model_weakref),
         )
 
     badge_markdown = """[<img src="https://raw.githubusercontent.com/OpenAccess-AI-Collective/axolotl/main/image/axolotl-badge-web.png" alt="Built with Axolotl" width="200" height="32"/>](https://github.com/OpenAccess-AI-Collective/axolotl)"""


### PR DESCRIPTION
Basically passing model to sigint handler via a normal reference captures it in the handler closure and prevents it from being garbage collected even when train() function has completely finished.

To avoid leaking memory like this, this change passes the model to sigint handler using a weak reference

---

I discovered this because post train() function I am calling gc.collect() and torch.cuda.empty_cache() and noticed the model still sticks around on the gpu.