### PR TITLE
don't run multigpu tests twice, run SP in separate test

### DIFF
--- a/cicd/multigpu.sh
+++ b/cicd/multigpu.sh
@@ -3,8 +3,8 @@ set -e
 
 # Only run two tests at a time to avoid OOM on GPU (with coverage collection)
 pytest -v -n2 \
-  --ignore=/workspace/axolotl/tests/e2e/multigpu/solo/
-  --ignore=/workspace/axolotl/tests/e2e/multigpu/patched/
+  --ignore=/workspace/axolotl/tests/e2e/multigpu/solo/ \
+  --ignore=/workspace/axolotl/tests/e2e/multigpu/patched/ \
   /workspace/axolotl/tests/e2e/multigpu/ \
   --cov=axolotl \
   --cov-report=xml:multigpu-coverage.xml

--- a/cicd/multigpu.sh
+++ b/cicd/multigpu.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 set -e
 
-# only run one test at a time so as not to OOM the GPU
-pytest -v  --durations=10 -n2 /workspace/axolotl/tests/e2e/multigpu/ --ignore=/workspace/axolotl/tests/e2e/multigpu/solo/
-pytest -v  --durations=10 -n1 /workspace/axolotl/tests/e2e/multigpu/solo/
-
 # Only run two tests at a time to avoid OOM on GPU (with coverage collection)
 pytest -v -n2 \
   --ignore=/workspace/axolotl/tests/e2e/multigpu/solo/
+  --ignore=/workspace/axolotl/tests/e2e/multigpu/patched/
   /workspace/axolotl/tests/e2e/multigpu/ \
   --cov=axolotl \
   --cov-report=xml:multigpu-coverage.xml
 
 pytest -v  --durations=10 -n1 /workspace/axolotl/tests/e2e/multigpu/solo/ \
+  --cov=axolotl \
+  --cov-append \
+  --cov-report=xml:multigpu-coverage.xml
+
+pytest -v  --durations=10 -n1 /workspace/axolotl/tests/e2e/multigpu/patched/ \
   --cov=axolotl \
   --cov-append \
   --cov-report=xml:multigpu-coverage.xml

--- a/tests/e2e/multigpu/patched/test_sp.py
+++ b/tests/e2e/multigpu/patched/test_sp.py
@@ -10,7 +10,7 @@ from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
 
-from ..utils import check_tensorboard
+from ...utils import check_tensorboard
 
 os.environ["WANDB_DISABLED"] = "true"
 


### PR DESCRIPTION
It looks like the multigpu tests were being run twice when we added coverage and also, the sequence-parallel/ring-flash-attn patching was causing it to fail other tests when it wasn't needed.

EDIT, looks like the culprit might be the broken multi-line statement