### PR TITLE
add-llama3-format-sharegpt-and-dpo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ scipy
 scikit-learn==1.2.2
 pynvml
 art
-fschat @ git+https://github.com/lm-sys/FastChat.git@5095615810cf613dba7f27dd155f571fcff976d8
+fschat @ git+https://github.com/lm-sys/FastChat.git@be66155213e291d565c1aaf979593c1140ec7f43
 gradio==3.50.2
 tensorboard
 

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -123,6 +123,18 @@ def get_turns(  # pylint: disable=too-many-return-statements
             else:
                 yield role, ""
         return
+    if self.sep_style == SeparatorStyle.LLAMA3 and self.name != "mistral":
+        yield "<|begin_of_text|>", ""
+        if self.system_message:
+            yield "", system_prompt
+        else:
+            yield "", ""
+        for i, (role, message) in enumerate(self.messages):
+            if message:
+                yield f"<|start_header_id|>{role}<|end_header_id|>\n\n", f"{message.strip()}<|eot_id|>"
+            else:
+                yield f"<|start_header_id|>{role}<|end_header_id|>\n\n", ""
+        return
     if self.sep_style == SeparatorStyle.GEMMA:
         if self.system_message:
             raise ValueError("Gemma chat template does not support system messages")

--- a/src/axolotl/monkeypatch/fastchat_conversation_turns.py
+++ b/src/axolotl/monkeypatch/fastchat_conversation_turns.py
@@ -124,7 +124,7 @@ def get_turns(  # pylint: disable=too-many-return-statements
                 yield role, ""
         return
     if self.sep_style == SeparatorStyle.LLAMA3 and self.name != "mistral":
-        yield "<|begin_of_text|>", ""
+        yield "", "<|begin_of_text|>"
         if self.system_message:
             yield "", system_prompt
         else:

--- a/src/axolotl/prompt_strategies/dpo/llama3.py
+++ b/src/axolotl/prompt_strategies/dpo/llama3.py
@@ -1,0 +1,133 @@
+"""
+DPO strategies for chatml
+"""
+
+
+def argilla(
+    cfg,
+    **kwargs,
+):  # pylint: disable=possibly-unused-variable,unused-argument
+    def transform_fn(sample):
+        if "system" in sample and sample["system"]:
+            sample["prompt"] = (
+                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{sample['instruction']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        else:
+            sample[
+                "prompt"
+            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['instruction']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen_response']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected_response']}<|eot_id|>"
+        return sample
+
+    return transform_fn
+
+
+def argilla_chat(
+    cfg,
+    **kwargs,
+):  # pylint: disable=possibly-unused-variable,unused-argument
+    """
+    for argilla/dpo-mix-7k conversations
+    """
+
+    def transform_fn(sample):
+        sample[
+            "prompt"
+        ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['chosen'][0]['content']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|>"
+        return sample
+
+    return transform_fn
+
+
+def icr(
+    cfg,
+    **kwargs,
+):  # pylint: disable=possibly-unused-variable,unused-argument
+    """
+    chatml transforms for datasets with system, input, chosen, rejected
+    ex. https://huggingface.co/datasets/argilla/distilabel-intel-orca-dpo-pairs
+    """
+
+    def transform_fn(sample):
+        if "system" in sample and sample["system"]:
+            sample["prompt"] = (
+                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{sample['input']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        else:
+            sample[
+                "prompt"
+            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['input']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+        return sample
+
+    return transform_fn
+
+
+def intel(cfg, **kwargs):  # pylint: disable=possibly-unused-variable,unused-argument
+    """
+    For Intel Orca DPO Pairs
+    """
+
+    def transform_fn(sample):
+        if "system" in sample and sample["system"]:
+            sample["prompt"] = (
+                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{sample['question']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        else:
+            sample[
+                "prompt"
+            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['question']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+        return sample
+
+    return transform_fn
+
+
+def prompt_pairs(
+    cfg, **kwargs
+):  # pylint: disable=possibly-unused-variable,unused-argument
+    def transform_fn(sample):
+        if "system" in sample and sample["system"]:
+            sample["prompt"] = (
+                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        else:
+            sample[
+                "prompt"
+            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+        return sample
+
+    return transform_fn
+
+
+def ultra(cfg, **kwargs):  # pylint: disable=possibly-unused-variable,unused-argument
+    """
+    for ultrafeedback binarized conversations
+    """
+
+    def transform_fn(sample):
+        if "system" in sample and sample["system"]:
+            sample["prompt"] = (
+                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        else:
+            sample[
+                "prompt"
+            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|>"
+        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|>"
+        return sample
+
+    return transform_fn

--- a/src/axolotl/prompt_strategies/dpo/llama3.py
+++ b/src/axolotl/prompt_strategies/dpo/llama3.py
@@ -10,15 +10,15 @@ def argilla(
     def transform_fn(sample):
         if "system" in sample and sample["system"]:
             sample["prompt"] = (
-                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
                 f"<|start_header_id|>user<|end_header_id|>\n\n{sample['instruction']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         else:
             sample[
                 "prompt"
-            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['instruction']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen_response']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected_response']}<|eot_id|>"
+            ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['instruction']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen_response']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected_response']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn
@@ -35,9 +35,9 @@ def argilla_chat(
     def transform_fn(sample):
         sample[
             "prompt"
-        ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['chosen'][0]['content']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|>"
+        ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['chosen'][0]['content']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn
@@ -55,15 +55,15 @@ def icr(
     def transform_fn(sample):
         if "system" in sample and sample["system"]:
             sample["prompt"] = (
-                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
                 f"<|start_header_id|>user<|end_header_id|>\n\n{sample['input']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         else:
             sample[
                 "prompt"
-            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['input']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+            ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['input']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn
@@ -77,15 +77,15 @@ def intel(cfg, **kwargs):  # pylint: disable=possibly-unused-variable,unused-arg
     def transform_fn(sample):
         if "system" in sample and sample["system"]:
             sample["prompt"] = (
-                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
                 f"<|start_header_id|>user<|end_header_id|>\n\n{sample['question']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         else:
             sample[
                 "prompt"
-            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['question']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+            ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['question']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn
@@ -97,15 +97,15 @@ def prompt_pairs(
     def transform_fn(sample):
         if "system" in sample and sample["system"]:
             sample["prompt"] = (
-                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
                 f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         else:
             sample[
                 "prompt"
-            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected']}<|eot_id|>"
+            ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn
@@ -119,15 +119,15 @@ def ultra(cfg, **kwargs):  # pylint: disable=possibly-unused-variable,unused-arg
     def transform_fn(sample):
         if "system" in sample and sample["system"]:
             sample["prompt"] = (
-                f"<|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{sample['system']}<|eot_id|>"
                 f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         else:
             sample[
                 "prompt"
-            ] = f"<|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|>"
-        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|>"
+            ] = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{sample['prompt']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        sample["chosen"] = f"{sample['chosen'][1]['content']}<|eot_id|><|end_of_text|>"
+        sample["rejected"] = f"{sample['rejected'][1]['content']}<|eot_id|><|end_of_text|>"
         return sample
 
     return transform_fn


### PR DESCRIPTION
I just wanted to get llama 3 chat format working for both instruct tuning using a sharegpt dataset and DPO tuning. I made minimal changes that made this work. Missing are adding llama-3 chat template to the prompters.py and chat_templates.py

# Description

I saw the other adding llama 3 PRs but they registered new chat templates into fastchat which were not necessary with their latest commits since llama 3 format is already in fastchat now. Those other PR also did not include a DPO tuning for llama 3. I have successfully created DPO tuned llama 3 models with my PR now.

## How has this been tested?

Tested the tokenization with --debug for both sharegpt with llama-3 conversation options. The datasets seem to get processed properly into the llama 3 format. Including the <|begin_of_text|> bos token and <|end_of_text|> eos token.

I just followed exactly the fastchat llama3 template into the monkeypatch to make sure the bos token is always added.

Example tokenized llama3 sft format:
```
[2024-05-09 14:33:44,305] [INFO] [axolotl.check_example_labels:45] [PID:250136] [RANK:0] <|begin_of_text|>(-100, 128000) <|start_header_id|>(-100, 128006) user(-100, 882) <|end_header_id|>(-100, 128007)

(-100, 271) What(-100, 3923)  is(-100, 374)  the(-100, 279)  solution(-100, 6425) ?

(-100, 1980) S(-100, 50) olve(-100, 4035)  -(-100, 482) 983(-100, 24742) *z(-100, 57513)  -(-100, 482)  (-100, 220) 381(-100, 19162) *z(-100, 57513)  -(-100, 482)  (-100, 220) 711(-100, 22375) 0(-100, 15)  =(-100, 284)  (-100, 220) 361(-100, 18277) 30(-100, 966)  -(-100, 482)  (-100, 220) 641(-100, 23525) 2(-100, 17)  for(-100, 369)  z(-100, 1167) .(-100, 13) <|eot_id|>(-100, 128009) <|start_header_id|>(-100, 128006) assistant(-100, 78191) <|end_header_id|>(-100, 128007)

(271, 271) To(1271, 1271)  solve(11886, 11886)  the(279, 279)  equation(24524, 24524)  -(482, 482) 983(24742, 24742) z(89, 89)  -(482, 482)  (220, 220) 381(19162, 19162) z(89, 89)  -(482, 482)  (220, 220) 711(22375, 22375) 0(15, 15)  =(284, 284)  (220, 220) 361(18277, 18277) 30(966, 966)  -(482, 482)  (220, 220) 641(23525, 23525) 2(17, 17)  for(369, 369)  z(1167, 1167) ,(11, 11)  we(584, 584)  can(649, 649)  start(1212, 1212)  by(555, 555)  combining(35271, 35271)  the(279, 279)  terms(3878, 3878)  with(449, 449)  '(364, 364) z(89, 89) ':(1232, 1232)  (-(10505, 10505) 983(24742, 24742) z(89, 89)  -(482, 482)  (220, 220) 381(19162, 19162) z(89, 89) )(8, 8)  =(284, 284)  (-(10505, 10505) 136(9795, 9795) 4(19, 19) z(89, 89) ).(570, 570)  Then(5112, 5112) ,(11, 11)  we(584, 584)  simplify(40821, 40821)  the(279, 279)  numerical(35876, 35876)  terms(3878, 3878) :(25, 25)  (220, 220) 361(18277, 18277) 30(966, 966)  -(482, 482)  (220, 220) 641(23525, 23525) 2(17, 17)  -(482, 482)  (220, 220) 711(22375, 22375) 0(15, 15)  =(284, 284)  (220, 220) 226(14057, 14057) 08(2318, 2318) .(13, 13)  This(1115, 1115)  gives(6835, 6835)  us(603, 603)  the(279, 279)  equation(24524, 24524)  -(482, 482) 136(9795, 9795) 4(19, 19) z(89, 89)  =(284, 284)  (220, 220) 226(14057, 14057) 08(2318, 2318) .(13, 13)  Div(8940, 8940) iding(6714, 6714)  both(2225, 2225)  sides(11314, 11314)  by(555, 555)  -(482, 482) 136(9795, 9795) 4(19, 19)  yields(36508, 36508)  z(1167, 1167)  =(284, 284)  (220, 220) 226(14057, 14057) 08(2318, 2318)  /(611, 611)  -(482, 482) 136(9795, 9795) 4(19, 19)  =(284, 284)  -(482, 482) 16(845, 845) .(13, 13) 58(2970, 2970) .(13, 13)  Therefore(15636, 15636) ,(11, 11)  the(279, 279)  solution(6425, 6425)  is(374, 374)  z(1167, 1167)  =(284, 284)  -(482, 482) 16(845, 845) .(13, 13) 58(2970, 2970) .(13, 13) <|eot_id|>(128009, 128009) <|end_of_text|>(128001, 128001)
```

Example tokenized llama3 DPO format:
```
[2024-05-09 14:37:17,626] [INFO] [axolotl.check_rl_example_labels:91] [PID:251040] [RANK:0] INPUT PROMPT: <|start_header_id|>(128006) user(882) <|end_header_id|>(128007)

(271) You(2675)  are(527)  an(459)  AI(15592)  assistant(18328) .(13)  You(1472)  will(690)  be(387)  given(2728)  a(264)  task(3465) .(13)  You(1472)  must(2011)  generate(7068)  a(264)  detailed(11944)  and(323)  long(1317)  answer(4320) .

(382) Translate(28573)  the(279)  following(2768)  sentence(11914)  to(311)  Finnish(58953) :
(512) I(40)  listened(34793)  very(1633)  carefully(15884)  to(311)  Commissioner(30454)  Bang(17343) emann(80998) .

(382) F(37) inn(6258) ish(819) :(25) <|eot_id|>(128009) <|start_header_id|>(128006) assistant(78191) <|end_header_id|>(128007)

(271)


[2024-05-09 14:37:17,626] [INFO] [axolotl.check_rl_example_labels:92] [PID:251040] [RANK:0] CHOSEN RESPONSE:  Sure(23371) ,(11)  I(358) 'd(4265)  be(387)  happy(6380)  to(311)  help(1520) !(0)  The(578)  sentence(11914)  "(330) I(40)  listened(34793)  very(1633)  carefully(15884)  to(311)  Commissioner(30454)  Bang(17343) emann(80998) "(1)  can(649)  be(387)  translated(25548)  to(311)  Finnish(58953)  as(439) :

(1473) F(37) inn(6258) ish(819) :(25)  Min(3468) ä(2357)  ku(37700) unt(3935) elin(33830)  hy(6409) vin(9799)  t(259) ark(847) ka(4657) an(276)  kom(11129) issa(22144) ari(2850)  Bang(17343) emann(80998) ia(689) .

(382) Here(8586) 's(596)  a(264)  breakdown(31085)  of(315)  the(279)  translation(14807) :

(1473) *(9)  "(330) I(40)  listened(34793) "(1)  is(374)  translated(25548)  as(439)  "(330) min(1083) ä(2357)  ku(37700) unt(3935) elin(33830) ",(498)  which(902)  is(374)  the(279)  first(1176)  person(1732)  singular(35044)  form(1376)  of(315)  the(279)  verb(19120)  "(330) ku(12407) unn(15278) ella(6985) "(1)  ((320) to(998)  listen(9020) ).
(4390) *(9)  "(330) very(1225)  carefully(15884) "(1)  is(374)  translated(25548)  as(439)  "(330) hy(8671) vin(9799)  t(259) ark(847) ka(4657) an(276) ",(498)  which(902)  is(374)  an(459)  ad(1008) verb(23129) ial(532)  phrase(17571)  made(1903)  up(709)  of(315)  the(279)  ad(1008) verb(23129)  "(330) hy(8671) vin(9799) "(1)  ((320) well(9336) )(8)  and(323)  the(279)  noun(38021)  "(330) t(83) ark(847) ka(4657) an(276) "(1)  ((320) care(10727) fully(3725) ).
(4390) *(9)  "(330) to(998)  Commissioner(30454)  Bang(17343) emann(80998) "(1)  is(374)  translated(25548)  as(439)  "(330) kom(22873) issa(22144) ari(2850)  Bang(17343) emann(80998) ille(4618) ",(498)  which(902)  is(374)  the(279)  d(294) ative(1413)  form(1376)  of(315)  the(279)  noun(38021)  "(330) kom(22873) issa(22144) ari(2850) "(1)  ((320) commission(81164) er(261) )(8)  and(323)  the(279)  proper(6300)  noun(38021)  "(330) Bang(63919) emann(80998) ".

(11690) So(4516) ,(11)  the(279)  entire(4553)  sentence(11914)  "(330) I(40)  listened(34793)  very(1633)  carefully(15884)  to(311)  Commissioner(30454)  Bang(17343) emann(80998) "(1)  is(374)  translated(25548)  to(311)  Finnish(58953)  as(439)  "(330) Min(6349) ä(2357)  ku(37700) unt(3935) elin(33830)  hy(6409) vin(9799)  t(259) ark(847) ka(4657) an(276)  kom(11129) issa(22144) ari(2850)  Bang(17343) emann(80998) ia(689) ".(3343) <|eot_id|>(128009)


[2024-05-09 14:37:17,626] [INFO] [axolotl.check_rl_example_labels:93] [PID:251040] [RANK:0] REJECTED RESPONSE: K(42) u(84) unt(3935) elin(33830)  er(2781) itt(1468) ä(2357) in(258)  t(259) ark(847) ka(4657) av(402) ais(2852) esti(54583)  kom(11129) issa(22144) ari(2850)  Bang(17343) emann(80998) ia(689) .(13) <|eot_id|>(128009)
```

Completed tuning of a few models already with this:
https://huggingface.co/AwanLLM/Awanllm-Llama-3-8B-Dolfin-v0.3
https://huggingface.co/AwanLLM/Awanllm-Llama-3-8B-Dolfin-v0.3-DPO

## Example usage

YAML config for instruct tuning using sharegpt dataset:
```
# Data
datasets:
  - path: /home/datasets/no-robots-sharegpt-fixed.jsonl
    type: sharegpt
    conversation: llama-3
```

YAML config for DPO fine tuning using sharegpt dataset:
```
dpo_beta: 0.1
rl: dpo

# Data
datasets:
  - ds_type: json
    data_files:
      - /home/datasets/orpo-dpo-mix-40k.jsonl
    split: train
    type: llama3.argilla_chat
```
