### PR TITLE
Fix llama type model check

### DIFF
--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -153,7 +153,7 @@ def normalize_config(cfg):
     cfg.is_llama_derived_model = (
         (
             hasattr(model_config, "model_type")
-            and model_config.model_type == ["llama", "mllama_text_model"]
+            and model_config.model_type in ["llama", "mllama_text_model"]
         )
         or cfg.is_llama_derived_model
         or "llama" in cfg.base_model.lower()


### PR DESCRIPTION
# Description

I am seeing some unusally high eval losses and garbage predictions (might open another issue for that) and was checking with a debugger, noticed this check was changed when adding multimodal support. `==` seems incorrect here. 

## Motivation and Context

N/A

## How has this been tested?

N/A

## Screenshots (if appropriate)

N/A

## Types of changes

N/A

## Social Handles (Optional)

N/A
