### PR TITLE
upgrade bnb 0.45.0 and peft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/
 packaging==23.2
-peft @ git+https://github.com/huggingface/peft.git@860f7838c885ada7d48bb91fbc65b5f1843b9bc6
+peft==0.14.0
 transformers==4.46.3
 tokenizers>=0.20.1
 bitsandbytes==0.45.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ packaging==23.2
 peft==0.13.2
 transformers==4.46.3
 tokenizers>=0.20.1
-bitsandbytes==0.44.1
+bitsandbytes==0.45.0
 accelerate==1.1.0
 datasets==3.1.0
 deepspeed==0.15.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/
 packaging==23.2
-peft==0.13.2
+peft @ git+https://github.com/huggingface/peft.git@860f7838c885ada7d48bb91fbc65b5f1843b9bc6
 transformers==4.46.3
 tokenizers>=0.20.1
 bitsandbytes==0.45.0

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -1523,19 +1523,6 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
 
     @model_validator(mode="before")
     @classmethod
-    def check_hopper_8bit_lora(cls, data):
-        is_sm_90: bool = (
-            data["capabilities"]
-            and data["capabilities"].get("compute_capability") == "sm_90"
-        )
-        if data.get("adapter") and data.get("load_in_8bit") and is_sm_90:
-            # see https://github.com/bitsandbytes-foundation/bitsandbytes/issues/538#issuecomment-2262945464
-            raise ValueError("8-bit LoRA is not supported on Hopper GPUs")
-
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
     def check_fsdp_deepspeed(cls, data):
         if data.get("deepspeed") and data.get("fsdp"):
             raise ValueError("deepspeed and fsdp cannot be used together.")

--- a/tests/e2e/multigpu/test_llama.py
+++ b/tests/e2e/multigpu/test_llama.py
@@ -14,8 +14,6 @@ from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
 
-from ..utils import is_hopper
-
 LOG = logging.getLogger("axolotl.tests.e2e.multigpu")
 os.environ["WANDB_DISABLED"] = "true"
 
@@ -144,7 +142,6 @@ class TestMultiGPULlama:
             ]
         )
 
-    @pytest.mark.skipif(is_hopper(), reason="h100 doesn't support 8-bit lora")
     def test_dpo_lora_ddp(self, temp_dir):
         # pylint: disable=duplicate-code
         cfg = DictDefault(


### PR DESCRIPTION
latest bnb supports finetuning 8-bit LoRAs on H100s. While we can use the peft commit directly, we can't cut an axolotl release for this, so this is on hold for now.