### PR TITLE
only validate hf user token on rank 0

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -1,6 +1,7 @@
 """CLI to run training on a model."""
 
 import logging
+import os
 from pathlib import Path
 from typing import Union
 
@@ -34,7 +35,8 @@ def do_train(cfg: DictDefault, cli_args: TrainerCliArgs) -> None:
     """
     print_axolotl_text_art()
     check_accelerate_default_config()
-    check_user_token()
+    if int(os.getenv("LOCAL_RANK", "0")) == 0:
+        check_user_token()
 
     if cfg.rl:
         dataset_meta = load_preference_datasets(cfg=cfg, cli_args=cli_args)


### PR DESCRIPTION
When training with multi-node, it's easy to hit rate limits, this ensures that we only check the token on rank 0 which should be sufficient to fail the process if it is found to be invalid.

```
[rank3]: Traceback (most recent call last):                                                                                                                                                                                                    [rank3]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/huggingface_hub/hf_api.py", line 1639, in whoami                                                                                                                    
[rank3]:     hf_raise_for_status(r)                                                                                                                                                                                                            [rank3]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/huggingface_hub/utils/_http.py", line 477, in hf_raise_for_status                                                                                                   
[rank3]:     raise _format(HfHubHTTPError, str(e), response) from e                                                                                                                                                                            [rank3]: huggingface_hub.errors.HfHubHTTPError: 504 Server Error: Gateway Time-out for url: https://huggingface.co/api/whoami-v2      
```