### PR TITLE
fix(vlm): handle legacy conversation data format and check image in data

### DIFF
--- a/src/axolotl/utils/collators/mm_chat.py
+++ b/src/axolotl/utils/collators/mm_chat.py
@@ -1,6 +1,8 @@
 """
 Collators for multi-modal chat messages and packing
 """
+
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
@@ -46,6 +48,116 @@ class MultiModalChatDataCollator(DataCollatorMixin):
         # *** This is COPIED from the trl example sft_vlm.py code ***
         # use this as a starting point
 
+        def _preprocess(examples: list[dict]) -> dict:
+            """
+            Preprocess conversation examples to ensure consistent format.
+
+            Converts different conversation formats to OpenAI format with 'messages'.
+            Supports two formats:
+            1. OpenAI format with 'messages'
+            2. Legacy format with 'conversations'
+
+            Args:
+                examples: list of conversation dictionaries
+
+            Returns:
+                dict in OpenAI format with 'messages' key
+
+            Raises:
+                ValueError: If the conversation format is not supported
+            """
+            role_mapping = {
+                "human": "user",
+                "gpt": "assistant",
+            }
+
+            def normalize_role(role: str) -> str:
+                """Normalize role names to OpenAI format. Default to original role if not found."""
+                return role_mapping.get(role, role)
+
+            def convert_legacy_format(example: Dict) -> Dict:
+                """Convert legacy 'conversations' format to OpenAI 'messages' format."""
+                messages = [
+                    {
+                        "role": normalize_role(convo["from"]),
+                        "content": convo["value"],
+                    }
+                    for convo in example["conversations"]
+                ]
+
+                # Create new dict without 'conversations' key
+                result = deepcopy(example)
+                result.pop("conversations")
+                return {"messages": messages, **result}
+
+            for example in examples:
+                # OpenAI format
+                if "messages" in example:
+                    return example
+
+                # Legacy format
+                if "conversations" in example:
+                    return convert_legacy_format(example)
+
+            raise ValueError(
+                "Only `messages` and `conversations` message keys are currently supported."
+            )
+
+        def _process_images(examples, max_images):
+            """
+            Process images from examples, ensuring consistency in image presence and applying max_images limit.
+
+            Args:
+                examples: List of dictionaries that may contain 'images' key
+                max_images: Maximum number of images to keep per example (0 means no limit)
+
+            Returns:
+                Either None (if no images) or List[Image objects] (if all examples have images)
+
+            Raises:
+                ValueError: If there's a mix of None and non-None images
+            """
+
+            def get_image(example):
+                if "images" not in example:
+                    return None
+                images = example["images"]
+                if isinstance(images, str):
+                    return Image.open(images)
+                return images
+
+            images = [get_image(example) for example in examples]
+
+            # Count None and non-None images
+            none_count = sum(1 for img in images if img is None)
+
+            # All images are None
+            if none_count == len(images):
+                return None
+
+            # Mix of None and non-None images
+            if none_count > 0:
+                raise ValueError(
+                    "All images should be either None or not None. "
+                    "Please provide images for all examples or None."
+                )
+
+            # Apply max_images limit if specified
+            if max_images > 0:
+                images = [
+                    (
+                        img_batch[:max_images]
+                        if isinstance(img_batch, (list, tuple))
+                        else img_batch
+                    )
+                    for img_batch in images
+                ]
+
+            return images
+
+        # Preprocess the examples
+        examples = _preprocess(examples)
+
         # Get the texts and images, and apply the chat template
         texts = [
             processor.apply_chat_template(
@@ -53,15 +165,8 @@ class MultiModalChatDataCollator(DataCollatorMixin):
             )
             for example in examples
         ]
-        images = [
-            Image.open(example["images"])
-            if isinstance(example["images"], str)
-            else example["images"]
-            for example in examples
-        ]
 
-        if max_images > 0:
-            images = [img_batch[:max_images] for img_batch in images]
+        images = _process_images(examples, max_images=max_images)
 
         # Tokenize the texts and process the images
         batch = processor(text=texts, images=images, return_tensors="pt", padding=True)

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -25,17 +25,16 @@ class TestLlamaVision(unittest.TestCase):
     """
 
     @with_temp_dir
-    def test_llama_vision_text_only_dataset(self, temp_dir):
+    def test_lora_llama_vision_text_only_dataset(self, temp_dir):
         # pylint: disable=duplicate-code
         cfg = DictDefault(
             {
-                "base_model": "alpindale/Llama-3.2-11B-Vision-Instruct",
+                "base_model": "axolotl-ai-co/Llama-3.2-39M-Vision",
                 "processor_type": "AutoProcessor",
                 "skip_prepare_dataset": True,
                 "remove_unused_columns": False,
                 "sample_packing": False,
                 "sequence_len": 1024,
-                "load_in_8bit": True,
                 "adapter": "lora",
                 "lora_r": 8,
                 "lora_alpha": 16,
@@ -58,6 +57,7 @@ class TestLlamaVision(unittest.TestCase):
                 "lr_scheduler": "cosine",
                 "max_steps": 5,
                 "save_safetensors": True,
+                "bf16": True,
             }
         )
         normalize_config(cfg)
@@ -65,20 +65,19 @@ class TestLlamaVision(unittest.TestCase):
         dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
 
         train(cfg=cfg, cli_args=cli_args, dataset_meta=dataset_meta)
-        assert (Path(temp_dir) / "model-00001-of-00005.safetensors").exists()
+        assert (Path(temp_dir) / "adapter_model.safetensors").exists()
 
     @with_temp_dir
-    def test_llama_vision_multimodal_dataset(self, temp_dir):
+    def test_lora_llama_vision_multimodal_dataset(self, temp_dir):
         # pylint: disable=duplicate-code
         cfg = DictDefault(
             {
-                "base_model": "alpindale/Llama-3.2-11B-Vision-Instruct",
+                "base_model": "axolotl-ai-co/Llama-3.2-39M-Vision",
                 "processor_type": "AutoProcessor",
                 "skip_prepare_dataset": True,
                 "remove_unused_columns": False,
                 "sample_packing": False,
                 "sequence_len": 1024,
-                "load_in_8bit": True,
                 "adapter": "lora",
                 "lora_r": 8,
                 "lora_alpha": 16,
@@ -88,9 +87,9 @@ class TestLlamaVision(unittest.TestCase):
                 "chat_template": "llama3_2_vision",
                 "datasets": [
                     {
-                        "path": "HuggingFaceH4/llava-instruct-mix-vsft",
+                        "path": "axolotl-ai-co/llava-instruct-mix-vsft-small",
                         "type": "chat_template",
-                        "split": "train[:1%]",
+                        "split": "train",
                         "field_messages": "messages",
                     },
                 ],
@@ -103,6 +102,7 @@ class TestLlamaVision(unittest.TestCase):
                 "lr_scheduler": "cosine",
                 "max_steps": 5,
                 "save_safetensors": True,
+                "bf16": True,
             }
         )
         normalize_config(cfg)
@@ -110,4 +110,4 @@ class TestLlamaVision(unittest.TestCase):
         dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
 
         train(cfg=cfg, cli_args=cli_args, dataset_meta=dataset_meta)
-        assert (Path(temp_dir) / "model-00001-of-00005.safetensors").exists()
+        assert (Path(temp_dir) / "adapter_model.safetensors").exists()

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -46,6 +46,9 @@ class TestLlamaVision(unittest.TestCase):
                     {
                         "path": "LDJnr/Puffin",
                         "type": "chat_template",
+                        "field_messages": "conversations",
+                        "message_field_role": "from",
+                        "message_field_content": "value",
                     },
                 ],
                 "num_epochs": 1,

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -1,0 +1,111 @@
+"""
+E2E tests for lora llama
+"""
+
+import logging
+import os
+import unittest
+from pathlib import Path
+
+from axolotl.cli import load_datasets
+from axolotl.common.cli import TrainerCliArgs
+from axolotl.train import train
+from axolotl.utils.config import normalize_config
+from axolotl.utils.dict import DictDefault
+
+from .utils import with_temp_dir
+
+LOG = logging.getLogger("axolotl.tests.e2e")
+os.environ["WANDB_DISABLED"] = "true"
+
+
+class TestLlamaVision(unittest.TestCase):
+    """
+    Test case for Llama Vision models
+    """
+
+    @with_temp_dir
+    def test_llama_vision_text_only_dataset(self, temp_dir):
+        # pylint: disable=duplicate-code
+        cfg = DictDefault(
+            {
+                "base_model": "alpindale/Llama-3.2-11B-Vision-Instruct",
+                "processor_type": "AutoProcessor",
+                "skip_prepare_dataset": True,
+                "remove_unused_columns": False,
+                "sample_packing": False,
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_modules": r"language_model.model.layers.[\d]+.(mlp|cross_attn|self_attn).(up|down|gate|q|k|v|o)_proj",
+                "val_set_size": 0,
+                "chat_template": "llama3_2_vision",
+                "datasets": [
+                    {
+                        "path": "LDJnr/Puffin",
+                        "type": "chat_template",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 4,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "adamw_bnb_8bit",
+                "lr_scheduler": "cosine",
+                "save_safetensors": True,
+            }
+        )
+        normalize_config(cfg)
+        cli_args = TrainerCliArgs()
+        dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
+
+        train(cfg=cfg, cli_args=cli_args, dataset_meta=dataset_meta)
+        assert (Path(temp_dir) / "model-00001-of-00005.safetensors").exists()
+
+    @with_temp_dir
+    def test_llama_vision_multimodal_dataset(self, temp_dir):
+        # pylint: disable=duplicate-code
+        cfg = DictDefault(
+            {
+                "base_model": "alpindale/Llama-3.2-11B-Vision-Instruct",
+                "processor_type": "AutoProcessor",
+                "skip_prepare_dataset": True,
+                "remove_unused_columns": False,
+                "sample_packing": False,
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_modules": r"language_model.model.layers.[\d]+.(mlp|cross_attn|self_attn).(up|down|gate|q|k|v|o)_proj",
+                "val_set_size": 0,
+                "chat_template": "llama3_2_vision",
+                "datasets": [
+                    {
+                        "path": "HuggingFaceH4/llava-instruct-mix-vsft",
+                        "type": "chat_template",
+                        "split": "train[:1%]",
+                        "field_messages": "messages",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 4,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "adamw_bnb_8bit",
+                "lr_scheduler": "cosine",
+                "save_safetensors": True,
+            }
+        )
+        normalize_config(cfg)
+        cli_args = TrainerCliArgs()
+        dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
+
+        train(cfg=cfg, cli_args=cli_args, dataset_meta=dataset_meta)
+        assert (Path(temp_dir) / "model-00001-of-00005.safetensors").exists()

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -56,6 +56,7 @@ class TestLlamaVision(unittest.TestCase):
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_bnb_8bit",
                 "lr_scheduler": "cosine",
+                "max_steps": 5,
                 "save_safetensors": True,
             }
         )
@@ -100,6 +101,7 @@ class TestLlamaVision(unittest.TestCase):
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_bnb_8bit",
                 "lr_scheduler": "cosine",
+                "max_steps": 5,
                 "save_safetensors": True,
             }
         )

--- a/tests/e2e/test_lora_llama.py
+++ b/tests/e2e/test_lora_llama.py
@@ -57,6 +57,7 @@ class TestLoraLlama(unittest.TestCase):
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_torch",
                 "lr_scheduler": "cosine",
+                "max_steps": 20,
             }
         )
         normalize_config(cfg)

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -56,6 +56,7 @@ class TestCustomOptimizers(unittest.TestCase):
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
                 "optimizer": "optimi_adamw",
+                "max_steps": 5,
                 "lr_scheduler": "cosine",
             }
         )

--- a/tests/e2e/test_relora_llama.py
+++ b/tests/e2e/test_relora_llama.py
@@ -57,6 +57,7 @@ class TestReLoraLlama(unittest.TestCase):
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_torch",
+                "max_steps": 5,
                 "lr_scheduler": "cosine",
             }
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

The current vision data processing expects in the OAI format and with images. This PR allows passing text-only dataset to training vision models and converts the old sharegpt-like format datasets.

The caveat is that, it still does not allow mixing text-only and text+image data points per batch yet. We would need to patch upstream for this.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Could not pass normal sharegpt dataset.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Not yet after refactor.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->

@hjc-puro 
