### PR TITLE
expandable segments by default

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -1,7 +1,10 @@
 """CLI to run training on a model."""
 
+import os  # noqa
+# Reduce memory fragmentation in PyTorch for less VRAM usage and more stable training.
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import logging
-import os
 from pathlib import Path
 from typing import Union
 


### PR DESCRIPTION
## Motivation and Context

This helped me train with 65k context in axolotl. A common problem at this context length is high memory pressure and fragmentation, which the following default will help alleviate.

## How has this been tested?

I tested with/without and the job crashes without this in PyTorch. At this point, this optimization is common (e.g. it's on by default in Unsloth).

There is a [long blog post](https://www.gilesthomas.com/2024/07/fine-tuning-5) written about this and it concludes that this variable should generally be used.