### PR TITLE
Fix README quick start example usage model dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ accelerate launch -m axolotl.cli.train examples/openllama-3b/lora.yml
 
 # inference
 accelerate launch -m axolotl.cli.inference examples/openllama-3b/lora.yml \
-    --lora_model_dir="./lora-out"
+    --lora_model_dir="./outputs/lora-out"
 
 # gradio
 accelerate launch -m axolotl.cli.inference examples/openllama-3b/lora.yml \
-    --lora_model_dir="./lora-out" --gradio
+    --lora_model_dir="./outputs/lora-out" --gradio
 
 # remote yaml files - the yaml config can be hosted on a public URL
 # Note: the yaml config must directly link to the **raw** yaml


### PR DESCRIPTION
# Description

The README quick start examples use a different model dir than the example YAML's output dir which causes an error

## Motivation and Context

When following the README quick start examples literally, I got the following error at the inference step:

```
accelerate launch -m axolotl.cli.inference examples/openllama-3b/lora.yml \
    --lora_model_dir="./lora-out"
The following values were not passed to `accelerate launch` and had defaults used instead:
	`--num_processes` was set to a value of `1`
	`--num_machines` was set to a value of `1`
	`--mixed_precision` was set to a value of `'no'`
	`--dynamo_backend` was set to a value of `'no'`
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
[2024-05-28 12:47:32,384] [INFO] [numexpr.utils._init_num_threads:148] [PID:1583962] Note: NumExpr detected 32 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
[2024-05-28 12:47:32,435] [INFO] [datasets.<module>:58] [PID:1583962] PyTorch version 2.3.0 available.
[2024-05-28 12:47:32,910] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
[2024-05-28 12:47:32,937] [INFO] [root.spawn:38] [PID:1583962] gcc -pthread -B /home/abe/anaconda3/envs/axolotl-test4/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /home/abe/anaconda3/envs/axolotl-test4/include -fPIC -O2 -isystem /home/abe/anaconda3/envs/axolotl-test4/include -fPIC -c /tmp/tmp95sl3nqs/test.c -o /tmp/tmp95sl3nqs/test.o
[2024-05-28 12:47:32,951] [INFO] [root.spawn:38] [PID:1583962] gcc -pthread -B /home/abe/anaconda3/envs/axolotl-test4/compiler_compat /tmp/tmp95sl3nqs/test.o -laio -o /tmp/tmp95sl3nqs/a.out
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.0), only 1.0.0 is known to be compatible
                                 dP            dP   dP 
                                 88            88   88 
      .d8888b. dP.  .dP .d8888b. 88 .d8888b. d8888P 88 
      88'  `88  `8bd8'  88'  `88 88 88'  `88   88   88 
      88.  .88  .d88b.  88.  .88 88 88.  .88   88   88 
      `88888P8 dP'  `dP `88888P' dP `88888P'   dP   dP 
                                                       
                                                       

****************************************
**** Axolotl Dependency Versions *****
  accelerate: 0.30.1         
        peft: 0.10.0         
transformers: 4.40.2         
         trl: 0.8.5          
       torch: 2.3.0          
bitsandbytes: 0.43.1         
****************************************
[2024-05-28 12:47:33,563] [WARNING] [axolotl.utils.config.models.input.hint_sample_packing_padding:745] [PID:1583962] [RANK:0] `pad_to_sequence_len: true` is recommended when using sample_packing
[2024-05-28 12:47:33,563] [INFO] [axolotl.utils.config.models.input.check_bf16:1100] [PID:1583962] [RANK:0] bf16 support detected, but not enabled for this configuration.
/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
[2024-05-28 12:47:33,748] [INFO] [axolotl.normalize_config:182] [PID:1583962] [RANK:0] GPU memory usage baseline: 0.000GB (+1.267GB misc)
[2024-05-28 12:47:33,750] [INFO] [axolotl.common.cli.load_model_and_tokenizer:50] [PID:1583962] [RANK:0] loading tokenizer... openlm-research/open_llama_3b_v2
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama.LlamaTokenizer'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565
[2024-05-28 12:47:33,992] [DEBUG] [axolotl.load_tokenizer:280] [PID:1583962] [RANK:0] EOS: 2 / </s>
[2024-05-28 12:47:33,992] [DEBUG] [axolotl.load_tokenizer:281] [PID:1583962] [RANK:0] BOS: 1 / <s>
[2024-05-28 12:47:33,992] [DEBUG] [axolotl.load_tokenizer:282] [PID:1583962] [RANK:0] PAD: 2 / </s>
[2024-05-28 12:47:33,992] [DEBUG] [axolotl.load_tokenizer:283] [PID:1583962] [RANK:0] UNK: 0 / <unk>
[2024-05-28 12:47:33,992] [INFO] [axolotl.load_tokenizer:294] [PID:1583962] [RANK:0] No Chat template selected. Consider adding a chat template for easier inference.
[2024-05-28 12:47:33,992] [INFO] [axolotl.common.cli.load_model_and_tokenizer:52] [PID:1583962] [RANK:0] loading model and (optionally) peft_config...
`low_cpu_mem_usage` was None, now set to True since model is quantized.
[2024-05-28 12:47:38,804] [INFO] [axolotl.load_model:734] [PID:1583962] [RANK:0] GPU memory usage after model load: 3.430GB (+0.146GB cache, +1.701GB misc)
[2024-05-28 12:47:38,809] [INFO] [axolotl.load_model:785] [PID:1583962] [RANK:0] converting PEFT model w/ prepare_model_for_kbit_training
[2024-05-28 12:47:38,810] [INFO] [axolotl.load_model:794] [PID:1583962] [RANK:0] converting modules to torch.float16 for flash attention
[2024-05-28 12:47:38,810] [DEBUG] [axolotl.load_lora:993] [PID:1583962] [RANK:0] Loading pretrained PEFT - LoRA
Traceback (most recent call last):
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/peft/config.py", line 197, in _get_peft_type
    config_file = hf_hub_download(
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 106, in _inner_fn
    validate_repo_id(arg_value)
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 160, in validate_repo_id
    raise HFValidationError(
huggingface_hub.errors.HFValidationError: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: './lora-out'.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/abe/axolotl/src/axolotl/cli/inference.py", line 36, in <module>
    fire.Fire(do_cli)
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/fire/core.py", line 143, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/fire/core.py", line 477, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/fire/core.py", line 693, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/home/abe/axolotl/src/axolotl/cli/inference.py", line 32, in do_cli
    do_inference(cfg=parsed_cfg, cli_args=parsed_cli_args)
  File "/home/abe/axolotl/src/axolotl/cli/__init__.py", line 167, in do_inference
    model, tokenizer = load_model_and_tokenizer(cfg=cfg, cli_args=cli_args)
  File "/home/abe/axolotl/src/axolotl/common/cli.py", line 53, in load_model_and_tokenizer
    model, _ = load_model(cfg, tokenizer, inference=cli_args.inference)
  File "/home/abe/axolotl/src/axolotl/utils/models.py", line 813, in load_model
    model, lora_config = load_adapter(model, cfg, cfg.adapter)
  File "/home/abe/axolotl/src/axolotl/utils/models.py", line 866, in load_adapter
    return load_lora(model, cfg, inference=inference)
  File "/home/abe/axolotl/src/axolotl/utils/models.py", line 998, in load_lora
    model = PeftModel.from_pretrained(
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/peft/peft_model.py", line 328, in from_pretrained
    PeftConfig._get_peft_type(
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/peft/config.py", line 203, in _get_peft_type
    raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
ValueError: Can't find 'adapter_config.json' at './lora-out'
Traceback (most recent call last):
  File "/home/abe/anaconda3/envs/axolotl-test4/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 46, in main
    args.func(args)
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/accelerate/commands/launch.py", line 1082, in launch_command
    simple_launcher(args)
  File "/home/abe/anaconda3/envs/axolotl-test4/lib/python3.10/site-packages/accelerate/commands/launch.py", line 688, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/home/abe/anaconda3/envs/axolotl-test4/bin/python', '-m', 'axolotl.cli.inference', 'examples/openllama-3b/lora.yml', '--lora_model_dir=./lora-out']' returned non-zero exit status 1.
```

## How has this been tested?

Locally, I re-ran the command with `--lora_model_dir="./outputs/lora-out"` which matches the

```yaml
output_dir: ./outputs/lora-out
```

value in `examples/openllama-3b/lora.yml`. It worked.

## Screenshots (if appropriate)

N/A

## Types of changes

Documentation only

## Social Handles (Optional)

```
Twitter: @abevoelker
Discord: abe_______
```
