### PR TITLE
fix for indexing error inside torch.embeddings caused by  num embeddings > num tokens in tokenizer

### DIFF
--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1057,7 +1057,7 @@ class ModelLoader:
         )
         if (
             hasattr(self.model, "get_input_embeddings")
-            and self.model.get_input_embeddings().num_embeddings < embeddings_len
+            and self.model.get_input_embeddings().num_embeddings != embeddings_len
         ):
             resize_kwargs = {}
             if self.cfg.mean_resizing_embeddings is not None:


### PR DESCRIPTION
# Description
https://github.com/axolotl-ai-cloud/axolotl/blob/d8b4027200de0fe60f4ae0a71272c1a8cb2888f7/src/axolotl/utils/models.py#L1060
token_embeddings should be resized when num input embeddings > num tokens in tokenizer since you would need to truncate the embeddings list.

## Motivation and Context
Currently trying to run therealcyberlord/magicwand-opt-125m that uses the GPT2tokenizer. 
Number of embeddings in the model: 50272
Number of tokens in the tokenizer: 50265
This causes an index error in torch.embeddings.
Usually if num embeddings > len(tokens) you would remove the last few embeddings. Therefore, resize_token_embeddings should be called.
