### PR TITLE
prevent rate limiting to hf when using dispatch batches

### DIFF
--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -660,6 +660,7 @@ class AxolotlInputConfig(
             data.get("val_set_size") == 0
             and (data.get("eval_steps") or data.get("eval_strategy"))
             and not data.get("test_datasets")
+            and data.get("eval_strategy") != "no"
         ):
             raise ValueError(
                 "eval_steps and eval_strategy are not supported with val_set_size == 0"


### PR DESCRIPTION
when using datasets from the hf hub and multi-gpu, it's easy to hit rate limits. by enabling dispatch batches in accelerator, it will only use the dataset/dataloader from the main process, so we can simply generate dummy data on other ranks