### PR TITLE
also debug if other debug args are set

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -462,7 +462,12 @@ def load_datasets(
         processor=processor,
     )
 
-    if cli_args.debug or cfg.debug:
+    if (
+        cli_args.debug
+        or cfg.debug
+        or cli_args.debug_text_only
+        or cli_args.debug_num_examples
+    ):
         LOG.info("check_dataset_labels...")
         check_dataset_labels(
             train_dataset.select(


### PR DESCRIPTION
right now, you have to include `--debug` even if you set `--debug_text_only` which seems redundant