### PR TITLE
Fix sample packing producing longer sequences than specified by `sequence_len`

### DIFF
--- a/src/axolotl/utils/samplers/utils.py
+++ b/src/axolotl/utils/samplers/utils.py
@@ -5,12 +5,12 @@ import numpy as np
 
 
 def get_dataset_lengths(dataset):
-    if "length" in dataset.data.column_names:
-        lengths = np.array(dataset.data.column("length"))
-    elif "position_ids" in dataset.data.column_names:
-        position_ids = dataset.data.column("position_ids")
+    if "length" in dataset.column_names:
+        lengths = np.array(dataset["length"])
+    elif "position_ids" in dataset.column_names:
+        position_ids = dataset["position_ids"]
         lengths = np.array([x[-1] + 1 for x in position_ids])
     else:
-        input_ids = dataset.data.column("input_ids")
+        input_ids = dataset["input_ids"]
         lengths = np.vectorize(len)(np.array(input_ids, dtype=object))
     return lengths

--- a/src/axolotl/utils/samplers/utils.py
+++ b/src/axolotl/utils/samplers/utils.py
@@ -12,5 +12,5 @@ def get_dataset_lengths(dataset):
         lengths = np.array([x[-1] + 1 for x in position_ids])
     else:
         input_ids = dataset["input_ids"]
-        lengths = np.vectorize(len)(np.array(input_ids, dtype=object))
+        lengths = np.array([len(seq) for seq in input_ids])
     return lengths


### PR DESCRIPTION
# Description

Return tokenized sequence lengths in `get_dataset_lengths` directly from the `Dataset` object instead of accessing the underlying PyArrow table. Filtering the dataset (e.g., by applying `drop_long_seq_in_dataset`) would update the `Dataset` object but not the underlying table. Thus, the sequence lengths returned by `get_dataset_lengths` would no longer correspond to the correct sequences and the sample packing algorithm may produce samples longer than `cfg.sequence_len`.

## Motivation and Context

Training with sample packing and `pad_to_sequence_len=True` should result in stable VRAM usage. However, due to this bug, sequence length may differ between batches, which caused increased VRAM usage and even OOMs in the middle of training in my case. Fine-tuning Phi-3.5 with `sequence_len=4096`, `micro_batch_size=1`, `gradient_accumulation_steps=4`, and `gradient_checkpointing=False` went from random OOMs after ~500 steps to using stable ~42GB VRAM on a single A100 80GB with the fix.

Note that pretraining does not seem to be affected since the underlying in-memory table is updated along with the `IterableDataset` when applying any filters.

Pre-processing the dataset in a separate step and then loading the prepared dataset for training should theoretically also circumvent this issue, but I was not able confirm this yet.

## How has this been tested?

I extended `test_packed_batch_sampler.py` to use `drop_long_seq_in_dataset` before applying the `MultipackBatchSampler` and parametrized the test to additionally use a `sequence_len` of 512 so that some samples are actually dropped from the dataset. Running the extended test without the fix fails, while it runs successfully on my setup with the fix.

My env:
OS: Windows 10 (WSL Ubuntu 24.04)
Python: 3.12.9
Torch: 2.5.1 (CPU-only)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
