### PR TITLE
Add Post_model_load, post_lora_load, post_train, post_train_unload function calls

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -1,5 +1,6 @@
 """CLI to run training on a model."""
 
+import gc
 import logging
 import os
 from pathlib import Path
@@ -49,11 +50,11 @@ def do_train(cfg: DictDefault, cli_args: TrainerCliArgs):
 
     model, tokenizer, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
 
-    plugin_manager = PluginManager.get_instance()
-    plugin_manager.post_train(cfg, model)
-
     del model, tokenizer, trainer
 
+    gc.collect()
+
+    plugin_manager = PluginManager.get_instance()
     plugin_manager.post_train_unload(cfg)
 
 

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -48,9 +48,12 @@ def do_train(cfg: DictDefault, cli_args: TrainerCliArgs):
         dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
 
     model, tokenizer, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-    del model, tokenizer, trainer
 
     plugin_manager = PluginManager.get_instance()
+    plugin_manager.post_train(cfg, model)
+    
+    del model, tokenizer, trainer
+    
     plugin_manager.post_train_unload(cfg)
 
 

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -51,9 +51,9 @@ def do_train(cfg: DictDefault, cli_args: TrainerCliArgs):
 
     plugin_manager = PluginManager.get_instance()
     plugin_manager.post_train(cfg, model)
-    
+
     del model, tokenizer, trainer
-    
+
     plugin_manager.post_train_unload(cfg)
 
 

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -82,11 +82,8 @@ class BasePlugin:
         """
         Performs actions after the model is built/loaded, but before any adapters are applied.
 
-        Parameters:
-        cfg (dict): The configuration for the plugin.
-
-        Returns:
-        None
+        Args:
+            cfg (dict): The configuration for the plugin.
         """
 
     def post_model_load(self, cfg, model):  # pylint: disable=unused-argument

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -457,7 +457,7 @@ class PluginManager:
             if plugin_callbacks:
                 callbacks.extend(plugin_callbacks)
         return callbacks
-        
+
     def post_train(self, cfg, model):
         """
         Calls the post_train method of all registered plugins.
@@ -471,7 +471,7 @@ class PluginManager:
         """
         for plugin in self.plugins.values():
             plugin.post_train(cfg, model)
-            
+
     def post_train_unload(self, cfg):
         """
         Calls the post_train_unload method of all registered plugins.

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -457,7 +457,21 @@ class PluginManager:
             if plugin_callbacks:
                 callbacks.extend(plugin_callbacks)
         return callbacks
+        
+    def post_train(self, cfg, model):
+        """
+        Calls the post_train method of all registered plugins.
 
+        Parameters:
+        cfg (dict): The configuration for the plugins.
+        model (object): The loaded model.
+
+        Returns:
+        None
+        """
+        for plugin in self.plugins.values():
+            plugin.post_train(cfg, model)
+            
     def post_train_unload(self, cfg):
         """
         Calls the post_train_unload method of all registered plugins.

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -36,9 +36,10 @@ class BasePlugin:
     Methods:
     register(cfg): Registers the plugin with the given configuration.
     pre_model_load(cfg): Performs actions before the model is loaded.
-    post_model_load(cfg, model): Performs actions after the model is loaded.
+    post_model_build(cfg, model): Performs actions after the model is loaded, but before LoRA adapters are applied.
     pre_lora_load(cfg, model): Performs actions before LoRA weights are loaded.
     post_lora_load(cfg, model): Performs actions after LoRA weights are loaded.
+    post_model_load(cfg, model): Performs actions after the model is loaded, inclusive of any adapters.
     create_optimizer(cfg, trainer): Creates and returns an optimizer for training.
     create_lr_scheduler(cfg, trainer, optimizer): Creates and returns a learning rate scheduler.
     add_callbacks_pre_trainer(cfg, model): Adds callbacks to the trainer before training.
@@ -69,6 +70,17 @@ class BasePlugin:
     def pre_model_load(self, cfg):  # pylint: disable=unused-argument
         """
         Performs actions before the model is loaded.
+
+        Parameters:
+        cfg (dict): The configuration for the plugin.
+
+        Returns:
+        None
+        """
+
+    def post_model_build(self, cfg, model):  # pylint: disable=unused-argument
+        """
+        Performs actions after the model is built/loaded, but before any adapters are applied.
 
         Parameters:
         cfg (dict): The configuration for the plugin.
@@ -329,9 +341,25 @@ class PluginManager:
         for plugin in self.plugins.values():
             plugin.pre_model_load(cfg)
 
+    def post_model_build(self, cfg, model):
+        """
+        Calls the post_model_build method of all registered plugins after the model has been built/loaded,
+        but before any adapters have been applied.
+
+        Parameters:
+        cfg (dict): The configuration for the plugins.
+        model (object): The loaded model.
+
+        Returns:
+        None
+        """
+        for plugin in self.plugins.values():
+            plugin.post_model_build(cfg, model)
+
     def post_model_load(self, cfg, model):
         """
-        Calls the post_model_load method of all registered plugins.
+        Calls the post_model_load method of all registered plugins after the model has been loaded
+        inclusive of any adapters
 
         Parameters:
         cfg (dict): The configuration for the plugins.

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -343,12 +343,9 @@ class PluginManager:
         Calls the post_model_build method of all registered plugins after the model has been built/loaded,
         but before any adapters have been applied.
 
-        Parameters:
-        cfg (dict): The configuration for the plugins.
-        model (object): The loaded model.
-
-        Returns:
-        None
+        Args:
+            cfg (dict): The configuration for the plugins.
+            model (object): The loaded model.
         """
         for plugin in self.plugins.values():
             plugin.post_model_build(cfg, model)

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -514,7 +514,6 @@ def train(
 
     plugin_manager = PluginManager.get_instance()
     plugin_manager.post_model_load(cfg, model)
-    plugin_manager.post_lora_load(cfg, model)
 
     # Handle untrained tokens if configured
     safe_serialization = cfg.save_safetensors is True

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -512,9 +512,6 @@ def train(
         processor,
     ) = setup_model_and_trainer(cfg, dataset_meta)
 
-    plugin_manager = PluginManager.get_instance()
-    plugin_manager.post_model_load(cfg, model)
-
     # Handle untrained tokens if configured
     safe_serialization = cfg.save_safetensors is True
     train_dataset = dataset_meta.train_dataset

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -511,6 +511,10 @@ def train(
         processor,
     ) = setup_model_and_trainer(cfg, dataset_meta)
 
+    plugin_manager = PluginManager.get_instance()
+    plugin_manager.post_model_load(cfg, model)
+    plugin_manager.post_lora_load(cfg, model)
+
     # Handle untrained tokens if configured
     safe_serialization = cfg.save_safetensors is True
     train_dataset = dataset_meta.train_dataset

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -29,9 +29,9 @@ from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuil
 from axolotl.core.trainers.mixins.sequence_parallel import (
     SequenceParallelContextManager,
 )
+from axolotl.integrations.base import PluginManager
 from axolotl.logging_config import configure_logging
 from axolotl.utils.dict import DictDefault
-from axolotl.integrations.base import PluginManager
 from axolotl.utils.distributed import cleanup_distributed
 from axolotl.utils.freeze import freeze_layers_except
 from axolotl.utils.models import load_model, load_processor, load_tokenizer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -29,6 +29,7 @@ from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuil
 from axolotl.core.trainers.mixins.sequence_parallel import (
     SequenceParallelContextManager,
 )
+from axolotl.integrations.base import PluginManager
 from axolotl.logging_config import configure_logging
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.distributed import cleanup_distributed
@@ -532,5 +533,8 @@ def train(
     create_model_card(cfg, trainer)
     if not cfg.use_ray:
         cleanup_distributed()
+
+    plugin_manager = PluginManager.get_instance()
+    plugin_manager.post_train(cfg, model)
 
     return model, tokenizer, trainer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -29,7 +29,6 @@ from axolotl.core.trainer_builder import HFCausalTrainerBuilder, HFRLTrainerBuil
 from axolotl.core.trainers.mixins.sequence_parallel import (
     SequenceParallelContextManager,
 )
-from axolotl.integrations.base import PluginManager
 from axolotl.logging_config import configure_logging
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.distributed import cleanup_distributed

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -31,6 +31,7 @@ from axolotl.core.trainers.mixins.sequence_parallel import (
 )
 from axolotl.logging_config import configure_logging
 from axolotl.utils.dict import DictDefault
+from axolotl.integrations.base import PluginManager
 from axolotl.utils.distributed import cleanup_distributed
 from axolotl.utils.freeze import freeze_layers_except
 from axolotl.utils.models import load_model, load_processor, load_tokenizer

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1251,6 +1251,8 @@ class ModelLoader:
 
         try:
             skip_move_to_device = self.build_model(qlora_fsdp)
+            plugin_manager = PluginManager.get_instance()
+            plugin_manager.post_model_build(self.cfg, self.model)
         except Exception as err:  # pylint: disable=broad-exception-caught
             LOG.exception(err)
             raise err
@@ -1331,7 +1333,6 @@ class ModelLoader:
             )
 
         plugin_manager = PluginManager.get_instance()
-        plugin_manager.post_model_build(self.cfg, self.model)
         plugin_manager.pre_lora_load(self.cfg, self.model)
 
         # ---------------------------------------------------------

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1435,10 +1435,10 @@ def load_adapter(model, cfg, adapter, inference=False):
         plugin_manager.post_lora_load(cfg, res[0])
         return res
     if adapter == "llama-adapter":
-        res = load_llama_adapter(model, cfg)
+        model, lora_config = load_llama_adapter(model, cfg)
         plugin_manager = PluginManager.get_instance()
-        plugin_manager.post_lora_load(cfg, res[0])
-        return res
+        plugin_manager.post_lora_load(cfg, model)
+        return model, lora_config
 
     raise NotImplementedError(f"{adapter} peft adapter not available")
 

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -75,6 +75,7 @@ from axolotl.utils.lora_embeddings import get_linear_embedding_layers
 from axolotl.utils.model_shard_quant import load_sharded_model, load_sharded_model_quant
 
 LOG = logging.getLogger(__name__)
+PLUGIN_MANAGER = PluginManager.get_instance()
 
 MULTIMODAL_AUTO_MODEL_MAPPING = {
     "mllama": MllamaForConditionalGeneration,
@@ -572,8 +573,8 @@ class ModelLoader:
             patch_gemma3conditionalgeneration_forward()
 
         # load any patches from plugins
-        plugin_manager = PluginManager.get_instance()
-        plugin_manager.pre_model_load(self.cfg)
+        
+        PLUGIN_MANAGER.pre_model_load(self.cfg)
 
         # monkey patch to allow additional Accelerator init kwargs
         if self.cfg.fp8:
@@ -1251,8 +1252,7 @@ class ModelLoader:
 
         try:
             skip_move_to_device = self.build_model(qlora_fsdp)
-            plugin_manager = PluginManager.get_instance()
-            plugin_manager.post_model_build(self.cfg, self.model)
+            PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
         except Exception as err:  # pylint: disable=broad-exception-caught
             LOG.exception(err)
             raise err
@@ -1332,8 +1332,7 @@ class ModelLoader:
                 before_kbit_train_or_finetune=False,
             )
 
-        plugin_manager = PluginManager.get_instance()
-        plugin_manager.pre_lora_load(self.cfg, self.model)
+        PLUGIN_MANAGER.pre_lora_load(self.cfg, self.model)
 
         # ---------------------------------------------------------
         #  load lora or adapter
@@ -1396,7 +1395,7 @@ class ModelLoader:
             gc.collect()
             torch.cuda.empty_cache()
 
-        plugin_manager.post_model_load(self.cfg, self.model)
+        PLUGIN_MANAGER.post_model_load(self.cfg, self.model)
         return self.model, lora_config
 
 
@@ -1432,13 +1431,11 @@ def load_adapter(model, cfg, adapter, inference=False):
         model.enable_input_require_grads()
     if adapter in ["lora", "qlora"]:
         model, lora_config = load_lora(model, cfg, inference=inference)
-        plugin_manager = PluginManager.get_instance()
-        plugin_manager.post_lora_load(cfg, model)
+        PLUGIN_MANAGER.post_lora_load(cfg, model)
         return model, lora_config
     if adapter == "llama-adapter":
         model, lora_config = load_llama_adapter(model, cfg)
-        plugin_manager = PluginManager.get_instance()
-        plugin_manager.post_lora_load(cfg, model)
+        PLUGIN_MANAGER.post_lora_load(cfg, model)
         return model, lora_config
 
     raise NotImplementedError(f"{adapter} peft adapter not available")

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1430,10 +1430,10 @@ def load_adapter(model, cfg, adapter, inference=False):
     if hasattr(model, "enable_input_require_grads"):
         model.enable_input_require_grads()
     if adapter in ["lora", "qlora"]:
-        res = load_lora(model, cfg, inference=inference)
+        model, lora_config = load_lora(model, cfg, inference=inference)
         plugin_manager = PluginManager.get_instance()
-        plugin_manager.post_lora_load(cfg, res[0])
-        return res
+        plugin_manager.post_lora_load(cfg, model)
+        return model, lora_config
     if adapter == "llama-adapter":
         model, lora_config = load_llama_adapter(model, cfg)
         plugin_manager = PluginManager.get_instance()

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -573,7 +573,7 @@ class ModelLoader:
             patch_gemma3conditionalgeneration_forward()
 
         # load any patches from plugins
-        
+
         PLUGIN_MANAGER.pre_model_load(self.cfg)
 
         # monkey patch to allow additional Accelerator init kwargs

--- a/tests/e2e/integrations/test_hooks.py
+++ b/tests/e2e/integrations/test_hooks.py
@@ -1,0 +1,176 @@
+"""
+e2e tests to make sure all the hooks are fired on the plugin
+"""
+
+import os
+from pathlib import Path
+
+from axolotl.cli.args import TrainerCliArgs
+from axolotl.common.datasets import load_datasets
+from axolotl.integrations.base import BasePlugin
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+from ..utils import check_model_output_exists
+
+
+class LogHooksPlugin(BasePlugin):
+    """
+    fixture to capture in a log file each hook that was fired
+    """
+
+    base_dir = Path("/tmp/axolotl-log-hooks")
+
+    def __init__(self):
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.remove(self.base_dir.joinpath("plugin_hooks.log"))
+        except FileNotFoundError:
+            pass
+
+    def pre_model_load(self, cfg):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("pre_model_load\n")
+
+    def post_model_build(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("post_model_build\n")
+
+    def pre_lora_load(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("pre_lora_load\n")
+
+    def post_lora_load(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("post_lora_load\n")
+
+    def post_model_load(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("post_model_load\n")
+
+    def create_optimizer(self, cfg, trainer):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("create_optimizer\n")
+
+    def get_trainer_cls(self, cfg):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("get_trainer_cls\n")
+
+    def create_lr_scheduler(self, cfg, trainer, optimizer):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("create_lr_scheduler\n")
+
+    def add_callbacks_pre_trainer(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("add_callbacks_pre_trainer\n")
+        return []
+
+    def add_callbacks_post_trainer(self, cfg, trainer):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("add_callbacks_post_trainer\n")
+        return []
+
+    def post_train(self, cfg, model):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("post_train\n")
+
+    def post_train_unload(self, cfg):
+        with open(
+            self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
+        ) as f:
+            f.write("post_train_unload\n")
+
+
+class TestPluginHooks:
+    """
+    e2e tests to make sure all the hooks are fired during the training
+    """
+
+    def test_plugin_hooks(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "plugins": [
+                    "tests.e2e.integrations.test_hooks.LogHooksPlugin",
+                ],
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "adamw_torch_fused",
+                "lr_scheduler": "cosine",
+                "max_steps": 5,
+                "flash_attention": True,
+                "bf16": "auto",
+            }
+        )
+
+        cfg = validate_config(cfg)
+        prepare_plugins(cfg)
+        normalize_config(cfg)
+        cli_args = TrainerCliArgs()
+        dataset_meta = load_datasets(cfg=cfg, cli_args=cli_args)
+
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+
+        with open(
+            "/tmp/axolotl-log-hooks" + "/plugin_hooks.log", "r", encoding="utf-8"
+        ) as f:
+            file_contents = f.readlines()
+            file_contents = "\n".join(file_contents)
+            assert "pre_model_load" in file_contents
+            assert "post_model_build" in file_contents
+            assert "pre_lora_load" in file_contents
+            assert "post_lora_load" in file_contents
+            assert "post_model_load" in file_contents
+            # assert "create_optimizer" in file_contents  # not implemented yet
+            assert "get_trainer_cls" in file_contents
+            # assert "create_lr_scheduler" in file_contents  # not implemented yet
+            assert "add_callbacks_pre_trainer" in file_contents
+            assert "add_callbacks_post_trainer" in file_contents
+            assert "post_train" in file_contents
+            # assert "post_train_unload" in file_contents  # not called from test train call
+
+        os.remove(temp_dir + "/plugin_hooks.log")

--- a/tests/e2e/integrations/test_hooks.py
+++ b/tests/e2e/integrations/test_hooks.py
@@ -178,4 +178,7 @@ class TestPluginHooks:
             assert "post_train" in file_contents
             # assert "post_train_unload" in file_contents  # not called from test train call
 
-        os.remove(temp_dir + "/plugin_hooks.log")
+        try:
+            os.remove("/tmp/axolotl-log-hooks" + "/plugin_hooks.log")
+        except FileNotFoundError:
+            pass

--- a/tests/e2e/integrations/test_hooks.py
+++ b/tests/e2e/integrations/test_hooks.py
@@ -29,75 +29,79 @@ class LogHooksPlugin(BasePlugin):
         except FileNotFoundError:
             pass
 
-    def pre_model_load(self, cfg):
+    def pre_model_load(self, cfg):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("pre_model_load\n")
 
-    def post_model_build(self, cfg, model):
+    def post_model_build(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("post_model_build\n")
 
-    def pre_lora_load(self, cfg, model):
+    def pre_lora_load(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("pre_lora_load\n")
 
-    def post_lora_load(self, cfg, model):
+    def post_lora_load(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("post_lora_load\n")
 
-    def post_model_load(self, cfg, model):
+    def post_model_load(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("post_model_load\n")
 
-    def create_optimizer(self, cfg, trainer):
+    def create_optimizer(self, cfg, trainer):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("create_optimizer\n")
 
-    def get_trainer_cls(self, cfg):
+    def get_trainer_cls(self, cfg):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("get_trainer_cls\n")
 
-    def create_lr_scheduler(self, cfg, trainer, optimizer):
+    def create_lr_scheduler(
+        self, cfg, trainer, optimizer
+    ):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("create_lr_scheduler\n")
 
-    def add_callbacks_pre_trainer(self, cfg, model):
+    def add_callbacks_pre_trainer(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("add_callbacks_pre_trainer\n")
         return []
 
-    def add_callbacks_post_trainer(self, cfg, trainer):
+    def add_callbacks_post_trainer(
+        self, cfg, trainer
+    ):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("add_callbacks_post_trainer\n")
         return []
 
-    def post_train(self, cfg, model):
+    def post_train(self, cfg, model):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
             f.write("post_train\n")
 
-    def post_train_unload(self, cfg):
+    def post_train_unload(self, cfg):  # pylint: disable=unused-argument
         with open(
             self.base_dir.joinpath("plugin_hooks.log"), "a", encoding="utf-8"
         ) as f:
@@ -110,6 +114,7 @@ class TestPluginHooks:
     """
 
     def test_plugin_hooks(self, temp_dir):
+        # pylint: disable=duplicate-code
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",

--- a/tests/e2e/test_lora_llama.py
+++ b/tests/e2e/test_lora_llama.py
@@ -50,13 +50,13 @@ class TestLoraLlama(unittest.TestCase):
                     },
                 ],
                 "num_epochs": 1,
-                "micro_batch_size": 8,
+                "micro_batch_size": 2,
                 "gradient_accumulation_steps": 1,
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
                 "optimizer": "adamw_torch_fused",
                 "lr_scheduler": "cosine",
-                "max_steps": 20,
+                "max_steps": 5,
             }
         )
 


### PR DESCRIPTION
Add Post_model_load, post_lora_load, post_train, post_train_unload function calls in the training pipeline to help integrations module.

# Description

Added  function calls to use integrations more effectively

## Motivation and Context
While using integrations for my use case, I could not use the above functions as they were never called in the training pipeline.

## How has this been tested?
tested it in my environment. 

## Screenshots (if appropriate)

## Types of changes
code change

## Social Handles (Optional)
twitter: @divyanshuaggarw

