### PR TITLE
Fix bug in grpo reward module import

### DIFF
--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -135,7 +135,9 @@ class GRPOStrategy:
         try:
             # use importlib to dynamically load the reward function from the module
             reward_func_module_name = reward_func_fqn.split(".")[-1]
-            reward_func_module = importlib.import_module(reward_func_fqn.split(".")[-2])
+            reward_func_module = importlib.import_module(
+                ".".join(reward_func_fqn.split(".")[:-1])
+            )
             reward_func = getattr(reward_func_module, reward_func_module_name)
             if not len(inspect.signature(reward_func).parameters) >= 2:
                 raise ValueError(


### PR DESCRIPTION
# Description

Fix the module imports for GRPO, allowing importing reward module from a package 

This allows using a reward even if the reward function is present in a module which is inside another package (i.e. A.B.reward_fn)

## Motivation and Context

Bug: https://github.com/axolotl-ai-cloud/axolotl/issues/2557: unable to specify a reward function if present in another package.

## How has this been tested?

If the reward function is: ``` rewards.gsm8k_grpo.correctness_reward_func ``` instead of ``` gsm8k_grpo.correctness_reward_func ``` in the cookbook example: https://github.com/axolotl-ai-cloud/axolotl-cookbook/blob/main/grpo/gsm8k.yaml#L16

**Prior to the code change:** 

```
[2025-04-28 01:28:06,619] [INFO] [axolotl.get_reward_func:149] [PID:5968] [RANK:0] Reward function rewards.gsm8k_grpo.correctness_reward_func is a pre-trained model path - if this is unexpected, please check the reward function path.
Traceback (most recent call last):
  File "/workspace/axolotl/src/axolotl/core/trainers/grpo/__init__.py", line 139, in get_reward_func
    reward_func_module = importlib.import_module(reward_func_fqn.split(".")[-2])
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/envs/py3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'gsm8k_grpo'
```

**Now:** 

No error, training works as expected.

## Types of changes

Bug fix

## Social Handles (Optional)

http://linkedin.com/in/dhruvmullick/
