### PR TITLE
Update instruct-lora-8b.yml

### DIFF
--- a/examples/llama-3/instruct-lora-8b.yml
+++ b/examples/llama-3/instruct-lora-8b.yml
@@ -74,3 +74,5 @@ deepspeed:
 weight_decay: 0.0
 fsdp:
 fsdp_config:
+special_tokens:
+   pad_token: <|end_of_text|>


### PR DESCRIPTION
Config is giving an error if not using the end of the token as the `pad_to_sequence_len` is true.