### PR TITLE
don't automatically enable lora kernels for RL training

### DIFF
--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1319,6 +1319,9 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
     @classmethod
     def check_auto_enable_lora_kernels(cls, data):
         # Only proceed if using LoRA or QLoRA adapter
+        if data.get("rl"):
+            # RL trainers not tested so don't enable kernels by default
+            return data
         if data.get("adapter") in ["lora", "qlora"]:
             # Skip if already set, using unsloth optimizations, or using 8-bit
             unsloth_fields = ["unsloth_lora_mlp", "unsloth_lora_qkv", "unsloth_lora_o"]


### PR DESCRIPTION
#2589 didn't trigger the multigpu CI and is causing failures with the RL trainers + PEFT. Let's disable for now on RL since it's not as battle tested.  see recent failures here https://github.com/axolotl-ai-cloud/axolotl/actions/runs/14755394008/job/41422234427?pr=2592