### PR TITLE
chore: refactor SaveModelCallback to stop handle fractional save_steps

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import gc
 import logging
-import math
 import os
 import traceback
 from shutil import copyfile
@@ -829,13 +828,6 @@ class SaveModelCallback(TrainerCallback):
     ):
         # Save
         if state.global_step >= state.max_steps:
-            control.should_save = True
-        elif (
-            args.save_strategy == IntervalStrategy.STEPS
-            and state.save_steps < 1.0
-            and state.global_step % math.ceil(state.save_steps * state.max_steps) == 0
-        ):
-            # workaround to save model on fractional save_steps
             control.should_save = True
 
     def on_train_end(  # pylint: disable=unused-argument


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Discussed on slack. We don't need to handle fractional `save_steps` as that is already supported in base transformers.

https://github.com/huggingface/transformers/blame/main/src/transformers/trainer.py#L2306-L2310

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Tested running on cloud pod and verified that with changes, it saves at around proper step.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
