### PR TITLE
fix: crash when pretraining_dataset with dispatch_batches is false

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -134,10 +134,9 @@ def prepare_dataset(cfg, tokenizer, processor=None, preprocess_iterable=None):
                     "csv", data_files=f.name, split="train", streaming=True
                 )
         else:
-            if is_local_main_process():
-                iter_ds = load_dataset(
-                    path, streaming=True, split=split, name=name, data_files=data_files
-                )
+            iter_ds = load_dataset(
+                path, streaming=True, split=split, name=name, data_files=data_files
+            )
 
         if skip:
             LOG.info(f"Skipping {skip} samples from the dataset")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

After #2536, when we use `pretraining_dataset` without setting `accelerator_config.dispatch_batches` to true explicitly, we got `UnboundedLocalError` for `iter_ds` variable in [line 145 of src/axolotl/utils/data/sft.py](https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/utils/data/sft.py#L145).

To fix this error, this PR changes the default value of `accelerator_config.dispatch_batches` to true if `pretraining_dataset` is set.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
