### PR TITLE
Fix setting correct repo id when pushing dataset to hub 

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -161,7 +161,8 @@ def load_tokenized_prepared_datasets(
     try:
         if cfg.push_dataset_to_hub:
             dataset = load_dataset(
-                f"{cfg.push_dataset_to_hub}/{ds_hash}",
+                cfg.push_dataset_to_hub,
+                ds_hash,
                 token=use_auth_token,
             )
             dataset = dataset[split]
@@ -424,10 +425,12 @@ def load_tokenized_prepared_datasets(
             dataset.save_to_disk(str(prepared_ds_path))
             if cfg.push_dataset_to_hub:
                 LOG.info(
-                    f"Saving merged prepared dataset with push_to_hub... {cfg.push_dataset_to_hub}/{ds_hash}"
+                    f"Saving merged prepared dataset with push_to_hub... {cfg.push_dataset_to_hub}"
                 )
                 dataset.push_to_hub(
-                    f"{cfg.push_dataset_to_hub}/{ds_hash}", private=True
+                    cfg.push_dataset_to_hub,
+                    ds_hash,
+                    private=True,
                 )
 
     return dataset, prompters

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -161,7 +161,7 @@ def load_tokenized_prepared_datasets(
     try:
         if cfg.push_dataset_to_hub:
             LOG.info(
-                f"Attempting to load prepared dataset from Huggingface hub at {cfg.push_dataset_to_hub} with configuration name {ds_hash}..."
+                f"Attempting to load prepared dataset from Huggingface hub at {cfg.push_dataset_to_hub} (version {ds_hash})..."
             )
             dataset = load_dataset(
                 cfg.push_dataset_to_hub,
@@ -186,7 +186,7 @@ def load_tokenized_prepared_datasets(
     else:
         if cfg.push_dataset_to_hub:
             LOG.info("Unable to find prepared dataset in Huggingface hub")
-        LOG.info("Unable to find prepared dataset in {prepared_ds_path}")
+        LOG.info(f"Unable to find prepared dataset in {prepared_ds_path}")
         LOG.info("Loading raw datasets...")
         if not cfg.is_preprocess:
             LOG.warning(
@@ -430,7 +430,7 @@ def load_tokenized_prepared_datasets(
             dataset.save_to_disk(str(prepared_ds_path))
             if cfg.push_dataset_to_hub:
                 LOG.info(
-                    f"Pushing merged prepared dataset to Huggingface hub at {cfg.push_dataset_to_hub} with configuration name {ds_hash}..."
+                    f"Pushing merged prepared dataset to Huggingface hub at {cfg.push_dataset_to_hub} (version {ds_hash})..."
                 )
                 dataset.push_to_hub(
                     cfg.push_dataset_to_hub,

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -160,6 +160,9 @@ def load_tokenized_prepared_datasets(
     use_auth_token = cfg.hf_use_auth_token
     try:
         if cfg.push_dataset_to_hub:
+            LOG.info(
+                f"Attempting to load prepared dataset from Huggingface hub at {cfg.push_dataset_to_hub} with configuration name {ds_hash}..."
+            )
             dataset = load_dataset(
                 cfg.push_dataset_to_hub,
                 ds_hash,
@@ -181,7 +184,9 @@ def load_tokenized_prepared_datasets(
         dataset = load_from_disk(str(prepared_ds_path))
         LOG.info("Prepared dataset loaded from disk...")
     else:
-        LOG.info(f"Unable to find prepared dataset in {prepared_ds_path}")
+        if cfg.push_dataset_to_hub:
+            LOG.info("Unable to find prepared dataset in Huggingface hub")
+        LOG.info("Unable to find prepared dataset in {prepared_ds_path}")
         LOG.info("Loading raw datasets...")
         if not cfg.is_preprocess:
             LOG.warning(
@@ -425,7 +430,7 @@ def load_tokenized_prepared_datasets(
             dataset.save_to_disk(str(prepared_ds_path))
             if cfg.push_dataset_to_hub:
                 LOG.info(
-                    f"Saving merged prepared dataset with push_to_hub... {cfg.push_dataset_to_hub}"
+                    f"Pushing merged prepared dataset to Huggingface hub at {cfg.push_dataset_to_hub} with configuration name {ds_hash}..."
                 )
                 dataset.push_to_hub(
                     cfg.push_dataset_to_hub,


### PR DESCRIPTION
# Description
In the dataset preprocessing step, pass the dataset hash as the [config_name ](https://huggingface.co/docs/datasets/v2.19.0/en/package_reference/main_classes#datasets.Dataset.push_to_hub.config_name)parameter in push_to_hub if `push_dataset_to_hub` is set. The `config_name `parameter is used for handling different versions/configurations of a dataset, which fits our case here.

## Motivation and Context

The `push_dataset_to_hub` config setting takes a value in the form `<user>/<dataset_name>`, but the previous implementation was pushing to hub with the id `f"{cfg.push_dataset_to_hub}/{ds_hash}"`, which was causing an error because `<user>/<dataset_name>/<ds_hash>` is an invalid hf repo id. 

## How has this been tested?

- With `push_dataset_to_hub` set, ran the dataset preprocessing step several times with different dataset settings each time. 
- Confirmed that this successfully pushed different variations of the dataset to hf hub (screenshot)
- On subequent dataset preprocessing runs with the same settings, confirmed that we successfully pulled down the variation of that dataset from hf hub.
![image](https://github.com/OpenAccess-AI-Collective/axolotl/assets/44345856/a087169f-b4ca-4df0-9ae7-7bec8b79d626)

## Types of changes
- [x] Dataset preprocessing step