### PR TITLE
examples: fix tiny-llama pretrain yml syntax

### DIFF
--- a/examples/tiny-llama/pretrain.yml
+++ b/examples/tiny-llama/pretrain.yml
@@ -9,9 +9,9 @@ strict: false
 
 max_steps: 200
 pretraining_dataset:
-  path: c4
-  name: en
-  type: pretrain
+  - path: allenai/c4
+    name: en
+    type: pretrain
 dataset_prepared_path:
 val_set_size: 0.0
 output_dir: ./outputs/model-out


### PR DESCRIPTION
this example was not running due to incorrect syntax

```
File "/root/code/axolotl/src/axolotl/cli/__init__.py", line 374, in load_cfg
    cfg = validate_config(
          ^^^^^^^^^^^^^^^^
  File "/root/code/axolotl/src/axolotl/utils/config/__init__.py", line 213, in validate_config
    AxolotlConfigWCapabilities(
  File "/root/micromamba/envs/dev/lib/python3.11/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for AxolotlConfigWCapabilities
pretraining_dataset
  Input should be a valid list [type=list_type, input_value={'path': 'c4', 'name': 'en', 'type': 'pretrain'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/list_type
```
