### PR TITLE
FIX: TRL trainer preprocessing step was running in one process

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1532,6 +1532,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             logging_steps=1,
             optim=self.cfg.optimizer,
             save_total_limit=self.cfg.save_total_limit or 5,
+            dataset_num_proc=self.cfg.dataset_processes,
             **training_args_kwargs,
         )
 

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1518,8 +1518,9 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             training_args_kwargs["beta"] = self.cfg.orpo_alpha
 
         training_args_cls = TrainingArguments
-        if self.cfg.rl == "orpo":
+        if self.cfg.rl in ["cpo", "kto_pair", "orpo"]:
             training_args_cls = ORPOConfig
+            training_args_kwargs["dataset_num_proc"] = self.cfg.dataset_processes
 
         training_args = training_args_cls(
             per_device_train_batch_size=self.cfg.micro_batch_size,
@@ -1532,7 +1533,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             logging_steps=1,
             optim=self.cfg.optimizer,
             save_total_limit=self.cfg.save_total_limit or 5,
-            dataset_num_proc=self.cfg.dataset_processes,
             **training_args_kwargs,
         )
 
@@ -1565,6 +1565,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             dpo_trainer_kwargs["max_target_length"] = None
             dpo_trainer_kwargs["max_prompt_length"] = self.cfg.sequence_len
             dpo_trainer_kwargs["generate_during_eval"] = True
+            if self.cfg.rl == "dpo":
+                dpo_trainer_kwargs["dataset_num_proc"] = self.cfg.dataset_processes
         elif self.cfg.rl == "orpo":
             trainer_cls = AxolotlORPOTrainer
             trainer_cls_args = [self.model]

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1462,6 +1462,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             training_args_kwargs["eval_steps"] = self.cfg.eval_steps
         else:
             training_args_kwargs["evaluation_strategy"] = "no"
+
         if self.cfg.bf16 or self.cfg.bfloat16:
             training_args_kwargs["bf16"] = True
 
@@ -1518,7 +1519,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             training_args_kwargs["beta"] = self.cfg.orpo_alpha
 
         training_args_cls = TrainingArguments
-        if self.cfg.rl in ["cpo", "kto_pair", "orpo"]:
+        if self.cfg.rl == "orpo":
             training_args_cls = ORPOConfig
             training_args_kwargs["dataset_num_proc"] = self.cfg.dataset_processes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

We weren't passing dataset_num_proc to TRL training config, thus the initial data preprocessing steps in the TRL trainer was running in one process only.
 
## Motivation and Context

Speeds up training start time by a lot depending on the number logical cores you have.

## How has this been tested?

Tested it with the ORPO trainer in axolotl.

## Screenshots (if appropriate)

## Types of changes

## Social Handles (Optional)

https://www.linkedin.com/in/ali-mosavian-7a27457/
https://github.com/ali-mosavian