### PR TITLE
Handle image input as string paths for MMLMs

### DIFF
--- a/src/axolotl/utils/collators/mm_chat.py
+++ b/src/axolotl/utils/collators/mm_chat.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from transformers import PreTrainedTokenizerBase, ProcessorMixin
 from transformers.data.data_collator import DataCollatorMixin
 from transformers.utils import PaddingStrategy
-
+from PIL import Image
 
 @dataclass
 class MultiModalChatDataCollator(DataCollatorMixin):
@@ -52,7 +52,7 @@ class MultiModalChatDataCollator(DataCollatorMixin):
             )
             for example in examples
         ]
-        images = [example["images"] for example in examples]
+        images = [Image.open(example["images"]) if type(example["images"])==str else example["images"] for example in examples]
 
         if max_images > 0:
             images = [img_batch[:max_images] for img_batch in images]

--- a/src/axolotl/utils/collators/mm_chat.py
+++ b/src/axolotl/utils/collators/mm_chat.py
@@ -4,10 +4,11 @@ Collators for multi-modal chat messages and packing
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
+from PIL import Image
 from transformers import PreTrainedTokenizerBase, ProcessorMixin
 from transformers.data.data_collator import DataCollatorMixin
 from transformers.utils import PaddingStrategy
-from PIL import Image
+
 
 @dataclass
 class MultiModalChatDataCollator(DataCollatorMixin):
@@ -52,7 +53,12 @@ class MultiModalChatDataCollator(DataCollatorMixin):
             )
             for example in examples
         ]
-        images = [Image.open(example["images"]) if type(example["images"])==str else example["images"] for example in examples]
+        images = [
+            Image.open(example["images"])
+            if isinstance(example["images"], str)
+            else example["images"]
+            for example in examples
+        ]
 
         if max_images > 0:
             images = [img_batch[:max_images] for img_batch in images]


### PR DESCRIPTION
### Description

- Accept datasets with the `image` path as a string
- The original code would throw a `ValueError` because the trainer processor expects an image directly
- Images are loaded online during training in batches

### Motivation and Context

- Some datasets store the image rows as string paths so it can be handled easier and faster

### How has this been tested?

- `ValueError` is gone and training runs smoothly