### PR TITLE
Fix tokenization for CodeQwen models

### DIFF
--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -84,10 +84,14 @@ class PromptTokenizingStrategy(abc.ABC):
         ):
             result["input_ids"].append(self.tokenizer.eos_token_id)
             result["attention_mask"].append(1)
+            if "token_type_ids" in result:
+                result["token_type_ids"].append(result["token_type_ids"][-1])
 
         if result["input_ids"][0] == self.tokenizer.bos_token_id and strip_bos_token:
             result["input_ids"] = result["input_ids"][1:]
             result["attention_mask"] = result["attention_mask"][1:]
+            if "token_type_ids" in result:
+                result["token_type_ids"] = result["token_type_ids"][1:]
 
         result["labels"] = result["input_ids"].copy()
         return result


### PR DESCRIPTION

Update token_type_ids in PromptTokenizer to match changes to input_ids and attention_mask.

# Description

Some models, like the Qwen series, return a token_type_ids along with input_ids and attention_mask from the tokenizer. In some cases, when finetuning in completion mode, Axolotl will add/strip EOS/BOS tokens. When this case was hit, token_type_ids would differ in length from input_ids, and the dataset could not be saved.

This change makes Qwen models work by modifying token_type_ids along with the other values returned from the tokenizer.

## Motivation and Context

This change enables Qwen 1.5 models (tested on CodeQwen) to be finetuned in completion mode. Fixes Issue #1632 . 

## How has this been tested?

Issue #1632 has an attached dataset and config that replicates the issue; after this change it no longer triggers an error.

## Screenshots (if appropriate)

## Types of changes

Changes the the _tokenizer method of PromptTokenizingStrategy

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
