### PR TITLE
docs: minor syntax highlight fix

### DIFF
--- a/docs/unsloth.qmd
+++ b/docs/unsloth.qmd
@@ -34,7 +34,7 @@ unsloth_lora_o: true
 ```
 
 These options are composable and can be used with multi-gpu finetuning
-```
+```yaml
 unsloth_cross_entropy_loss: true
 unsloth_rms_norm: true
 unsloth_rope: true


### PR DESCRIPTION
https://axolotl-ai-cloud.github.io/axolotl/docs/unsloth.html

second code block wasn't syntax highlighted the same way as the first