### PR TITLE
disable ray tests for latest torch release

### DIFF
--- a/tests/e2e/multigpu/test_ray.py
+++ b/tests/e2e/multigpu/test_ray.py
@@ -19,12 +19,12 @@ os.environ["WANDB_DISABLED"] = "true"
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 
 
-@require_torch_lt_2_6_0
 class TestMultiGPURay:
     """
     Test cases for AnyScale Ray post training
     """
 
+    @require_torch_lt_2_6_0
     def test_lora_ddp(self, temp_dir):
         # pylint: disable=duplicate-code
         cfg = DictDefault(
@@ -81,6 +81,7 @@ class TestMultiGPURay:
             temp_dir + "/runs", "train/train_loss", 2.3, "Train Loss is too high"
         )
 
+    @require_torch_lt_2_6_0
     @pytest.mark.parametrize(
         "gradient_accumulation_steps",
         [1, 2],

--- a/tests/e2e/multigpu/test_ray.py
+++ b/tests/e2e/multigpu/test_ray.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from accelerate.test_utils import execute_subprocess_async
-from e2e.utils import check_tensorboard
+from e2e.utils import check_tensorboard, require_torch_lt_2_6_0
 
 from axolotl.utils.dict import DictDefault
 
@@ -19,6 +19,7 @@ os.environ["WANDB_DISABLED"] = "true"
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 
 
+@require_torch_lt_2_6_0
 class TestMultiGPURay:
     """
     Test cases for AnyScale Ray post training

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -66,6 +66,18 @@ def require_torch_2_5_1(test_case):
     return unittest.skipUnless(is_min_2_5_1(), "test requires torch>=2.5.1")(test_case)
 
 
+def require_torch_lt_2_6_0(test_case):
+    """
+    Decorator marking a test that requires torch >= 2.5.1
+    """
+
+    def is_max_2_6_0():
+        torch_version = version.parse(torch.__version__)
+        return torch_version < version.parse("2.6.0")
+
+    return unittest.skipUnless(is_max_2_6_0(), "test requires torch<2.6.0")(test_case)
+
+
 def is_hopper():
     compute_capability = torch.cuda.get_device_capability()
     return compute_capability == (9, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Disabling ray tests on latest torch 2.6.0 for now. Per @erictang000 

```
it looks like the issue is actually with triton 3.2.0 and ray.
Bug details:
deepspeed uses the @triton.autotuner decorator, which gets initialized at import time in triton 3.2.0,
they add logic to the autotuner that checks torch.cuda.is_available() in the autotuner constructor
the ray TrainTrainable cpu only actor, which packages environments for the RayTrainWorker gpu actors, 
tries to import deepspeed but torch.cuda.is_available() is false, and the new triton version doesn't like that

Fixing triton to 3.1.0 will fix the issue for now, but this might cause other issues with torch 2.6.0 since triton==3.2.0 
was a dependency. We're looking into the best way to resolve this either on our end or through putting an issue up 
on deepspeed to allow a way to avoid the offending triton autotuner code.
```