### PR TITLE
Warn if we override the chat template in the tokenizer config

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -291,6 +291,12 @@ def load_tokenizer(cfg):
                 "You are a helpful assistant.", cfg.default_system_message
             )
 
+        if tokenizer.chat_template and tokenizer.chat_template != chat_template_string:
+            LOG.warning(
+                "The chat template is being overridden by the one in the config. "
+                "This may cause a mismatch with the existing chat template in the base model. "
+                "Please verify that this override is intended and compatible."
+            )
         tokenizer.chat_template = chat_template_string
     else:
         LOG.info(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR adds a warning message if we override the chat template in the tokenizer config with the one in the training config.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR resolves #1120.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
