### PR TITLE
fix the incorrect `max_length` for chat template

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -350,6 +350,7 @@ def load(tokenizer, cfg, ds_cfg: Optional[Dict[str, Any]] = None):
         ),
         "roles": ds_cfg.get("roles"),
         "drop_system_message": ds_cfg.get("drop_system_message", False),
+        "max_length": cfg.sequence_len,
     }
 
     strategy_params = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The preprocessed data was being cut off at a maximum length of 2048 tokens, even when the user set `sequence_len` to a number greater than 2048. This PR fixes the bug by passing `sequence_len` from the configuration to `max_length` in `ChatTemplatePrompter`.

## Motivation and Context

There is an issue reporting the same cut off problem. (#1749)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
