### PR TITLE
Select input_ids explicitly after panda conversion

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -396,8 +396,8 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
     ):
         total_num_tokens = np.sum(
             train_dataset.select_columns("input_ids")
-            .to_pandas()
-            .apply(lambda x: len(x))  # pylint: disable=unnecessary-lambda
+            .to_pandas()["input_ids"]
+            .apply(len)
             .values
         )
         LOG.debug(f"total_num_tokens: {total_num_tokens:_}", main_process_only=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Without selecting the column, applying `len` counts the whole row as 1 which resulting the total number of the samples instead of the token counts.

## Motivation and Context

https://github.com/axolotl-ai-cloud/axolotl/issues/2334

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Ran a training with the fix.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

```
[2025-02-15 17:32:59,757] [DEBUG] [axolotl.calculate_total_num_steps:403] [PID:3274911] [RANK:0] total_num_tokens: 16_452_017_178
[2025-02-15 17:37:01,314] [DEBUG] [axolotl.calculate_total_num_steps:421] [PID:3274911] [RANK:0] `total_supervised_tokens: 16_452_017_178`
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
