### PR TITLE
Fixed Rex Scheduler Warm Up

### DIFF
--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -40,7 +40,7 @@ class RexLR(LRScheduler):
         self.max_lr = max_lr
         self.total_steps = total_steps
         self.num_warmup_steps = num_warmup_steps
-        self.last_step = last_step - 1
+        self.last_step = max(last_step - 1,0)
 
         # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
         for group in optimizer.param_groups:

--- a/src/axolotl/utils/schedulers.py
+++ b/src/axolotl/utils/schedulers.py
@@ -40,7 +40,7 @@ class RexLR(LRScheduler):
         self.max_lr = max_lr
         self.total_steps = total_steps
         self.num_warmup_steps = num_warmup_steps
-        self.last_step = max(last_step - 1,0)
+        self.last_step = max(last_step - 1, 0)
 
         # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming.
         for group in optimizer.param_groups:


### PR DESCRIPTION
# Description

Fixes an issue with the Rex scheduler where the warmup was incorrect due to the last step calculation going negative on training step 1.

## Motivation and Context

This change fixes the warm up for Rex which was incorrectly spiking the LR on the first turn. This occurs if your final LR is greater than zero ( with cosine_min_lr_ratio > 0 )

## How has this been tested?

I ran a training job both with and without the changes. With the changes I observed step 1 LR was correctly calculated.

## Screenshots (if appropriate)
Green line is after changes. 
Red line is before changes.
![image](https://github.com/user-attachments/assets/53286b71-d9c2-42fa-8662-02363a118987)