### PR TITLE
Update unsloth for torch.cuda.amp deprecation

### DIFF
--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -20,7 +20,7 @@ import torch
 
 torch_version = version("torch")
 
-if torch_version < "2.5.1":
+if torch_version < "2.4.0":
     torch_cuda_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_cuda_amp_custom_bwd = torch.cuda.amp.custom_bwd
 else:

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
+from functools import partial
+
+
+torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type='cuda')
+torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type='cuda')
 
 
 class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name
@@ -25,7 +30,7 @@ class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name
     """
 
     @staticmethod
-    @torch.cuda.amp.custom_fwd
+    @torch_cuda_amp_custom_fwd
     def forward(ctx, forward_function, hidden_states, *args):
         saved_hidden_states = hidden_states.to("cpu", non_blocking=True)
         with torch.no_grad():
@@ -36,7 +41,7 @@ class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name
         return output
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @torch_cuda_amp_custom_bwd
     def backward(ctx, dY):
         (hidden_states,) = ctx.saved_tensors
         hidden_states = hidden_states.to("cuda", non_blocking=True).detach()

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -24,8 +24,8 @@ if torch_version < "2.4.0":
     torch_cuda_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_cuda_amp_custom_bwd = torch.cuda.amp.custom_bwd
 else:
-    torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type="cuda")
-    torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type="cuda")
+    torch_cuda_amp_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+    torch_cuda_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
 
 
 class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -13,9 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import torch
 from functools import partial
 from importlib.metadata import version
+
+import torch
 
 torch_version = version("torch")
 
@@ -23,8 +24,8 @@ if torch_version < "2.5.1":
     torch_cuda_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_cuda_amp_custom_bwd = torch.cuda.amp.custom_bwd
 else:
-    torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type='cuda')
-    torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type='cuda')
+    torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type="cuda")
+    torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type="cuda")
 
 
 class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
 from importlib.metadata import version
 
 import torch

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -13,13 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from importlib.metadata import version
-
 import torch
+from packaging import version
 
-torch_version = version("torch")
+torch_version = version.parse(torch.__version__)
 
-if torch_version < "2.4.0":
+if torch_version < version.parse("2.4.0"):
     torch_cuda_amp_custom_fwd = torch.cuda.amp.custom_fwd
     torch_cuda_amp_custom_bwd = torch.cuda.amp.custom_bwd
 else:

--- a/src/axolotl/utils/gradient_checkpointing/unsloth.py
+++ b/src/axolotl/utils/gradient_checkpointing/unsloth.py
@@ -15,10 +15,16 @@
 # limitations under the License.
 import torch
 from functools import partial
+from importlib.metadata import version
 
+torch_version = version("torch")
 
-torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type='cuda')
-torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type='cuda')
+if torch_version < "2.5.1":
+    torch_cuda_amp_custom_fwd = torch.cuda.amp.custom_fwd
+    torch_cuda_amp_custom_bwd = torch.cuda.amp.custom_bwd
+else:
+    torch_cuda_amp_custom_fwd = partial(torch.amp.custom_fwd, device_type='cuda')
+    torch_cuda_amp_custom_bwd = partial(torch.amp.custom_bwd, device_type='cuda')
 
 
 class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

torch.cuda.amp is deprecated in newer version of Pytorch. This PR updates unsloth.py to reflect that. Fixes [issue#2015](https://github.com/axolotl-ai-cloud/axolotl/issues/2015)

## Motivation and Context

`axolotl/src/axolotl/utils/gradient_checkpointing/unsloth.py:28: FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.
axolotl/src/axolotl/utils/gradient_checkpointing/unsloth.py:39: FutureWarning: `torch.cuda.amp.custom_bwd(args...)` is deprecated. Please use `torch.amp.custom_bwd(args..., device_type='cuda')` instead.
10.10.10.2:   @torch.cuda.amp.custom_bwd`

## How has this been tested?

manually imported unsloth and now there are no more warning of deprecation

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
