### PR TITLE
xformers attention with packing

### DIFF
--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -73,11 +73,12 @@ load_in_8bit: true
 load_in_4bit:
 
 # Use CUDA bf16
-bf16: true # bool or 'full' for `bf16_full_eval`. require >=ampere
+bf16: true # bool or 'full' for `bf16_full_eval`, or 'auto' for automatic detection. require >=ampere
 # Use CUDA fp16
 fp16: true
 # Use CUDA tf32
 tf32: true # require >=ampere
+# Note: if bf16 is set to 'auto', and fp16 is set to true, we will prefer the explict fp16 setting
 
 # No AMP (automatic mixed precision)
 bfloat16: true # require >=ampere

--- a/src/axolotl/core/trainer_builder.py
+++ b/src/axolotl/core/trainer_builder.py
@@ -21,6 +21,7 @@ import importlib.util
 import inspect
 import logging
 import math
+import os
 import sys
 from abc import abstractmethod
 from pathlib import Path
@@ -72,6 +73,7 @@ from axolotl.utils.callbacks import (
     SaveBetterTransformerModelCallback,
     bench_eval_callback_factory,
     causal_lm_bench_eval_callback_factory,
+    colab_inference_post_train_callback,
     log_prediction_callback_factory,
 )
 from axolotl.utils.callbacks.lisa import lisa_callback_factory
@@ -292,6 +294,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.lisa_step_interval and self.cfg.lisa_n_layers:
             callbacks.append(lisa_callback_factory(trainer))
+
+        if any("COLAB_" in key for key in os.environ):
+            ColabCallback = colab_inference_post_train_callback(trainer)
+            callbacks.append(ColabCallback(self.cfg))
 
         callbacks.extend(super().get_post_trainer_create_callbacks(trainer=trainer))
         return callbacks

--- a/src/axolotl/monkeypatch/attention/__init__.py
+++ b/src/axolotl/monkeypatch/attention/__init__.py
@@ -1,0 +1,19 @@
+"""
+attention module for attention monkeypatches
+"""
+
+from transformers.integrations.flash_attention import flash_attention_forward
+
+
+def patch_xformers_attn_over_fa2():
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    from .xformers import xformers_attention_forward
+
+    ALL_ATTENTION_FUNCTIONS["flash_attention_2"] = xformers_attention_forward
+
+
+def unpatch_xformers_attn_over_fa2():
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    ALL_ATTENTION_FUNCTIONS["flash_attention_2"] = flash_attention_forward()

--- a/src/axolotl/monkeypatch/attention/xformers.py
+++ b/src/axolotl/monkeypatch/attention/xformers.py
@@ -65,6 +65,7 @@ def xformers_attention_forward(
             key = key.reshape(-1, key.size(-2), key.size(-1))
             value = value.reshape(-1, value.size(-2), value.size(-1))
 
+        # pylint: disable=duplicate-code
         if module.config.num_attention_heads != module.config.num_key_value_heads:
             key = key.repeat_interleave(
                 module.config.num_attention_heads // module.config.num_key_value_heads,
@@ -75,20 +76,12 @@ def xformers_attention_forward(
                 dim=2,
             )
 
-            attn_output = xformers_attention(
-                query,
-                key,
-                value,
-                attn_bias=attn_bias,
-            )
-
-        else:
-            attn_output = xformers_attention(
-                query,
-                key,
-                value,
-                attn_bias=attn_bias,
-            )
+        attn_output = xformers_attention(
+            query,
+            key,
+            value,
+            attn_bias=attn_bias,
+        )
     elif attention_mask is not None:
         batch_size = query.shape[0]
         query, key, value, indices_q, cu_seq_lens, _ = _upad_input(
@@ -111,6 +104,17 @@ def xformers_attention_forward(
         )
         attn_output = pad_input(attn_output_unpad, indices_q, batch_size, query_length)
     else:
+        # pylint: disable=duplicate-code
+        if module.config.num_attention_heads != module.config.num_key_value_heads:
+            key = key.repeat_interleave(
+                module.config.num_attention_heads // module.config.num_key_value_heads,
+                dim=2,
+            )
+            value = value.repeat_interleave(
+                module.config.num_attention_heads // module.config.num_key_value_heads,
+                dim=2,
+            )
+
         attn_output = xformers_attention(
             query,
             key,

--- a/src/axolotl/monkeypatch/attention/xformers.py
+++ b/src/axolotl/monkeypatch/attention/xformers.py
@@ -39,6 +39,7 @@ def xformers_attention_forward(
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
     query_length = query.shape[2]
+    batch_size = query.size(0)
 
     attn_bias = xformers.ops.LowerTriangularMask()
 
@@ -49,8 +50,6 @@ def xformers_attention_forward(
         max_length_q is not None
         or (query_length != 1 and not (torch.diff(position_ids, dim=-1) >= 0).all())
     ):
-        batch_size = query.size(0)
-
         if cu_seq_lens_q is None or cu_seq_lens_k is None:
             cu_seq_lens_q = get_cu_seqlens_from_pos_ids(position_ids)[0]
             cu_seq_lens_q = cu_seq_lens_q.squeeze()
@@ -83,7 +82,6 @@ def xformers_attention_forward(
             attn_bias=attn_bias,
         )
     elif attention_mask is not None:
-        batch_size = query.shape[0]
         query, key, value, indices_q, cu_seq_lens, _ = _upad_input(
             query, key, value, attention_mask, query_length
         )

--- a/src/axolotl/monkeypatch/attention/xformers.py
+++ b/src/axolotl/monkeypatch/attention/xformers.py
@@ -1,0 +1,133 @@
+"""
+xformers attention implementation for packing
+"""
+
+from typing import Optional
+
+import torch
+import xformers
+import xformers.ops.fmha
+from flash_attn.bert_padding import pad_input
+from transformers.modeling_flash_attention_utils import (
+    _upad_input,
+    prepare_fa2_from_position_ids,
+)
+
+xformers_attention = xformers.ops.fmha.memory_efficient_attention
+
+
+def xformers_attention_forward(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    dropout: float = 0.0,  # pylint: disable=unused-argument
+    scaling: Optional[float] = None,  # pylint: disable=unused-argument
+    sliding_window: Optional[int] = None,  # pylint: disable=unused-argument
+    softcap: Optional[float] = None,  # pylint: disable=unused-argument
+    cu_seq_lens_q: Optional[torch.LongTensor] = None,
+    cu_seq_lens_k: Optional[torch.LongTensor] = None,
+    max_length_q: Optional[int] = None,
+    max_length_k: Optional[int] = None,  # pylint: disable=unused-argument
+    **kwargs,  # pylint: disable=unused-argument
+):
+
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+    query_length = query.shape[2]
+
+    attn_bias = xformers.ops.LowerTriangularMask()
+
+    if attention_mask is not None:
+        batch_size = query.shape[0]
+        query, key, value, indices_q, cu_seq_lens, _ = _upad_input(
+            query, key, value, attention_mask, query_length
+        )
+        cu_seqlens_q, cu_seq_lens_k = cu_seq_lens
+        seq_lengths = []
+        for i in range(len(cu_seq_lens_q) - 1):
+            seq_lengths.append(cu_seqlens_q[i + 1] - cu_seq_lens_q[i])
+        attn_bias = xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask.from_seqlens(
+            q_seqlen=seq_lengths,
+            kv_seqlen=seq_lengths,
+        )
+
+        attn_output_unpad = xformers_attention(
+            query,
+            key,
+            value,
+            attn_bias=attn_bias,
+        )
+        attn_output = pad_input(attn_output_unpad, indices_q, batch_size, query_length)
+
+    # If position_ids is provided and check all examples do not contain only 1 sequence, If tensor in increasing
+    # then we probably have one sequence, otherwise it is packed. Additionally check we are in pre-fill/training stage.
+    # Use `flash_attn_varlen_func` to prevent cross-example attention and also allow padding free approach
+    elif position_ids is not None and (
+        max_length_q is not None
+        or (query_length != 1 and not (torch.diff(position_ids, dim=-1) >= 0).all())
+    ):
+        batch_size = query.size(0)
+
+        if cu_seq_lens_q is None or cu_seq_lens_k is None:
+            _, _, _, indices_q, cu_seq_lens, _ = prepare_fa2_from_position_ids(
+                query, key, value, position_ids
+            )
+
+            cu_seq_lens_q, cu_seq_lens_k = cu_seq_lens
+            seq_lengths = []
+            for i in range(len(cu_seq_lens_q) - 1):
+                seq_lengths.append(
+                    cu_seq_lens_q[i + 1].item() - cu_seq_lens_q[i].item()
+                )
+            attn_bias = (
+                xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask.from_seqlens(
+                    q_seqlen=seq_lengths,
+                )
+            )
+
+        else:
+            query = query.reshape(-1, query.size(-2), query.size(-1))
+            key = key.reshape(-1, key.size(-2), key.size(-1))
+            value = value.reshape(-1, value.size(-2), value.size(-1))
+
+        if module.config.num_attention_heads != module.config.num_key_value_heads:
+            key = key.repeat_interleave(
+                module.config.num_attention_heads // module.config.num_key_value_heads,
+                dim=2,
+            )
+            value = value.repeat_interleave(
+                module.config.num_attention_heads // module.config.num_key_value_heads,
+                dim=2,
+            )
+
+            attn_output = xformers_attention(
+                query,
+                key,
+                value,
+                attn_bias=attn_bias,
+            )
+
+        else:
+            attn_output = xformers_attention(
+                query,
+                key,
+                value,
+                attn_bias=attn_bias,
+            )
+
+    else:
+        attn_output = xformers_attention(
+            query,
+            key,
+            value,
+            attn_bias=attn_bias,
+        )
+
+    attn_output = attn_output.view(
+        batch_size, -1, attn_output.size(-2), attn_output.size(-1)
+    )
+    return attn_output, None

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -885,10 +885,9 @@ def colab_inference_post_train_callback(trainer: Trainer):
             handle T4 gpu, we need to convert attention to eager for inference
             """
             if "Tesla T4" in self.gpu_name and self.cfg.xformers_attention:
-                trainer.model.eval()
-            trainer.model.config._attn_implementation = (  # pylint: disable=protected-access
-                "eager"
-            )
+                trainer.model.config._attn_implementation = (  # pylint: disable=protected-access
+                    "eager"
+                )
             trainer.model.gradient_checkpointing_disable()
             trainer.model.config.use_cache = True
             trainer.model.eval()

--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -70,6 +70,9 @@ def resolve_dtype(cfg):
             if cfg.fp16 is None and not cfg.float16:
                 cfg.fp16 = True
 
+    if cfg.fp16 and cfg.bf16 == "auto":
+        cfg.bf16 = False
+
     if cfg.device == "mps":
         cfg.load_in_8bit = False
         cfg.tf32 = False

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -556,6 +556,11 @@ class ModelLoader:
         self.auto_model_loader = AutoModelForCausalLM  # pylint: disable=invalid-name
 
     def apply_patches(self) -> None:
+        if self.cfg.xformers_attention and self.cfg.sample_packing:
+            from axolotl.monkeypatch.attention import patch_xformers_attn_over_fa2
+
+            patch_xformers_attn_over_fa2()
+            self.cfg.flash_attention = True
         if self.cfg.fsdp_config and str(self.cfg.fsdp_config.fsdp_version) == "2":
             from axolotl.monkeypatch.accelerate.fsdp2 import patch_accelerate_fsdp_utils
 

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -461,9 +461,10 @@ class AxolotlInputConfig(
             and not data.get("flash_attention")
             and not data.get("sdp_attention")
             and not data.get("flex_attention")
+            and not data.get("xformers_attention")
         ):
             LOG.warning(
-                "sample_packing without flash, sdp or flex attention does not handle cross sample decontamination."
+                "sample_packing without flash, sdp, xformers or flex attention does not handle cross sample decontamination."
             )
 
         return data

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -437,16 +437,6 @@ class AxolotlInputConfig(
 
     @model_validator(mode="before")
     @classmethod
-    def check_sample_packing_w_xformers(cls, data):
-        if data.get("sample_packing") and data.get("xformers_attention"):
-            raise ValueError(
-                "sample_packing not compatible with xformers_attention. Use flash_attention"
-            )
-
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
     # pylint: disable=duplicate-code
     def check_chat_template_config(cls, data):
         # if chat_template is set to jinja, chat_template_jinja is required


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
This PR adds packing support when using xformers attention for training. xformers supports fp16 attention, allowing us to train on T4 devices. We have to patch over FA2, as there are some attention checks that handle the attention masking that aren't easily overridable as we would have to do it for every model arch.
