### PR TITLE
make sure to save on the last step

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -778,6 +778,17 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
 class SaveModelOnTrainEndCallback(TrainerCallback):
     """Callback to save model on train end"""
 
+    def on_step_end(  # pylint: disable=unused-argument
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        # Save
+        if state.global_step >= state.max_steps:
+            control.should_save = True
+
     def on_train_end(  # pylint: disable=unused-argument
         self, args, state, control, **kwargs
     ):


### PR DESCRIPTION
fixes #1613 

Due to rounding, the default trainer code may not properly save on the final step. 
<img width="1069" alt="Screenshot 2024-05-14 at 7 46 05 AM" src="https://github.com/OpenAccess-AI-Collective/axolotl/assets/381258/cf0bc477-40e8-40bd-88ad-bc13817af432">
