### PR TITLE
sanity check ranges in freeze.py

### DIFF
--- a/src/axolotl/utils/freeze.py
+++ b/src/axolotl/utils/freeze.py
@@ -121,7 +121,7 @@ def _merge_ranges(
         (start, end if end is not None else layer_size) for start, end in given_ranges
     ]
     for start, end in processed_ranges:
-        if start < 0 or (end > layer_size and layer_size > 0) or start >= end:
+        if start < 0 or end > layer_size > 0 or start >= end:
             raise ValueError(f"invalid unfreeze range: start={start}, end={end}")
 
     # No need to merge if there's only one or no ranges

--- a/src/axolotl/utils/freeze.py
+++ b/src/axolotl/utils/freeze.py
@@ -120,6 +120,9 @@ def _merge_ranges(
     processed_ranges = [
         (start, end if end is not None else layer_size) for start, end in given_ranges
     ]
+    for start, end in processed_ranges:
+        if start < 0 or (end > layer_size and layer_size > 0) or start >= end:
+            raise ValueError(f"invalid unfreeze range: start={start}, end={end}")
 
     # No need to merge if there's only one or no ranges
     if len(processed_ranges) <= 1:


### PR DESCRIPTION
# Description

this will catch range-related problems earlier and more clearly.

## Motivation and Context

in my case, it appears that deepspeed doesn't play well with ranges.
i am still investigating.

## How has this been tested?

manually, in my broken setup.
(it fails because the param length is 0.)
