### PR TITLE
Fix logging deprecation warnings

### DIFF
--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -190,7 +190,7 @@ class MultipackBatchSampler(BatchSampler):
         self.len_across_ranks = None
 
         if self.sequential and not isinstance(sampler, SequentialSampler):
-            LOG.warn(
+            LOG.warning(
                 "using sequential sample packing with non-sequential sampler, did you want to also enable curriculum_sampling?"
             )
 


### PR DESCRIPTION
# Description

This small PR resolves the `logging` deprecation warnings:
```python
/workspace/axolotl/src/axolotl/utils/samplers/multipack.py:193: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Motivation and Context


## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

## Social Handles (Optional)

