### PR TITLE
document how to use `share_strategy="no"`

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -290,7 +290,7 @@ lr_quadratic_warmup:
 logging_steps:
 eval_steps: # Leave empty to eval at each epoch, integers for every N steps. decimal for fraction of total steps
 evals_per_epoch: # number of times per epoch to run evals, mutually exclusive with eval_steps
-save_strategy: # Set to `no` to skip checkpoint saves
+save_strategy: # Set to `"no"` to skip checkpoint saves
 save_steps: # Leave empty to save at each epoch
 saves_per_epoch: # number of times per epoch to save a checkpoint, mutually exclusive with save_steps
 save_total_limit: # Checkpoints saved at a time


### PR DESCRIPTION
# Description

Wraps the `no` in the docs for configs in `"` so that users don't accidentally trigger a cursed YAML parser behavior.

## Motivation and Context

The literal value `no` is parsed in some YAML parsers to the boolean `False`, which fails Pydantic validation. To be sure that the value is parsed to the string `"no"`, the value should be enclosed in quotes. [Discussion on StackOverflow](https://stackoverflow.com/questions/53648244/specifying-the-string-value-yes-in-yaml).

## How has this been tested?

This suggestion comes from a fix I pushed to [this repo](https://github.com/modal-labs/llm-finetuning). The error trace is not captured in the CI there, but you can see configs using the suggested `"no"` that work with the latest version of `axolotl` in our CI, e.g. [here](https://github.com/modal-labs/llm-finetuning/actions/runs/9215433814/job/25353807282#step:5:64).

## Types of changes

- [x] docs

## Social Handles (Optional)

@charles_irl on Twitter and Discord
