### PR TITLE
support for auto_find_batch_size when packing

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -502,11 +502,14 @@ class AxolotlTrainer(SchedulerMixin, Trainer):
     def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
         if self.args.sample_packing and not self.args.pretraining:
             if self.args.multipack_real_batches:
-                batch_size = self.state.per_device_train_batch_size
+                batch_size = self.args.per_device_train_batch_size
                 batch_max_len = self.args.max_seq_length
             else:
                 batch_size = 1
-                batch_max_len = self.state.train_batch_size * self.args.max_seq_length
+                train_batch_size = (
+                    self.state.train_batch_size or self.args.per_device_train_batch_size
+                )
+                batch_max_len = train_batch_size * self.args.max_seq_length
             return MultipackBatchSampler(
                 RandomSampler(self.train_dataset),
                 lengths=get_dataset_lengths(self.train_dataset),

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1379,6 +1379,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             training_arguments_kwargs[
                 "per_device_eval_batch_size"
             ] = self.cfg.eval_batch_size
+        if self.cfg.auto_find_batch_size is not None:
+            training_arguments_kwargs[
+                "auto_find_batch_size"
+            ] = self.cfg.auto_find_batch_size
         training_arguments_kwargs[
             "gradient_accumulation_steps"
         ] = self.cfg.gradient_accumulation_steps
@@ -1461,9 +1465,9 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         )
 
         training_arguments_kwargs["sample_packing"] = bool(self.cfg.sample_packing)
-        training_arguments_kwargs[
-            "multipack_real_batches"
-        ] = not self.cfg.flash_attention
+        training_arguments_kwargs["multipack_real_batches"] = (
+            not self.cfg.flash_attention or self.cfg.multipack_real_batches
+        )
         training_arguments_kwargs["eval_sample_packing"] = bool(
             self.cfg.eval_sample_packing
         )

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -502,13 +502,11 @@ class AxolotlTrainer(SchedulerMixin, Trainer):
     def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
         if self.args.sample_packing and not self.args.pretraining:
             if self.args.multipack_real_batches:
-                batch_size = self.args.per_device_train_batch_size
+                batch_size = self.state.per_device_train_batch_size
                 batch_max_len = self.args.max_seq_length
             else:
                 batch_size = 1
-                batch_max_len = (
-                    self.args.per_device_train_batch_size * self.args.max_seq_length
-                )
+                batch_max_len = self.state.train_batch_size * self.args.max_seq_length
             return MultipackBatchSampler(
                 RandomSampler(self.train_dataset),
                 lengths=get_dataset_lengths(self.train_dataset),

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -843,34 +843,6 @@ class AxolotlInputConfig(
 
     @model_validator(mode="before")
     @classmethod
-    def check_auto_find_batch_size_w_multipack(cls, data):
-        if (
-            data.get("auto_find_batch_size")
-            and data.get("sample_packing")
-            and not data.get("multipack_real_batches")
-        ):
-            raise ValueError(
-                "auto_find_batch_size requires multipack_real_batches when using sample_packing"
-            )
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
-    def hint_auto_find_batch_size_w_multipack_pad_max(cls, data):
-        if (
-            data.get("auto_find_batch_size")
-            and data.get("sample_packing")
-            and data.get("multipack_real_batches")
-            and data.get("pad_to_sequence_len")
-        ):
-            LOG.warning(
-                "pad_to_sequence_len with auto_find_batch_size may lead "
-                "to inefficient training with extra padding tokens"
-            )
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
     def check_push_ds_auth(cls, data):
         if (
             data.get("push_dataset_to_hub")

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -594,6 +594,7 @@ class AxolotlInputConfig(
     eval_sample_packing: Optional[bool] = None
     pad_to_sequence_len: Optional[bool] = None
     curriculum_sampling: Optional[bool] = None
+    multipack_real_batches: Optional[bool] = None
 
     # for PoSE context length extension
     use_pose: Optional[bool] = None

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -851,6 +851,7 @@ class AxolotlInputConfig(
             raise ValueError(
                 "auto_find_batch_size requires multipack_real_batches when using sample_packing"
             )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -865,6 +865,7 @@ class AxolotlInputConfig(
                 "pad_to_sequence_len with auto_find_batch_size may lead "
                 "to inefficient training with extra padding tokens"
             )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -11,6 +11,8 @@ import numba
 import numpy as np
 from torch.utils.data import BatchSampler, Sampler
 
+from axolotl.utils.distributed import reduce_and_broadcast
+
 LOG = logging.getLogger("axolotl.utils.samplers.multipack")
 
 
@@ -174,16 +176,35 @@ class MultipackBatchSampler(BatchSampler):
     def efficiency(self):
         return self.eff_total_used / self.eff_total_slots
 
+    def gather_efficiency(self):
+        def calc_sample_packing_eff_est(estimates: List[float]):
+            LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
+            return max(estimates)
+
+        sample_packing_actual_eff_all = reduce_and_broadcast(
+            lambda: self.efficiency(),  # pylint: disable=unnecessary-lambda
+            calc_sample_packing_eff_est,
+        )
+        sample_packing_eff_est = (
+            math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
+        )
+        return sample_packing_eff_est
+
     def __len__(self):
         self.num_batches()
         return self._len_est()
 
     def _len_est(self):
+        efficiency = (
+            self.packing_efficiency_estimate
+            if self.packing_efficiency_estimate
+            else self.gather_efficiency()
+        )
         world_size = int(os.getenv("WORLD_SIZE", "1"))
         lengths_sum = np.sum(self.lengths)
         lengths_sum_per_device = lengths_sum // world_size
         LOG.info(
-            f"packing_efficiency_estimate: {self.packing_efficiency_estimate} "
+            f"packing_efficiency_estimate: {efficiency} "
             f"total_num_tokens per device: {lengths_sum_per_device}"
         )
 
@@ -195,7 +216,7 @@ class MultipackBatchSampler(BatchSampler):
                 * math.floor(
                     0.99
                     * lengths_sum_per_device
-                    / self.packing_efficiency_estimate
+                    / efficiency
                     // (self.batch_max_len * self.batch_size)
                 )
                 - 1

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -16,7 +16,8 @@ from torch.utils.data import DataLoader, RandomSampler
 from transformers.utils import is_torch_bf16_gpu_available
 
 from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuilder
-from axolotl.utils.distributed import reduce_and_broadcast
+
+# from axolotl.utils.distributed import reduce_and_broadcast
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 
 LOG = get_logger("axolotl")
@@ -383,23 +384,23 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             # on the agreed on value for sample_packing_eff_est
             total_num_steps = int(math.floor(data_loader_len * cfg.num_epochs))
 
-            def calc_sample_packing_eff_est(estimates: List[float]):
-                LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
-                return max(estimates)
-
-            sample_packing_actual_eff_all = reduce_and_broadcast(
-                lambda: sampler.efficiency(),  # pylint: disable=unnecessary-lambda
-                calc_sample_packing_eff_est,
-            )
-            sample_packing_eff_est = (
-                math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
-            )
-            if update:
-                cfg.sample_packing_eff_est = sample_packing_eff_est
-            LOG.debug(
-                f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
-                main_process_only=True,
-            )
+            # def calc_sample_packing_eff_est(estimates: List[float]):
+            #     LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
+            #     return max(estimates)
+            #
+            # sample_packing_actual_eff_all = reduce_and_broadcast(
+            #     lambda: sampler.efficiency(),  # pylint: disable=unnecessary-lambda
+            #     calc_sample_packing_eff_est,
+            # )
+            # sample_packing_eff_est = (
+            #     math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
+            # )
+            # if update:
+            #     cfg.sample_packing_eff_est = sample_packing_eff_est
+            # LOG.debug(
+            #     f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
+            #     main_process_only=True,
+            # )
     else:
         total_num_steps = int(
             math.ceil(len(train_dataset) * cfg.num_epochs / cfg.batch_size)

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -357,7 +357,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 main_process_only=True,
             )
         else:
-            if cfg.flash_attention:
+            if cfg.flash_attention and not cfg.multipack_real_batches:
                 sampler_batch_size = 1
                 batch_max_len = cfg.micro_batch_size * cfg.sequence_len
             else:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -16,8 +16,7 @@ from torch.utils.data import DataLoader, RandomSampler
 from transformers.utils import is_torch_bf16_gpu_available
 
 from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuilder
-
-# from axolotl.utils.distributed import reduce_and_broadcast
+from axolotl.utils.distributed import reduce_and_broadcast
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 
 LOG = get_logger("axolotl")
@@ -384,23 +383,23 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             # on the agreed on value for sample_packing_eff_est
             total_num_steps = int(math.floor(data_loader_len * cfg.num_epochs))
 
-            # def calc_sample_packing_eff_est(estimates: List[float]):
-            #     LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
-            #     return max(estimates)
-            #
-            # sample_packing_actual_eff_all = reduce_and_broadcast(
-            #     lambda: sampler.efficiency(),  # pylint: disable=unnecessary-lambda
-            #     calc_sample_packing_eff_est,
-            # )
-            # sample_packing_eff_est = (
-            #     math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
-            # )
-            # if update:
-            #     cfg.sample_packing_eff_est = sample_packing_eff_est
-            # LOG.debug(
-            #     f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
-            #     main_process_only=True,
-            # )
+            def calc_sample_packing_eff_est(estimates: List[float]):
+                LOG.info(f"sample_packing_eff_est across ranks: {repr(estimates)}")
+                return max(estimates)
+
+            sample_packing_actual_eff_all = reduce_and_broadcast(
+                lambda: sampler.efficiency(),  # pylint: disable=unnecessary-lambda
+                calc_sample_packing_eff_est,
+            )
+            sample_packing_eff_est = (
+                math.ceil(sample_packing_actual_eff_all * 100.0) / 100.0
+            )
+            if update:
+                cfg.sample_packing_eff_est = sample_packing_eff_est
+            LOG.debug(
+                f"sample_packing_eff_est: {cfg.sample_packing_eff_est}",
+                main_process_only=True,
+            )
     else:
         total_num_steps = int(
             math.ceil(len(train_dataset) * cfg.num_epochs / cfg.batch_size)


### PR DESCRIPTION
added support for

```yaml
auto_find_batch_size: true
```

simply crank up the micro_batch_size to the top of the search range. keep in mind that transformers has no support for changing the lr/gradient_accumulation_Steps to compensate for the different batch size.