### PR TITLE
pretrain: fix with sample_packing=false

### DIFF
--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -18,10 +18,10 @@ LOG = logging.getLogger("axolotl")
 
 
 def encode_pretraining(
-    tokenizer: PreTrainedTokenizerBase, max_tokens: int, examples: List[str]
+    tokenizer: PreTrainedTokenizerBase, max_tokens: int, examples: Dict[str, List]
 ) -> Dict[str, List]:
     res = tokenizer(
-        examples,
+        examples["text"],
         truncation=True,
         max_length=max_tokens - 2,
         add_special_tokens=True,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -35,7 +35,7 @@ class TestEncodePretraining(unittest.TestCase):
                 "hello, hello",
             ]
         }
-        result = encode_pretraining(self.tokenizer, self.max_tokens, examples["text"])
+        result = encode_pretraining(self.tokenizer, self.max_tokens, examples)
 
         self.assertEqual(len(result["input_ids"]), 3)
 


### PR DESCRIPTION
fixes #1713

`encode_pretraining` and `encode_packed_pretraining` need to have matching function signatures for the `examples` argument, because they are used interchangibly in `wrap_pretraining_dataset`

https://github.com/axolotl-ai-cloud/axolotl/blob/5aac4bc2846ac7379c0a52dd894dd1ba5499ec22/src/axolotl/utils/data/pretraining.py#L128-L159