### PR TITLE
reapply multipack patches after model load for trust_remote_code compat

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -751,7 +751,7 @@ def load_model(
     if cfg.trust_remote_code:
         model_module = sys.modules[model.__class__.__module__]
         if hasattr(model_module, "_axolotl_multipack_patch"):
-            model_module._get_unpad_data = get_unpad_data
+            setattr(model_module, "_get_unpad_data", get_unpad_data)
 
     if isinstance(model, (PeftModel, PeftModelForCausalLM)) and not qlora_fsdp:
         model = model.merge_and_unload()


### PR DESCRIPTION
cc #1873 #1872 https://github.com/axolotl-ai-cloud/axolotl/issues/1340#issuecomment-2301160001


note that this was a regression in https://github.com/huggingface/transformers/pull/30370 after which transformers will reload modules causing our patched function to get replaced