### PR TITLE
examples: Fix config llama3

### DIFF
--- a/examples/llama-3/instruct-dpo-lora-8b.yml
+++ b/examples/llama-3/instruct-dpo-lora-8b.yml
@@ -6,7 +6,6 @@ load_in_8bit: true
 load_in_4bit: false
 strict: false
 
-chat_template: llama3
 rl: dpo
 datasets:
   - path: fozziethebeat/alpaca_messages_2k_dpo_test

--- a/examples/llama-3/instruct-dpo-lora-8b.yml
+++ b/examples/llama-3/instruct-dpo-lora-8b.yml
@@ -6,11 +6,11 @@ load_in_8bit: true
 load_in_4bit: false
 strict: false
 
+chat_template: llama3
 rl: dpo
 datasets:
   - path: fozziethebeat/alpaca_messages_2k_dpo_test
     type: chat_template.default
-    chat_template: llama3
     field_messages: conversation
     field_chosen: chosen
     field_rejected: rejected

--- a/examples/llama-3/instruct-lora-8b.yml
+++ b/examples/llama-3/instruct-lora-8b.yml
@@ -6,7 +6,6 @@ load_in_8bit: true
 load_in_4bit: false
 strict: false
 
-chat_template: llama3
 datasets:
   - path: fozziethebeat/alpaca_messages_2k_test
     type: chat_template

--- a/examples/llama-3/instruct-lora-8b.yml
+++ b/examples/llama-3/instruct-lora-8b.yml
@@ -6,10 +6,10 @@ load_in_8bit: true
 load_in_4bit: false
 strict: false
 
+chat_template: llama3
 datasets:
   - path: fozziethebeat/alpaca_messages_2k_test
     type: chat_template
-    chat_template: llama3
     field_messages: messages
     message_field_role: role
     message_field_content: content


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

chat_template shouldn't be set in the datasets in accordans with https://axolotl-ai-cloud.github.io/axolotl/docs/config.html, you set it in the outer level. It is set correctly at line 9. 

## Motivation and Context

Cleaning up the config

## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

## Social Handles (Optional)
