### PR TITLE
Fix documentation for pre-tokenized dataset

### DIFF
--- a/docs/dataset-formats/tokenized.qmd
+++ b/docs/dataset-formats/tokenized.qmd
@@ -7,7 +7,7 @@ order: 5
 - Pass an empty `type:` in your axolotl config.
 - Columns in Dataset must be exactly `input_ids`, `attention_mask`, `labels`
 - To indicate that a token should be ignored during training, set its corresponding label to `-100`.
-- Do not add BOS/EOS. Axolotl will add them for you based on the default tokenizer for the model you're using.
+- You must add BOS and EOS, and make sure that you are training on EOS by not setting its label to -100.
 - For pretraining, do not truncate/pad documents to the context window length.
 - For instruction training, documents must be truncated/padded as desired.
 


### PR DESCRIPTION
It's currently asking to not add BOS and EOS, stating that Axolotl adds them, but this is not true. Fixed documentation to instead ask to add BOS and EOS, as well as to emphasize making sure that EOS is trained on by not setting its label to -100.