### PR TITLE
Fix: remove the numerous sequential log

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -320,8 +320,12 @@ total_num_tokens:
 sample_packing_group_size: 100000
 # The number of samples which can be packed into one sequence. Increase if using a large sequence_len with many short samples.
 sample_packing_bin_size: 200
+sample_pack_sequentially: # Optional[bool]. Whether to pack samples sequentially.
+
 # whether to concatenate samples during pretraining
 pretraining_sample_concatenation:
+
+curriculum_sampling: # Optional[bool]. Whether to use sequential sampling for curriculum learning
 
 # Use batch flattening for speedups when not using sample_packing
 batch_flattening:

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -12,7 +12,9 @@ from torch.utils.data import BatchSampler, Sampler, SequentialSampler
 
 from axolotl.utils.distributed import reduce_and_broadcast
 
-LOG = logging.getLogger("axolotl.utils.samplers.multipack")
+LOG = logging.getLogger(__name__)
+
+LOG.setLevel(logging.INFO)
 
 
 @numba.njit
@@ -202,7 +204,6 @@ class MultipackBatchSampler(BatchSampler):
         lengths_cumsum = np.cumsum(lengths)
 
         if self.sequential:
-            LOG.debug("using sequential sample packing algorithm")
             batches, total_used, total_slots = allocate_sequentially(
                 lengths=lengths,
                 rank=0,
@@ -210,7 +211,6 @@ class MultipackBatchSampler(BatchSampler):
                 n=1,
             )
         else:
-            LOG.debug("using non-sequential sample packing algorithm")
             batches, total_used, total_slots = allocate(
                 lengths=lengths,
                 lengths_cumsum=lengths_cumsum,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
There's a lot of redundant logs here. I think we can remove this.


```
          1 09:02:14,495] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                         [147/3662]
[2025-04-01 09:02:14,520] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,543] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,566] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
/workspace/axolotl/src/axolotl/core/trainers/base.py:62: FutureWarning: `tokenizer` is deprecated and will be removed in version 5.0.0 for `AxolotlTrainer.__init__`. Use `processing_class` instead.                                                                         
  super().__init__(*_args, **kwargs)                                                                                                                                                                                                                                          
          1 09:02:14,580] [INFO] [axolotl.train.save_initial_configs:343] [PID:9278] [RANK:0] Pre-saving tokenizer to outputs/out...                                                                                                                                [141/3662]
          1 09:02:14,590] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                         [140/3662]
[2025-04-01 09:02:14,613] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,636] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,660] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,683] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,706] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,730] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm                                                                                                                   
[2025-04-01 09:02:14,753] [DEBUG] [axolotl.utils.samplers.multipack.generate_batches:221] [PID:9279] [RANK:1] using non-sequential sample packing algorithm 
```

Log set level INFO seems to be ignored hence I removed the logs itself.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
