### PR TITLE
fix: lm_head is a view or related view modified for CCE

### DIFF
--- a/src/axolotl/integrations/cut_cross_entropy/monkeypatch/llama4.py
+++ b/src/axolotl/integrations/cut_cross_entropy/monkeypatch/llama4.py
@@ -310,13 +310,14 @@ def cce_forward_multimodal(
     if _PATCH_OPTS is not None and _PATCH_OPTS.use_lce(labels, self.training):
         assert labels is not None
 
-        # reset lm head if not already done. linear model has some lm_head weight issue
+        # reset lm head gradient on first pass.
+        # linear model has some lm_head weight issue
+        # see https://github.com/axolotl-ai-cloud/axolotl/pull/2505
         global RESET_LM_HEAD  # pylint: disable=global-statement
         if RESET_LM_HEAD:
             RESET_LM_HEAD = False
-            self.language_model.lm_head.weight = (
-                self.language_model.lm_head.weight.detach().requires_grad_(True)
-            )
+            self.language_model.lm_head.weight.requires_grad_(False)  # Detach
+            self.language_model.lm_head.weight.requires_grad_(True)  # Reattach
 
         loss = apply_lce(
             hidden_states,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Found out from a lot of tests that `lm_head` has some issues with linearized model. Can't even `.clone()` it. Chose to detach then reattach the gradient. The conversion handling for lm_head in linear model wasn't modified, so this issue is weird. Patch for TextExperts were not found to be the cause.

I checked quickly that `lm_head is not embed_tokens` to ensure it's not tied weights, so I don't think need to re-tie?

Loss w and without CCE 
<img width="815" alt="image" src="https://github.com/user-attachments/assets/75916b80-d665-4ced-9574-dd5de483f28a" />


```

2025-04-08 08:24:03
[rank0]:   File "/workspace/axolotl/src/axolotl/integrations/cut_cross_entropy/monkeypatch/llama4.py", line 312, in cce_forward_multimodal
192
2025-04-08 08:24:03
[rank0]:     loss = apply_lce(
193
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^
194
2025-04-08 08:24:03
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/transformers/utils.py", line 66, in apply_lce
195
2025-04-08 08:24:03
[rank0]:     loss = linear_cross_entropy(
196
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
197
2025-04-08 08:24:03
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/linear_cross_entropy.py", line 71, in linear_cross_entropy
198
2025-04-08 08:24:03
[rank0]:     return cce_linear_cross_entropy(
199
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
200
2025-04-08 08:24:03
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/cce.py", line 196, in cce_linear_cross_entropy
201
2025-04-08 08:24:03
[rank0]:     return linear_cross_entropy_apply(
202
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
203
2025-04-08 08:24:03
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/cce.py", line 146, in linear_cross_entropy_apply
204
2025-04-08 08:24:03
[rank0]:     loss = LinearCrossEntropyFunction.apply(e, c, bias, params)
205
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
206
2025-04-08 08:24:03
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/torch/autograd/function.py", line 575, in apply
207
2025-04-08 08:24:03
[rank0]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
208
2025-04-08 08:24:03
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
209
2025-04-08 08:24:03
[rank0]: RuntimeError: Output 0 of ViewBackward0 is a view and its base or another view of its base has been modified inplace. This view is the output of a function that returns multiple views. Such functions do not allow the output views to be modified inplace. You should replace the inplace operation by an out-of-place one.
```



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
