### PR TITLE
Added eager_attention to AxolotlInputConfig

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -580,6 +580,7 @@ class AxolotlInputConfig(
     xformers_attention: Optional[bool] = None
     sdp_attention: Optional[bool] = None
     s2_attention: Optional[bool] = None
+    eager_attention: Optional[bool] = None
     flash_attention: Optional[bool] = None
     flash_attn_cross_entropy: Optional[bool] = None
     flash_attn_rms_norm: Optional[bool] = None


### PR DESCRIPTION
# Description

Adds eager_attention to AxolotlInputConfig so it can be set in the config files

## Motivation and Context

When fine-tuning Gemma 2 there is a warning on the attention mechanism used, with eager attention strongly recommended. This allows it to be explicitly set, allowing users to pick between using the flash attention or eager attention.