### PR TITLE
fix: allow merge lora on pre-quantized model

### DIFF
--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -32,7 +32,13 @@ def do_merge_lora(*, cfg: DictDefault) -> None:
 
     LOG.info("Running merge of LoRA with base model...")
     model = model.merge_and_unload(progressbar=True)
-    model.to(dtype=cfg.torch_dtype)
+    try:
+        model.to(dtype=cfg.torch_dtype)
+    except ValueError as e:
+        LOG.warning("Failed to convert model to dtype %s", cfg.torch_dtype)
+        LOG.warning("Ignore this if the base_model is pre-quantized.")
+        LOG.warning("Error raised: %s", e)
+
     model.generation_config.do_sample = True
 
     if cfg.local_rank == 0:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -151,11 +151,12 @@ def check_model_config(cfg: DictDefault, model_config: PretrainedConfig):
             "Please make sure to point to a GPTQ model."
         )
 
-    if not cfg.gptq and quant_config_exists and not cfg.load_in_4bit:
-        raise ValueError(
-            "model_config.quantization_config is set but `gptq` flag is not. "
-            "Please use the `gptq` flag to train quantized model or point to a non-quantized model."
-        )
+    # if quant_config_exists, transformers will use the quant_config to load the model
+    # if not cfg.gptq and quant_config_exists and not cfg.load_in_4bit:
+    #     raise ValueError(
+    #         "model_config.quantization_config is set but `gptq` flag is not. "
+    #         "Please use the `gptq` flag to train quantized model or point to a non-quantized model."
+    #     )
 
     lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
     if (

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -151,13 +151,6 @@ def check_model_config(cfg: DictDefault, model_config: PretrainedConfig):
             "Please make sure to point to a GPTQ model."
         )
 
-    # if quant_config_exists, transformers will use the quant_config to load the model
-    # if not cfg.gptq and quant_config_exists and not cfg.load_in_4bit:
-    #     raise ValueError(
-    #         "model_config.quantization_config is set but `gptq` flag is not. "
-    #         "Please use the `gptq` flag to train quantized model or point to a non-quantized model."
-    #     )
-
     lora_modules_to_save = get_linear_embedding_layers(model_config.model_type)
     if (
         cfg.adapter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

When merging adapter to pre-quantized model (like `axolotl-quants/Llama-4-Scout-17B-16E-Linearized-bnb-nf4-bf16`), there would be two errors:
- `ValueError: model_config.quantization_config is set but `gptq` flag is not.` due to pre-quantization
- `ValueError: You cannot cast a bitsandbytes model in a new `dtype`.` as it's still a bnb model at that point.

This PR fixes that and allows merging adapter to quantized NF4 model.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested to run with adapter trained on llama scout nf4 and merged.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
