### PR TITLE
fix dpo eval override to call grandparent instead of the broken super

### DIFF
--- a/src/axolotl/core/trainers/dpo/trainer.py
+++ b/src/axolotl/core/trainers/dpo/trainer.py
@@ -247,7 +247,9 @@ class AxolotlDPOTrainer(RngLoaderMixin, SchedulerMixin, DPOTrainer):
                 )
 
         # Base evaluation
-        initial_output = super().evaluation_loop(
+        initial_output = super(  # pylint: disable=bad-super-call
+            DPOTrainer, self
+        ).evaluation_loop(
             dataloader,
             description,
             prediction_loss_only,


### PR DESCRIPTION
continuation of a fix from #2572 

because this is an override of the evaluation_loop method, we don't want to call the parent, but the grandparent in this case.