### PR TITLE
bump autoawq to 0.2.7.post3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ art
 gradio==3.50.2
 tensorboard
 python-dotenv==1.0.1
-autoawq==0.2.7.post2
+autoawq==0.2.7.post3
 triton>=2.3.0
 liger-kernel==0.4.2
 


### PR DESCRIPTION
per @casper-hansen: 
```
There was a bug in huggingface_hub that impacted tied weights, so only lm_head was saved but not embed_tokens
This meant users could not load models in vLLM, but it otherwise worked fine with transformers package
```