### PR TITLE
Doc fix: TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL not necessary to use Triton kernel patches

### DIFF
--- a/docs/lora_optims.qmd
+++ b/docs/lora_optims.qmd
@@ -82,6 +82,7 @@ lora_o_kernel: true
 ## Requirements
 
 - One or more NVIDIA or AMD GPUs (in order to use the Triton kernels)
+    - Note: Set `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1` to enable [memory-efficient attention on AMD GPUs](https://github.com/ROCm/aotriton/issues/16#issuecomment-2346675491)
 - Targeted LoRA adapters cannot use Dropout
     - This may limit model expressivity / cause overfitting
 - Targeted LoRA adapters cannot have bias terms

--- a/docs/lora_optims.qmd
+++ b/docs/lora_optims.qmd
@@ -82,7 +82,6 @@ lora_o_kernel: true
 ## Requirements
 
 - One or more NVIDIA or AMD GPUs (in order to use the Triton kernels)
-    - AMD can be used with experimental Triton support by setting the environment variable `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1`
 - Targeted LoRA adapters cannot use Dropout
     - This may limit model expressivity / cause overfitting
 - Targeted LoRA adapters cannot have bias terms


### PR DESCRIPTION
# Description

Title. Turns out that env variable is not needed.

## How has this been tested?

Confirmed by the Triton docs and by running benchmarks on a AMD GPU.

Relevant: https://github.com/axolotl-ai-cloud/axolotl/pull/2324#issuecomment-2665021803.
