### PR TITLE
Refactor func load_model to class ModelLoader

### DIFF
--- a/cicd/cicd.sh
+++ b/cicd/cicd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-pytest --ignore=tests/e2e/ /workspace/axolotl/tests/
+pytest -n4 --ignore=tests/e2e/ /workspace/axolotl/tests/
 pytest -n1 --dist loadfile -v /workspace/axolotl/tests/e2e/patched/ /workspace/axolotl/tests/e2e/integrations/
 pytest --ignore=tests/e2e/patched/ --ignore=tests/e2e/multigpu/ --ignore=tests/e2e/integrations/ /workspace/axolotl/tests/e2e/

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -598,10 +598,8 @@ class ModelLoader:
             del self.model_kwargs["device_map"]
 
     def set_quantization_config(self) -> None:
-        if self.cfg.load_in_8bit and self.cfg.adapter is not None:
-            self.model_kwargs["load_in_8bit"] = True
-        if self.cfg.load_in_4bit and self.cfg.adapter is not None:
-            self.model_kwargs["load_in_4bit"] = True
+        self.model_kwargs["load_in_8bit"] = self.cfg.load_in_8bit
+        self.model_kwargs["load_in_4bit"] = self.cfg.load_in_4bit
 
         if self.cfg.gptq:
             if not hasattr(self.model_config, "quantization_config"):
@@ -1073,17 +1071,16 @@ class ModelLoader:
         # ---------------------------------------------------------
         #  put model to accelerator
         # ---------------------------------------------------------
+        is_load_in_8bit = (
+            "load_in_8bit" in self.model_kwargs and self.model_kwargs["load_in_8bit"]
+        )
+        is_load_in_4bit = (
+            "load_in_4bit" in self.model_kwargs and self.model_kwargs["load_in_4bit"]
+        )
         if (
             self.cfg.ddp
-            and not (
-                "load_in_8bit" in self.model_kwargs
-                and self.model_kwargs["load_in_8bit"]
-            )
-            and not (
-                self.cfg.rl
-                and "load_in_4bit" in self.model_kwargs
-                and self.model_kwargs["load_in_4bit"]
-            )
+            and not is_load_in_8bit
+            and not (self.cfg.rl and is_load_in_4bit)
             and not skip_move_to_device
         ):
             # TODO revaldate this conditional

--- a/tests/e2e/test_load_model.py
+++ b/tests/e2e/test_load_model.py
@@ -26,10 +26,9 @@ class TestLoadModelUtils:
         # load config
         self.cfg = DictDefault(
             {
-                "base_model": "openlm-research/open_llama_3b_v2",
+                "base_model": "JackFram/llama-68m",
                 "model_type": "LlamaForCausalLM",
                 "tokenizer_type": "LlamaTokenizer",
-                "tokenizer_config": "openlm-research/open_llama_3b_v2",
                 "load_in_8bit": True,
                 "load_in_4bit": False,
                 "strict": False,

--- a/tests/e2e/test_load_model.py
+++ b/tests/e2e/test_load_model.py
@@ -27,50 +27,33 @@ class TestLoadModelUtils:
         self.cfg = DictDefault(
             {
                 "base_model": "JackFram/llama-68m",
-                "model_type": "LlamaForCausalLM",
                 "tokenizer_type": "LlamaTokenizer",
-                "load_in_8bit": True,
-                "load_in_4bit": False,
-                "strict": False,
-                "datasets": [
-                    {
-                        "path": "teknium/GPT4-LLM-Cleaned",
-                        "type": "alpaca",
-                    },
-                ],
-                "val_set_size": 0.02,
+                "tokenizer_config": "JackFram/llama-68m",
                 "sequence_len": 1024,
-                "sample_packing": True,
+                "load_in_8bit": False,
                 "adapter": "lora",
                 "lora_r": 8,
                 "lora_alpha": 16,
-                "lora_dropout": 0.0,
-                "lora_target_modules": [
-                    "gate_proj",
-                    "down_proj",
-                    "up_proj",
-                    "q_proj",
-                    "v_proj",
-                    "k_proj",
-                    "o_proj",
-                ],
-                "gradient_accumulation_steps": 1,
-                "num_epochs": 1,
-                "micro_batch_size": 2,
-                "optimizer": "adamw_bnb_8bit",
-                "lr_scheduler": "cosine",
-                "learning_rate": 0.0002,
-                "train_on_inputs": False,
-                "group_by_length": False,
-                "bf16": False,
-                "fp16": True,
-                "tf32": False,
-                "gradient_checkpointing": True,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.1,
                 "special_tokens": {
                     "unk_token": "<unk>",
                     "bos_token": "<s>",
                     "eos_token": "</s>",
                 },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "learning_rate": 0.00001,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
             }
         )
         self.model_loader = (  # pylint: disable=attribute-defined-outside-init
@@ -108,5 +91,5 @@ class TestLoadModelUtils:
                     and hasattr(module, "weight")
                 )
             ):
-                for _, param in module.named_parameters(recurse=False):
+                for _, param in module.named_parameters():
                     assert param.dtype == dist_dtype

--- a/tests/e2e/test_load_model.py
+++ b/tests/e2e/test_load_model.py
@@ -1,36 +1,84 @@
-"""Module for testing models utils file."""
+"""Module for testing ModelLoader."""
+
+import shutil
+import tempfile
 
 import pytest
 import torch
 
-from axolotl.cli import load_cfg
+from axolotl.utils.dict import DictDefault
 from axolotl.utils.models import ModelLoader, load_model, load_tokenizer
 
 
-class TestLoadModelUtils:
-    """Testing module for models utils."""
+@pytest.fixture(name="temp_dir")
+def fixture_temp_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)
 
-    def setup_method(self) -> None:
+
+class TestLoadModelUtils:
+    """
+    Testing module testing ModelLoader.
+    """
+
+    def setup_method(self):
         # load config
-        self.cfg = load_cfg(  # pylint: disable=attribute-defined-outside-init
-            "examples/openllama-3b/config.yml"
+        self.cfg = DictDefault(
+            {
+                "base_model": "openlm-research/open_llama_3b_v2",
+                "model_type": "LlamaForCausalLM",
+                "tokenizer_type": "LlamaTokenizer",
+                "tokenizer_config": "openlm-research/open_llama_3b_v2",
+                "load_in_8bit": True,
+                "load_in_4bit": False,
+                "strict": False,
+                "datasets": [
+                    {
+                        "path": "teknium/GPT4-LLM-Cleaned",
+                        "type": "alpaca",
+                    },
+                ],
+                "val_set_size": 0.02,
+                "sequence_len": 1024,
+                "sample_packing": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.0,
+                "lora_target_modules": [
+                    "gate_proj",
+                    "down_proj",
+                    "up_proj",
+                    "q_proj",
+                    "v_proj",
+                    "k_proj",
+                    "o_proj",
+                ],
+                "gradient_accumulation_steps": 1,
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "optimizer": "adamw_bnb_8bit",
+                "lr_scheduler": "cosine",
+                "learning_rate": 0.0002,
+                "train_on_inputs": False,
+                "group_by_length": False,
+                "bf16": False,
+                "fp16": True,
+                "tf32": False,
+                "gradient_checkpointing": True,
+                "special_tokens": {
+                    "unk_token": "<unk>",
+                    "bos_token": "<s>",
+                    "eos_token": "</s>",
+                },
+            }
         )
-        # flash-attn not installed in env of CI
-        self.cfg.flash_attention = (
-            False  # pylint: disable=attribute-defined-outside-init
-        )
-        self.tokenizer = load_tokenizer(self.cfg)  # pylint: disable=all
         self.model_loader = (  # pylint: disable=attribute-defined-outside-init
             ModelLoader(
                 cfg=self.cfg,
-                tokenizer=self.tokenizer,
+                tokenizer="",
             )
-        )
-        self.model_loader.model, _ = load_model(
-            self.cfg,
-            self.tokenizer,
-            inference=False,
-            reference_model=True,
         )
 
     @pytest.mark.parametrize("embedding_modules", ["embed_tokens", "lm_head"])
@@ -39,8 +87,16 @@ class TestLoadModelUtils:
     )
     @pytest.mark.parametrize("before_kbit_train_or_finetune", [True, False])
     def test_convert_embedding_modules_dtype(
-        self, embedding_modules, dist_dtype, before_kbit_train_or_finetune
+        self, temp_dir, embedding_modules, dist_dtype, before_kbit_train_or_finetune
     ):
+        self.cfg.output_dir = temp_dir
+        self.model_loader.tokenizer = load_tokenizer(self.cfg)  # pylint: disable=all
+        self.model_loader.model, _ = load_model(
+            self.cfg,
+            self.model_loader.tokenizer,
+            inference=False,
+            reference_model=True,
+        )
         self.model_loader.convert_embedding_modules_dtype(
             embedding_modules, dist_dtype, before_kbit_train_or_finetune
         )

--- a/tests/e2e/test_load_model.py
+++ b/tests/e2e/test_load_model.py
@@ -1,0 +1,57 @@
+"""Module for testing models utils file."""
+
+import pytest
+import torch
+
+from axolotl.cli import load_cfg
+from axolotl.utils.models import ModelLoader, load_model, load_tokenizer
+
+
+class TestLoadModelUtils:
+    """Testing module for models utils."""
+
+    def setup_method(self) -> None:
+        # load config
+        self.cfg = load_cfg(  # pylint: disable=attribute-defined-outside-init
+            "examples/openllama-3b/config.yml"
+        )
+        # flash-attn not installed in env of CI
+        self.cfg.flash_attention = (
+            False  # pylint: disable=attribute-defined-outside-init
+        )
+        self.tokenizer = load_tokenizer(self.cfg)  # pylint: disable=all
+        self.model_loader = (  # pylint: disable=attribute-defined-outside-init
+            ModelLoader(
+                cfg=self.cfg,
+                tokenizer=self.tokenizer,
+            )
+        )
+        self.model_loader.model, _ = load_model(
+            self.cfg,
+            self.tokenizer,
+            inference=False,
+            reference_model=True,
+        )
+
+    @pytest.mark.parametrize("embedding_modules", ["embed_tokens", "lm_head"])
+    @pytest.mark.parametrize(
+        "dist_dtype", [torch.bfloat16, torch.float16, torch.float32]
+    )
+    @pytest.mark.parametrize("before_kbit_train_or_finetune", [True, False])
+    def test_convert_embedding_modules_dtype(
+        self, embedding_modules, dist_dtype, before_kbit_train_or_finetune
+    ):
+        self.model_loader.convert_embedding_modules_dtype(
+            embedding_modules, dist_dtype, before_kbit_train_or_finetune
+        )
+        for name, module in self.model_loader.model.named_modules():
+            if (
+                "norm" in name
+                or (before_kbit_train_or_finetune and name.endswith(".gate"))
+                or (
+                    any(m in name for m in embedding_modules)
+                    and hasattr(module, "weight")
+                )
+            ):
+                for _, param in module.named_parameters(recurse=False):
+                    assert param.dtype == dist_dtype

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -7,7 +7,6 @@ from transformers import BitsAndBytesConfig, PreTrainedTokenizerBase
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.utils.import_utils import is_torch_mps_available
 
-from axolotl.cli import load_cfg
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.models import ModelLoader, load_model
 
@@ -17,12 +16,18 @@ class TestModelsUtils:
 
     def setup_method(self) -> None:
         # load config
-        config_path = "examples/openllama-3b/config.yml"
-        self.cfg = load_cfg(  # pylint: disable=attribute-defined-outside-init
-            config_path
-        )
-        self.cfg.flash_attention = (
-            False  # pylint: disable=attribute-defined-outside-init
+        self.cfg = DictDefault(  # pylint: disable=attribute-defined-outside-init
+            {
+                "base_model": "openlm-research/open_llama_3b_v2",
+                "model_type": "LlamaForCausalLM",
+                "tokenizer_type": "LlamaTokenizer",
+                "load_in_8bit": True,
+                "load_in_4bit": False,
+                "adapter": "lora",
+                "flash_attention": False,
+                "sample_packing": True,
+                "device_map": "auto",
+            }
         )
         self.tokenizer = MagicMock(  # pylint: disable=attribute-defined-outside-init
             spec=PreTrainedTokenizerBase

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -1,17 +1,42 @@
 """Module for testing models utils file."""
 
-
-import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
+from transformers import BitsAndBytesConfig, PreTrainedTokenizerBase
+from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
+from transformers.utils.import_utils import is_torch_mps_available
 
+from axolotl.cli import load_cfg
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.models import load_model
+from axolotl.utils.models import ModelLoader, load_model, load_tokenizer
 
 
-class ModelsUtilsTest(unittest.TestCase):
+class TestModelsUtils:
     """Testing module for models utils."""
+
+    def setup_method(self) -> None:
+        # load config
+        config_path = "examples/openllama-3b/config.yml"
+        self.cfg = load_cfg(  # pylint: disable=attribute-defined-outside-init
+            config_path
+        )
+        self.tokenizer = MagicMock(  # pylint: disable=attribute-defined-outside-init
+            spec=PreTrainedTokenizerBase
+        )
+        self.inference = False  # pylint: disable=attribute-defined-outside-init
+        self.reference_model = True  # pylint: disable=attribute-defined-outside-init
+
+        # init ModelLoader
+        self.model_loader = (  # pylint: disable=attribute-defined-outside-init
+            ModelLoader(
+                cfg=self.cfg,
+                tokenizer=self.tokenizer,
+                inference=self.inference,
+                reference_model=self.reference_model,
+            )
+        )
 
     def test_cfg_throws_error_with_s2_attention_and_sample_packing(self):
         cfg = DictDefault(
@@ -35,3 +60,78 @@ class ModelsUtilsTest(unittest.TestCase):
                 "shifted-sparse attention does not currently support sample packing"
                 in str(exc.value)
             )
+
+    def test_set_device_map_config(self):
+        # check device_map
+        device_map = self.cfg.device_map
+        if is_torch_mps_available():
+            device_map = "mps"
+        self.model_loader.set_device_map_config()
+        if is_deepspeed_zero3_enabled():
+            assert "device_map" not in self.model_loader.model_kwargs
+        else:
+            assert device_map in self.model_loader.model_kwargs["device_map"]
+
+        # check torch_dtype
+        assert self.cfg.torch_dtype == self.model_loader.model_kwargs["torch_dtype"]
+
+    @pytest.mark.parametrize("adapter", ["lora", "qlora", None])
+    @pytest.mark.parametrize("load_in_8bit", [True, False])
+    @pytest.mark.parametrize("load_in_4bit", [True, False])
+    @pytest.mark.parametrize("gptq", [True, False])
+    def test_set_quantization_config(
+        self,
+        adapter,
+        load_in_8bit,
+        load_in_4bit,
+        gptq,
+    ):
+        # init cfg as args
+        self.cfg.load_in_8bit = load_in_8bit
+        self.cfg.load_in_4bit = load_in_4bit
+        self.cfg.gptq = gptq
+        self.cfg.adapter = adapter
+
+        self.model_loader.set_quantization_config()
+        if "quantization_config" in self.model_loader.model_kwargs or self.cfg.gptq:
+            assert not (
+                hasattr(self.model_loader.model_kwargs, "load_in_8bit")
+                and hasattr(self.model_loader.model_kwargs, "load_in_4bit")
+            )
+        elif load_in_8bit and self.cfg.adapter is not None:
+            assert self.model_loader.model_kwargs["load_in_8bit"]
+        elif load_in_4bit and self.cfg.adapter is not None:
+            assert self.model_loader.model_kwargs["load_in_4bit"]
+
+        if (self.cfg.adapter == "qlora" and load_in_4bit) or (
+            self.cfg.adapter == "lora" and load_in_8bit
+        ):
+            assert self.model_loader.model_kwargs.get(
+                "quantization_config", BitsAndBytesConfig
+            )
+
+    @pytest.mark.parametrize("embedding_modules", ["embed_tokens", "lm_head"])
+    @pytest.mark.parametrize(
+        "dist_dtype", [torch.bfloat16, torch.float16, torch.float32]
+    )
+    @pytest.mark.parametrize("before_kbit_train_or_finetune", [True, False])
+    def test_convert_embedding_modules_dtype(
+        self, embedding_modules, dist_dtype, before_kbit_train_or_finetune
+    ):
+        tokenizer = load_tokenizer(self.cfg)
+        self.model_loader.model, _ = load_model(self.cfg, tokenizer, inference=False)
+
+        self.model_loader.convert_embedding_modules_dtype(
+            embedding_modules, dist_dtype, before_kbit_train_or_finetune
+        )
+        for name, module in self.model_loader.model.named_modules():
+            if (
+                "norm" in name
+                or (before_kbit_train_or_finetune and name.endswith(".gate"))
+                or (
+                    any(m in name for m in embedding_modules)
+                    and hasattr(module, "weight")
+                )
+            ):
+                for _, param in module.named_parameters(recurse=False):
+                    assert param.dtype == dist_dtype

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -3,14 +3,13 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-import torch
 from transformers import BitsAndBytesConfig, PreTrainedTokenizerBase
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.utils.import_utils import is_torch_mps_available
 
 from axolotl.cli import load_cfg
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.models import ModelLoader, load_model, load_tokenizer
+from axolotl.utils.models import ModelLoader, load_model
 
 
 class TestModelsUtils:
@@ -112,29 +111,3 @@ class TestModelsUtils:
             assert self.model_loader.model_kwargs.get(
                 "quantization_config", BitsAndBytesConfig
             )
-
-    @pytest.mark.parametrize("embedding_modules", ["embed_tokens", "lm_head"])
-    @pytest.mark.parametrize(
-        "dist_dtype", [torch.bfloat16, torch.float16, torch.float32]
-    )
-    @pytest.mark.parametrize("before_kbit_train_or_finetune", [True, False])
-    def test_convert_embedding_modules_dtype(
-        self, embedding_modules, dist_dtype, before_kbit_train_or_finetune
-    ):
-        tokenizer = load_tokenizer(self.cfg)
-        self.model_loader.model, _ = load_model(self.cfg, tokenizer, inference=False)
-
-        self.model_loader.convert_embedding_modules_dtype(
-            embedding_modules, dist_dtype, before_kbit_train_or_finetune
-        )
-        for name, module in self.model_loader.model.named_modules():
-            if (
-                "norm" in name
-                or (before_kbit_train_or_finetune and name.endswith(".gate"))
-                or (
-                    any(m in name for m in embedding_modules)
-                    and hasattr(module, "weight")
-                )
-            ):
-                for _, param in module.named_parameters(recurse=False):
-                    assert param.dtype == dist_dtype

--- a/tests/utils/test_models.py
+++ b/tests/utils/test_models.py
@@ -18,7 +18,7 @@ class TestModelsUtils:
         # load config
         self.cfg = DictDefault(  # pylint: disable=attribute-defined-outside-init
             {
-                "base_model": "openlm-research/open_llama_3b_v2",
+                "base_model": "JackFram/llama-68m",
                 "model_type": "LlamaForCausalLM",
                 "tokenizer_type": "LlamaTokenizer",
                 "load_in_8bit": True,


### PR DESCRIPTION
# Description

part of https://github.com/axolotl-ai-cloud/axolotl/pull/1758

This PR refactor the func `load_model` in `src/axolotl/utils/models.py` into a class `ModelLoader`. Different member functions of class `ModelLoader` are separated according to their features, and all the member vars of `ModelLoader` are shared in these funcs. Moreover, this refactoring make the pipeline of model loading more clearly.

TODO:

- [ ] add UT for ModelLoader

Mainly changes are listed here:

- organize comman var into member var of class `ModelLoader`
- split operations in `load_model` into separate member funcs
- refactor `cfg.load_in_Xbit` to kwarg

The UML of `ModelLoader`:

![9ef679eaeeff1fe01dbff0c4b67f81c](https://github.com/user-attachments/assets/048bba9b-8952-4f96-9a33-edbc0697c7c3)

## Motivation and Context

**Why is this change required?**

As the models loaded in Axolotl support more and more features, the func `load_model` is huge now. And this results in confusion about variable changes when abstracting part of func `load_model` (https://github.com/axolotl-ai-cloud/axolotl/pull/1758#pullrequestreview-2180877655). Refactoring `load_model` will **optimize the code structure** and **facilitate stable evolution** when introducing more features in the future.

## How has this been tested?

1. part of UTs for ModelLoader is added and tests passed
2. I tested to funtune, inference (on both terminal and gradio webui) on `open_llama_3b_v2` model, and here comes the screenshot of inferencing:

![GPU-INFERENCE](https://github.com/user-attachments/assets/7ee4911d-2644-48de-bfb2-212a11c1a981)

However, I **don't have access to Ampere or newer GPU**, thus I cannot pass the UT on my local machine. It would be nice if all UTs could be tested on CI.