### PR TITLE
fix: allow tool_calling for chat_template

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -41,6 +41,7 @@ class ChatTemplatePrompter(Prompter):
                 "assistant": "assistant",
                 "gpt": "assistant",
                 "system": "system",
+                "tool": "tool",
             }
         self.message_field_role = message_field_role
         self.message_field_content = message_field_content
@@ -58,6 +59,8 @@ class ChatTemplatePrompter(Prompter):
                 "role": self.roles[t[self.message_field_role]],
                 "content": t[self.message_field_content],
                 "training": t.get(self.message_field_training, None),
+                "tool_calls": t.get("tool_calls", None),
+                "name": t.get("name", None),
             }
             for t in conversation
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Previously, we would ignore all `tool_calling` fields, this PR solves it and passes it along.

However, we still do not pass `tools=tools` within `.apply_chat_template`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
