### PR TITLE
fix(log): update perplexity log to clarify from eval split

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -462,7 +462,7 @@ def causal_lm_bench_eval_callback_factory(trainer: Trainer, tokenizer):
                             references=[[r] for r in references],
                             predictions=predictions,
                         )
-                    scores[metric_name] = score
+                    scores["eval_" + metric_name] = score
                 return scores
 
             def predict_with_generate():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Previously, `perplexity` would be saved under train split.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/f8f4a1f8-7630-4c07-a6cf-6875f0f7715f">

This modification moves it under `eval` 

<img width="360" alt="image" src="https://github.com/user-attachments/assets/4322e6cf-6071-4418-83fa-807f5060af2c">


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/axolotl-ai-cloud/axolotl/discussions/1908

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with A40 on wandb

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
