### PR TITLE
fix: mistral nemo does not recognize token_type_ids in forward

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -196,7 +196,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         if eval_dataset:
             eval_dataset = eval_dataset.remove_columns("attention_mask")
 
-    if cfg.model_config_type == "falcon":
+    if cfg.model_config_type in ["falcon", "mistral"]:
         LOG.info("dropping token_type_ids column if it exists")
         if "token_type_ids" in train_dataset.column_names:
             train_dataset = train_dataset.remove_columns("token_type_ids")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Closes https://github.com/axolotl-ai-cloud/axolotl/issues/2225

The issue does not appear for mistral 7b v03 even though they used same source model type `mistral`.

Mistral Nemo uses `PreTrainedTokenizerFast` for tokenizer class which returns `token_type_ids` https://github.com/huggingface/transformers/blob/42865860ec6dc135972d9555753cb7ee17f51fb4/src/transformers/tokenization_utils_base.py#L1397  whereas mistral 7b 03 uses `LlamaTokenizer` which doesn't https://github.com/huggingface/transformers/blob/42865860ec6dc135972d9555753cb7ee17f51fb4/src/transformers/models/llama/tokenization_llama.py#L128

A more future proof method could be following LlamaFactory where they check the `.forward` signature of the model and drop `token_type_ids` if not found

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Confirmed fixes mistral Nemo for packing.

The issue did not appear without packing from limited testing.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
