### PR TITLE
add option for resizing embeddings when adding new tokens

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -549,6 +549,7 @@ class AxolotlInputConfig(
     resume_from_checkpoint: Optional[str] = None
     auto_resume_from_checkpoints: Optional[bool] = None
     resize_token_embeddings_to_32x: Optional[bool] = None
+    mean_resizing_embeddings: Optional[bool] = None
 
     rl: Optional[RLType] = None
     reward_model: Optional[bool] = None

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -549,7 +549,7 @@ class AxolotlInputConfig(
     resume_from_checkpoint: Optional[str] = None
     auto_resume_from_checkpoints: Optional[bool] = None
     resize_token_embeddings_to_32x: Optional[bool] = None
-    mean_resizing_embeddings: Optional[bool] = None
+    mean_resizing_embeddings: Optional[bool] = False
 
     rl: Optional[RLType] = None
     reward_model: Optional[bool] = None

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1042,7 +1042,10 @@ class ModelLoader:
             hasattr(self.model, "get_input_embeddings")
             and self.model.get_input_embeddings().num_embeddings < embeddings_len
         ):
-            self.model.resize_token_embeddings(embeddings_len)
+            resize_kwargs = {}
+            if self.cfg.mean_resizing_embeddings is not None:
+                resize_kwargs["mean_resizing"] = self.cfg.mean_resizing_embeddings
+            self.model.resize_token_embeddings(embeddings_len, **resize_kwargs)
         else:
             self.model.tie_weights()
 


### PR DESCRIPTION
it's reported that when adding new tokens, after upgrading transformers, the model isn't learning new tokens and the loss doesn't converge as well.  added an option to change from the new default for the upstream change added here

https://github.com/huggingface/transformers/pull/33325

<img width="451" alt="Screenshot 2024-10-28 at 3 03 48 PM" src="https://github.com/user-attachments/assets/2e1c5391-4fef-4bc7-89fd-1030fe960bfd">
