### PR TITLE
WIP: Allow "weight: 0" in messages to mask them

### DIFF
--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -361,7 +361,11 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                     continue
 
                 user, assistant = conversation.roles
-                role, content = part
+                if len(part) <= 2:
+                    role, content = part
+                    weight = 1
+                else: 
+                    role, content, weight = part
 
                 # Uses "in" because role contains extra characters
                 if user in role:
@@ -379,7 +383,7 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                         add_eos_token=False,
                         strip_bos_token=True,
                     )
-                    if self.train_on_inputs:
+                    if self.train_on_inputs and weight == 1:
                         labels = copy.deepcopy(res["input_ids"])
                     else:
                         # everything from this is masked out from the labels
@@ -415,13 +419,18 @@ class ShareGPTPromptTokenizingStrategy(PromptTokenizingStrategy):
                         labels[:len_role] = [IGNORE_TOKEN_ID] * min(
                             len_role, len(labels)
                         )
+                    if weight == 0:
+                        # everything from this is masked out from the labels 
+                        # (role is masked out too because it makes no sense if contents is masked out)
+                        labels = [IGNORE_TOKEN_ID] * len(res["input_ids"])
+
                 elif role == "":
                     turn = content
                     # this is only ever the first part, should include the bos token and the user query
                     res = self._tokenize(
                         turn, add_eos_token=False, strip_bos_token=False
                     )
-                    if self.train_on_inputs:
+                    if self.train_on_inputs and weight == 1:
                         labels = copy.deepcopy(res["input_ids"])
                     else:
                         # everything from this is masked out from the labels

--- a/tests/prompt_strategies/test_sharegpt.py
+++ b/tests/prompt_strategies/test_sharegpt.py
@@ -24,10 +24,22 @@ def fixture_sharegpt_dataset():
                     {
                         "from": "human",
                         "value": "hello",
+                        "weight": 1,
                     },
                     {
                         "from": "gpt",
                         "value": "hello",
+                        "weight": 0,
+                    },
+                    {
+                        "from": "human",
+                        "value": "rehello",
+                        "weight": 0,
+                    },
+                    {
+                        "from": "gpt",
+                        "value": "rehello",
+                        "weight": 1,
                     },
                     {
                         "from": "human",
@@ -36,12 +48,12 @@ def fixture_sharegpt_dataset():
                     {
                         "from": "gpt",
                         "value": "goodbye",
+                        "weight": 0,
                     },
                 ]
             }
         ]
     )
-
 
 @pytest.fixture(name="tokenizer")
 def fixture_tokenizer():
@@ -91,12 +103,14 @@ class TestSharegpt:
             32001, 1587, 13, 25997, 32000, 28705, 13,  # system
             32001, 2188, 13, 21558, 32000, 28705, 13,  # human
             32001, 13892, 13, 21558, 32000, 28705, 13,  # gpt
+            32001, 2188, 13, 267, 21558, 32000, 28705, 13, # human
+            32001, 13892, 13, 267, 21558, 32000, 28705, 13, # gpt
             32001, 2188, 13, 12684, 17664, 32000, 28705, 13,   # human
             32001, 13892, 13, 12684, 17664, 32000, 28705, 13,  # gpt
         ]
         # fmt: on
 
-    def test_w_train_on_input(self, sharegpt_dataset, tokenizer):
+    def test_no_train_on_input(self, sharegpt_dataset, tokenizer):
         strategy = SimpleShareGPTPromptTokenizingStrategy(
             ShareGPTPrompterV2(
                 conversation="chatml",
@@ -118,13 +132,17 @@ class TestSharegpt:
             -100,   # bos
             -100, -100, -100, -100, -100, -100, -100,  # system
             -100, -100, -100, -100, -100, -100, -100,  # human
-            -100, -100, 13, 21558, 32000, 28705, 13,  # gpt
+            # -100, -100, 13, 21558, 32000, 28705, 13,  # gpt 
+            -100, -100, -100, -100, -100, -100, -100,  # gpt with weight zero
+            -100, -100, -100, -100, -100, -100, -100, -100,  # human
+            -100, -100, 13, 267, 21558, 32000, 28705, 13,  # gpt
             -100, -100, -100, -100, -100, -100, -100, -100,   # human
-            -100, -100, 13, 12684, 17664, 32000, 28705, 13,  # gpt
+            # -100, -100, 13, 12684, 17664, 32000, 28705, 13,  # gpt
+            -100, -100, -100, -100, -100, -100, -100, -100  # gpt with weight zero
         ]
         # fmt: on
 
-    def test_no_train_on_input(self, sharegpt_dataset, tokenizer):
+    def test_w_train_on_input(self, sharegpt_dataset, tokenizer):
         strategy = SimpleShareGPTPromptTokenizingStrategy(
             ShareGPTPrompterV2(
                 conversation="chatml",
@@ -146,8 +164,13 @@ class TestSharegpt:
             1,   # bos
             32001, 1587, 13, 25997, 32000, 28705, 13,  # system
             32001, 2188, 13, 21558, 32000, 28705, 13,  # human
-            32001, 13892, 13, 21558, 32000, 28705, 13,  # gpt
-            32001, 2188, 13, 12684, 17664, 32000, 28705, 13,   # human
-            32001, 13892, 13, 12684, 17664, 32000, 28705, 13,  # gpt
+            # 32001, 13892, 13, 21558, 32000, 28705, 13,  # gpt
+            -100, -100, -100, -100, -100, -100,- 100,  # gpt with weight 0
+            # 32001, 2188, 13, 267, 21558, 32000, 28705, 13,  # human
+            -100, -100, -100, -100, -100, -100, -100, -100,  # human with weight 0
+            32001, 13892, 13, 267, 21558, 32000, 28705, 13,  # gpt
+            32001, 2188, 13, 12684, 17664, 32000, 28705, 13,  # human
+            # 32001, 13892, 13, 12684, 17664, 32000, 28705, 13,  # gpt
+            -100, -100, -100, -100, -100, -100, -100, -100  # gpt with weight 0
         ]
         # fmt: on


### PR DESCRIPTION
TODO: Rebase onto HEAD once https://github.com/OpenAccess-AI-Collective/axolotl/issues/1624 is fixed.

Allow in message objects the additional key `weight`, which can be set to 0 (or 1) to cause that the message is masked out (or left unmasked) for training (similar to [1]). This is helpful for training the model to be robust and capable of error recovery upon a bad assistant message. A missing `weight` key defaults to weight 1, to guarantee downward compatibility.

Extend `tests/prompt_strategies/test_sharegpt.py` to contain messages with `weight` keys.

Extend `src/axolotl/prompters.py::_build_result` to return the turns with weights as additional tuple element. Do this in axolotl directly instead of modifying `fastchat.conversation`'s `Conversation`.

Extend `src/axolotl/prompt_tokenizers.py::tokenize_prompt` to mask out tokens when weight is set to 0.

[1]: https://github.com/mistralai/mistral-finetune

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
