### PR TITLE
fix: chat_template masking due to truncation, consolidate turn build and keys within field

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -32,9 +32,16 @@ class ChatTemplatePrompter(Prompter):
         roles: Optional[Dict[str, List[str]]] = None,
         drop_system_message: bool = False,
     ):
-        self.roles = (
-            {s: t for t, sources in roles.items() for s in sources} if roles else {}
-        )
+        if roles:
+            self.roles = {s: t for t, sources in roles.items() for s in sources}
+        else:
+            self.roles = {
+                "human": "user",
+                "user": "user",
+                "assistant": "assistant",
+                "gpt": "assistant",
+                "system": "system",
+            }
 
         self.message_field_role = message_field_role
         self.message_field_content = message_field_content

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -262,8 +262,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         for index, turn in enumerate(turns):
             role = turn.get("role")
             content = turn.get("content")
-            train_turn = turn.get(self.prompter.message_field_training)
-            train_detail = turn.get(self.prompter.message_field_training_detail)
+            train_turn = turn.get("training")
+            train_detail = turn.get("training_detail")
 
             LOG.debug(
                 f"Processing turn {index}: role={role}, content={content}, train_turn={train_turn}, train_detail={train_detail}"
@@ -405,7 +405,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             {
                 "role": self.prompter.roles[t[self.prompter.message_field_role]],
                 "content": t[self.prompter.message_field_content],
-                "training": t.get(self.prompter.message_field_training, None),
+                "training": t.get(self.prompter.message_field_training),
+                "training_detail": t.get(self.prompter.message_field_training_detail),
             }
             for t in prompt[self.messages]
         ]

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -285,11 +285,10 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
             if turn_start_idx == -1 or turn_end_idx == -1:
                 LOG.warning(f"Failed to find boundaries for turn {index}")
-                continue
 
             LOG.debug(f"Turn indices: start={turn_start_idx}, end={turn_end_idx}")
 
-            if should_train:
+            if should_train and turn_start_idx != -1 and turn_end_idx != -1:
                 if train_detail:
                     token_offsets = self.prompter.get_offsets_for_train_detail(
                         content, train_detail
@@ -397,7 +396,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                     LOG.debug(f"Found turn {turn} content at position {i}")
                     return i, i + len(content_ids)
 
-        LOG.warning(f"Could not find content for turn {turn}")
         return -1, -1
 
     def get_conversation_thread(self, prompt):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

This fixes cases where masking would fail for `chat_template` using the new behavior.

Changes:
- Remove `truncation` while applying `chat_template` as that would cut off conversation and affect masking downstream. We have another section that would drop long conversation already.
~- Removed default `roles` within the prompter to not automatically map roles (in case users intend to keep the original names and wasn't aware we mapped) <- Comment needed for this design choice!~
- Map `roles_to_train` if it exist within `roles`. For example, `roles_to_train: ["gpt"]` but the convo maps it all the `assistant` leading to everything being ignored.
- Consolidates building `turn` across modules and dropping off system prompt if done.
- Refactors `should_train`
- Optimize handling of matching tokens in a turn
- Explicitly truncates chat_template for reward model Bradleyterry. Previously, this was silently truncating.

TODO:
- ~[ ] handle `tool_calling` for assistant response for tools datasets~ we support nous tool calling dataset but not hf one for now.
- ~[] discuss whether to revert removing default `roles`~ temporarily revert for now
- ~[ ] update chat_template doc for explicitly specifying `roles`~
- ~[ ] Fix tests to specify `roles`~


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Test with Puffin dataset locally.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
