### PR TITLE
adding test_datasets compat with pretraining_dataset (streaming)

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -85,6 +85,7 @@ def prepare_dataset(cfg, tokenizer, processor=None):
                     processor=processor,
                 )
     else:
+        # Load streaming dataset if pretraining_dataset is given
         path = cfg.pretraining_dataset
         split = "train"
         name = None
@@ -116,7 +117,18 @@ def prepare_dataset(cfg, tokenizer, processor=None):
         )
         # https://discuss.huggingface.co/t/how-to-use-huggingface-trainer-streaming-datasets-without-wrapping-it-with-torchdatas-iterablewrapper/25230
         train_dataset = train_dataset.with_format("torch")
+
+        # Load eval dataset (non-streaming) if specified
         eval_dataset = None
+        if cfg.test_datasets:
+            _, eval_dataset, _ = load_prepare_datasets(
+                tokenizer,
+                cfg,
+                DEFAULT_DATASET_PREPARED_PATH,
+                split="test",
+                processor=processor,
+            )
+
         if cfg.dataset_exact_deduplication:
             LOG.info("Deduplication not available for pretrained datasets")
 


### PR DESCRIPTION
# Description

Title.

## Motivation and Context

We don't currently have a way of evaluating our models while training on a streaming (pretraining_dataset) dataset.

## How has this been tested?

Simple config to show behavior:

```yaml
base_model: HuggingFaceTB/SmolLM2-135M
pretraining_dataset:
  - path: mhenrichsen/alpaca_2k_test
    type: alpaca
test_datasets:
  - path: mhenrichsen/alpaca_2k_test
    type: alpaca
    split: train[:10%]

gradient_accumulation_steps: 1
learning_rate: 1e-4
max_steps: 1000
eval_steps: 10
micro_batch_size: 1
sequence_len: 2048
special_tokens:
  pad_token: <|endoftext|>
```

## Screenshots (if appropriate)

## Types of changes

Simple code change to the streaming case in our dataset loading logic.