### PR TITLE
Update tiny-llama qlora.yml addressing eval packing error

### DIFF
--- a/examples/tiny-llama/qlora.yml
+++ b/examples/tiny-llama/qlora.yml
@@ -18,6 +18,7 @@ lora_model_dir:
 
 sequence_len: 4096
 sample_packing: true
+eval_sample_packing: false
 pad_to_sequence_len: true
 
 lora_r: 32


### PR DESCRIPTION
Running accelerate launch -m axolotl.cli.train examples/tiny-llama/qlora.yml *without* eval_sample_packing set to fase raises this error:

`ValueError: eval dataset split is too small for sample_packing. You should set 'eval_sample_packing: False'. `


### Description
added: `eval_sample_packing: false`

## Impact
Setting eval sample packing to false no longer produces the error.

## Social Handles (Optional)
https://www.linkedin.com/in/jaydeep-thik-7a524b12a/

