### PR TITLE
Sequential sample packing

### DIFF
--- a/examples/llama-3/lora-1b-sample-packing-sequentially.yml
+++ b/examples/llama-3/lora-1b-sample-packing-sequentially.yml
@@ -1,0 +1,80 @@
+base_model: meta-llama/Llama-3.2-1B
+# optionally might have model_type or tokenizer_type
+model_type: LlamaForCausalLM
+tokenizer_type: AutoTokenizer
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+load_in_8bit: true
+load_in_4bit: false
+strict: false
+
+datasets:
+  - path: mhenrichsen/alpaca_2k_test
+    type: alpaca
+  - path: mhenrichsen/alpaca_2k_test
+    type: alpaca
+dataset_prepared_path:
+val_set_size: 0.0
+output_dir: ./outputs/lora-out
+
+test_value: true
+
+sequence_len: 4096
+sample_packing: true
+sample_packing_sequentially: true
+curriculum_sampling: true
+eval_sample_packing: false
+pad_to_sequence_len: true
+
+adapter: lora
+lora_model_dir:
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0.05
+lora_target_linear: true
+lora_fan_in_fan_out:
+lora_modules_to_save:
+  - embed_tokens
+  - lm_head
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 4
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+train_on_inputs: false
+group_by_length: false
+bf16: auto
+fp16:
+tf32: false
+
+gradient_checkpointing: true
+early_stopping_patience:
+resume_from_checkpoint:
+local_rank:
+logging_steps: 1
+xformers_attention:
+flash_attention: true
+s2_attention:
+
+warmup_steps: 10
+evals_per_epoch: 4
+eval_table_size:
+eval_max_new_tokens: 128
+saves_per_epoch: 1
+debug:
+deepspeed:
+weight_decay: 0.0
+fsdp:
+fsdp_config:
+special_tokens:
+  pad_token: <|end_of_text|>

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -112,6 +112,7 @@ class AxolotlTrainer(SchedulerMixin, OptimizerMixin, SequenceParallelMixin, Trai
             packing_efficiency_estimate=self.args.sample_packing_efficiency,
             batch_max_len=batch_max_len,
             batch_size=batch_size,
+            sequential=self.args.sample_packing_sequentially,
             drop_last=True,
         )
 

--- a/src/axolotl/core/training_args.py
+++ b/src/axolotl/core/training_args.py
@@ -34,6 +34,10 @@ class AxolotlTrainingMixins:
         default=False,
         metadata={"help": "Use sample packing for efficient training."},
     )
+    sample_packing_sequentially: bool = field(
+        default=False,
+        metadata={"help": "Use next-fit sample packing that preserves the order of samples coming from the sampler. Use in combination with curriculum_sampling for fully sequential packing."},
+    )
     multipack_real_batches: bool = field(
         default=False,
         metadata={"help": "Use real batches for efficient training."},

--- a/src/axolotl/core/training_args.py
+++ b/src/axolotl/core/training_args.py
@@ -36,7 +36,9 @@ class AxolotlTrainingMixins:
     )
     sample_packing_sequentially: bool = field(
         default=False,
-        metadata={"help": "Use next-fit sample packing that preserves the order of samples coming from the sampler. Use in combination with curriculum_sampling for fully sequential packing."},
+        metadata={
+            "help": "Use next-fit sample packing that preserves the order of samples coming from the sampler. Use in combination with curriculum_sampling for fully sequential packing."
+        },
     )
     multipack_real_batches: bool = field(
         default=False,

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -124,7 +124,7 @@ def allocate_sequentially(lengths: np.ndarray, rank: int, c: int, n: int):
 
     # First, do sequential packing into bins
     all_bins = []
-    current_bin = [0 for i in range(0)] # numba hint
+    current_bin = [0 for i in range(0)]  # numba hint
     remaining_capacity = c
 
     for idx, size in enumerate(lengths):
@@ -188,8 +188,9 @@ class MultipackBatchSampler(BatchSampler):
         self.len_across_ranks = None
 
         if self.sequential and not isinstance(sampler, SequentialSampler):
-            LOG.warn("using sequential sample packing with non-sequential sampler, did you want to also enable curriculum_sampling?")
-
+            LOG.warn(
+                "using sequential sample packing with non-sequential sampler, did you want to also enable curriculum_sampling?"
+            )
 
     def set_epoch(self, epoch: int):
         self.epoch = epoch

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -188,6 +188,7 @@ class AxolotlInputConfig(
     sample_packing: bool | None = None
     sample_packing_group_size: int | None = 100_000
     sample_packing_bin_size: int | None = 200
+    sample_packing_sequentially: bool | None = None
     eval_sample_packing: bool | None = None
     pad_to_sequence_len: bool | None = None
     curriculum_sampling: bool | None = None

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -13,7 +13,7 @@ import torch
 import torch.cuda
 from accelerate.logging import get_logger
 from datasets import IterableDataset, disable_caching, enable_caching
-from torch.utils.data import DataLoader, RandomSampler
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from transformers.utils import is_torch_bf16_gpu_available
 
 from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuilder
@@ -456,13 +456,18 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             else:
                 sampler_batch_size = cfg.micro_batch_size
                 batch_max_len = cfg.sequence_len
+            if cfg.curriculum_sampling:
+                sampler = SequentialSampler(train_dataset)
+            else:
+                sampler = RandomSampler(train_dataset)
             sampler = MultipackBatchSampler(
-                sampler=RandomSampler(train_dataset),
+                sampler=sampler,
                 lengths=get_dataset_lengths(train_dataset),
                 batch_size=sampler_batch_size,
                 batch_max_len=batch_max_len,
                 group_size=cfg.sample_packing_group_size,
                 bin_size=cfg.sample_packing_bin_size,
+                sequential=cfg.sample_packing_sequentially,
                 drop_last=True,
             )
 

--- a/tests/test_packed_batch_sampler.py
+++ b/tests/test_packed_batch_sampler.py
@@ -39,7 +39,9 @@ class TestBatchedSamplerPacking:
     @pytest.mark.parametrize("max_seq_length", [4096, 512])
     @pytest.mark.parametrize("sequential", [True, False])
     @enable_hf_offline
-    def test_packing(self, batch_size, num_workers, tokenizer, max_seq_length, sequential):
+    def test_packing(
+        self, batch_size, num_workers, tokenizer, max_seq_length, sequential
+    ):
         import axolotl.monkeypatch.data.batch_dataset_fetcher  # pylint: disable=unused-import  # noqa: F401
 
         dataset = load_dataset(
@@ -75,7 +77,7 @@ class TestBatchedSamplerPacking:
             batch_max_len=max_seq_length,
             group_size=100000,
             bin_size=200,
-            sequential=sequential
+            sequential=sequential,
         )
 
         loader = DataLoader(

--- a/tests/test_packed_batch_sampler.py
+++ b/tests/test_packed_batch_sampler.py
@@ -37,8 +37,9 @@ class TestBatchedSamplerPacking:
         ],
     )
     @pytest.mark.parametrize("max_seq_length", [4096, 512])
+    @pytest.mark.parametrize("sequential", [True, False])
     @enable_hf_offline
-    def test_packing(self, batch_size, num_workers, tokenizer, max_seq_length):
+    def test_packing(self, batch_size, num_workers, tokenizer, max_seq_length, sequential):
         import axolotl.monkeypatch.data.batch_dataset_fetcher  # pylint: disable=unused-import  # noqa: F401
 
         dataset = load_dataset(
@@ -74,6 +75,7 @@ class TestBatchedSamplerPacking:
             batch_max_len=max_seq_length,
             group_size=100000,
             bin_size=200,
+            sequential=sequential
         )
 
         loader = DataLoader(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This change adds support for next-fit bin packing in MultipackBatchSampler. What this means is that we can now use sample packing while preserving the order of the examples.

## Motivation and Context

Current sample packing affects order of examples in ways that can affect training results. This PR adds a new flag:
`--sample_pack_sequentially` which uses a simple greedy / sequential next-fit bin packing.

If you use `--sample_pack_sequentially` alone, the order of the examples will be determined by the underlying `RandomSampler`. If you use `--sample_pack_sequentially` with `--curriculum_sampling`, the order of the examples will be the same as in the training data. Both options make sense and differ from the current settings.

For example, previously it was not possible to do proper curriculum learning since the bin packing algorithm would reorder the examples anyway.

## How has this been tested?

I tested it by running the new config: `examples/llama-3/lora-1b-sample-packing-sequentially.yml`
On this dataset, packing efficiency is high (>97%).

---

I would also like to bring attention to a potential bug in the multipack code:
- [Here](https://github.com/axolotl-ai-cloud/axolotl/blob/4a736986fa6f3387f21391f186f472926754dac1/src/axolotl/utils/trainer.py#L463) we set `group_size` and `bin_size`
- But [it's never used](https://github.com/axolotl-ai-cloud/axolotl/blob/4a736986fa6f3387f21391f186f472926754dac1/src/axolotl/utils/samplers/multipack.py#L111).
