### PR TITLE
update deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,11 @@ jobs:
             python_version: "3.11"
             pytorch: 2.2.2
             num_gpus: 1
+          - cuda: 121
+            cuda_version: 12.1.0
+            python_version: "3.11"
+            pytorch: 2.3.0
+            num_gpus: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/
 packaging==23.2
-peft==0.10.0
-transformers==4.40.2
+peft==0.11.1
+transformers==4.41.1
 tokenizers==0.19.1
 bitsandbytes==0.43.1
 accelerate==0.30.1
@@ -16,7 +16,7 @@ flash-attn==2.5.8
 sentencepiece
 wandb
 einops
-xformers==0.0.23.post1
+xformers==0.0.26.post1
 optimum==1.16.2
 hf_transfer
 colorama
@@ -39,6 +39,6 @@ s3fs
 gcsfs
 # adlfs
 
-trl==0.8.5
+trl==0.8.6
 zstandard==0.22.0
 fastcore

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,6 @@ from importlib.metadata import PackageNotFoundError, version
 from setuptools import find_packages, setup
 
 
-def extract_requirements_info(requirement_line):
-    pattern = r"(?P<egg>\w+) @ git\+https://github.com/(?P<namespace>[\w-]+)/(?P<repo>[\w-]+)\.git@(?P<gitsha>[a-f0-9]{40})"
-    match = re.match(pattern, requirement_line)
-    if match:
-        info = match.groupdict()
-        info["namespace/repo"] = f"{info.pop('namespace')}/{info.pop('repo')}"
-        return info
-    raise ValueError("The requirement line is not in the expected format")
-
-
 def parse_requirements():
     _install_requires = []
     _dependency_links = []
@@ -35,14 +25,8 @@ def parse_requirements():
                 _, url = line.split()
                 _dependency_links.append(url)
             elif not is_extras and line and line[0] != "#":
-                if " @ " in line:
-                    req_data = extract_requirements_info(line)
-                    _dependency_links.append(
-                        f"git+https://github.com/{req_data['namespace/repo']}.git@{req_data['gitsha']}#egg={req_data['egg']}"
-                    )
-                else:
-                    # Handle standard packages
-                    _install_requires.append(line)
+                # Handle standard packages
+                _install_requires.append(line)
 
     try:
         if "Darwin" in platform.system():

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def parse_requirements():
                 if " @ " in line:
                     req_data = extract_requirements_info(line)
                     _dependency_links.append(
-                        f"https://github.com/{req_data['namespace/repo']}/tarball/{req_data['gitsha']}#egg={req_data['egg']}"
+                        f"git+https://github.com/{req_data['namespace/repo']}.git@{req_data['gitsha']}#egg={req_data['egg']}"
                     )
                 else:
                     # Handle standard packages


### PR DESCRIPTION
~right now axolotl isn't pip installable. adding logic to detect GitHub pinned versions and setting those as dependency links should help.~

this also updates various versions of dependencies to the latest version and also runs ci on modal on torch 2.3.0