### PR TITLE
Correctly reference mount paths

### DIFF
--- a/src/axolotl/cli/cloud/modal_.py
+++ b/src/axolotl/cli/cloud/modal_.py
@@ -261,9 +261,7 @@ class ModalCloud(Cloud):
 
 def _preprocess(config_yaml: str, volumes=None):
     Path("/workspace/mounts").mkdir(parents=True, exist_ok=True)
-    with open(
-        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
-    ) as f_out:
+    with open("/workspace/mounts/config.yaml", "w", encoding="utf-8") as f_out:
         f_out.write(config_yaml)
     run_folder = "/workspace/mounts"
     run_cmd(
@@ -274,9 +272,7 @@ def _preprocess(config_yaml: str, volumes=None):
 
 
 def _train(config_yaml: str, accelerate: bool = True, volumes=None, **kwargs):
-    with open(
-        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
-    ) as f_out:
+    with open("/workspace/mounts/config.yaml", "w", encoding="utf-8") as f_out:
         f_out.write(config_yaml)
     run_folder = "/workspace/mounts"
     if accelerate:
@@ -294,9 +290,7 @@ def _train(config_yaml: str, accelerate: bool = True, volumes=None, **kwargs):
 
 
 def _lm_eval(config_yaml: str, volumes=None):
-    with open(
-        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
-    ) as f_out:
+    with open("/workspace/mounts/config.yaml", "w", encoding="utf-8") as f_out:
         f_out.write(config_yaml)
     run_folder = "/workspace/mounts"
     run_cmd(

--- a/src/axolotl/cli/cloud/modal_.py
+++ b/src/axolotl/cli/cloud/modal_.py
@@ -295,12 +295,12 @@ def _train(config_yaml: str, accelerate: bool = True, volumes=None, **kwargs):
 
 def _lm_eval(config_yaml: str, volumes=None):
     with open(
-        "/workspace/artifacts/axolotl/config.yaml", "w", encoding="utf-8"
+        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
     ) as f_out:
         f_out.write(config_yaml)
-    run_folder = "/workspace/artifacts/axolotl"
+    run_folder = "/workspace/mounts"
     run_cmd(
-        "axolotl lm-eval /workspace/artifacts/axolotl/config.yaml",
+        "axolotl lm-eval /workspace/mounts/config.yaml",
         run_folder,
         volumes,
     )

--- a/src/axolotl/cli/cloud/modal_.py
+++ b/src/axolotl/cli/cloud/modal_.py
@@ -260,14 +260,14 @@ class ModalCloud(Cloud):
 
 
 def _preprocess(config_yaml: str, volumes=None):
-    Path("/workspace/artifacts/axolotl").mkdir(parents=True, exist_ok=True)
+    Path("/workspace/mounts").mkdir(parents=True, exist_ok=True)
     with open(
-        "/workspace/artifacts/axolotl/config.yaml", "w", encoding="utf-8"
+        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
     ) as f_out:
         f_out.write(config_yaml)
-    run_folder = "/workspace/artifacts/axolotl"
+    run_folder = "/workspace/mounts"
     run_cmd(
-        "axolotl preprocess /workspace/artifacts/axolotl/config.yaml --dataset-processes=8",
+        "axolotl preprocess /workspace/mounts/config.yaml --dataset-processes=8",
         run_folder,
         volumes,
     )
@@ -275,10 +275,10 @@ def _preprocess(config_yaml: str, volumes=None):
 
 def _train(config_yaml: str, accelerate: bool = True, volumes=None, **kwargs):
     with open(
-        "/workspace/artifacts/axolotl/config.yaml", "w", encoding="utf-8"
+        "/workspace/mounts/config.yaml", "w", encoding="utf-8"
     ) as f_out:
         f_out.write(config_yaml)
-    run_folder = "/workspace/artifacts/axolotl"
+    run_folder = "/workspace/mounts"
     if accelerate:
         accelerate_args = "--accelerate"
     else:
@@ -287,7 +287,7 @@ def _train(config_yaml: str, accelerate: bool = True, volumes=None, **kwargs):
     if num_processes := kwargs.pop("num_processes", None):
         num_processes_args = f"--num-processes {num_processes}"
     run_cmd(
-        f"axolotl train {accelerate_args} {num_processes_args} /workspace/artifacts/axolotl/config.yaml",
+        f"axolotl train {accelerate_args} {num_processes_args} /workspace/mounts/config.yaml",
         run_folder,
         volumes,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes the mount paths referenced in the Axolotl code that runs inside the Modal containers to correctly match the mount path set in `src/axolotl/cli/cloud/__init__.py`.

## Motivation and Context

Fixes https://github.com/axolotl-ai-cloud/axolotl/issues/2346

## How has this been tested?

I ran `axolotl train ./config.yaml --cloud ./cloud_config.yaml` and it no longer crashed immediately as soon as the container booted inside Modal due to the hardcoded mismatched mount paths.

FWIW, it appears that `preprocess` and `lm_eval` actually never mount any local files or directories at all in `__init__.py`, and so I suspect they will continue to be broken since none of the configs will be copied over (they already are broken in master), but this fixes `train`, at least.

I'm working on a fix for `preprocess`, which I can add as a followup PR as it's a more involved change.

## Types of changes

Bugfix

## Social Handles (Optional)

[@reissbaker](https://x.com/reissbaker) on Twitter