### PR TITLE
Fix: ensure correct handling of `val_set_size` as `float` or `int`

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -494,7 +494,9 @@ def load_prepare_datasets(
         test_fingerprint = md5(to_hash_test)
 
         dataset = dataset.train_test_split(
-            test_size=int(cfg.val_set_size) if cfg.val_set_size == int(cfg.val_set_size) else cfg.val_set_size,
+            test_size=int(cfg.val_set_size)
+            if cfg.val_set_size == int(cfg.val_set_size)
+            else cfg.val_set_size,
             shuffle=False,
             seed=cfg.seed or 42,
             train_new_fingerprint=train_fingerprint,

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -494,7 +494,7 @@ def load_prepare_datasets(
         test_fingerprint = md5(to_hash_test)
 
         dataset = dataset.train_test_split(
-            test_size=cfg.val_set_size,
+            test_size=int(cfg.val_set_size) if cfg.val_set_size == int(cfg.val_set_size) else cfg.val_set_size,
             shuffle=False,
             seed=cfg.seed or 42,
             train_new_fingerprint=train_fingerprint,


### PR DESCRIPTION
# Description

Previously, the variable `val_set_size` was always treated as a float, leading to incorrect behavior when it was intended to be an integer. Added a runtime check to ensure that if `val_set_size` is an integer, it is parsed back to an int. This ensures proper functionality depending on whether `val_set_size` is a float or an int.

## Motivation and Context

By **scikit-learn** documentation, the configuration option `val_set_size` is supposed to operate in two possible scenarios:
1. If `float`, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
2. If `int`, represents the absolute number of test samples.

However with the latest version of Axolotl this does not seems the case anymore. 
This fix is totally **backward compatible** as any number between `0` and `1` will be kept as float, while an integer number `>= 1` will be transformed to `int`.

### Why it is important to be able to specify the exact size of validation set?

There are several use cases where the **validation set** size must be a number divisible by total number of GPUs in a distributed cluster training. We have faced this issue while training on 8 nodes with 8xH100 on a NVIDIA cluster using the older version of Axolotl.
