### PR TITLE
fix: allow trainer builder to use custom jinja chat template

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -68,7 +68,7 @@ from axolotl.utils.callbacks import (
 )
 from axolotl.utils.callbacks.lisa import lisa_callback_factory
 from axolotl.utils.callbacks.profiler import PytorchProfilerCallback
-from axolotl.utils.chat_templates import get_chat_template
+from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.collators import (
     BatchSamplerDataCollatorForSeq2Seq,
     DataCollatorForSeq2Seq,

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1836,6 +1836,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         if self.cfg.chat_template:
             training_arguments_kwargs["chat_template"] = get_chat_template(
                 self.cfg.chat_template,
+                jinja_template=self.cfg.chat_template_jinja,
                 tokenizer=self.tokenizer,
             )
 

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -1834,9 +1834,8 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["model_type"] = self.cfg.model_config_type
         training_arguments_kwargs["pretraining"] = bool(self.cfg.pretraining_dataset)
         if self.cfg.chat_template:
-            training_arguments_kwargs["chat_template"] = get_chat_template(
-                self.cfg.chat_template,
-                jinja_template=self.cfg.chat_template_jinja,
+            training_arguments_kwargs["chat_template"] = get_chat_template_from_config(
+                cfg=self.cfg,
                 tokenizer=self.tokenizer,
             )
 


### PR DESCRIPTION
Fixes #2218 

# Description

Passed the `chat_template_jinja` config to `get_chat_template`

## Motivation and Context

Using jinja as the chat_template type previously failed.


