### PR TITLE
Add REX LR Scheduler

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -445,7 +445,7 @@ gradient_checkpointing: false
 early_stopping_patience: 3
 
 # Specify a scheduler and kwargs to use with the optimizer
-lr_scheduler: # 'one_cycle' | 'log_sweep' | empty for cosine
+lr_scheduler: # 'one_cycle' | 'rex' | 'log_sweep' | empty for cosine
 lr_scheduler_kwargs:
 cosine_min_lr_ratio: # decay lr to some percentage of the peak lr, e.g. cosine_min_lr_ratio=0.1 for 10% of peak lr
 cosine_constant_lr_ratio: # freeze lr at some percentage of the step, e.g. cosine_constant_lr_ratio=0.8 means start cosine_min_lr at 80% of training step (https://arxiv.org/pdf/2308.04014.pdf)

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -574,7 +574,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["embedding_lr_scale"] = self.cfg.embedding_lr_scale
         training_arguments_kwargs["lr_groups"] = self.cfg.lr_groups
 
-        if self.cfg.lr_scheduler in ["one_cycle", "log_sweep"]:
+        if self.cfg.lr_scheduler in ["one_cycle", "rex", "log_sweep"]:
             training_arguments_kwargs["lr_scheduler_type"] = "cosine"
             training_arguments_kwargs[
                 "alternate_lr_scheduler_type"

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -66,10 +66,9 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
         self.last_epoch = value
 
     def get_lr(self):
-        # Warmup phase: if defined, increase lr linearly from min_lr to max_lr.
-        if self.num_warmup_steps > 0 and self.last_step < self.num_warmup_steps:
-            warmup_lr = self.min_lr + (self.max_lr - self.min_lr) * (self.last_step / self.num_warmup_steps)
-            return [warmup_lr]
+        # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
+        if 0 <= (self.last_step - 2) <= (self.num_warmup_steps - 1):
+            return [self.max_lr * (self.last_step - 2) / (self.num_warmup_steps - 1)]
 
         # Post-warmup phase: adjust step relative to the end of warmup.
         step_after = (self.last_step - self.num_warmup_steps) - 2
@@ -81,8 +80,7 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
 
         mod_iter = step_after % remaining_steps
         z = (remaining_steps - mod_iter) / remaining_steps
-        lr = self.min_lr + (self.max_lr - self.min_lr) * (z / (0.1 + 0.9 * z))
-        return [lr]
+        return [self.min_lr + (self.max_lr - self.min_lr) * (z / (0.1 + 0.9 * z))]
 
 
 def _sanitize_kwargs_for_tagging(tag_names, kwargs=None):

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -171,7 +171,7 @@ class SchedulerMixin(Trainer):
                     max_lr=self.args.learning_rate,
                     min_lr=0 if not use_cosine_min_lr else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
                     total_steps=num_training_steps,
-                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
+                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps) + 1,
                 )
             elif use_cosine_quadratic:
                 if use_cosine_min_lr:

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -38,18 +38,18 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
 class RexLR(_LRScheduler):
-    def __init__(self, optimizer, max_val, min_val, num_epochs=1, last_epoch=-1):
-        if min_val > max_val:
-            raise ValueError(f'Value of "min_val" should be less than value of "max_val". Got min_val={min_val} and max_val={max_val}')
-        self.num_epochs = num_epochs
-        self.min_val = min_val
-        self.max_val = max_val
-        super().__init__(optimizer, last_epoch)
+    def __init__(self, optimizer, max_lr, min_lr, total_steps=1, last_step=0):
+        if min_lr > max_lr:
+            raise ValueError(f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}')
+        self.total_steps = total_steps
+        self.min_lr = min_lr
+        self.max_lr = max_lr
+        super().__init__(optimizer, last_step)
 
     def get_lr(self):
-        mod_iter = self.last_epoch % self.num_epochs
-        z = (self.num_epochs - mod_iter) / self.num_epochs
-        lr = self.min_val + (self.max_val - self.min_val) * (z / (1 - 0.9 + 0.9 * z))
+        mod_iter = self.last_step % self.total_steps
+        z = (self.total_steps - mod_iter) / self.total_steps
+        lr = self.min_lr + (self.max_lr - self.min_lr) * (z / (1 - 0.9 + 0.9 * z))
         return [lr]
 
 
@@ -135,9 +135,9 @@ class SchedulerMixin(Trainer):
             elif self.args.alternate_lr_scheduler_type == "rex":
                 self.lr_scheduler = RexLR(
                     optimizer=optimizer,
-                    max_val=self.args.learning_rate,
-                    min_val=0 if not self.args.cosine_min_lr_ratio else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
-                    num_epochs=num_training_steps + 1,
+                    max_lr=self.args.learning_rate,
+                    min_lr=0 if not self.args.cosine_min_lr_ratio else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
+                    total_steps=num_training_steps,
                 )
             elif use_cosine_quadratic:
                 if use_cosine_min_lr:

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
 class RexLR(_LRScheduler):
-    def __init__(self, optimizer, max_lr, min_lr, total_steps=1, num_warmup_steps=0, last_step=-2):
+    def __init__(self, optimizer, max_lr, min_lr, total_steps=1, num_warmup_steps=0, last_step=-1):
         if min_lr > max_lr:
             raise ValueError(f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}')
         if num_warmup_steps > total_steps:
@@ -163,10 +163,13 @@ class SchedulerMixin(Trainer):
                     **self.args.lr_scheduler_kwargs,
                 )
             elif self.args.alternate_lr_scheduler_type == "rex":
+                if use_cosine_min_lr:
+                    assert 0 <= self.args.cosine_min_lr_ratio <= 1.0, "cosine_min_lr_ratio must be between 0.0 and 1.0"
+
                 self.lr_scheduler = RexLR(
                     optimizer=optimizer,
                     max_lr=self.args.learning_rate,
-                    min_lr=0 if not self.args.cosine_min_lr_ratio else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
+                    min_lr=0 if not use_cosine_min_lr else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
                     total_steps=num_training_steps,
                     num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 )

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -39,7 +39,7 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
 class RexLR(torch.optim.lr_scheduler.LRScheduler):
     """
-    Reverse exponential learning rate scheduler.
+    Reflected exponential learning rate scheduler.
 
     Original implementation: https://github.com/IvanVassi/REX_LR
     Based on: https://arxiv.org/abs/2107.04197

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -89,7 +89,10 @@ class RexLR(torch.optim.lr_scheduler.LRScheduler):
     def get_lr(self):
         # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
         if 0 <= self.last_step <= self.num_warmup_steps:
-            return [base_lr * self.last_step / self.num_warmup_steps for base_lr in self.base_lrs]
+            return [
+                base_lr * self.last_step / self.num_warmup_steps
+                for base_lr in self.base_lrs
+            ]
 
         # Post-warmup phase: adjust step relative to the end of warmup.
         step_after = self.last_step - self.num_warmup_steps
@@ -101,7 +104,9 @@ class RexLR(torch.optim.lr_scheduler.LRScheduler):
 
         mod_iter = step_after % remaining_steps
         z = (remaining_steps - mod_iter) / remaining_steps
-        rex_factor = self.min_lr / self.max_lr + (1.0 - self.min_lr / self.max_lr) * (z / (0.1 + 0.9 * z))
+        rex_factor = self.min_lr / self.max_lr + (1.0 - self.min_lr / self.max_lr) * (
+            z / (0.1 + 0.9 * z)
+        )
         return [base_lr * rex_factor for base_lr in self.base_lrs]
 
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -168,6 +168,7 @@ class SchedulerMixin(Trainer):
                     max_lr=self.args.learning_rate,
                     min_lr=0 if not self.args.cosine_min_lr_ratio else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
                     total_steps=num_training_steps,
+                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 )
             elif use_cosine_quadratic:
                 if use_cosine_min_lr:

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -75,12 +75,8 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
         step_after = (self.last_step - self.num_warmup_steps) - 2
         remaining_steps = (self.total_steps - self.num_warmup_steps) - 1
 
-        # Avoid division by zero if remaining_steps is zero (i.e., total_steps == num_warmup_steps)
-        if remaining_steps <= 0:
-            return [self.min_lr]
-
         # Avoid LR spiking
-        if step_after >= remaining_steps or step_after == -1:
+        if step_after >= remaining_steps or step_after == -1 or remaining_steps <= 0:
             return [self.min_lr]
 
         mod_iter = step_after % remaining_steps

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -37,7 +37,7 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 
 
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
-class RexLR(torch.optim.lr_scheduler._LRScheduler):
+class RexLR(torch.optim.lr_scheduler.LRScheduler):
     """
     Reverse exponential learning rate scheduler.
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -28,7 +28,7 @@ from axolotl.utils.schedulers import (
     get_cosine_schedule_with_min_lr,
     get_cosine_schedule_with_quadratic_warmup,
     get_cosine_schedule_with_warmup_decay_constant,
-    RexLR
+    RexLR,
 )
 
 if is_sagemaker_mp_enabled():

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -170,8 +170,8 @@ class SchedulerMixin(Trainer):
                     optimizer=optimizer,
                     max_lr=self.args.learning_rate,
                     min_lr=0 if not use_cosine_min_lr else (self.args.learning_rate * self.args.cosine_min_lr_ratio),
-                    total_steps=num_training_steps,
-                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps) + 1,
+                    total_steps=num_training_steps + 1,
+                    num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 )
             elif use_cosine_quadratic:
                 if use_cosine_min_lr:

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -38,6 +38,21 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
 class RexLR(torch.optim.lr_scheduler._LRScheduler):
+    """
+    Reverse exponential learning rate scheduler.
+
+    Original implementation: https://github.com/IvanVassi/REX_LR
+    Based on: https://arxiv.org/abs/2107.04197
+
+    Args:
+        optimizer (torch.optim.Optimizer): The optimizer to schedule the learning rate for.
+        max_lr (float): The maximum learning rate.
+        min_lr (float): The minimum learning rate.
+        total_steps (int): The total number of training steps.
+        num_warmup_steps (int): The number of warmup steps.
+        last_step (int): The index of last step. Defaults to 0.
+    """
+
     def __init__(
         self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0
     ):

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -25,10 +25,10 @@ from trl.trainer.utils import pad_to_length
 from axolotl.monkeypatch.relora import ReLoRAScheduler
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 from axolotl.utils.schedulers import (
+    RexLR,
     get_cosine_schedule_with_min_lr,
     get_cosine_schedule_with_quadratic_warmup,
     get_cosine_schedule_with_warmup_decay_constant,
-    RexLR,
 )
 
 if is_sagemaker_mp_enabled():

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -38,11 +38,17 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 
 # https://github.com/IvanVassi/REX_LR - Apache 2.0
 class RexLR(torch.optim.lr_scheduler._LRScheduler):
-    def __init__(self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0):
+    def __init__(
+        self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0
+     ):
         if min_lr > max_lr:
-            raise ValueError(f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}')
+            raise ValueError(
+                f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}'
+            )
         if num_warmup_steps > total_steps:
-            raise ValueError(f'num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps}).')
+            raise ValueError(
+                f'num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps}).'
+            )
 
         self.min_lr = min_lr
         self.max_lr = max_lr
@@ -50,9 +56,9 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
         self.num_warmup_steps = num_warmup_steps
         self.last_step = last_step
 
-        # Ensure each parameter group has an 'initial_lr' key to avoid issues when resuming.
+        # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
         for group in optimizer.param_groups:
-            group.setdefault('initial_lr', group['lr'])
+            group.setdefault("initial_lr", group["lr"])
 
         # Pass last_step as last_epoch to the parent.
         super().__init__(optimizer, last_epoch=last_step)

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -88,7 +88,7 @@ class RexLR(torch.optim.lr_scheduler.LRScheduler):
 
     def get_lr(self):
         # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
-        if self.num_warmup_steps > 0 and 0 <= self.last_step <= self.num_warmup_steps:
+        if 1 <= self.last_step <= self.num_warmup_steps:
             return [
                 base_lr * self.last_step / self.num_warmup_steps
                 for base_lr in self.base_lrs

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -40,7 +40,7 @@ LOG = logging.getLogger("axolotl.core.trainer_builder")
 class RexLR(torch.optim.lr_scheduler._LRScheduler):
     def __init__(
         self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0
-     ):
+    ):
         if min_lr > max_lr:
             raise ValueError(
                 f"Value of \"min_lr\" should be less than value of \"max_lr\". Got min_lr={min_lr} and max_lr={max_lr}"

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -67,9 +67,9 @@ class RexLR(torch.optim.lr_scheduler.LRScheduler):
 
         self.min_lr = min_lr
         self.max_lr = max_lr
-        self.total_steps = total_steps - 1
-        self.num_warmup_steps = num_warmup_steps - 1
-        self.last_step = last_step - 2
+        self.total_steps = total_steps
+        self.num_warmup_steps = num_warmup_steps
+        self.last_step = last_step - 1
 
         # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
         for group in optimizer.param_groups:
@@ -88,7 +88,7 @@ class RexLR(torch.optim.lr_scheduler.LRScheduler):
 
     def get_lr(self):
         # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
-        if 0 <= self.last_step <= self.num_warmup_steps:
+        if self.num_warmup_steps > 0 and 0 <= self.last_step <= self.num_warmup_steps:
             return [
                 base_lr * self.last_step / self.num_warmup_steps
                 for base_lr in self.base_lrs

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -43,7 +43,7 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
     ):
         if min_lr > max_lr:
             raise ValueError(
-                f"Value of \"min_lr\" should be less than value of \"max_lr\". Got min_lr={min_lr} and max_lr={max_lr}"
+                f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}'
             )
         if num_warmup_steps > total_steps:
             raise ValueError(

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -28,86 +28,13 @@ from axolotl.utils.schedulers import (
     get_cosine_schedule_with_min_lr,
     get_cosine_schedule_with_quadratic_warmup,
     get_cosine_schedule_with_warmup_decay_constant,
+    RexLR
 )
 
 if is_sagemaker_mp_enabled():
     import smdistributed.modelparallel.torch as smp
 
 LOG = logging.getLogger("axolotl.core.trainer_builder")
-
-
-# https://github.com/IvanVassi/REX_LR - Apache 2.0
-class RexLR(torch.optim.lr_scheduler.LRScheduler):
-    """
-    Reflected exponential learning rate scheduler.
-
-    Original implementation: https://github.com/IvanVassi/REX_LR
-    Based on: https://arxiv.org/abs/2107.04197
-
-    Args:
-        optimizer (torch.optim.Optimizer): The optimizer to schedule the learning rate for.
-        max_lr (float): The maximum learning rate.
-        min_lr (float): The minimum learning rate.
-        total_steps (int): The total number of training steps.
-        num_warmup_steps (int): The number of warmup steps.
-        last_step (int): The index of last step. Defaults to 0.
-    """
-
-    def __init__(
-        self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0
-    ):
-        if min_lr > max_lr:
-            raise ValueError(
-                f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}'
-            )
-        if num_warmup_steps > total_steps:
-            raise ValueError(
-                f"num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps})."
-            )
-
-        self.min_lr = min_lr
-        self.max_lr = max_lr
-        self.total_steps = total_steps
-        self.num_warmup_steps = num_warmup_steps
-        self.last_step = last_step - 1
-
-        # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
-        for group in optimizer.param_groups:
-            group.setdefault("initial_lr", group["lr"])
-
-        # Pass self.last_step as last_epoch to the parent.
-        super().__init__(optimizer, last_epoch=self.last_step)
-
-    @property
-    def last_step(self):
-        return self.last_epoch
-
-    @last_step.setter
-    def last_step(self, value):
-        self.last_epoch = value
-
-    def get_lr(self):
-        # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
-        if 1 <= self.last_step <= self.num_warmup_steps:
-            return [
-                base_lr * self.last_step / self.num_warmup_steps
-                for base_lr in self.base_lrs
-            ]
-
-        # Post-warmup phase: adjust step relative to the end of warmup.
-        step_after = self.last_step - self.num_warmup_steps
-        remaining_steps = self.total_steps - self.num_warmup_steps
-
-        # Avoid LR spiking
-        if step_after >= remaining_steps or step_after == -1 or remaining_steps <= 0:
-            return [self.min_lr for _ in self.base_lrs]
-
-        mod_iter = step_after % remaining_steps
-        z = (remaining_steps - mod_iter) / remaining_steps
-        rex_factor = self.min_lr / self.max_lr + (1.0 - self.min_lr / self.max_lr) * (
-            z / (0.1 + 0.9 * z)
-        )
-        return [base_lr * rex_factor for base_lr in self.base_lrs]
 
 
 def _sanitize_kwargs_for_tagging(tag_names, kwargs=None):

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -43,11 +43,11 @@ class RexLR(torch.optim.lr_scheduler._LRScheduler):
      ):
         if min_lr > max_lr:
             raise ValueError(
-                f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}'
+                f"Value of \"min_lr\" should be less than value of \"max_lr\". Got min_lr={min_lr} and max_lr={max_lr}"
             )
         if num_warmup_steps > total_steps:
             raise ValueError(
-                f'num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps}).'
+                f"num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps})."
             )
 
         self.min_lr = min_lr

--- a/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
+++ b/src/axolotl/utils/config/models/input/v0_4_1/__init__.py
@@ -518,7 +518,7 @@ class HyperparametersConfig(BaseModel):
     )
     torchdistx_path: Optional[str] = None
     lr_scheduler: Optional[
-        Union[SchedulerType, Literal["one_cycle"]]
+        Union[SchedulerType, Literal["one_cycle"], Literal["rex"]]
     ] = SchedulerType.COSINE
     lr_scheduler_kwargs: Optional[Dict[str, Any]] = None
     lr_quadratic_warmup: Optional[bool] = None

--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -6,6 +6,80 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR, LRScheduler
 
 
+class RexLR(LRScheduler):
+    """
+    Reflected exponential learning rate scheduler.
+
+    Original implementation: https://github.com/IvanVassi/REX_LR
+    Original license: Apache 2.0
+    Based on: https://arxiv.org/abs/2107.04197
+
+    Args:
+        optimizer (torch.optim.Optimizer): The optimizer to schedule the learning rate for.
+        max_lr (float): The maximum learning rate.
+        min_lr (float): The minimum learning rate.
+        total_steps (int): The total number of training steps.
+        num_warmup_steps (int): The number of warmup steps.
+        last_step (int): The index of last step. Defaults to 0.
+    """
+
+    def __init__(
+        self, optimizer, max_lr, min_lr, total_steps=0, num_warmup_steps=0, last_step=0
+    ):
+        if min_lr > max_lr:
+            raise ValueError(
+                f'Value of "min_lr" should be less than value of "max_lr". Got min_lr={min_lr} and max_lr={max_lr}'
+            )
+        if num_warmup_steps > total_steps:
+            raise ValueError(
+                f"num_warmup_steps ({num_warmup_steps}) must be less than or equal to total_steps ({total_steps})."
+            )
+
+        self.min_lr = min_lr
+        self.max_lr = max_lr
+        self.total_steps = total_steps
+        self.num_warmup_steps = num_warmup_steps
+        self.last_step = last_step - 1
+
+        # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
+        for group in optimizer.param_groups:
+            group.setdefault("initial_lr", group["lr"])
+
+        # Pass self.last_step as last_epoch to the parent.
+        super().__init__(optimizer, last_epoch=self.last_step)
+
+    @property
+    def last_step(self):
+        return self.last_epoch
+
+    @last_step.setter
+    def last_step(self, value):
+        self.last_epoch = value
+
+    def get_lr(self):
+        # Warmup phase: if defined, increase lr linearly from 0 to max_lr.
+        if 1 <= self.last_step <= self.num_warmup_steps:
+            return [
+                base_lr * self.last_step / self.num_warmup_steps
+                for base_lr in self.base_lrs
+            ]
+
+        # Post-warmup phase: adjust step relative to the end of warmup.
+        step_after = self.last_step - self.num_warmup_steps
+        remaining_steps = self.total_steps - self.num_warmup_steps
+
+        # Avoid LR spiking
+        if step_after >= remaining_steps or step_after == -1 or remaining_steps <= 0:
+            return [self.min_lr for _ in self.base_lrs]
+
+        mod_iter = step_after % remaining_steps
+        z = (remaining_steps - mod_iter) / remaining_steps
+        rex_factor = self.min_lr / self.max_lr + (1.0 - self.min_lr / self.max_lr) * (
+            z / (0.1 + 0.9 * z)
+        )
+        return [base_lr * rex_factor for base_lr in self.base_lrs]
+
+
 class InterpolatingLogScheduler(LRScheduler):
     """
     A scheduler that interpolates learning rates in a logarithmic fashion

--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -8,11 +8,11 @@ from torch.optim.lr_scheduler import LambdaLR, LRScheduler
 
 class RexLR(LRScheduler):
     """
-    Reflected exponential learning rate scheduler.
+    Reflected Exponential (REX) learning rate scheduler.
 
-    Original implementation: https://github.com/IvanVassi/REX_LR
-    Original license: Apache 2.0
-    Based on: https://arxiv.org/abs/2107.04197
+    - Original implementation: https://github.com/IvanVassi/REX_LR
+    - Original license: Apache 2.0
+    - Based on: https://arxiv.org/abs/2107.04197
 
     Args:
         optimizer (torch.optim.Optimizer): The optimizer to schedule the learning rate for.
@@ -20,7 +20,7 @@ class RexLR(LRScheduler):
         min_lr (float): The minimum learning rate.
         total_steps (int): The total number of training steps.
         num_warmup_steps (int): The number of warmup steps.
-        last_step (int): The index of last step. Defaults to 0.
+        last_step (int): The index of last step.
     """
 
     def __init__(

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -54,7 +54,7 @@ class TestCustomSchedulers(unittest.TestCase):
                 "gradient_accumulation_steps": 1,
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
-                "optimizer": "optimi_adamw",
+                "optimizer": "adamw_hf",
                 "max_steps": 5,
                 "lr_scheduler": "rex",
             }

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -55,8 +55,10 @@ class TestCustomSchedulers(unittest.TestCase):
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_hf",
-                "max_steps": 5,
+                "max_steps": 20,
                 "lr_scheduler": "rex",
+                "warmup_steps": 5,
+                "cosine_min_lr_ratio": 0.05
             }
         )
 

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -1,0 +1,69 @@
+"""
+E2E tests for custom schedulers using Llama
+"""
+
+import logging
+import os
+import unittest
+
+from axolotl.cli.args import TrainerCliArgs
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config
+from axolotl.utils.dict import DictDefault
+
+from .utils import check_model_output_exists, require_torch_2_5_1, with_temp_dir
+
+LOG = logging.getLogger("axolotl.tests.e2e")
+os.environ["WANDB_DISABLED"] = "true"
+
+
+class TestCustomSchedulers(unittest.TestCase):
+    """
+    Test case for Llama models using LoRA
+    """
+
+    @with_temp_dir
+    def test_rex_scheduler(self, temp_dir):
+        # pylint: disable=duplicate-code
+        cfg = DictDefault(
+            {
+                "base_model": "JackFram/llama-68m",
+                "tokenizer_type": "LlamaTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.1,
+                "special_tokens": {
+                    "unk_token": "<unk>",
+                    "bos_token": "<s>",
+                    "eos_token": "</s>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "optimi_adamw",
+                "max_steps": 5,
+                "lr_scheduler": "rex",
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        cli_args = TrainerCliArgs()
+        dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
+
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -12,7 +12,7 @@ from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
 
-from .utils import check_model_output_exists, require_torch_2_5_1, with_temp_dir
+from .utils import check_model_output_exists, with_temp_dir
 
 LOG = logging.getLogger("axolotl.tests.e2e")
 os.environ["WANDB_DISABLED"] = "true"

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -58,7 +58,7 @@ class TestCustomSchedulers(unittest.TestCase):
                 "max_steps": 20,
                 "lr_scheduler": "rex",
                 "warmup_steps": 5,
-                "cosine_min_lr_ratio": 0.05
+                "cosine_min_lr_ratio": 0.05,
             }
         )
 


### PR DESCRIPTION
# Description

https://arxiv.org/abs/2107.04197
https://github.com/IvanVassi/REX_LR

```yaml
lr_scheduler: rex
```

Works with `cosine_min_lr_ratio` and `warmup_steps`.

## Screenshots (if appropriate)

![Screenshot 2025-03-03 at 11-16-03 LLaMa-3 2-1B-Instruct Workspace – Weights   Biases](https://github.com/user-attachments/assets/9b059d4c-55ef-41ce-bd73-d95fe5a9da6f)

<details>
  <summary>Axolotl Config</summary>

```yaml
# Weights and Biases logging config
wandb_project: LLaMa-3.2-1B-Instruct
wandb_entity:
wandb_watch:
wandb_name: rex
wandb_log_model:

# Model checkpointing config
output_dir: ./Outputs/rex
resume_from_checkpoint:
save_steps: 50
save_safetensors: true
save_total_limit: 3
save_only_model: false

# Model architecture config
base_model: meta-llama/Llama-3.2-1B-Instruct
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

# Mixed precision training config
bf16: true
fp16: false
tf32: false

# Model loading config
load_in_8bit: false
load_in_4bit: true
strict: false

# Sequence config
sequence_len: 4096
min_sample_len: 256
sample_packing: true
eval_sample_packing: true
pad_to_sequence_len: true
train_on_inputs: false
group_by_length: false

# LoRA adapter config
adapter: qlora
lora_model_dir:
lora_r: 32
lora_alpha: 32
lora_dropout: 0.125
peft_layers_to_transform:
peft_use_dora:
peft_use_rslora:
peft_layer_replication:
lora_target_modules:
  - gate_proj
  - down_proj
  - up_proj
  - q_proj
  - v_proj
  - k_proj
  - o_proj
lora_modules_to_save:

# Fix uninitialized tokens (such as <|start_header_id|> on the base L3 models)
fix_untrained_tokens:

# Dataset config
# Completion: https://github.com/xzuyn/axolotl/blob/prompt_formats/src/axolotl/prompt_strategies/customcompletion-regex.py
datasets:
# Completion
  - path: PJMixers-Dev/fundusnewsonly
    split: train[:1024]  # Only the first 1024
    type: customcompletion-regex
test_datasets:
# Completion
  - path: PJMixers-Dev/fundusnewsonly
    split: train[-32:]  # Only the last 32
    type: customcompletion-regex
val_set_size: 0
eval_strategy: steps
eval_steps: 1
dataset_prepared_path: ./00-Tokenized-Datasets/testt
shuffle_merged_datasets: true
dataset_processes:

# Training hyperparameters
num_epochs: 1
gradient_accumulation_steps: 1
micro_batch_size: 8
eval_batch_size: 8
warmup_steps: 0
optimizer: paged_adamw_8bit
optim_args:
optim_target_modules:
lr_scheduler: rex
learning_rate: 1e-5
cosine_min_lr_ratio:
loraplus_lr_ratio:
loraplus_lr_embedding:
weight_decay: 0.1
max_grad_norm: 1
logging_steps: 1

# Model optimization
gradient_checkpointing: unsloth
sdp_attention: true
plugins:
  - axolotl.integrations.liger.LigerPlugin
  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
cut_cross_entropy: true
liger_rope: true
liger_rms_norm: true
liger_layer_norm: true
liger_glu_activation: true
liger_cross_entropy: false
liger_fused_linear_cross_entropy: false
lora_mlp_kernel: false
lora_qkv_kernel: false
lora_o_kernel: false

# DeepSpeed
deepspeed:

# Garbage Collection
gc_steps: 1

# Debug config
debug: true
seed: 42

# Token config
special_tokens:
  bos_token: "<|begin_of_text|>"
  eos_token: "<|end_of_text|>"
  pad_token: "<|finetune_right_pad_id|>"
tokens:
```

</details>

---

![Screenshot 2025-03-03 at 21-32-28 LLaMa-3 2-1B-Instruct Workspace – Weights   Biases](https://github.com/user-attachments/assets/2f90af90-53f5-4912-96a8-6d54316fd5e7)

<details>
  <summary>Axolotl Config</summary>

```yaml
# Weights and Biases logging config
wandb_project: LLaMa-3.2-1B-Instruct
wandb_entity:
wandb_watch:
wandb_name: rex3
wandb_log_model:

# Model checkpointing config
output_dir: ./Outputs/rex3
resume_from_checkpoint:
save_steps: 100
save_safetensors: true
save_total_limit: 3
save_only_model: false

# Model architecture config
base_model: meta-llama/Llama-3.2-1B-Instruct
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

# Mixed precision training config
bf16: true
fp16: false
tf32: false

# Model loading config
load_in_8bit: false
load_in_4bit: false
strict: false

# Sequence config
sequence_len: 4096
min_sample_len: 256
sample_packing: true
eval_sample_packing: true
pad_to_sequence_len: true
train_on_inputs: false
group_by_length: false

# LoRA adapter config
adapter: lora
lora_model_dir:
lora_r: 64
lora_alpha: 64
lora_dropout: 0.125
peft_layers_to_transform:
peft_use_dora:
peft_use_rslora:
peft_layer_replication:
lora_target_modules:
  - gate_proj
  - down_proj
  - up_proj
  - q_proj
  - v_proj
  - k_proj
  - o_proj
lora_modules_to_save:

# Fix uninitialized tokens (such as <|start_header_id|> on the base L3 models)
fix_untrained_tokens:

# Dataset config
# Instruct: https://github.com/xzuyn/axolotl/blob/prompt_formats/src/axolotl/prompt_strategies/customllama3-regex.py
datasets:
# Instruct
  - path: PJMixers-Dev/sequelbox_Tachibana2-DeepSeek-R1-PREVIEW-Shuffled-ShareGPT
    split: train[128:]  # Everything except the first 128
    type: customllama3-regex
test_datasets:
# Instruct
  - path: PJMixers-Dev/sequelbox_Tachibana2-DeepSeek-R1-PREVIEW-Shuffled-ShareGPT
    split: train[:128]  # Only the first 128
    type: customllama3-regex
val_set_size: 0
eval_strategy: steps
eval_steps: 10
dataset_prepared_path: ./00-Tokenized-Datasets/testt2
shuffle_merged_datasets: true
dataset_processes:

# Training hyperparameters
num_epochs: 1
gradient_accumulation_steps: 1
micro_batch_size: 16
eval_batch_size: 16
warmup_steps: 0
optimizer: paged_adamw_8bit
optim_args:
optim_target_modules:
lr_scheduler: cosine
learning_rate: 2e-5
cosine_min_lr_ratio:
loraplus_lr_ratio:
loraplus_lr_embedding:
weight_decay: 0.1
max_grad_norm: 1
logging_steps: 1

# Early Stopping
early_stopping_patience:

# Model optimization
gradient_checkpointing: unsloth
sdp_attention: true
plugins:
  - axolotl.integrations.liger.LigerPlugin
  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
cut_cross_entropy: true
liger_rope: true
liger_rms_norm: true
liger_layer_norm: true
liger_glu_activation: true
liger_cross_entropy: false
liger_fused_linear_cross_entropy: false
lora_mlp_kernel: false
lora_qkv_kernel: false
lora_o_kernel: false

# DeepSpeed
deepspeed:

# Garbage Collection
gc_steps: 1

# Debug config
debug: true
seed: 42

# Token config
special_tokens:
  bos_token: "<|begin_of_text|>"
  eos_token: "<|end_of_text|>"
  pad_token: "<|finetune_right_pad_id|>"
tokens:
```

</details>