### PR TITLE
Correct name of MixtralBlockSparseTop2MLP (L -> l)

### DIFF
--- a/src/axolotl/monkeypatch/mixtral/__init__.py
+++ b/src/axolotl/monkeypatch/mixtral/__init__.py
@@ -42,9 +42,9 @@ def patch_mixtral_moe_forward_zero3() -> None:
         return final_hidden_states, router_logits
 
     from transformers.models.mixtral.modeling_mixtral import (
-        MixtralBLockSparseTop2MLP,
+        MixtralBlockSparseTop2MLP,
         MixtralSparseMoeBlock,
     )
 
-    MixtralBLockSparseTop2MLP.forward = mlp_forward
+    MixtralBlockSparseTop2MLP.forward = mlp_forward
     MixtralSparseMoeBlock.forward = moe_forward


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The class name with a typo has been removed recently.
https://github.com/huggingface/transformers/commit/57c965a8f1000b4016ad219e616f509d8af3f5b5#diff-733ab0a772c69f78b1d8ed361e6ae1fda7243652887aed0bab5d3ecf07794c01L808

And the version of transformers has been upgraded to 4.41.1
https://github.com/OpenAccess-AI-Collective/axolotl/pull/1663/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R4