### PR TITLE
make sure the all of the model is on the same device

### DIFF
--- a/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
+++ b/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
@@ -144,7 +144,7 @@ def test_swiglu_mlp_integration(small_llama_model):
 def test_geglu_model_integration():
     """Test GeGLU activation with Gemma model."""
     model = AutoModelForCausalLM.from_pretrained(
-        "mhenrichsen/gemma-2b", torch_dtype=torch.float16, device_map="auto"
+        "mhenrichsen/gemma-2b", torch_dtype=torch.float16, device_map="cuda:0"
     )
     peft_config = get_peft_config(
         {
@@ -347,7 +347,7 @@ def test_model_architecture(model_config):
     """Test LoRA kernel patches across different model architectures."""
     # Load model with appropriate dtype
     model = AutoModelForCausalLM.from_pretrained(
-        model_config["name"], torch_dtype=model_config["dtype"], device_map="auto"
+        model_config["name"], torch_dtype=model_config["dtype"], device_map="cuda:0"
     )
 
     # Apply LoRA configuration


### PR DESCRIPTION
On multigpu, running this test locally fails with 

```
src/axolotl/kernels/lora.py:174: in forward
    output = matmul_lora(                                                                                                                                                                                                                                      
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                                                                                                                                                                                                                                                               
X = tensor([[-0., -0., 0.,  ..., -0., -0., -0.],
        [-0., -0., -0.,  ..., -0., -0., -0.],                                                                                                                                                                                                                  
        [-0., 0., -0.,  ......, -0.,  ..., -0., -0., -0.],                                                                                                                                                                                                     
        [-0., 0., -0.,  ..., -0., -0., -0.]], device='cuda:0',                                                                 
       dtype=torch.float16)                                                                                                    
W = tensor([[ 3.1250e-02, -2.1973e-03, -3.7994e-03,  ..., -1.9165e-02,                                                                                                                                                                                                   4.9829e-05,  4.1199e-04],                                                                                            
        [-1.232...-2.7161e-03,  7.9346e-03,  ...,  1.5625e-02,
          5.3711e-03,  5.8594e-03]], device='cuda:1', dtype=torch.float16)
W_quant = None                                                                                                                 
A = Parameter containing:                                                                                                                                                                                                                                      
tensor([[-6.1188e-03, -3.0785e-03, -3.6526e-03,  ..., -3.7880e-03,                                                                                                                                                                                                       6.4964e-03, -2.6913... -2.7256e-03,  3.5019e-03,  ..., -4.7340e-03,
          6.7024e-03,  9.7275e-04]], device='cuda:1', requires_grad=True)                                                                                                                                                                                      B = Parameter containing:         
tensor([[0., 0., 0.,  ..., 0., 0., 0.],                                                                                                                                                                                                                                [0., 0., 0.,  ..., 0., 0., 0.],
        [0., 0.,...,                                                                                                                                                                                                                                                   [0., 0., 0.,  ..., 0., 0., 0.],
        [0., 0., 0.,  ..., 0., 0., 0.]], device='cuda:1', requires_grad=True), s = 2.0
out = None       
                                                               
    def matmul_lora(                                                                                                           
        X: torch.Tensor,                                                                                                       
        W: torch.Tensor,                                                                                                       
        W_quant: QuantState,                                                                                                   
        A: torch.Tensor,                                                                                                                                                                                                                                       
        B: torch.Tensor,                                                                                                                                                                                                                                       
        s: float,                                                                                                                                                                                                                                              
        out: torch.Tensor | None = None,                                                                                       
    ) -> torch.Tensor:     
        """               
        Efficient fused matmul + LoRA computation.         
                                       
        Args:
            X: Input tensor [*, in_features]                                                                                                                                                                                                                   
            W: Base weight matrix [out_features, in_features]                                                                                                                                                                                                  
            W_quant: Quantization state for W                                                                                  
            A: LoRA A matrix [rank, in_features]                                                                               
            B: LoRA B matrix [out_features, rank]                                                                                                                                                                                                                          s: LoRA scaling factor                                                                                             
            out: Optional output tensor for inplace operations
     
        Returns:                                                                                                               
            Result of X @ W + X @ A @ B
        """      
        dtype = X.dtype
        W = dequantize(W.t(), W_quant)
     
        if X.dim() == 3:
            batch, seq_len, _ = X.shape
            X = X.view(-1, X.shape[-1])
            reshape = True
        else:
            reshape = False
     
>       out = torch.matmul(X, W, out=out)
E       RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1! (when checking argument for argument mat2 in method wrapper_CUDA_mm)
```