### PR TITLE
Num epochs float

### DIFF
--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -489,7 +489,7 @@ class HyperparametersConfig(BaseModel):
     adam_beta1: Optional[float] = None
     adam_beta2: Optional[float] = None
     max_grad_norm: Optional[float] = None
-    num_epochs: int = Field(default=1)
+    num_epochs: float = Field(default=1.0)
 
     @field_validator("batch_size")
     @classmethod

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -374,7 +374,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         if cfg.sample_packing_eff_est:
             total_num_steps = (
                 # match count to len est in dataloader
-                (
+                int(
                     math.floor(
                         0.99
                         * cfg.total_num_tokens


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
Lets `num_epochs` be a float in the config instead of restricting it to ints. Huggingface takes the parameter as a float anyway.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Often you want to train on 1.2 epochs or 0.4 epochs instead of 1 or 2. This lets you do that.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran preprocess + train once on a config that had `sample_packing` set to `True`. The training began for a few steps and then I ended it.

(The extremely light testing is due to me having not enough time and minimal compute resources.)