### PR TITLE
fix: gradient checkpointing functools.partial object has no attribute __self__

### DIFF
--- a/src/axolotl/utils/gradient_checkpointing/__init__.py
+++ b/src/axolotl/utils/gradient_checkpointing/__init__.py
@@ -11,8 +11,10 @@ def hf_grad_checkpoint_offload_wrapper(
     decoder_layer, *args, use_reentrant=None
 ):  # pylint: disable=unused-argument
     return Unsloth_Offloaded_Gradient_Checkpointer.apply(
-        decoder_layer.func.__self__
-        if isinstance(decoder_layer, partial)
-        else decoder_layer.__self__,
+        (
+            decoder_layer.func.__self__
+            if isinstance(decoder_layer, partial)
+            else decoder_layer.__self__
+        ),
         *args,
     )

--- a/src/axolotl/utils/gradient_checkpointing/__init__.py
+++ b/src/axolotl/utils/gradient_checkpointing/__init__.py
@@ -1,14 +1,18 @@
 """custom checkpointing utils"""
 
+from functools import partial
+
 from axolotl.utils.gradient_checkpointing.unsloth import (
     Unsloth_Offloaded_Gradient_Checkpointer,
 )
 
 
 def hf_grad_checkpoint_offload_wrapper(
-    decoder_layer, *args, use_reentrant=None
+        decoder_layer, *args, use_reentrant=None
 ):  # pylint: disable=unused-argument
     return Unsloth_Offloaded_Gradient_Checkpointer.apply(
-        decoder_layer.__self__,
+        decoder_layer.func.__self__
+        if isinstance(decoder_layer, partial)
+        else decoder_layer.__self__,
         *args,
     )

--- a/src/axolotl/utils/gradient_checkpointing/__init__.py
+++ b/src/axolotl/utils/gradient_checkpointing/__init__.py
@@ -8,7 +8,7 @@ from axolotl.utils.gradient_checkpointing.unsloth import (
 
 
 def hf_grad_checkpoint_offload_wrapper(
-        decoder_layer, *args, use_reentrant=None
+    decoder_layer, *args, use_reentrant=None
 ):  # pylint: disable=unused-argument
     return Unsloth_Offloaded_Gradient_Checkpointer.apply(
         decoder_layer.func.__self__


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2561 

# Description

<!--- Describe your changes in detail -->

Adds a simple conditional check to correct handle `partial` objects.
