### PR TITLE
batch api HF adapter for ring-flash-attn; cleanup and improvements

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -693,6 +693,9 @@ sequence_parallel_degree:
 # Optional; strides across the key dimension. Larger values use more memory but should make training faster.
 # Must evenly divide the number of KV heads in your model.
 heads_k_stride: 1
+# One of "varlen_llama3", "batch_ring", "batch_zigzag", "batch_stripe". Defaults to "varlen_llama3"
+# in the sample packing case, and "batch_ring" in the non-sample packing case.
+ring_attn_func:
 
 # Path to torch distx for optim 'adamw_anyprecision'
 torchdistx_path:

--- a/docs/sequence_parallelism.qmd
+++ b/docs/sequence_parallelism.qmd
@@ -28,7 +28,7 @@ sequence_parallel_degree: 4  # Split sequences across 4 GPUs
 # Optional; strides across the key dimension. Larger values use more memory but should make training faster.
 heads_k_stride: 1
 # Optional; one of "varlen_llama3", "batch_ring", "batch_zigzag", "batch_stripe". Defaults to
-"varlen_llama3" when `sample_packing: true`, and "batch_ring" otherwise.
+# "varlen_llama3" when `sample_packing: true`, and "batch_ring" otherwise.
 ring_attn_func:
 ```
 

--- a/docs/sequence_parallelism.qmd
+++ b/docs/sequence_parallelism.qmd
@@ -27,6 +27,9 @@ To enable sequence parallelism, add the following to your configuration file:
 sequence_parallel_degree: 4  # Split sequences across 4 GPUs
 # Optional; strides across the key dimension. Larger values use more memory but should make training faster.
 heads_k_stride: 1
+# Optional; one of "varlen_llama3", "batch_ring", "batch_zigzag", "batch_stripe". Defaults to
+"varlen_llama3" when `sample_packing: true`, and "batch_ring" otherwise.
+ring_attn_func:
 ```
 
 The `sequence_parallel_degree` should be a divisor of the total number of GPUs. For example:

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -776,6 +776,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["sequence_parallel_degree"] = (
             self.cfg.sequence_parallel_degree
         )
+        training_arguments_kwargs["ring_attn_func"] = self.cfg.ring_attn_func
 
         if self.cfg.reward_model:
             training_args_cls = AxolotlRewardConfig

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -934,6 +934,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         kwargs["return_tensors"] = "pt"
         if issubclass(collator, DataCollatorForSeq2Seq):
             kwargs["sequence_parallel_degree"] = training_args.sequence_parallel_degree
+            kwargs["ring_attn_func"] = training_args.ring_attn_func
 
         return collator(
             *collator_args,

--- a/src/axolotl/core/training_args.py
+++ b/src/axolotl/core/training_args.py
@@ -9,6 +9,8 @@ from PIL.Image import Resampling
 from transformers import TrainingArguments
 from trl import CPOConfig, KTOConfig, ORPOConfig, PRMConfig, RewardConfig
 
+from axolotl.monkeypatch.attention.ring_attn.patch import RingAttnFunc
+
 
 @dataclass
 class AxolotlTrainingMixins:
@@ -217,6 +219,12 @@ class AxolotlTrainingMixins:
     sequence_parallel_degree: Optional[int] = field(
         default=1,
         metadata={"help": "The number of workers to use in sequence parallelism"},
+    )
+    ring_attn_func: Optional[RingAttnFunc] = field(
+        default=None,
+        metadata={
+            "help": "The ring-flash-attn function to use in sequence parallelism"
+        },
     )
 
     # multi-modal section

--- a/src/axolotl/monkeypatch/attention/ring_attn/__init__.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/__init__.py
@@ -1,0 +1,12 @@
+"""Init for ring attention monkeypatch module"""
+
+# pylint: disable=unused-import
+# flake8: noqa
+
+from .patch import (
+    RingAttnFunc,
+    get_ring_attn_group,
+    register_ring_attn,
+    set_ring_attn_group,
+    update_ring_attn_params,
+)

--- a/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch.py
@@ -38,7 +38,7 @@ RING_ATTN_FUNC_MAPPING = {
 
 
 def create_flash_attn_forward(
-    process_group: dist.ProcessGroup, ring_attn_func: Callable
+    process_group: dist.ProcessGroup, ring_attn_func: RingAttnFunc
 ) -> Callable:
     """
     Create a ring flash attention forward function compatible with HuggingFace's

--- a/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch_ring.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch_ring.py
@@ -34,8 +34,7 @@ def create_ring_flash_attention_forward(process_group: dist.ProcessGroup) -> Cal
     Create a ring flash attention forward function compatible with HuggingFace's interface.
 
     Args:
-        process_group: A PyTorch distributed process group that defines the communication
-            topology for the ring attention pattern.
+        process_group: A PyTorch distributed process group.
 
     Returns:
         A function that implements the ring flash attention forward pass with the

--- a/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch_ring.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/adapters/batch_ring.py
@@ -1,0 +1,175 @@
+"""
+HuggingFace flash attention adapter for basic ring attention (batch API).
+
+Inspired by
+https://github.com/zhuzilin/ring-flash-attention/blob/ce9fd3935ca0e5f0592bb0826cbed18ec69da729/ring_flash_attn/adapters/hf_adapter.py.
+Our implementation closely follows the structure of that module, but we've minified it
+somewhat to support only the latest versions of transformers.
+"""
+
+# pylint: disable=protected-access
+
+import os
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+import transformers
+import transformers.modeling_flash_attention_utils
+from ring_flash_attn import ring_flash_attn_func
+from ring_flash_attn.adapters.hf_adapter import check_params
+from transformers.modeling_flash_attention_utils import (
+    _flash_supports_window_size,
+    is_flash_attn_greater_or_equal,
+)
+
+try:
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+except ImportError:
+    ALL_ATTENTION_FUNCTIONS = None
+
+
+def create_ring_flash_attention_forward(process_group: dist.ProcessGroup) -> Callable:
+    """
+    Create a ring flash attention forward function compatible with HuggingFace's interface.
+
+    Args:
+        process_group: A PyTorch distributed process group that defines the communication
+            topology for the ring attention pattern.
+
+    Returns:
+        A function that implements the ring flash attention forward pass with the
+            signature expected by HuggingFace Transformers.
+    """
+
+    # transformers 4.48+
+    # pylint: disable=unused-argument
+    def _flash_attention_forward(
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        query_length: int,
+        is_causal: bool,
+        dropout: float = 0.0,
+        position_ids: torch.Tensor | None = None,
+        softmax_scale: float | None = None,
+        sliding_window: int | None = None,
+        use_top_left_mask: bool = False,
+        softcap: float | None = None,
+        deterministic: bool = None,
+        cu_seq_lens_q: torch.LongTensor | None = None,
+        cu_seq_lens_k: torch.LongTensor | None = None,
+        max_length_q: int | None = None,
+        max_length_k: int | None = None,
+        target_dtype: torch.dtype | None = None,
+        **kwargs,
+    ):
+        """
+        Calls the forward method of Ring Flash Attention.
+
+        Args:
+            query_states: Tensor containing the query vectors.
+            key_states: Tensor containing the key vectors.
+            value_states: Tensor containing the value vectors.
+            attention_mask: Not used in this implementation.
+            query_length: Integer representing the length of the query sequence.
+            is_causal: Boolean indicating whether to apply a causal mask to the attention.
+            dropout: Float representing the dropout probability. Default is 0.0.
+            position_ids: Not used in this implementation.
+            softmax_scale: Optional float value for the softmax scaling factor. Default is None.
+            sliding_window: Optional integer defining the size of the sliding attention window.
+                Default is None.
+            use_top_left_mask: Boolean indicating whether to use a top-left mask for the attention.
+                Default is False.
+            softcap: Not used in this implementation.
+            deterministic: Optional boolean to enforce deterministic computation. Default is None.
+            cu_seq_lens_q: Not used in this implementation.
+            cu_seq_lens_k: Not used in this implementation.
+            max_length_q: Not used in this implementation.
+            max_length_k: Not used in this implementation.
+            target_dtype: Not used in this implementation.
+            **kwargs: Additional keyword arguments. Not used in this implementation.
+
+        Returns:
+            torch.Tensor: The output of the attention mechanism, with shape
+                `[batch_size, query_length, num_heads, head_dim]`.
+        """
+        if not use_top_left_mask:
+            causal = is_causal
+        else:
+            causal = is_causal and query_length != 1
+
+        # Handle sliding window
+        use_sliding_windows = (
+            _flash_supports_window_size
+            and sliding_window is not None
+            and key_states.shape[1] > sliding_window
+        )
+        window_size = (
+            (sliding_window, sliding_window) if use_sliding_windows else (-1, -1)
+        )
+
+        # Handle deterministic mode
+        if is_flash_attn_greater_or_equal("2.4.1"):
+            if deterministic is None:
+                deterministic = (
+                    os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
+                )
+
+        # Call ring flash attention function
+        attn_output = ring_flash_attn_func(
+            query_states,
+            key_states,
+            value_states,
+            dropout_p=dropout,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            alibi_slopes=None,
+            deterministic=deterministic,
+            return_attn_probs=False,
+            group=process_group,
+        )
+
+        return attn_output
+
+    return _flash_attention_forward
+
+
+# pylint: disable=unused-argument
+def substitute_hf_flash_attn(process_group: dist.ProcessGroup):
+    """
+    Substitute HuggingFace's flash attention implementation with ring-based implementation.
+
+    Args:
+        process_group: PyTorch distributed process group for communication.
+    """
+    try:
+        # Substitute flash attention
+        old_flash_attention_forward = (
+            transformers.modeling_flash_attention_utils._flash_attention_forward
+        )
+        new_flash_attention_forward = create_ring_flash_attention_forward(process_group)
+
+        if check_params(old_flash_attention_forward, new_flash_attention_forward):
+            transformers.modeling_flash_attention_utils._flash_attention_forward = (
+                new_flash_attention_forward
+            )
+        else:
+            raise ValueError(
+                "The signature of the new flash attention forward function does not match the old one."
+            )
+    except Exception as exception:
+        raise ValueError(
+            f"The current transformer version {transformers.__version__} is not supported. "
+            "Please use pip install -U transformers to upgrade to the latest version. "
+            "If the code failed with the latest version, "
+            f"please file an issue."
+        ) from exception
+
+    # Register with ALL_ATTENTION_FUNCTIONS if available
+    if ALL_ATTENTION_FUNCTIONS is not None:
+        from ring_flash_attn.adapters.hf_adapter import flash_attention_forward
+
+        ALL_ATTENTION_FUNCTIONS["flash_attention_2"] = flash_attention_forward

--- a/src/axolotl/monkeypatch/attention/ring_attn/patch.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/patch.py
@@ -43,7 +43,7 @@ def set_ring_attn_group(ring_attn_group: dist.ProcessGroup | None):
     RING_ATTN_GROUP = ring_attn_group
 
 
-class RingAttnFunc(Enum):
+class RingAttnFunc(str, Enum):
     """Enum class for supported `ring-flash-attn` implementations"""
 
     # VARLEN_RING = "varlen_ring"
@@ -78,7 +78,7 @@ def register_ring_attn(
 
     if ring_attn_func is not None:
         # Set the ring attention function if passed in config
-        valid_funcs = [enum.value for enum in RingAttnFunc]
+        valid_funcs = list(RingAttnFunc)
         if ring_attn_func in valid_funcs:
             ring_attn_func = RingAttnFunc(ring_attn_func)
         else:

--- a/src/axolotl/monkeypatch/attention/ring_attn/patch.py
+++ b/src/axolotl/monkeypatch/attention/ring_attn/patch.py
@@ -58,7 +58,7 @@ def register_ring_attn(
     sequence_parallel_degree: int,
     heads_k_stride: int | None,
     sample_packing: bool,
-    ring_attn_func: str | None,
+    ring_attn_func: RingAttnFunc | None,
 ):
     """
     Create ring attention group and substitute flash attn with ring flash attn.

--- a/src/axolotl/utils/collators/batching.py
+++ b/src/axolotl/utils/collators/batching.py
@@ -162,8 +162,8 @@ class DataCollatorForSeq2Seq:
         total_seq_len = batch["input_ids"].size(1)
 
         # Update params for varlen ring attention calculation
-        if position_ids := batch.get("position_ids") is not None:
-            update_ring_attn_params(position_ids=position_ids)
+        if batch.get("position_ids") is not None:
+            update_ring_attn_params(position_ids=batch["position_ids"])
 
         # Slice batch for sequence parallel processing
         for key in batch:

--- a/src/axolotl/utils/collators/batching.py
+++ b/src/axolotl/utils/collators/batching.py
@@ -157,7 +157,7 @@ class DataCollatorForSeq2Seq:
             Sliced batch dictionary.
         """
         # Get local (start, end) for sequence parallelism slicing
-        total_seq_len = batch["input_ids"].shape[1]
+        total_seq_len = batch["input_ids"].size(1)
         slice_size = total_seq_len // self.local_world_size
         start = self.local_rank * slice_size
         end = start + slice_size

--- a/src/axolotl/utils/collators/batching.py
+++ b/src/axolotl/utils/collators/batching.py
@@ -4,7 +4,7 @@ includes logic for handling sequence parallelism collation.
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import torch
@@ -13,6 +13,7 @@ from transformers import PreTrainedTokenizerBase
 from transformers.utils import PaddingStrategy
 
 from axolotl.monkeypatch.attention.ring_attn import update_ring_attn_params
+from axolotl.monkeypatch.attention.ring_attn.patch import RingAttnFunc
 
 
 @dataclass
@@ -53,14 +54,15 @@ class DataCollatorForSeq2Seq:
     """
 
     tokenizer: PreTrainedTokenizerBase
-    model: Optional[Any] = None
-    padding: Union[bool, str, PaddingStrategy] = True
-    max_length: Optional[int] = None
-    pad_to_multiple_of: Optional[int] = None
+    model: Any | None = None
+    padding: bool | str | PaddingStrategy = True
+    max_length: int | None = None
+    pad_to_multiple_of: int | None = None
     label_pad_token_id: int = -100
     position_pad_token_id: int = 0
     return_tensors: str = "pt"
     sequence_parallel_degree: int = 1
+    ring_attn_func: RingAttnFunc | None = None
 
     def __post_init__(self):
         if self.sequence_parallel_degree > 1:
@@ -158,20 +160,49 @@ class DataCollatorForSeq2Seq:
         """
         # Get local (start, end) for sequence parallelism slicing
         total_seq_len = batch["input_ids"].size(1)
-        slice_size = total_seq_len // self.local_world_size
-        start = self.local_rank * slice_size
-        end = start + slice_size
 
         # Update params for varlen ring attention calculation
-        if batch.get("position_ids") is not None:
-            update_ring_attn_params(
-                input_ids=batch["input_ids"], position_ids=batch.get("position_ids")
-            )
+        if position_ids := batch.get("position_ids") is not None:
+            update_ring_attn_params(position_ids=position_ids)
 
         # Slice batch for sequence parallel processing
         for key in batch:
             if batch[key].size(1) == total_seq_len:
-                batch[key] = batch[key][:, start:end]
+                if self.ring_attn_func in [
+                    RingAttnFunc.VARLEN_LLAMA3,
+                    RingAttnFunc.BATCH_RING,
+                ]:
+                    batch[key] = (
+                        batch[key]
+                        .chunk(self.local_world_size, dim=1)[self.local_rank]
+                        .contiguous()
+                    )
+                elif self.ring_attn_func is RingAttnFunc.BATCH_ZIGZAG:
+                    chunks = batch[key].chunk(2 * self.local_world_size, dim=1)
+
+                    # Take rank's chunk and opposing chunk for zigzag pattern
+                    selected_chunks = [
+                        chunks[self.local_rank],
+                        chunks[2 * self.local_world_size - self.local_rank - 1],
+                    ]
+
+                    # Concatenate the selected chunks
+                    batch[key] = torch.cat(selected_chunks, dim=1).contiguous()
+                elif self.ring_attn_func is RingAttnFunc.BATCH_ZIGZAG:
+                    # Create the stripe pattern for the given rank
+                    # Rank 0 gets poitions 0, w, 2w, 3w, ...
+                    # Rank 1 gets positions 1, w+1, 2w+1, 3w+1, ...
+                    stripe_indices = torch.arange(
+                        self.local_rank,
+                        total_seq_len,
+                        self.local_world_size,
+                        device=batch[key].device,
+                    )
+
+                    # Select along the sequence dimension
+                    batch[key] = torch.index_select(
+                        batch[key], 1, stripe_indices
+                    ).contiguous()
 
         return batch
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -644,7 +644,6 @@ class ModelLoader:
             register_ring_attn(
                 sequence_parallel_degree=self.cfg.sequence_parallel_degree,
                 heads_k_stride=self.cfg.heads_k_stride,
-                sample_packing=self.cfg.sample_packing,
                 ring_attn_func=self.cfg.ring_attn_func,
             )
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -636,21 +636,7 @@ class ModelLoader:
             patch_self_attn_lora(self.cfg)
 
         if self.cfg.sequence_parallel_degree and self.cfg.sequence_parallel_degree > 1:
-            from axolotl.monkeypatch.attention.ring_attn import (
-                RingAttnFunc,
-                register_ring_attn,
-            )
-
-            # Set the ring attention function if passed in config
-            ring_attn_func = None
-            if self.cfg.ring_attn_func:
-                valid_funcs = [enum.value for enum in RingAttnFunc]
-                if self.cfg.ring_attn_func in valid_funcs:
-                    ring_attn_func = RingAttnFunc(self.cfg.ring_attn_func)
-                else:
-                    LOG.warning(
-                        f"ring_attn_func: {self.cfg.ring_attn_func} must be one of {valid_funcs}"
-                    )
+            from axolotl.monkeypatch.attention.ring_attn import register_ring_attn
 
             # Initialize ring attn for sequence parallelism. This must be done after
             # model init but before the first forward pass, since it modifies flash
@@ -659,7 +645,7 @@ class ModelLoader:
                 sequence_parallel_degree=self.cfg.sequence_parallel_degree,
                 heads_k_stride=self.cfg.heads_k_stride,
                 sample_packing=self.cfg.sample_packing,
-                ring_attn_func=ring_attn_func,
+                ring_attn_func=self.cfg.ring_attn_func,
             )
 
     def patch_attention(self) -> None:

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -258,6 +258,7 @@ class AxolotlInputConfig(
 
     sequence_parallel_degree: int | None = None
     heads_k_stride: int | None = None
+    ring_attn_func: str | None = None
 
     special_tokens: SpecialTokensConfig | None = None
     tokens: list[str] | None = None
@@ -1158,9 +1159,12 @@ class AxolotlInputConfig(
                     "flash_attention: true must be set with sequence_parallel_degree > 1"
                 )
 
-            if not info.data["micro_batch_size"] == 1:
+            if (
+                info.data.get("sample_packing")
+                and not info.data["micro_batch_size"] == 1
+            ):
                 raise ValueError(
-                    "micro_batch_size must be set to 1 "
+                    "micro_batch_size must be set to 1 when sample_packing is enabled"
                     "due to a `ring-flash-attn` requirement"
                 )
 

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -18,7 +18,6 @@ from pydantic import (
 )
 from transformers.utils.import_utils import is_torch_npu_available
 
-from axolotl.monkeypatch.attention.ring_attn.patch import RingAttnFunc
 from axolotl.utils.schemas.datasets import (
     DatasetConfig,
     DPODataset,
@@ -259,7 +258,7 @@ class AxolotlInputConfig(
 
     sequence_parallel_degree: int | None = None
     heads_k_stride: int | None = None
-    ring_attn_func: RingAttnFunc | None = None
+    ring_attn_func: str | None = None
 
     special_tokens: SpecialTokensConfig | None = None
     tokens: list[str] | None = None
@@ -1195,6 +1194,8 @@ class AxolotlInputConfig(
     @field_validator("ring_attn_func", mode="before")
     @classmethod
     def check_ring_attn_func(cls, value, info):
+        from axolotl.monkeypatch.attention.ring_attn.patch import RingAttnFunc
+
         if value is not None:
             # Set the ring attention function if passed in config
             valid_funcs = list(RingAttnFunc)

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1147,7 +1147,7 @@ class AxolotlInputConfig(
 
         return data
 
-    @field_validator("sequence_parallel_degree", mode="before")
+    @field_validator("sequence_parallel_degree", mode="after")
     @classmethod
     def check_sequence_parallel_degree(cls, value, info):
         if not value:
@@ -1191,9 +1191,12 @@ class AxolotlInputConfig(
 
         return value
 
-    @field_validator("ring_attn_func", mode="before")
+    @field_validator("ring_attn_func", mode="after")
     @classmethod
     def check_ring_attn_func(cls, value, info):
+        if not info.data.get("sequence_parallel_degree", 1) > 1:
+            return value
+
         from axolotl.monkeypatch.attention.ring_attn.patch import RingAttnFunc
 
         if value is not None:

--- a/tests/e2e/multigpu/test_sp.py
+++ b/tests/e2e/multigpu/test_sp.py
@@ -24,6 +24,7 @@ class TestSequenceParallelism:
         sample_packing=True,
         micro_batch_size=1,
         pad_to_sequence_len=True,
+        ring_attn_func=None,
     ):
         """Helper method to run sequence parallel tests with different configurations"""
         cfg = DictDefault(
@@ -68,6 +69,7 @@ class TestSequenceParallelism:
                 "weight_decay": 0.0,
                 "use_tensorboard": True,
                 "sequence_parallel_degree": 2,
+                "ring_attn_func": ring_attn_func,
             }
         )
 
@@ -95,20 +97,27 @@ class TestSequenceParallelism:
         )
 
     @pytest.mark.parametrize(
-        "sample_packing, micro_batch_size, pad_to_sequence_len",
+        "sample_packing, micro_batch_size, pad_to_sequence_len, ring_attn_func",
         [
-            (True, 1, True),
-            (False, 2, True),
+            (True, 1, True, None),  # defaults to varlen_llama3 ring_attn_func
+            (False, 2, True, None),  # defaults to batch_ring ring_attn_func
+            (False, 2, True, "batch_zigzag"),
             # (False, 2, False),  # not yet working
         ],
         ids=[
-            "sample_packing",
-            "no sample_packing, no pad_to_sequence_len",
+            "sample_packing, varlen_llama3 ring_attn_func",
+            "no sample_packing, no pad_to_sequence_len, batch_ring ring_attn_func",
+            "no sample_packing, no pad_to_sequence_len, batch_zigzag ring_attn_func",
             # "no sample_packing, pad_to_sequence_len",  # not yet working
         ],
     )
     def test_sequence_parallel_training(
-        self, temp_dir, sample_packing, micro_batch_size, pad_to_sequence_len
+        self,
+        temp_dir,
+        sample_packing,
+        micro_batch_size,
+        pad_to_sequence_len,
+        ring_attn_func,
     ):
         """Test sequence parallel training with different configurations"""
         self._run_sequence_parallel_test(
@@ -116,4 +125,5 @@ class TestSequenceParallelism:
             sample_packing=sample_packing,
             micro_batch_size=micro_batch_size,
             pad_to_sequence_len=pad_to_sequence_len,
+            ring_attn_func=ring_attn_func,
         )

--- a/tests/e2e/multigpu/test_sp.py
+++ b/tests/e2e/multigpu/test_sp.py
@@ -17,8 +17,14 @@ os.environ["WANDB_DISABLED"] = "true"
 class TestSequenceParallelism:
     """Test case for training with sequence parallelism enabled"""
 
-    def test_sequence_parallel_training(self, temp_dir):
-        # pylint: disable=duplicate-code
+    def _run_sequence_parallel_test(
+        self,
+        temp_dir,
+        sample_packing=True,
+        micro_batch_size=1,
+        pad_to_sequence_len=True,
+    ):
+        """Helper method to run sequence parallel tests with different configurations"""
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",
@@ -27,9 +33,9 @@ class TestSequenceParallelism:
                 "strict": False,
                 "sequence_len": 2048,
                 "adapter": "qlora",
-                "sample_packing": True,
-                "eval_sample_packing": True,
-                "pad_to_sequence_len": True,
+                "sample_packing": sample_packing,
+                "eval_sample_packing": sample_packing,
+                "pad_to_sequence_len": pad_to_sequence_len,
                 "lora_r": 8,
                 "lora_alpha": 16,
                 "lora_dropout": 0.05,
@@ -45,7 +51,7 @@ class TestSequenceParallelism:
                 ],
                 "num_epochs": 1,
                 "max_steps": 8,
-                "micro_batch_size": 1,
+                "micro_batch_size": micro_batch_size,
                 "gradient_accumulation_steps": 2,
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
@@ -85,4 +91,25 @@ class TestSequenceParallelism:
 
         check_tensorboard(
             temp_dir + "/runs", "train/train_loss", 2.6, "Train Loss is too high"
+        )
+
+    def test_sequence_parallel_training_varlen(self, temp_dir):
+        """Test sequence parallel training with variable length (sample packing enabled)"""
+        self._run_sequence_parallel_test(
+            temp_dir, sample_packing=True, micro_batch_size=1, pad_to_sequence_len=True
+        )
+
+    def test_sequence_parallel_training_batch(self, temp_dir):
+        """Test sequence parallel training with fixed batch size (sample packing disabled)"""
+        self._run_sequence_parallel_test(
+            temp_dir, sample_packing=False, micro_batch_size=2, pad_to_sequence_len=True
+        )
+
+    def test_sequence_parallel_training_batch_no_pad2seqlen(self, temp_dir):
+        """Test sequence parallel training with fixed batch size (sample packing disabled)"""
+        self._run_sequence_parallel_test(
+            temp_dir,
+            sample_packing=False,
+            micro_batch_size=2,
+            pad_to_sequence_len=False,
         )

--- a/tests/e2e/multigpu/test_sp.py
+++ b/tests/e2e/multigpu/test_sp.py
@@ -105,11 +105,12 @@ class TestSequenceParallelism:
             temp_dir, sample_packing=False, micro_batch_size=2, pad_to_sequence_len=True
         )
 
-    def test_sequence_parallel_training_batch_no_pad2seqlen(self, temp_dir):
-        """Test sequence parallel training with fixed batch size (sample packing disabled)"""
-        self._run_sequence_parallel_test(
-            temp_dir,
-            sample_packing=False,
-            micro_batch_size=2,
-            pad_to_sequence_len=False,
-        )
+    # TODO(djsaunde): Get this to work. Currently, gradients go to inf / nan in this setting.
+    # def test_sequence_parallel_training_batch_no_pad2seqlen(self, temp_dir):
+    #     """Test sequence parallel training with fixed batch size (sample packing disabled)"""
+    #     self._run_sequence_parallel_test(
+    #         temp_dir,
+    #         sample_packing=False,
+    #         micro_batch_size=2,
+    #         pad_to_sequence_len=False,
+    #     )

--- a/tests/e2e/patched/test_sp.py
+++ b/tests/e2e/patched/test_sp.py
@@ -89,7 +89,7 @@ class TestRingAttention:
             sequence_parallel_degree=4,
             heads_k_stride=1,
             sample_packing=True,
-            ring_attn_func=RingAttnFunc.VARLEN_LLAMA3,
+            ring_attn_func=RingAttnFunc.VARLEN_LLAMA3.value,
         )
 
         # Verify the number of calls without examining the arguments

--- a/tests/e2e/patched/test_sp.py
+++ b/tests/e2e/patched/test_sp.py
@@ -73,7 +73,10 @@ class TestRingAttention:
         self, mock_world_size, mock_rank, mock_new_group, partial_state
     ):
         """Test that ring attention groups are created correctly."""
-        from axolotl.monkeypatch.attention.ring_attn import register_ring_attn
+        from axolotl.monkeypatch.attention.ring_attn import (
+            RingAttnFunc,
+            register_ring_attn,
+        )
 
         # Setup mocks
         mock_world_size.return_value = 8  # 8 GPUs total
@@ -82,7 +85,12 @@ class TestRingAttention:
         mock_new_group.return_value = mock_group
 
         # Call register_ring_attn with size 4
-        register_ring_attn(sequence_parallel_degree=4, heads_k_stride=1)
+        register_ring_attn(
+            sequence_parallel_degree=4,
+            heads_k_stride=1,
+            sample_packing=True,
+            ring_attn_func=RingAttnFunc.VARLEN_LLAMA3,
+        )
 
         # Verify the number of calls without examining the arguments
         assert mock_new_group.call_count == 2

--- a/tests/e2e/patched/test_sp.py
+++ b/tests/e2e/patched/test_sp.py
@@ -88,8 +88,7 @@ class TestRingAttention:
         register_ring_attn(
             sequence_parallel_degree=4,
             heads_k_stride=1,
-            sample_packing=True,
-            ring_attn_func=RingAttnFunc.VARLEN_LLAMA3.value,
+            ring_attn_func=RingAttnFunc.VARLEN_LLAMA3,
         )
 
         # Verify the number of calls without examining the arguments


### PR DESCRIPTION
# Description

Added an adapter similar to [`ring-flash-attn`'s](https://github.com/zhuzilin/ring-flash-attention/blob/c587a0def9eaac7709e0d439757033178f30069f/ring_flash_attn/adapters/hf_adapter.py#L93) for the ring attention batch API.

We should probably upstream this adapter at some point.

## Motivation and Context

This allows us to support sequence parallelism for the non-sample packed case, and allows for microbatch size > 1 (in that case). This will be useful for e.g. GRPO training, where we're currently not sample packing and use >1 microbatch size.

## How has this been tested?

Varied microbatch_size in [1, 2, 4] and 

Added smoke tests for these added features.

## Screenshots (if appropriate)

Example with varying SP in 1, 2, 4 and fixing microbatch size at 2:

![W B Chart 4_10_2025, 11_59_51 PM](https://github.com/user-attachments/assets/b3165087-7dd0-4ee7-9faa-340c7712de98)

FYI: losses ~match due to a fix in the logged loss calculation in the huggingface trainer (we may upstream).

## TODO / follow-ups

- [ ] Gradient explosion with `pad_to_sequence_len: false`
- [x] Additional HF adapters for the remaining `ring-flash-attn` batch functions (`zigzag` and `stripe`)
- [ ] Additional HF adapters for the remaining varlen functions (`ring`, `zigzag`)
- [ ] Move to `https://github.com/feifeibear/long-context-attention` instead?
  - This might just entail adding HF adapters for these that match what we're currently using + testing for perf gains / different scenarios