### PR TITLE
Fix broken CLI; remove duplicate metadata from setup.py

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -58,6 +58,10 @@ jobs:
           python scripts/cutcrossentropy_install.py | sh
           pip3 install -r requirements-dev.txt -r requirements-tests.txt
 
+      - name: Ensure axolotl CLI was installed
+        run: |
+          axolotl --help
+
       - name: Run tests
         run: |
           pytest -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,10 @@ jobs:
           pip3 install dist/axolotl*.tar.gz
           pip3 install -r requirements-dev.txt -r requirements-tests.txt
 
+      - name: Ensure axolotl CLI was installed
+        run: |
+          axolotl --help
+
       - name: Run tests
         run: |
           pytest -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,10 @@ jobs:
           python scripts/cutcrossentropy_install.py | sh
           pip3 install -r requirements-dev.txt -r requirements-tests.txt
 
+      - name: Ensure axolotl CLI was installed
+        run: |
+          axolotl --help
+
       - name: Run tests
         run: |
           pytest -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description = "LLM Trainer"
 readme = "README.md"
 requires-python = ">=3.10"
 
+[project.scripts]
+axolotl = "axolotl.cli.main:main"
+
 [project.urls]
 Homepage = "https://axolotl-ai-cloud.github.io/axolotl/"
 Repository = "https://github.com/axolotl-ai-cloud/axolotl.git"

--- a/setup.py
+++ b/setup.py
@@ -92,13 +92,7 @@ def parse_requirements():
 
 install_requires, dependency_links = parse_requirements()
 
-
 setup(
-    name="axolotl",
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
-    description="LLM Trainer",
-    long_description="Axolotl is a tool designed to streamline the fine-tuning of various AI models, offering support for multiple configurations and architectures.",
     package_dir={"": "src"},
     packages=find_packages("src"),
     install_requires=install_requires,

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -70,20 +70,3 @@ def test_fetch_from_github_network_error():
     with patch("requests.get", side_effect=requests.RequestException):
         with pytest.raises(requests.RequestException):
             fetch_from_github("examples/", None)
-
-
-@pytest.fixture
-def integration_test_dir(tmp_path):
-    """Fixture for integration test directory that cleans up after itself"""
-    test_dir = tmp_path / "github_downloads"
-    test_dir.mkdir(parents=True)
-    yield test_dir
-
-
-def test_fetch_from_github_real(integration_test_dir):
-    """Test actual GitHub API interaction"""
-    fetch_from_github("examples/", integration_test_dir)
-
-    # Verify some known files exist
-    assert (integration_test_dir / "openllama-3b" / "lora.yml").exists()
-    assert (integration_test_dir / "openllama-3b" / "qlora.yml").exists()


### PR DESCRIPTION
# Description

Title. Recent `pyproject.toml` addition clashes with the CLI PR changes. Fixed by specifiying the entry point in `pyproject.toml`. I was also able to remove some duplicate metadata in `setup.py`.

## Motivation and Context

CLI is broken.

## How has this been tested?

On this branch:

```shell
# pip install -e .
...
Successfully installed axolotl-0.5.3.dev38+g5726141c.d20241206

# axolotl train examples/openllama-3b/lora.yml  # runs without error
...
```