### PR TITLE
fix None-type not iterable error when deepspeed is left blank w/ use_…

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -1314,6 +1314,7 @@ class AxolotlInputConfig(
             and data.get("gradient_checkpointing_kwargs", {})
             and data.get("gradient_checkpointing_kwargs", {}).get("use_reentrant")
             is False
+            and data.get("deepspeed", "") is not None
             and "zero3" in data.get("deepspeed", "")
         ):
             # may result in:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -86,7 +86,7 @@ class TestValidation(BaseValidation):
                 "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values"
                 in self._caplog.records[0].message
             )
-    
+
     def test_deepspeed_empty(self, minimal_cfg):
         test_cfg = DictDefault(
             {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -68,6 +68,30 @@ class TestValidation(BaseValidation):
         assert cfg.train_on_inputs is False
         assert cfg.weight_decay is None
 
+    def test_deepspeed_empty(self, minimal_cfg):
+        test_cfg = DictDefault(
+            {
+                "deepspeed": "",
+                "gradient_checkpointing": True,
+                "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                "adapter": "qlora",
+            }
+            | minimal_cfg
+        )
+        _ = validate_config(test_cfg)
+
+    def test_deepspeed_not_set(self, minimal_cfg):
+        test_cfg = DictDefault(
+            {
+                "deepspeed": None,
+                "gradient_checkpointing": True,
+                "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                "adapter": "qlora",
+            }
+            | minimal_cfg
+        )
+        _ = validate_config(test_cfg)
+
     def test_datasets_min_length(self):
         cfg = DictDefault(
             {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -79,7 +79,10 @@ class TestValidation(BaseValidation):
             }
             | minimal_cfg
         )
-        _ = validate_config(test_cfg)
+
+        with self._caplog.at_level(logging.WARNING):
+            validate_config(test_cfg)
+            assert "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values" in self._caplog.records[0].message
 
     def test_deepspeed_not_set(self, minimal_cfg):
         test_cfg = DictDefault(
@@ -92,7 +95,10 @@ class TestValidation(BaseValidation):
             }
             | minimal_cfg
         )
-        _ = validate_config(test_cfg)
+        
+        with self._caplog.at_level(logging.WARNING):
+            validate_config(test_cfg)
+            assert "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values" in self._caplog.records[0].message
 
     def test_datasets_min_length(self):
         cfg = DictDefault(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -82,7 +82,10 @@ class TestValidation(BaseValidation):
 
         with self._caplog.at_level(logging.WARNING):
             validate_config(test_cfg)
-            assert "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values" in self._caplog.records[0].message
+            assert (
+                "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values"
+                in self._caplog.records[0].message
+            )
 
     def test_deepspeed_not_set(self, minimal_cfg):
         test_cfg = DictDefault(
@@ -95,10 +98,13 @@ class TestValidation(BaseValidation):
             }
             | minimal_cfg
         )
-        
+
         with self._caplog.at_level(logging.WARNING):
             validate_config(test_cfg)
-            assert "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values" in self._caplog.records[0].message
+            assert (
+                "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values"
+                in self._caplog.records[0].message
+            )
 
     def test_datasets_min_length(self):
         cfg = DictDefault(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -74,6 +74,7 @@ class TestValidation(BaseValidation):
                 "deepspeed": "",
                 "gradient_checkpointing": True,
                 "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                "load_in_4bit": True,
                 "adapter": "qlora",
             }
             | minimal_cfg
@@ -86,6 +87,7 @@ class TestValidation(BaseValidation):
                 "deepspeed": None,
                 "gradient_checkpointing": True,
                 "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                "load_in_4bit": True,
                 "adapter": "qlora",
             }
             | minimal_cfg

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -68,10 +68,10 @@ class TestValidation(BaseValidation):
         assert cfg.train_on_inputs is False
         assert cfg.weight_decay is None
 
-    def test_deepspeed_empty(self, minimal_cfg):
+    def test_zero3_qlora_use_reentrant_false(self, minimal_cfg):
         test_cfg = DictDefault(
             {
-                "deepspeed": "",
+                "deepspeed": "deepspeed_configs/zero3_bf16.json",
                 "gradient_checkpointing": True,
                 "gradient_checkpointing_kwargs": {"use_reentrant": False},
                 "load_in_4bit": True,
@@ -86,6 +86,20 @@ class TestValidation(BaseValidation):
                 "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values"
                 in self._caplog.records[0].message
             )
+    
+    def test_deepspeed_empty(self, minimal_cfg):
+        test_cfg = DictDefault(
+            {
+                "deepspeed": "",
+                "gradient_checkpointing": True,
+                "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                "load_in_4bit": True,
+                "adapter": "qlora",
+            }
+            | minimal_cfg
+        )
+
+        _ = validate_config(test_cfg)
 
     def test_deepspeed_not_set(self, minimal_cfg):
         test_cfg = DictDefault(
@@ -99,12 +113,7 @@ class TestValidation(BaseValidation):
             | minimal_cfg
         )
 
-        with self._caplog.at_level(logging.WARNING):
-            validate_config(test_cfg)
-            assert (
-                "qlora + zero3 with use_reentrant: false may result in a CheckpointError about recomputed values"
-                in self._caplog.records[0].message
-            )
+        _ = validate_config(test_cfg)
 
     def test_datasets_min_length(self):
         cfg = DictDefault(


### PR DESCRIPTION
If you use qlora and set `use_reentrant: false` while leaving deepspeed blank `deepspeed:  ` in the config yml, you get:

 `File "/workspace/axolotl/src/axolotl/utils/config/models/input/v0_4_1/__init__.py", line 1317, in warn_qlora_zero3_w_use_reentrant
    and "zero3" in data.get("deepspeed", "")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable`

This PR fixes it.
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
