### PR TITLE
feat: use SequentialSampler if `curriculum_sampling` is enabled with `sample_packing`

### DIFF
--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -608,8 +608,14 @@ class AxolotlTrainer(SchedulerMixin, Trainer):
                     self.state.train_batch_size or self.args.per_device_train_batch_size
                 )
                 batch_max_len = train_batch_size * self.args.max_seq_length
+
+            if self.args.curriculum_sampling:
+                sampler = SequentialSampler(self.train_dataset)
+            else:
+                sampler = RandomSampler(self.train_dataset)
+
             return MultipackBatchSampler(
-                RandomSampler(self.train_dataset),
+                sampler,
                 lengths=get_dataset_lengths(self.train_dataset),
                 packing_efficiency_estimate=self.args.sample_packing_efficiency,
                 batch_max_len=batch_max_len,


### PR DESCRIPTION
# Description

The `curriculum_sampling` flag introduced in https://github.com/axolotl-ai-cloud/axolotl/pull/1567 (cc @winglian) preserves dataset ordering by disabling shuffling, which simplifies experimenting with curriculum learning strategies. However, the flag is ignored if we use `sample_packing`. This PR sets the sampler to a `SequentialSampler` if the `curriculum_sampling` flag is enabled.

## How has this been tested?

I've verified that the DataLoader created in this way correctly yields batches with consecutive samples packed together. However, I'm not 100% sure whether other parameters of `MultipackBatchSampler` need adjustment if we potentially don't have a shuffled dataset (e.g., `packing_efficiency_estimate`).

Please note that `MultipackBatchSampler` is already used with a `SequentialSampler` in `_get_eval_sampler()`.