### PR TITLE
Take `split` param from config in all load_dataset instances

### DIFF
--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -107,6 +107,13 @@ def load_dataset_w_config(config_dataset, auth_token):
     except (FileNotFoundError, ConnectionError):
         pass
 
+    # gather extra args from the config
+    load_ds_kwargs = {}
+    if config_dataset.split:
+        load_ds_kwargs["split"] = config_dataset.split
+    else:
+        load_ds_kwargs["split"] = None
+
     # prefer local dataset, even if hub exists
     local_path = Path(config_dataset.path)
     if local_path.exists():
@@ -118,7 +125,7 @@ def load_dataset_w_config(config_dataset, auth_token):
                     name=config_dataset.name,
                     data_files=config_dataset.data_files,
                     streaming=False,
-                    split=None,
+                    **load_ds_kwargs,
                 )
             else:
                 try:
@@ -130,7 +137,7 @@ def load_dataset_w_config(config_dataset, auth_token):
                         config_dataset.path,
                         name=config_dataset.name,
                         streaming=False,
-                        split=None,
+                        **load_ds_kwargs,
                     )
         elif local_path.is_file():
             ds_type = get_ds_type(config_dataset)
@@ -140,16 +147,13 @@ def load_dataset_w_config(config_dataset, auth_token):
                 name=config_dataset.name,
                 data_files=config_dataset.path,
                 streaming=False,
-                split=None,
+                **load_ds_kwargs,
             )
         else:
             raise ValueError(
                 "unhandled dataset load: local path exists, but is neither a directory or a file"
             )
     elif ds_from_hub:
-        load_ds_kwargs = {}
-        if config_dataset.split:
-            load_ds_kwargs["split"] = config_dataset.split
         ds = load_dataset(
             config_dataset.path,
             name=config_dataset.name,
@@ -173,9 +177,9 @@ def load_dataset_w_config(config_dataset, auth_token):
                 name=config_dataset.name,
                 data_files=config_dataset.path,
                 streaming=False,
-                split=None,
                 storage_options=storage_options,
                 trust_remote_code=config_dataset.trust_remote_code,
+                **load_ds_kwargs,
             )
     elif config_dataset.path.startswith("https://"):
         ds_type = get_ds_type(config_dataset)
@@ -184,9 +188,9 @@ def load_dataset_w_config(config_dataset, auth_token):
             name=config_dataset.name,
             data_files=config_dataset.path,
             streaming=False,
-            split=None,
             storage_options=storage_options,
             trust_remote_code=config_dataset.trust_remote_code,
+            **load_ds_kwargs,
         )
     else:
         if isinstance(config_dataset.data_files, str):
@@ -214,7 +218,7 @@ def load_dataset_w_config(config_dataset, auth_token):
             name=config_dataset.name,
             data_files=fp,
             streaming=False,
-            split=None,
+            **load_ds_kwargs,
         )
     if not ds:
         raise ValueError("unhandled dataset load")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Lets the `split` parameter in a dataset's config be used in `load_dataset` whenever `load_dataset` is used to load the dataset.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had no idea what the split parameter was or was not doing because it wasn't manipulating my local jsonl data source in any way. Then I discovered in the code that it was being used only for datasets downloaded directly from Huggingface, when really we should be able to set it for all datasets.

The problem it solves is when I want to use only part of my training dataset, not all of it, which comes up very often for initial testing.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I've tested on the local file dataset, and it's functional - when I specified a split of `train[60%:70%]`, it correctly returned only 10% of my data, where previously axolotl had returned the whole dataset. I assume this is functional on the other dataset types as well. There is nothing the Huggingface docs to say otherwise.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Changes to `load_dataset_w_config` (I see no other boxes to check by the way)

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
