### PR TITLE
removing deepspeed guard for LoRA Triton kernels

### DIFF
--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1224,16 +1224,11 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
         ):
             capabilities = data.get("capabilities")
             is_fsdp = data.get("fsdp") is not None
-            is_deepspeed = data.get("deepspeed") is not None
 
             if capabilities and capabilities.get("n_gpu", 0) > 1:
                 if is_fsdp:
                     raise ValueError(
                         "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with FSDP."
-                    )
-                if is_deepspeed:
-                    raise ValueError(
-                        "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with DeepSpeed."
                     )
         return data
 


### PR DESCRIPTION
# Description

We note in our docs that DeepSpeed is compatible with our LoRA Triton kernels, but guard against this in our config pydantic model validations. This PR removes that guard.

Thanks to @nyxkrage for catching.

## How has this been tested?

Tested manually with a few runs of SmolLM2-135M on 2x H100s and various deepspeed configs.