### PR TITLE
refactor(optimizer): use `optimizer_cls_and_kwargs` for custom optim

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -397,7 +397,7 @@ lr_div_factor: # Learning rate div factor
 
 # Specify optimizer
 # Valid values are driven by the Transformers OptimizerNames class, see:
-# https://github.com/huggingface/transformers/blob/95b374952dc27d8511541d6f5a4e22c9ec11fb24/src/transformers/training_args.py#L134
+# https://github.com/huggingface/transformers/blob/9f06fb05059a973048f5865e7e385c9db5d6daa4/src/transformers/training_args.py#L145-L187
 #
 # Note that not all optimizers may be available in your environment, ex: 'adamw_anyprecision' is part of
 # torchdistx, 'adamw_bnb_8bit' is part of bnb.optim.Adam8bit, etc. When in doubt, it is recommended to start with the optimizer used
@@ -408,26 +408,48 @@ lr_div_factor: # Learning rate div factor
 # - adamw_torch
 # - adamw_torch_fused
 # - adamw_torch_xla
+# - adamw_torch_npu_fused
 # - adamw_apex_fused
 # - adopt_adamw (an EXPERIMENTAL optimizer, only for torch version >= 2.5.1)
 # - adafactor
 # - adamw_anyprecision
+# - adamw_torch_4bit
+# - ademamix
 # - sgd
 # - adagrad
 # - adamw_bnb_8bit
+# - adamw_8bit  # alias for adamw_bnb_8bit
+# - ademamix_8bit
 # - lion_8bit
 # - lion_32bit
 # - paged_adamw_32bit
 # - paged_adamw_8bit
+# - paged_ademamix_32bit
+# - paged_ademamix_8bit
 # - paged_lion_32bit
 # - paged_lion_8bit
+# - rmsprop
+# - rmsprop_bnb
+# - rmsprop_bnb_8bit
+# - rmsprop_bnb_32bit
 # - galore_adamw
 # - galore_adamw_8bit
 # - galore_adafactor
 # - galore_adamw_layerwise
 # - galore_adamw_8bit_layerwise
 # - galore_adafactor_layerwise
+# - lomo
+# - adalomo
+# - grokadamw
+# - schedule_free_adamw
+# - schedule_free_sgd
+#
+# Additional custom optimizers include:
+# - optimi_adamw
+# - ao_adamw_8bit
+# - ao_adamw_fp8
 optimizer:
+
 # Dictionary of arguments to pass to the optimizer
 optim_args:
 # For Galore Optimizers the following optim_args are available

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -74,6 +74,7 @@ from axolotl.utils.collators import (
     V2BatchSamplerDataCollatorForSeq2Seq,
 )
 from axolotl.utils.collators.mm_chat import MultiModalChatDataCollator
+from axolotl.utils.config.models.input.v0_4_1 import CustomSupportedOptimizers
 from axolotl.utils.models import ensure_dtype
 from axolotl.utils.optimizers.embedding_scaled import create_embedding_scaled_optimizer
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
@@ -1726,14 +1727,8 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             trainer_kwargs["max_length"] = self.cfg.sequence_len
 
         # Handle custom optimizer
-        if self.cfg.optimizer in [
-            "optimi_adamw",
-            "ao_adamw_4bit",
-            "ao_adamw_8bit",
-            "ao_adamw_fp8",
-            "adopt_adamw",
-            "lion_pytorch",
-        ]:
+        custom_supported_optimizers = [opt.value for opt in CustomSupportedOptimizers]
+        if self.cfg.optimizer in custom_supported_optimizers:
             # Common optimizer kwargs
             optimizer_kwargs = {
                 "lr": training_arguments_kwargs.get("learning_rate"),

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -71,8 +71,6 @@ class DeprecatedParameters(BaseModel):
     dpo_beta: Optional[float] = None
     evaluation_strategy: Optional[str] = None
 
-    alternate_optimizer: Optional[str] = None
-
     @field_validator("max_packed_sequence_len")
     @classmethod
     def validate_max_packed_sequence_len(cls, max_packed_sequence_len):

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -119,14 +119,6 @@ class DeprecatedParameters(BaseModel):
             LOG.warning("evaluation_strategy is deprecated, use eval_strategy instead")
         return evaluation_strategy
 
-    @field_validator("alternate_optimizer")
-    @classmethod
-    def validate_alternate_optimizer(cls, alternate_optimizer):
-        if alternate_optimizer:
-            raise DeprecationWarning(
-                "alternate_optimizer is deprecated, use optimizer instead"
-            )
-
 
 class RemappedParameters(BaseModel):
     """parameters that have been remapped to other names"""

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -62,6 +62,17 @@ class ChatTemplate(str, Enum):
     metharme = "metharme"  # pylint: disable=invalid-name
 
 
+class CustomSupportedOptimizers(str, Enum):
+    """Custom supported optimizers"""
+
+    optimi_adamw = "optimi_adamw"  # pylint: disable=invalid-name
+    ao_adamw_4bit = "ao_adamw_4bit"  # pylint: disable=invalid-name
+    ao_adamw_8bit = "ao_adamw_8bit"  # pylint: disable=invalid-name
+    ao_adamw_fp8 = "ao_adamw_fp8"  # pylint: disable=invalid-name
+    adopt_adamw = "adopt_adamw"  # pylint: disable=invalid-name
+    lion_pytorch = "lion_pytorch"  # pylint: disable=invalid-name
+
+
 class DeprecatedParameters(BaseModel):
     """configurations that are deprecated"""
 
@@ -445,17 +456,7 @@ class HyperparametersConfig(BaseModel):
     embedding_lr_scale: Optional[float] = None
     weight_decay: Optional[float] = 0.0
     optimizer: Optional[
-        Union[
-            OptimizerNames,
-            Literal[
-                "lion_pytorch",
-                "optimi_adamw",
-                "ao_adamw_4bit",
-                "ao_adamw_8bit",
-                "ao_adamw_fp8",
-                "adopt_adamw",
-            ],
-        ]
+        Union[OptimizerNames, CustomSupportedOptimizers]
     ] = OptimizerNames.ADAMW_HF.value
     optim_args: Optional[Union[str, Dict[str, Any]]] = Field(
         default=None,

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -71,6 +71,8 @@ class DeprecatedParameters(BaseModel):
     dpo_beta: Optional[float] = None
     evaluation_strategy: Optional[str] = None
 
+    alternate_optimizer: Optional[str] = None
+
     @field_validator("max_packed_sequence_len")
     @classmethod
     def validate_max_packed_sequence_len(cls, max_packed_sequence_len):
@@ -107,6 +109,14 @@ class DeprecatedParameters(BaseModel):
         if evaluation_strategy is not None:
             LOG.warning("evaluation_strategy is deprecated, use eval_strategy instead")
         return evaluation_strategy
+
+    @field_validator("alternate_optimizer")
+    @classmethod
+    def validate_alternate_optimizer(cls, alternate_optimizer):
+        if alternate_optimizer:
+            raise DeprecationWarning(
+                "alternate_optimizer is deprecated, use optimizer instead"
+            )
 
 
 class RemappedParameters(BaseModel):

--- a/src/axolotl/utils/optimizers/embedding_scaled.py
+++ b/src/axolotl/utils/optimizers/embedding_scaled.py
@@ -1,0 +1,68 @@
+"""
+Scales the learning rate of the embedding layer by a factor of `embedding_lr_scale` or to `embedding_lr` if set.
+
+Applies weight decay to parameters in `decay_parameters` and no weight decay to the rest.
+"""
+
+
+def create_embedding_scaled_optimizer(
+    opt_model,
+    embedding_lr_scale,
+    embedding_lr,
+    weight_decay,
+    decay_parameters,
+    optimizer_cls,
+    optimizer_kwargs,
+):
+    params = {
+        "embeddings": {},  # lm_head, embed_tokens,
+        "to_weight_decay": {},  # LayerNorm and bias
+        "no_weight_decay": {},
+    }
+
+    for name, param in opt_model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.endswith("modules_to_save.default.weight") or any(
+            embed_name in name for embed_name in ["embed_tokens", "lm_head"]
+        ):
+            params["embeddings"][name] = param
+        elif name in decay_parameters:
+            params["to_weight_decay"][name] = param
+        else:
+            params["no_weight_decay"][name] = param
+
+    optimizer_grouped_parameters = []
+    if params["to_weight_decay"]:
+        optimizer_grouped_parameters.append(
+            {
+                "params": list(params["to_weight_decay"].values()),
+                "weight_decay": weight_decay,
+                "lr": optimizer_kwargs["lr"],
+            }
+        )
+
+    if params["embeddings"]:
+        lr = optimizer_kwargs["lr"]  # pylint: disable=invalid-name
+        if embedding_lr_scale:
+            lr *= embedding_lr_scale  # pylint: disable=invalid-name
+        elif embedding_lr:
+            lr = embedding_lr  # pylint: disable=invalid-name
+        optimizer_grouped_parameters.append(
+            {
+                "params": list(params["embeddings"].values()),
+                "weight_decay": 0.0,
+                "lr": lr,
+            }
+        )
+
+    if params["no_weight_decay"]:
+        optimizer_grouped_parameters.append(
+            {
+                "params": list(params["no_weight_decay"].values()),
+                "weight_decay": 0.0,
+                "lr": optimizer_kwargs["lr"],
+            }
+        )
+
+    return optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)


### PR DESCRIPTION
# Breaking change

- Deprecates `alternate_optimizer`. Move to use `optimizer` instead to consolidate.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Refactors the optimizer handling to offload from `create_optimizer` into the Trainer instead. Only `lora_plus` requires overriding that function now.

- `ao_adamw_4bit` is available on `transformers` as `adamw_torch_4bit`.
- `lion_pytorch` is available on `transformers` as `lion_32bit`.
- Removed default handling of `loraplus_lr_embedding` to let it inherit from Model Input class instead
- Updated docs to include new upstream optimizers

TODO:
- [x] Verify `adamw_anyprecision` is not affected
- [x] Verify Galore is not affected
- [ ] Discuss whether to support other `optimi` optimizers https://optimi.benjaminwarner.dev/which_optimizer/
- [x] Update transformers to commit that includes the linked PR
- [ ] Test custom optimizers
- [ ] Test upstream optimizers

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is due to upstream PR opening a new config https://github.com/huggingface/transformers/pull/34358/

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->

## Next steps

Once some time passes:
- Deprecate `lion_pytorch` and remove the dependency