### PR TITLE
Basic evaluate CLI command / codepath

### DIFF
--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -476,7 +476,6 @@ def load_datasets(
         tokenizer,
         processor=processor,
     )
-    print(train_dataset, eval_dataset, total_num_steps)
 
     if (
         cli_args.debug

--- a/src/axolotl/cli/__init__.py
+++ b/src/axolotl/cli/__init__.py
@@ -476,6 +476,7 @@ def load_datasets(
         tokenizer,
         processor=processor,
     )
+    print(train_dataset, eval_dataset, total_num_steps)
 
     if (
         cli_args.debug

--- a/src/axolotl/cli/evaluate.py
+++ b/src/axolotl/cli/evaluate.py
@@ -20,10 +20,11 @@ from axolotl.cli import (
 from axolotl.common.cli import TrainerCliArgs
 from axolotl.evaluate import evaluate
 
-LOG = logging.getLogger("axolotl.cli.train")
+LOG = logging.getLogger("axolotl.cli.evaluate")
 
 
 def do_evaluate(cfg, cli_args) -> None:
+    # pylint: disable=duplicate-code
     print_axolotl_text_art()
     check_accelerate_default_config()
     check_user_token()

--- a/src/axolotl/cli/evaluate.py
+++ b/src/axolotl/cli/evaluate.py
@@ -1,0 +1,51 @@
+"""
+CLI to run training on a model
+"""
+import logging
+from pathlib import Path
+from typing import Union
+
+import fire
+from dotenv import load_dotenv
+from transformers.hf_argparser import HfArgumentParser
+
+from axolotl.cli import (
+    check_accelerate_default_config,
+    check_user_token,
+    load_cfg,
+    load_datasets,
+    load_rl_datasets,
+    print_axolotl_text_art,
+)
+from axolotl.common.cli import TrainerCliArgs
+from axolotl.evaluate import evaluate
+
+LOG = logging.getLogger("axolotl.cli.train")
+
+
+def do_evaluate(cfg, cli_args) -> None:
+    print_axolotl_text_art()
+    check_accelerate_default_config()
+    check_user_token()
+
+    if cfg.rl:  # and cfg.rl != "orpo":
+        dataset_meta = load_rl_datasets(cfg=cfg, cli_args=cli_args)
+    else:
+        dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
+
+    evaluate(cfg=cfg, cli_args=cli_args, dataset_meta=dataset_meta)
+
+
+def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs) -> None:
+    # pylint: disable=duplicate-code
+    parsed_cfg = load_cfg(config, **kwargs)
+    parser = HfArgumentParser(TrainerCliArgs)
+    parsed_cli_args, _ = parser.parse_args_into_dataclasses(
+        return_remaining_strings=True
+    )
+    do_evaluate(parsed_cfg, parsed_cli_args)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    fire.Fire(do_cli)

--- a/src/axolotl/common/cli.py
+++ b/src/axolotl/common/cli.py
@@ -16,6 +16,19 @@ LOG = logging.getLogger("axolotl.common.cli")
 
 
 @dataclass
+class PreprocessCliArgs:
+    """
+    dataclass representing arguments for preprocessing only
+    """
+
+    debug: bool = field(default=False)
+    debug_text_only: bool = field(default=False)
+    debug_num_examples: int = field(default=1)
+    prompter: Optional[str] = field(default=None)
+    download: Optional[bool] = field(default=True)
+
+
+@dataclass
 class TrainerCliArgs:
     """
     dataclass representing the various non-training arguments
@@ -31,16 +44,14 @@ class TrainerCliArgs:
 
 
 @dataclass
-class PreprocessCliArgs:
+class EvaluateCliArgs:
     """
-    dataclass representing arguments for preprocessing only
+    dataclass representing the various evaluation arguments
     """
 
     debug: bool = field(default=False)
     debug_text_only: bool = field(default=False)
-    debug_num_examples: int = field(default=1)
-    prompter: Optional[str] = field(default=None)
-    download: Optional[bool] = field(default=True)
+    debug_num_examples: int = field(default=0)
 
 
 def load_model_and_tokenizer(
@@ -50,7 +61,9 @@ def load_model_and_tokenizer(
 ):
     LOG.info(f"loading tokenizer... {cfg.tokenizer_config or cfg.base_model_config}")
     tokenizer = load_tokenizer(cfg)
+
     LOG.info("loading model and (optionally) peft_config...")
-    model, _ = load_model(cfg, tokenizer, inference=cli_args.inference)
+    inference = getattr(cli_args, "inference", False)
+    model, _ = load_model(cfg, tokenizer, inference=inference)
 
     return model, tokenizer

--- a/src/axolotl/evaluate.py
+++ b/src/axolotl/evaluate.py
@@ -14,7 +14,7 @@ from axolotl.logging_config import configure_logging
 from axolotl.train import TrainDatasetMeta
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.models import load_model, load_processor, load_tokenizer
-from axolotl.utils.trainer import setup_trainer
+from axolotl.utils.trainer import set_pytorch_cuda_alloc_conf, setup_trainer
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_dir = os.path.join(project_root, "src")
@@ -79,14 +79,8 @@ def evaluate(
         - Dictionary of evaluation metrics
     """
     # pylint: disable=duplicate-code
-    # Set up CUDA allocation config if using PyTorch >= 2.2
-    torch_version = torch.__version__.split(".")
-    torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
-    if torch_major == 2 and torch_minor >= 2:
-        if os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None:
-            os.environ[
-                "PYTORCH_CUDA_ALLOC_CONF"
-            ] = "expandable_segments:True,roundup_power2_divisions:16"
+    # Enable expandable segments for cuda allocation to improve VRAM usage
+    set_pytorch_cuda_alloc_conf()
 
     # Load tokenizer
     LOG.debug(

--- a/src/axolotl/evaluate.py
+++ b/src/axolotl/evaluate.py
@@ -1,0 +1,121 @@
+"""Module for evaluating models."""
+
+import os
+import sys
+from pathlib import Path
+from typing import Tuple, Union
+
+import torch
+from accelerate.logging import get_logger
+from peft import PeftModel
+from transformers import PreTrainedModel, PreTrainedTokenizer
+
+from axolotl.common.cli import TrainerCliArgs
+from axolotl.logging_config import configure_logging
+from axolotl.train import TrainDatasetMeta
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.models import load_model, load_processor, load_tokenizer
+from axolotl.utils.trainer import setup_trainer
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_dir = os.path.join(project_root, "src")
+sys.path.insert(0, src_dir)
+
+configure_logging()
+LOG = get_logger("axolotl.eval")
+
+
+def evaluate(
+    *, cfg: DictDefault, cli_args: TrainerCliArgs, dataset_meta: TrainDatasetMeta
+) -> Tuple[Union[PeftModel, PreTrainedModel], PreTrainedTokenizer, dict]:
+    """
+    Evaluate a model on a dataset
+
+    Args:
+        cfg: Configuration dictionary
+        cli_args: Command line arguments
+        dataset_meta: Dataset metadata containing evaluation dataset
+
+    Returns:
+        Tuple containing:
+        - The model (either PeftModel or PreTrainedModel)
+        - The tokenizer
+        - Dictionary of evaluation metrics
+    """
+    # Set up CUDA allocation config if using PyTorch >= 2.2
+    torch_version = torch.__version__.split(".")
+    torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
+    if torch_major == 2 and torch_minor >= 2:
+        if os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None:
+            os.environ[
+                "PYTORCH_CUDA_ALLOC_CONF"
+            ] = "expandable_segments:True,roundup_power2_divisions:16"
+
+    # Load tokenizer
+    LOG.debug(
+        f"loading tokenizer... {cfg.tokenizer_config or cfg.base_model_config}",
+        main_process_only=True,
+    )
+    tokenizer = load_tokenizer(cfg)
+
+    # Load processor for multimodal models if needed
+    processor = None
+    if cfg.is_multimodal:
+        processor = load_processor(cfg, tokenizer)
+
+    # Get evaluation dataset
+    eval_dataset = dataset_meta.eval_dataset
+    total_num_steps = dataset_meta.total_num_steps
+
+    # Load model
+    LOG.debug("loading model for evaluation...")
+    model, _ = load_model(
+        cfg, tokenizer, processor=processor, inference=cli_args.inference
+    )
+
+    # Set up trainer
+    trainer = setup_trainer(
+        cfg,
+        train_dataset=eval_dataset,  # None # No training dataset needed for evaluation
+        eval_dataset=eval_dataset,
+        model=(model, None, None),  # No need for model_ref or peft_config
+        tokenizer=tokenizer,
+        processor=processor,
+        total_num_steps=total_num_steps,
+    )
+
+    # Run evaluation
+    LOG.info("Starting evaluation...")
+
+    if cfg.flash_optimum:
+        with torch.backends.cuda.sdp_kernel(
+            enable_flash=True,
+            enable_math=True,
+            enable_mem_efficient=True,
+        ):
+            metrics = trainer.evaluate()
+    else:
+        metrics = trainer.evaluate()
+
+    # Log results
+    LOG.info("Evaluation completed!")
+    LOG.info("Metrics:")
+    for key, value in metrics.items():
+        LOG.info(f"{key}: {value}")
+
+    # Save metrics to file if output directory is specified
+    if cfg.output_dir:
+        output_dir = Path(cfg.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        metrics_file = output_dir / "eval_results.txt"
+        with metrics_file.open("w", encoding="utf-8") as file:
+            for key, value in metrics.items():
+                file.write(f"{key} = {value}\n")
+
+        LOG.info(f"Evaluation results saved to {metrics_file}")
+
+    del model
+    del tokenizer
+
+    return metrics

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -119,7 +119,9 @@ def prepare_dataset(cfg, tokenizer, processor=None):
         eval_dataset = None
         if cfg.dataset_exact_deduplication:
             LOG.info("Deduplication not available for pretrained datasets")
+
         return train_dataset, eval_dataset, cfg.max_steps, prompters
+
     if eval_dataset and cfg.sample_packing and cfg.eval_sample_packing is not False:
         total_eval_steps = calculate_total_num_steps(cfg, eval_dataset, update=False)
         if total_eval_steps == 0:
@@ -134,6 +136,7 @@ def prepare_dataset(cfg, tokenizer, processor=None):
         LOG.info(f"Maximum number of steps set at {total_num_steps}")
     else:
         total_num_steps = calculate_total_num_steps(cfg, train_dataset)
+
     return train_dataset, eval_dataset, total_num_steps, prompters
 
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -512,6 +512,17 @@ def prepare_opinionated_env(cfg):
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
+def set_pytorch_cuda_alloc_conf():
+    """Set up CUDA allocation config if using PyTorch >= 2.2"""
+    torch_version = torch.__version__.split(".")
+    torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
+    if torch_major == 2 and torch_minor >= 2:
+        if os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None:
+            os.environ[
+                "PYTORCH_CUDA_ALLOC_CONF"
+            ] = "expandable_segments:True,roundup_power2_divisions:16"
+
+
 def setup_trainer(
     cfg, train_dataset, eval_dataset, model, tokenizer, processor, total_num_steps
 ):

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -1,0 +1,73 @@
+"""Base test class for CLI commands."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from axolotl.cli.main import cli
+
+
+class BaseCliTest:
+    """Base class for CLI command tests."""
+
+    def _test_cli_validation(self, cli_runner, command: str):
+        """Test CLI validation for a command.
+
+        Args:
+            cli_runner: CLI runner fixture
+            command: Command to test (train/evaluate)
+        """
+        # Test missing config file
+        result = cli_runner.invoke(cli, [command, "--no-accelerate"])
+        assert result.exit_code != 0
+
+        # Test non-existent config file
+        result = cli_runner.invoke(cli, [command, "nonexistent.yml", "--no-accelerate"])
+        assert result.exit_code != 0
+        assert "Error: Invalid value for 'CONFIG'" in result.output
+
+    def _test_basic_execution(
+        self, cli_runner, tmp_path: Path, valid_test_config: str, command: str
+    ):
+        """Test basic execution with accelerate.
+
+        Args:
+            cli_runner: CLI runner fixture
+            tmp_path: Temporary path fixture
+            valid_test_config: Valid config fixture
+            command: Command to test (train/evaluate)
+        """
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(valid_test_config)
+
+        with patch("subprocess.run") as mock:
+            result = cli_runner.invoke(cli, [command, str(config_path)])
+
+            assert mock.called
+            assert mock.call_args.args[0] == [
+                "accelerate",
+                "launch",
+                "-m",
+                f"axolotl.cli.{command}",
+                str(config_path),
+                "--debug-num-examples",
+                "0",
+            ]
+            assert mock.call_args.kwargs == {"check": True}
+            assert result.exit_code == 0
+
+    def _test_cli_overrides(self, tmp_path: Path, valid_test_config: str):
+        """Test CLI argument overrides.
+
+        Args:
+            tmp_path: Temporary path fixture
+            valid_test_config: Valid config fixture
+            command: Command to test (train/evaluate)
+        """
+        config_path = tmp_path / "config.yml"
+        output_dir = tmp_path / "model-out"
+
+        test_config = valid_test_config.replace(
+            "output_dir: model-out", f"output_dir: {output_dir}"
+        )
+        config_path.write_text(test_config)
+        return config_path

--- a/tests/cli/test_cli_evaluate.py
+++ b/tests/cli/test_cli_evaluate.py
@@ -1,0 +1,120 @@
+"""pytest tests for axolotl CLI evaluate command."""
+from unittest.mock import patch
+
+from axolotl.cli.main import cli
+
+
+def test_evaluate_cli_validation(cli_runner):
+    """Test CLI validation"""
+    # Test missing config file
+    result = cli_runner.invoke(cli, ["evaluate", "--no-accelerate"])
+    assert result.exit_code != 0
+
+    # Test non-existent config file
+    result = cli_runner.invoke(cli, ["evaluate", "nonexistent.yml", "--no-accelerate"])
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'CONFIG'" in result.output
+
+
+def test_evaluate_basic_execution(cli_runner, tmp_path, valid_test_config):
+    """Test basic successful execution"""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(valid_test_config)
+
+    with patch("subprocess.run") as mock:
+        result = cli_runner.invoke(cli, ["evaluate", str(config_path)])
+
+        assert mock.called
+        assert mock.call_args.args[0] == [
+            "accelerate",
+            "launch",
+            "-m",
+            "axolotl.cli.evaluate",
+            str(config_path),
+            "--debug-num-examples",
+            "0",
+        ]
+        assert mock.call_args.kwargs == {"check": True}
+        assert result.exit_code == 0
+
+
+def test_evaluate_basic_execution_no_accelerate(
+    cli_runner, tmp_path, valid_test_config
+):
+    """Test basic successful execution without accelerate"""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(valid_test_config)
+
+    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
+        result = cli_runner.invoke(
+            cli,
+            [
+                "evaluate",
+                str(config_path),
+                "--micro-batch-size",
+                "2",
+                "--no-accelerate",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        mock_evaluate.assert_called_once()
+        cfg = mock_evaluate.call_args[0][0]
+        assert cfg.micro_batch_size == 2
+
+
+def test_evaluate_cli_overrides(cli_runner, tmp_path, valid_test_config):
+    """Test CLI arguments properly override config values"""
+    config_path = tmp_path / "config.yml"
+    output_dir = tmp_path / "model-out"
+
+    test_config = valid_test_config.replace(
+        "output_dir: model-out", f"output_dir: {output_dir}"
+    )
+    config_path.write_text(test_config)
+
+    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
+        result = cli_runner.invoke(
+            cli,
+            [
+                "evaluate",
+                str(config_path),
+                "--micro-batch-size",
+                "2",
+                "--sequence-len",
+                "128",
+                "--no-accelerate",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        mock_evaluate.assert_called_once()
+        cfg = mock_evaluate.call_args[0][0]
+        assert cfg.micro_batch_size == 2
+        assert cfg.sequence_len == 128
+
+
+def test_evaluate_with_rl_dpo(cli_runner, tmp_path, valid_test_config):
+    """Test evaluation with DPO reinforcement learning"""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(valid_test_config)
+
+    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
+        result = cli_runner.invoke(
+            cli,
+            [
+                "evaluate",
+                str(config_path),
+                "--rl",
+                "dpo",
+                "--no-accelerate",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        mock_evaluate.assert_called_once()
+        cfg = mock_evaluate.call_args[0][0]
+        assert cfg.rl == "dpo"

--- a/tests/cli/test_cli_evaluate.py
+++ b/tests/cli/test_cli_evaluate.py
@@ -1,120 +1,67 @@
-"""pytest tests for axolotl CLI evaluate command."""
+"""Tests for evaluate CLI command."""
+
 from unittest.mock import patch
 
 from axolotl.cli.main import cli
 
-
-def test_evaluate_cli_validation(cli_runner):
-    """Test CLI validation"""
-    # Test missing config file
-    result = cli_runner.invoke(cli, ["evaluate", "--no-accelerate"])
-    assert result.exit_code != 0
-
-    # Test non-existent config file
-    result = cli_runner.invoke(cli, ["evaluate", "nonexistent.yml", "--no-accelerate"])
-    assert result.exit_code != 0
-    assert "Error: Invalid value for 'CONFIG'" in result.output
+from .test_cli_base import BaseCliTest
 
 
-def test_evaluate_basic_execution(cli_runner, tmp_path, valid_test_config):
-    """Test basic successful execution"""
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(valid_test_config)
+class TestEvaluateCommand(BaseCliTest):
+    """Test cases for evaluate command."""
 
-    with patch("subprocess.run") as mock:
-        result = cli_runner.invoke(cli, ["evaluate", str(config_path)])
+    cli = cli
 
-        assert mock.called
-        assert mock.call_args.args[0] == [
-            "accelerate",
-            "launch",
-            "-m",
-            "axolotl.cli.evaluate",
-            str(config_path),
-            "--debug-num-examples",
-            "0",
-        ]
-        assert mock.call_args.kwargs == {"check": True}
-        assert result.exit_code == 0
+    def test_evaluate_cli_validation(self, cli_runner):
+        """Test CLI validation"""
+        self._test_cli_validation(cli_runner, "evaluate")
 
+    def test_evaluate_basic_execution(self, cli_runner, tmp_path, valid_test_config):
+        """Test basic successful execution"""
+        self._test_basic_execution(cli_runner, tmp_path, valid_test_config, "evaluate")
 
-def test_evaluate_basic_execution_no_accelerate(
-    cli_runner, tmp_path, valid_test_config
-):
-    """Test basic successful execution without accelerate"""
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(valid_test_config)
+    def test_evaluate_basic_execution_no_accelerate(
+        self, cli_runner, tmp_path, valid_test_config
+    ):
+        """Test basic successful execution without accelerate"""
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(valid_test_config)
 
-    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
-        result = cli_runner.invoke(
-            cli,
-            [
-                "evaluate",
-                str(config_path),
-                "--micro-batch-size",
-                "2",
-                "--no-accelerate",
-            ],
-            catch_exceptions=False,
-        )
+        with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "evaluate",
+                    str(config_path),
+                    "--no-accelerate",
+                ],
+                catch_exceptions=False,
+            )
 
-        assert result.exit_code == 0
-        mock_evaluate.assert_called_once()
-        cfg = mock_evaluate.call_args[0][0]
-        assert cfg.micro_batch_size == 2
+            assert result.exit_code == 0
+            mock_evaluate.assert_called_once()
 
+    def test_evaluate_cli_overrides(self, cli_runner, tmp_path, valid_test_config):
+        """Test CLI arguments properly override config values"""
+        config_path = self._test_cli_overrides(tmp_path, valid_test_config)
 
-def test_evaluate_cli_overrides(cli_runner, tmp_path, valid_test_config):
-    """Test CLI arguments properly override config values"""
-    config_path = tmp_path / "config.yml"
-    output_dir = tmp_path / "model-out"
+        with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "evaluate",
+                    str(config_path),
+                    "--micro-batch-size",
+                    "2",
+                    "--sequence-len",
+                    "128",
+                    "--no-accelerate",
+                ],
+                catch_exceptions=False,
+            )
 
-    test_config = valid_test_config.replace(
-        "output_dir: model-out", f"output_dir: {output_dir}"
-    )
-    config_path.write_text(test_config)
-
-    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
-        result = cli_runner.invoke(
-            cli,
-            [
-                "evaluate",
-                str(config_path),
-                "--micro-batch-size",
-                "2",
-                "--sequence-len",
-                "128",
-                "--no-accelerate",
-            ],
-            catch_exceptions=False,
-        )
-
-        assert result.exit_code == 0
-        mock_evaluate.assert_called_once()
-        cfg = mock_evaluate.call_args[0][0]
-        assert cfg.micro_batch_size == 2
-        assert cfg.sequence_len == 128
-
-
-def test_evaluate_with_rl_dpo(cli_runner, tmp_path, valid_test_config):
-    """Test evaluation with DPO reinforcement learning"""
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(valid_test_config)
-
-    with patch("axolotl.cli.evaluate.do_evaluate") as mock_evaluate:
-        result = cli_runner.invoke(
-            cli,
-            [
-                "evaluate",
-                str(config_path),
-                "--rl",
-                "dpo",
-                "--no-accelerate",
-            ],
-            catch_exceptions=False,
-        )
-
-        assert result.exit_code == 0
-        mock_evaluate.assert_called_once()
-        cfg = mock_evaluate.call_args[0][0]
-        assert cfg.rl == "dpo"
+            assert result.exit_code == 0
+            mock_evaluate.assert_called_once()
+            cfg = mock_evaluate.call_args[0][0]
+            assert cfg.micro_batch_size == 2
+            assert cfg.sequence_len == 128

--- a/tests/cli/test_cli_train.py
+++ b/tests/cli/test_cli_train.py
@@ -1,98 +1,71 @@
-"""pytest tests for axolotl CLI train command."""
+"""Tests for train CLI command."""
+
 from unittest.mock import MagicMock, patch
 
 from axolotl.cli.main import cli
 
-
-def test_train_cli_validation(cli_runner):
-    """Test CLI validation"""
-    # Test missing config file
-    result = cli_runner.invoke(cli, ["train", "--no-accelerate"])
-    assert result.exit_code != 0
-
-    # Test non-existent config file
-    result = cli_runner.invoke(cli, ["train", "nonexistent.yml", "--no-accelerate"])
-    assert result.exit_code != 0
-    assert "Error: Invalid value for 'CONFIG'" in result.output
+from .test_cli_base import BaseCliTest
 
 
-def test_train_basic_execution(cli_runner, tmp_path, valid_test_config):
-    """Test basic successful execution"""
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(valid_test_config)
+class TestTrainCommand(BaseCliTest):
+    """Test cases for train command."""
 
-    with patch("subprocess.run") as mock:
-        result = cli_runner.invoke(cli, ["train", str(config_path)])
+    cli = cli
 
-        assert mock.called
-        assert mock.call_args.args[0] == [
-            "accelerate",
-            "launch",
-            "-m",
-            "axolotl.cli.train",
-            str(config_path),
-            "--debug-num-examples",
-            "0",
-        ]
-        assert mock.call_args.kwargs == {"check": True}
-        assert result.exit_code == 0
+    def test_train_cli_validation(self, cli_runner):
+        """Test CLI validation"""
+        self._test_cli_validation(cli_runner, "train")
 
+    def test_train_basic_execution(self, cli_runner, tmp_path, valid_test_config):
+        """Test basic successful execution"""
+        self._test_basic_execution(cli_runner, tmp_path, valid_test_config, "train")
 
-def test_train_basic_execution_no_accelerate(cli_runner, tmp_path, valid_test_config):
-    """Test basic successful execution"""
-    config_path = tmp_path / "config.yml"
-    config_path.write_text(valid_test_config)
+    def test_train_basic_execution_no_accelerate(
+        self, cli_runner, tmp_path, valid_test_config
+    ):
+        """Test basic successful execution without accelerate"""
+        config_path = tmp_path / "config.yml"
+        config_path.write_text(valid_test_config)
 
-    with patch("axolotl.cli.train.train") as mock_train:
-        mock_train.return_value = (MagicMock(), MagicMock())
+        with patch("axolotl.cli.train.train") as mock_train:
+            mock_train.return_value = (MagicMock(), MagicMock())
 
-        result = cli_runner.invoke(
-            cli,
-            [
-                "train",
-                str(config_path),
-                "--learning-rate",
-                "1e-4",
-                "--micro-batch-size",
-                "2",
-                "--no-accelerate",
-            ],
-            catch_exceptions=False,
-        )
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "train",
+                    str(config_path),
+                    "--no-accelerate",
+                ],
+                catch_exceptions=False,
+            )
 
-        assert result.exit_code == 0
-        mock_train.assert_called_once()
+            assert result.exit_code == 0
+            mock_train.assert_called_once()
 
+    def test_train_cli_overrides(self, cli_runner, tmp_path, valid_test_config):
+        """Test CLI arguments properly override config values"""
+        config_path = self._test_cli_overrides(tmp_path, valid_test_config)
 
-def test_train_cli_overrides(cli_runner, tmp_path, valid_test_config):
-    """Test CLI arguments properly override config values"""
-    config_path = tmp_path / "config.yml"
-    output_dir = tmp_path / "model-out"
+        with patch("axolotl.cli.train.train") as mock_train:
+            mock_train.return_value = (MagicMock(), MagicMock())
 
-    test_config = valid_test_config.replace(
-        "output_dir: model-out", f"output_dir: {output_dir}"
-    )
-    config_path.write_text(test_config)
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "train",
+                    str(config_path),
+                    "--learning-rate",
+                    "1e-4",
+                    "--micro-batch-size",
+                    "2",
+                    "--no-accelerate",
+                ],
+                catch_exceptions=False,
+            )
 
-    with patch("axolotl.cli.train.train") as mock_train:
-        mock_train.return_value = (MagicMock(), MagicMock())
-
-        result = cli_runner.invoke(
-            cli,
-            [
-                "train",
-                str(config_path),
-                "--learning-rate",
-                "1e-4",
-                "--micro-batch-size",
-                "2",
-                "--no-accelerate",
-            ],
-            catch_exceptions=False,
-        )
-
-        assert result.exit_code == 0
-        mock_train.assert_called_once()
-        cfg = mock_train.call_args[1]["cfg"]
-        assert cfg["learning_rate"] == 1e-4
-        assert cfg["micro_batch_size"] == 2
+            assert result.exit_code == 0
+            mock_train.assert_called_once()
+            cfg = mock_train.call_args[1]["cfg"]
+            assert cfg["learning_rate"] == 1e-4
+            assert cfg["micro_batch_size"] == 2


### PR DESCRIPTION
# Description

Title.

## Motivation and Context

I'd like to use this codepath to validate my differential transformers work. I.e., when converting a base model to one where we've swapped out the attentions for (zero-init) differential attentions, we expect the loss to be the same as before the conversion.

This will be generally useful for evaluating models post training, comparing models apples-to-apples, evaluating on different datasets, etc.

## How has this been tested?

Only basic testing in Runpod on a A40 instance with the `axolotlai/axolotl-cloud:main-latest` image. 
For example, with this simple config:

```yaml
base_model: HuggingFaceTB/SmolLM2-135M
datasets:
  - path: mhenrichsen/alpaca_2k_test
    type: alpaca
test_datasets:
  - path: mhenrichsen/alpaca_2k_test
    type: alpaca
    split: train
sdp_attention: true
gradient_accumulation_steps: 1
learning_rate: 1e-4
max_steps: 1
micro_batch_size: 1
sequence_len: 2048
special_tokens:
  pad_token: <|endoftext|>
```

We get:

```shell
# axolotl evaluate ../smollm.yaml 
...
[2024-12-13 21:50:17,302] [INFO] [axolotl.eval.evaluate:88] [PID:72580] [RANK:0] Starting evaluation...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2000/2000 [00:56<00:00, 35.47it/s]
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:101] [PID:72580] [RANK:0] Evaluation completed!
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:102] [PID:72580] [RANK:0] Metrics:
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:104] [PID:72580] [RANK:0] eval_loss: 1.8818285465240479
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:104] [PID:72580] [RANK:0] eval_model_preparation_time: 0.0047
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:104] [PID:72580] [RANK:0] eval_runtime: 56.8085
[2024-12-13 21:51:14,254] [INFO] [axolotl.eval.evaluate:104] [PID:72580] [RANK:0] eval_samples_per_second: 35.206
[2024-12-13 21:51:14,255] [INFO] [axolotl.eval.evaluate:104] [PID:72580] [RANK:0] eval_steps_per_second: 35.206
[2024-12-13 21:51:14,255] [INFO] [axolotl.eval.evaluate:116] [PID:72580] [RANK:0] Evaluation results saved to model-out/eval_results.txt
```

## Types of changes

Adding a new top-level module `axolotl.evaluate` as well as a corresponding CLI module `axolotl.cli.evaluate`.

~~Test coverage is still outstanding.~~ Done.

~~I'd also like to add evaluation on the training dataset (if passed).~~ Done.