### PR TITLE
fix: phi system prompt

### DIFF
--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -66,7 +66,7 @@ class AlpacaPrompter(Prompter):
         elif self.prompt_style == PromptStyle.PHI.value:
             self.turn_format = "<|user|>\n{instruction}<|end|>{input}<|assistant|>"
             self.turn_no_input_format = "<|user|>\n{instruction}<|end|><|assistant|>"
-            self.system_format = "<|system|>{system}\n"
+            self.system_format = "<|system|>{system}<|end|>\n"
 
     def _build_result(self, instruction, input_text, output):
         # returns the full prompt from instruction and optional input

--- a/tests/test_prompters.py
+++ b/tests/test_prompters.py
@@ -47,7 +47,7 @@ class AlpacaPrompterTest(unittest.TestCase):
         res = next(
             prompter.build_prompt("tell me a joke about the following", "alpacas")
         )
-        assert """<|system|>Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.<|end|>"""
+        assert """<|system|>Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.<|end|>""" in res
     
 
     def test_prompt_style_w_chat(self):

--- a/tests/test_prompters.py
+++ b/tests/test_prompters.py
@@ -42,6 +42,14 @@ class AlpacaPrompterTest(unittest.TestCase):
         assert "USER:" not in res
         assert "ASSISTANT:" not in res
 
+    def test_prompt_style_w_phi(self):
+        prompter = AlpacaPrompter(prompt_style=PromptStyle.PHI.value)
+        res = next(
+            prompter.build_prompt("tell me a joke about the following", "alpacas")
+        )
+        assert """<|system|>Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.<|end|>"""
+    
+
     def test_prompt_style_w_chat(self):
         prompter = AlpacaPrompter(prompt_style=PromptStyle.CHAT.value)
         res = next(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The current prompt format for phi is missing <|end|> in the end of the system message. Se [here](<|end|>) 

## Motivation and Context

The current format is incorrect since <|end|> is missing in the end of the system message. 

## How has this been tested?
Added some new tests for the prompt

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
