### PR TITLE
DPO with the chat_template fix for trl errors (removes extra columns)

### DIFF
--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -91,4 +91,9 @@ def default(
 
         return result
 
-    return transform_fn
+    # Then when you call map, specify the original columns to remove
+    map_kwargs = {
+        "remove_columns": [field_messages, field_chosen, field_rejected] 
+    }
+
+    return transform_fn, map_kwargs


### PR DESCRIPTION
This fixes my reported issue #2415 where trl is not happy about the original rows being submitted.

When using the [documented fields](https://axolotl-ai-cloud.github.io/axolotl/docs/rlhf.html#chat_template.default), trl will give an error because the original fields are submitted and trl expects *only* prompt (optional), chosen, and rejected for the DPOTrainer.

The only way you could use the existing code without an error is if you made your original fields named prompt, chosen, and rejected I guess? In any case, it seems the best way to fix this (and to allow the field mapping to continue to work) is to remove the original fields from being sbumitted.

To do this, I simply add the original fields to `remove_columns` in the kwargs.