### PR TITLE
Tensor parallel w DeepSpeed AutoTP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ extras_require = {
         "yunchang==0.6.0",
     ],
     "deepspeed": [
-        "deepspeed==0.17.1",
+        "deepspeed==0.17.2",
         "deepspeed-kernels",
     ],
     "mamba-ssm": [

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -629,7 +629,12 @@ class AxolotlInputConfig(
             "description": "One of 'varlen_llama3', 'batch_ring', 'batch_zigzag', 'batch_stripe'. Defaults to 'varlen_llama3' in the sample packing case, and 'batch_ring' in the non-sample packing case."
         },
     )
-
+    tensor_parallel_size: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Number of tensor parallel processes in TP group. Only supported with DeepSpeed AutoTP."
+        },
+    )
     special_tokens: SpecialTokensConfig | None = Field(
         default=None,
         json_schema_extra={

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -584,6 +584,12 @@ class AxolotlInputConfig(
             "description": "Deepspeed config path. e.g., deepspeed_configs/zero3.json"
         },
     )
+    deepcompile: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Whether to use deepcompile for faster training with deepspeed"
+        },
+    )
     fsdp: list[str] | None = Field(
         default=None,
         json_schema_extra={"description": "FSDP configuration"},

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -877,7 +877,7 @@ class OptimizationValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
-    def check_tensor_parallel_size(cls, data):
+    def check_tensor_parallel_size_update_ds_json(cls, data):
         tensor_parallel_size = data.get("tensor_parallel_size")
         if tensor_parallel_size is not None and tensor_parallel_size > 1:
             if not data.get("deepspeed"):

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -886,8 +886,19 @@ class OptimizationValidationMixin:
                 )
             with open(data.get("deepspeed"), "r", encoding="utf-8") as ds_fin:
                 ds_config = json.load(ds_fin)
+                should_save = False
                 if "tensor_parallel" not in ds_config:
                     ds_config["tensor_parallel"] = {"autotp_size": tensor_parallel_size}
+                    should_save = True
+                if (
+                    "gather_16bit_weights_on_model_save"
+                    not in ds_config["zero_optimization"]
+                ):
+                    ds_config["zero_optimization"][
+                        "gather_16bit_weights_on_model_save"
+                    ] = True
+                    should_save = True
+                if should_save:
                     temp_dir = tempfile.mkdtemp()
                     with open(
                         Path(temp_dir) / "autotp_ds.json", "w", encoding="utf-8"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1172,6 +1172,12 @@ class ComplexValidationMixin:
         return self
 
     @model_validator(mode="after")
+    def check_tensor_parallel_size(self):
+        if not self.tensor_parallel_size:
+            self.tensor_parallel_size = 1
+        return self
+
+    @model_validator(mode="after")
     def check_sequence_parallel_degree(self):
         if not self.sequence_parallel_degree:
             self.sequence_parallel_degree = 1

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1,5 +1,7 @@
 """Module with validation methods for config pydantic model."""
 
+# pylint: disable=too-many-boolean-expressions
+
 import json
 import logging
 import tempfile

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -443,6 +443,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 )
                 * cfg.num_epochs
                 * cfg.sequence_parallel_degree
+                * cfg.tensor_parallel_size
             )
             LOG.debug(
                 f"total_num_tokens: {cfg.total_num_tokens:_}, total_num_steps: {total_num_steps:_}"
@@ -481,7 +482,10 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             # on the agreed on value for sample_packing_eff_est
             total_num_steps = int(
                 math.floor(
-                    data_loader_len * cfg.num_epochs * cfg.sequence_parallel_degree
+                    data_loader_len
+                    * cfg.num_epochs
+                    * cfg.sequence_parallel_degree
+                    * cfg.tensor_parallel_size
                 )
             )
             if cfg.dataloader_drop_last:
@@ -508,6 +512,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 len(train_dataset)
                 * cfg.num_epochs
                 * cfg.sequence_parallel_degree
+                * cfg.tensor_parallel_size
                 / cfg.batch_size
             )
         )

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -65,6 +65,7 @@ def fixture_base_cfg():
             "dataloader_pin_memory": True,
             "dataloader_prefetch_factor": 2,
             "sequence_parallel_degree": 1,
+            "tensor_parallel_size": 1,
             # Dtype
             "fp16": False,
             "bf16": False,


### PR DESCRIPTION
fixes #2491 

reference example from issue: https://github.com/deepspeedai/DeepSpeedExamples/blob/592d28fa45c12613f39ed388e043be760707237c/training/tensor_parallel/train.py

~I'm still getting the error: `AssertionError: Data inconsistency within the TP group. Please check the Dataloader implementation to ensure consistency.` with this branch~

see: https://wandb.ai/axolotl-ai/autotp ; lower vram as expected, slightly faster per step timing, but still takes longer since the data parallel size is reduced by a factor of the TP size.

<img width="936" height="317" alt="Screenshot 2025-07-13 at 9 04 18 PM" src="https://github.com/user-attachments/assets/735e914e-353a-49ba-977f-a58b5674b219" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring tensor parallelism and deepcompile options for DeepSpeed in the training configuration.
  * Enhanced validation to ensure correct DeepSpeed configuration when using tensor parallelism or deepcompile.

* **Bug Fixes**
  * Adjusted total training step calculations to account for tensor parallel size, improving accuracy for parallel training setups.

* **Chores**
  * Updated DeepSpeed package requirement to version 0.17.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->