### PR TITLE
Gradio configuration parameters

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -233,6 +233,12 @@ def do_inference_gradio(
 
     model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
     prompter = cli_args.prompter
+    default_tokens = {"unk_token": "<unk>", "bos_token": "<s>", "eos_token": "</s>"}
+
+    for token, symbol in default_tokens.items():
+        # If the token isn't already specified in the config, add it
+        if not (cfg.special_tokens and token in cfg.special_tokens):
+            tokenizer.add_special_tokens({token: symbol})
 
     prompter_module = None
     if prompter:
@@ -295,7 +301,12 @@ def do_inference_gradio(
         title=cfg.get("gradio_title", "Axolotl Gradio Interface"),
     )
 
-    demo.queue().launch(show_api=False, share=cfg.get("gradio_share", True), server_name=cfg.get("gradio_server_name", "127.0.0.1"), server_port=cfg.get("gradio_server_port", None))
+    demo.queue().launch(
+        show_api=False,
+        share=cfg.get("gradio_share", True),
+        server_name=cfg.get("gradio_server_name", "127.0.0.1"),
+        server_port=cfg.get("gradio_server_port", None),
+    )
 
 
 def choose_config(path: Path):

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -233,12 +233,6 @@ def do_inference_gradio(
 
     model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
     prompter = cli_args.prompter
-    default_tokens = {"unk_token": "<unk>", "bos_token": "<s>", "eos_token": "</s>"}
-
-    for token, symbol in default_tokens.items():
-        # If the token isn't already specified in the config, add it
-        if not (cfg.special_tokens and token in cfg.special_tokens):
-            tokenizer.add_special_tokens({token: symbol})
 
     prompter_module = None
     if prompter:

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -264,8 +264,8 @@ def do_inference_gradio(
         with torch.no_grad():
             generation_config = GenerationConfig(
                 repetition_penalty=1.1,
-                max_new_tokens=1024,
-                temperature=0.9,
+                max_new_tokens=cfg.get("gradio_max_new_tokens", 1024),
+                temperature=cfg.get("gradio_temperature", 0.9),
                 top_p=0.95,
                 top_k=40,
                 bos_token_id=tokenizer.bos_token_id,
@@ -301,7 +301,7 @@ def do_inference_gradio(
         title=cfg.get("gradio_title", "Axolotl Gradio Interface"),
     )
 
-    demo.queue().launch(show_api=False, share=cfg.share or True, server_name=cfg.server_name or "0.0.0.0", server_port=cfg.server_port)
+    demo.queue().launch(show_api=False, share=cfg.get("gradio_share", True), server_name=cfg.get("gradio_server_name", "127.0.0.1"), server_port=cfg.get("gradio_server_port", None))
 
 
 def choose_config(path: Path):

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -300,7 +300,8 @@ def do_inference_gradio(
         outputs="text",
         title=cfg.get("gradio_title", "Axolotl Gradio Interface"),
     )
-    demo.queue().launch(show_api=False, share=True)
+
+    demo.queue().launch(show_api=False, share=cfg.share or True, server_name=cfg.server_name or "0.0.0.0", server_port=cfg.server_port)
 
 
 def choose_config(path: Path):

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -408,6 +408,13 @@ class WandbConfig(BaseModel):
 
         return data
 
+class GradioConfig(BaseModel):
+    """Gradio configuration subset"""
+
+    share: Optional[bool] = None
+    server_name: Optional[str] = None
+    port: Optional[int] = None
+
 
 # pylint: disable=too-many-public-methods,too-many-ancestors
 class AxolotlInputConfig(
@@ -419,6 +426,7 @@ class AxolotlInputConfig(
     WandbConfig,
     MLFlowConfig,
     LISAConfig,
+    GradioConfig,
     RemappedParameters,
     DeprecatedParameters,
     BaseModel,

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -408,16 +408,18 @@ class WandbConfig(BaseModel):
 
         return data
 
+
 class GradioConfig(BaseModel):
     """Gradio configuration subset"""
 
     gradio_title: Optional[str] = None
     gradio_share: Optional[bool] = None
     gradio_server_name: Optional[str] = None
-    gradio_port: Optional[int] = None
+    gradio_server_port: Optional[int] = None
     gradio_max_new_tokens: Optional[int] = None
     gradio_temperature: Optional[float] = None
-    
+
+
 # pylint: disable=too-many-public-methods,too-many-ancestors
 class AxolotlInputConfig(
     ModelInputConfig,

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -411,11 +411,13 @@ class WandbConfig(BaseModel):
 class GradioConfig(BaseModel):
     """Gradio configuration subset"""
 
-    share: Optional[bool] = None
-    server_name: Optional[str] = None
-    port: Optional[int] = None
-
-
+    gradio_title: Optional[str] = None
+    gradio_share: Optional[bool] = None
+    gradio_server_name: Optional[str] = None
+    gradio_port: Optional[int] = None
+    gradio_max_new_tokens: Optional[int] = None
+    gradio_temperature: Optional[int] = None
+    
 # pylint: disable=too-many-public-methods,too-many-ancestors
 class AxolotlInputConfig(
     ModelInputConfig,

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -416,7 +416,7 @@ class GradioConfig(BaseModel):
     gradio_server_name: Optional[str] = None
     gradio_port: Optional[int] = None
     gradio_max_new_tokens: Optional[int] = None
-    gradio_temperature: Optional[int] = None
+    gradio_temperature: Optional[float] = None
     
 # pylint: disable=too-many-public-methods,too-many-ancestors
 class AxolotlInputConfig(


### PR DESCRIPTION
Various parameters of Gradio were hardcoded (e.g. share=True, ip address, port, number of tokens, temperature)
I made them configurable here.

Additionally the default tokens were overwritten into the tokenizer, which seems odd behaviour and broke llama3 for me, so I removed that.

# Description

Added configuration parameters to  ''src/axolotl/utils/config/models/input/v0_4_1/__init__.py', not sure if they should be added there?
The rest is in src/axolotl/cli/__init__.py, leaving the default behaviour from before

## Motivation and Context

Now aware of open issues for this, but it helps using Gradio. Mostly, I didn't want the public link, and wanted to bind to 0.0.0.0 instead of 127.0.0.1 so you can access gradio from your local network.

## How has this been tested?

I tested it locally, ideally someone else tests it as well

## Screenshots (if appropriate)

## Types of changes

Simple additions to configuration parameters for gradio

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
