### PR TITLE
Activation checkpointing with offloading to disk with prefetch

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -124,7 +124,8 @@ quartodoc:
         - utils.optimizers.adopt
         - utils.data.pretraining
         - utils.data.sft
-        - utils.gradient_checkpointing.unsloth
+        - utils.gradient_checkpointing.offload_cpu
+        - utils.gradient_checkpointing.offload_disk
     - title: Schemas
       desc: Pydantic data models for Axolotl config
       contents:

--- a/docs/config.qmd
+++ b/docs/config.qmd
@@ -539,7 +539,7 @@ train_on_inputs: false
 # Note that training loss may have an oscillating pattern with this enabled.
 group_by_length: false
 
-# Whether to use gradient checkpointing. Available options are: true, false, "offload".
+# Whether to use gradient checkpointing. Available options are: true, false, "offload", "offload_disk".
 # https://huggingface.co/docs/transformers/v4.18.0/en/performance#gradient-checkpointing
 gradient_checkpointing: false
 # additional kwargs to pass to the trainer for gradient checkpointing

--- a/src/axolotl/utils/gradient_checkpointing/__init__.py
+++ b/src/axolotl/utils/gradient_checkpointing/__init__.py
@@ -5,8 +5,11 @@ from functools import partial
 
 from packaging import version
 
-from axolotl.utils.gradient_checkpointing.unsloth import (
-    Unsloth_Offloaded_Gradient_Checkpointer,
+from axolotl.utils.gradient_checkpointing.offload_cpu import (
+    CPU_Offloaded_Gradient_Checkpointer,
+)
+from axolotl.utils.gradient_checkpointing.offload_disk import (
+    DiskOffloadedGradientCheckpointer,
 )
 
 transformers_version = version.parse(importlib.metadata.version("transformers"))
@@ -26,12 +29,31 @@ def hf_grad_checkpoint_offload_wrapper(
     decoder_layer, *args, use_reentrant=None
 ):  # pylint: disable=unused-argument
     if uses_gc_layers(decoder_layer):
-        return Unsloth_Offloaded_Gradient_Checkpointer.apply(
+        return CPU_Offloaded_Gradient_Checkpointer.apply(
             decoder_layer,
             *args,
         )
 
-    return Unsloth_Offloaded_Gradient_Checkpointer.apply(
+    return CPU_Offloaded_Gradient_Checkpointer.apply(
+        (
+            decoder_layer.func.__self__
+            if isinstance(decoder_layer, partial)
+            else decoder_layer.__self__
+        ),
+        *args,
+    )
+
+
+def hf_grad_checkpoint_disk_offload_wrapper(
+    decoder_layer, *args, use_reentrant=None
+):  # pylint: disable=unused-argument
+    if uses_gc_layers(decoder_layer):
+        return DiskOffloadedGradientCheckpointer.apply(
+            decoder_layer,
+            *args,
+        )
+
+    return DiskOffloadedGradientCheckpointer.apply(
         (
             decoder_layer.func.__self__
             if isinstance(decoder_layer, partial)

--- a/src/axolotl/utils/gradient_checkpointing/__init__.py
+++ b/src/axolotl/utils/gradient_checkpointing/__init__.py
@@ -9,7 +9,7 @@ from axolotl.utils.gradient_checkpointing.offload_cpu import (
     CPU_Offloaded_Gradient_Checkpointer,
 )
 from axolotl.utils.gradient_checkpointing.offload_disk import (
-    DiskOffloadedGradientCheckpointer,
+    Disco,
 )
 
 transformers_version = version.parse(importlib.metadata.version("transformers"))
@@ -48,12 +48,12 @@ def hf_grad_checkpoint_disk_offload_wrapper(
     decoder_layer, *args, use_reentrant=None
 ):  # pylint: disable=unused-argument
     if uses_gc_layers(decoder_layer):
-        return DiskOffloadedGradientCheckpointer.apply(
+        return Disco.apply(
             decoder_layer,
             *args,
         )
 
-    return DiskOffloadedGradientCheckpointer.apply(
+    return Disco.apply(
         (
             decoder_layer.func.__self__
             if isinstance(decoder_layer, partial)

--- a/src/axolotl/utils/gradient_checkpointing/offload_cpu.py
+++ b/src/axolotl/utils/gradient_checkpointing/offload_cpu.py
@@ -1,4 +1,4 @@
-"""Unsloth checkpointing"""
+"""CPU offloaded checkpointing"""
 
 # Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 #
@@ -26,7 +26,7 @@ else:
     torch_cuda_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
 
 
-class Unsloth_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name
+class CPU_Offloaded_Gradient_Checkpointer(  # pylint: disable=invalid-name
     torch.autograd.Function
 ):
     """

--- a/src/axolotl/utils/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/utils/gradient_checkpointing/offload_disk.py
@@ -1,8 +1,12 @@
 """Disk offloaded checkpointing"""
 
 import os
+import queue
 import tempfile
+import threading
+import time
 import uuid
+from collections import deque
 
 import torch
 
@@ -10,41 +14,183 @@ torch_cuda_amp_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
 torch_cuda_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
 
 
+class DiskOffloadManager:
+    """
+    Manages offloaded tensors and handles prefetching in a separate thread.
+    """
+
+    def __init__(self, prefetch_size=3, prefetch_to_gpu=False):
+        self.temp_dir = tempfile.mkdtemp(prefix="disk_checkpoint_")
+        self.tensor_paths = deque()  # Ordered history of tensor paths (FIFO)
+        self.max_prefetch = prefetch_size
+        self.prefetch_to_gpu = prefetch_to_gpu
+
+        # Prefetch queue and cache
+        self.prefetch_queue = queue.Queue()
+        self.prefetch_cache = {}  # Maps file_path -> tensor
+
+        # Start prefetch worker thread
+        self.stop_event = threading.Event()
+        self.prefetch_thread = threading.Thread(
+            target=self._prefetch_worker, daemon=True
+        )
+        self.prefetch_thread.start()
+
+    def _prefetch_worker(self):
+        """Background thread that loads tensors from disk ahead of time"""
+        while not self.stop_event.is_set():
+            try:
+                file_path = self.prefetch_queue.get(timeout=0.5)
+                if file_path is None:
+                    continue
+
+                # Load tensor from disk and store in cache
+                if file_path not in self.prefetch_cache:
+                    try:
+                        tensor = torch.load(file_path, weights_only=True)
+                        if self.prefetch_to_gpu:
+                            tensor = tensor.to("cuda", non_blocking=True)
+                        self.prefetch_cache[file_path] = tensor
+                    except FileNotFoundError as e:
+                        print(f"Prefetch error for {file_path}: {e}")
+
+                self.prefetch_queue.task_done()
+            except queue.Empty:
+                time.sleep(0.01)  # Small sleep to prevent CPU spinning
+                continue
+
+    def save_tensor(self, tensor):
+        """Save tensor to disk and return file path"""
+        file_path = os.path.join(self.temp_dir, f"{uuid.uuid4()}.pt")
+        cpu_tensor = tensor.detach().cpu()
+        torch.save(cpu_tensor, file_path)
+
+        # Add to history
+        self.tensor_paths.append(file_path)
+        return file_path
+
+    def load_tensor(self, file_path, target_device="cuda"):
+        """Load tensor from disk or prefetch cache"""
+        # Check if tensor is already in cache
+        if file_path in self.prefetch_cache:
+            tensor = self.prefetch_cache[file_path]
+            del self.prefetch_cache[file_path]
+
+            # Ensure tensor is on correct device
+            if target_device != "cpu" and tensor.device.type == "cpu":
+                tensor = tensor.to(target_device, non_blocking=True)
+
+            # Clean up file if possible
+            try:
+                os.remove(file_path)
+            except FileNotFoundError:
+                pass
+
+            return tensor
+
+        # If not in cache, load directly
+        tensor = torch.load(file_path, weights_only=True)
+        if target_device != "cpu":
+            tensor = tensor.to(target_device, non_blocking=True)
+
+        # Clean up file if possible
+        try:
+            os.remove(file_path)
+        except FileNotFoundError:
+            pass
+
+        return tensor
+
+    def trigger_prefetch(self, n=None):
+        """Trigger prefetching of the next N tensors"""
+        if n is None:
+            n = self.max_prefetch
+
+        # Select the n oldest tensors (those that will be needed first in FIFO)
+        prefetch_paths = [p for p in self.tensor_paths if p not in self.prefetch_cache][
+            :n
+        ]
+
+        # Add to prefetch queue
+        for path in prefetch_paths:
+            self.prefetch_queue.put(path)
+
+    def cleanup(self):
+        """Clean up all temp files and stop prefetch thread"""
+        self.stop_event.set()
+        self.prefetch_thread.join(timeout=2.0)
+
+        # Clear cache and remove any remaining files
+        self.prefetch_cache.clear()
+        for path in self.tensor_paths:
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except FileNotFoundError:
+                pass
+
+        # Remove temp directory
+        try:
+            os.rmdir(self.temp_dir)
+        except FileNotFoundError:
+            pass
+
+
 class DiskOffloadedGradientCheckpointer(torch.autograd.Function):
     """
-    Saves both VRAM and RAM by offloading activations to disk.
-    Greater hit to performance than RAM offloading, but useful for extremely memory-constrained environments.
+    Advanced disk-based gradient checkpointer with prefetching.
     """
 
-    # Create a temporary directory for storing tensors
-    _temp_dir = tempfile.mkdtemp(prefix="disk_checkpoint_")
+    # Shared manager instance across all checkpointing operations
+    _manager = None
 
     @staticmethod
-    def _get_temp_file_path():
-        """Generate a unique file path for tensor storage"""
-        return os.path.join(
-            DiskOffloadedGradientCheckpointer._temp_dir, f"{uuid.uuid4()}.pt"
-        )
+    def get_manager(prefetch_size=3, prefetch_to_gpu=True):
+        """Get or create the offload manager"""
+        if DiskOffloadedGradientCheckpointer._manager is None:
+            DiskOffloadedGradientCheckpointer._manager = DiskOffloadManager(
+                prefetch_size=prefetch_size, prefetch_to_gpu=prefetch_to_gpu
+            )
+        return DiskOffloadedGradientCheckpointer._manager
 
     @staticmethod
     @torch_cuda_amp_custom_fwd
-    def forward(ctx, forward_function, hidden_states, *args):
-        # Generate a unique file path for this tensor
-        file_path = DiskOffloadedGradientCheckpointer._get_temp_file_path()
+    def forward(
+        ctx,
+        forward_function,
+        hidden_states,
+        *args,
+        prefetch_size=3,
+        prefetch_to_gpu=False,
+    ):
+        # Get or create the manager
+        manager = DiskOffloadedGradientCheckpointer.get_manager(
+            prefetch_size=prefetch_size, prefetch_to_gpu=prefetch_to_gpu
+        )
 
-        # Save tensor to disk in a non-blocking way (detached from compute)
-        # First move to CPU, then save
-        cpu_hidden_states = hidden_states.detach().cpu()
-        torch.save(cpu_hidden_states, file_path)
-
-        # Free CPU memory
-        del cpu_hidden_states
+        # Save tensor to disk
+        file_path = manager.save_tensor(hidden_states)
 
         # Run forward pass
         with torch.no_grad():
             output = forward_function(hidden_states, *args)
 
-        # Store the path instead of the tensor
+        # Register a hook to trigger prefetching just before backward
+        def pre_backward_hook(grad_output):
+            manager.trigger_prefetch()
+            return grad_output
+
+        # Register the hook on the output tensor
+        if isinstance(output, torch.Tensor):
+            output.register_hook(pre_backward_hook)
+        elif (
+            isinstance(output, tuple)
+            and len(output) > 0
+            and isinstance(output[0], torch.Tensor)
+        ):
+            output[0].register_hook(pre_backward_hook)
+
+        # Store what we need for backward
         ctx.save_for_backward(torch.tensor([0]))  # Dummy tensor
         ctx.file_path = file_path
         ctx.forward_function = forward_function
@@ -54,40 +200,30 @@ class DiskOffloadedGradientCheckpointer(torch.autograd.Function):
     @staticmethod
     @torch_cuda_amp_custom_bwd
     def backward(ctx, dY):  # pylint: disable=invalid-name
-        # Load the hidden states from disk
-        hidden_states = torch.load(ctx.file_path, weights_only=True)
+        # Get the manager
+        manager = DiskOffloadedGradientCheckpointer._manager
 
-        # Move to CUDA and prepare for gradient computation
-        hidden_states = hidden_states.to("cuda", non_blocking=True).detach()
+        # Load hidden states from disk or prefetch cache
+        hidden_states = manager.load_tensor(ctx.file_path)
         hidden_states.requires_grad = True
-
-        # Clean up the temporary file
-        try:
-            os.remove(ctx.file_path)
-        except FileNotFoundError:
-            pass  # Ignore errors in file deletion
 
         # Compute gradients
         with torch.enable_grad():
             output = ctx.forward_function(hidden_states, *ctx.args)
-        # pylint: disable=duplicate-code
         torch.autograd.backward(output, dY)
 
         return (
             None,
             hidden_states.grad,
+            None,
+            None,
         ) + (
             None,
         ) * len(ctx.args)
 
     @staticmethod
     def cleanup():
-        """Clean up the temporary directory when done"""
-        import shutil
-
-        try:
-            shutil.rmtree(
-                DiskOffloadedGradientCheckpointer._temp_dir
-            )  # pylint: disable=protected-access
-        except FileNotFoundError:
-            pass
+        """Clean up the offload manager"""
+        if DiskOffloadedGradientCheckpointer._manager is not None:
+            DiskOffloadedGradientCheckpointer._manager.cleanup()
+            DiskOffloadedGradientCheckpointer._manager = None

--- a/src/axolotl/utils/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/utils/gradient_checkpointing/offload_disk.py
@@ -16,6 +16,7 @@ DISCO - DIsk-based Storage and Checkpointing with Optimized prefetching
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import concurrent.futures
 import logging
 import os
@@ -87,6 +88,8 @@ class DiskOffloadManager:
         self.save_worker.start()
         # logger.debug("Save worker thread started")
         self.idx = 0
+
+        atexit.register(self.cleanup)
 
     def _save_worker(self):
         """Background thread that processes the save queue"""
@@ -526,10 +529,3 @@ class Disco(torch.autograd.Function):
             # Clean up the file even on error
             manager.cleanup_tensor(file_path)
             raise
-
-    @staticmethod
-    def cleanup():
-        """Clean up the offload manager"""
-        if Disco._manager is not None:
-            Disco._manager.cleanup()
-            Disco._manager = None

--- a/src/axolotl/utils/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/utils/gradient_checkpointing/offload_disk.py
@@ -423,7 +423,7 @@ class DiskOffloadManager:
 
 class Disco(torch.autograd.Function):
     """
-    DiskOffloadedGradientCheckpointer: Tensor Efficient Management with Prefetched Offloading
+    Disco: DIsk-based Storage and Checkpointing with Optimized prefetching
     Advanced disk-based gradient checkpointer with prefetching.
     """
 

--- a/src/axolotl/utils/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/utils/gradient_checkpointing/offload_disk.py
@@ -1,0 +1,93 @@
+"""Disk offloaded checkpointing"""
+
+import os
+import tempfile
+import uuid
+
+import torch
+
+torch_cuda_amp_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+torch_cuda_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
+
+
+class DiskOffloadedGradientCheckpointer(torch.autograd.Function):
+    """
+    Saves both VRAM and RAM by offloading activations to disk.
+    Greater hit to performance than RAM offloading, but useful for extremely memory-constrained environments.
+    """
+
+    # Create a temporary directory for storing tensors
+    _temp_dir = tempfile.mkdtemp(prefix="disk_checkpoint_")
+
+    @staticmethod
+    def _get_temp_file_path():
+        """Generate a unique file path for tensor storage"""
+        return os.path.join(
+            DiskOffloadedGradientCheckpointer._temp_dir, f"{uuid.uuid4()}.pt"
+        )
+
+    @staticmethod
+    @torch_cuda_amp_custom_fwd
+    def forward(ctx, forward_function, hidden_states, *args):
+        # Generate a unique file path for this tensor
+        file_path = DiskOffloadedGradientCheckpointer._get_temp_file_path()
+
+        # Save tensor to disk in a non-blocking way (detached from compute)
+        # First move to CPU, then save
+        cpu_hidden_states = hidden_states.detach().cpu()
+        torch.save(cpu_hidden_states, file_path)
+
+        # Free CPU memory
+        del cpu_hidden_states
+
+        # Run forward pass
+        with torch.no_grad():
+            output = forward_function(hidden_states, *args)
+
+        # Store the path instead of the tensor
+        ctx.save_for_backward(torch.tensor([0]))  # Dummy tensor
+        ctx.file_path = file_path
+        ctx.forward_function = forward_function
+        ctx.args = args
+        return output
+
+    @staticmethod
+    @torch_cuda_amp_custom_bwd
+    def backward(ctx, dY):  # pylint: disable=invalid-name
+        # Load the hidden states from disk
+        hidden_states = torch.load(ctx.file_path, weights_only=True)
+
+        # Move to CUDA and prepare for gradient computation
+        hidden_states = hidden_states.to("cuda", non_blocking=True).detach()
+        hidden_states.requires_grad = True
+
+        # Clean up the temporary file
+        try:
+            os.remove(ctx.file_path)
+        except FileNotFoundError:
+            pass  # Ignore errors in file deletion
+
+        # Compute gradients
+        with torch.enable_grad():
+            output = ctx.forward_function(hidden_states, *ctx.args)
+        # pylint: disable=duplicate-code
+        torch.autograd.backward(output, dY)
+
+        return (
+            None,
+            hidden_states.grad,
+        ) + (
+            None,
+        ) * len(ctx.args)
+
+    @staticmethod
+    def cleanup():
+        """Clean up the temporary directory when done"""
+        import shutil
+
+        try:
+            shutil.rmtree(
+                DiskOffloadedGradientCheckpointer._temp_dir
+            )  # pylint: disable=protected-access
+        except FileNotFoundError:
+            pass

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -70,7 +70,10 @@ from axolotl.utils.distributed import (
     is_local_main_process,
     is_main_process,
 )
-from axolotl.utils.gradient_checkpointing import hf_grad_checkpoint_offload_wrapper
+from axolotl.utils.gradient_checkpointing import (
+    hf_grad_checkpoint_disk_offload_wrapper,
+    hf_grad_checkpoint_offload_wrapper,
+)
 from axolotl.utils.lora_embeddings import get_linear_embedding_layers
 from axolotl.utils.model_shard_quant import load_sharded_model, load_sharded_model_quant
 
@@ -619,6 +622,10 @@ class ModelLoader:
 
         if self.cfg.gradient_checkpointing in ["unsloth", "offload"]:
             transformers.modeling_utils.checkpoint = hf_grad_checkpoint_offload_wrapper
+        if self.cfg.gradient_checkpointing == "offload_disk":
+            transformers.modeling_utils.checkpoint = (
+                hf_grad_checkpoint_disk_offload_wrapper
+            )
 
         if self.cfg.flash_attention:
             self.patch_attention()

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -178,9 +178,9 @@ class AxolotlInputConfig(
 
     # torch_dtype: torch.dtype | None
 
-    gradient_checkpointing: (
-        Literal["unsloth", "offload", "offload_disk"] | bool | None
-    ) = Field(default=False)
+    gradient_checkpointing: Literal["offload", "offload_disk"] | bool | None = Field(
+        default=False
+    )
     gradient_checkpointing_kwargs: dict[str, Any] | None = None
 
     unfrozen_parameters: list[str] | None = None

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -178,9 +178,9 @@ class AxolotlInputConfig(
 
     # torch_dtype: torch.dtype | None
 
-    gradient_checkpointing: Literal["unsloth", "offload"] | bool | None = Field(
-        default=False
-    )
+    gradient_checkpointing: (
+        Literal["unsloth", "offload", "offload_disk"] | bool | None
+    ) = Field(default=False)
     gradient_checkpointing_kwargs: dict[str, Any] | None = None
 
     unfrozen_parameters: list[str] | None = None

--- a/tests/e2e/patched/test_activation_checkpointing.py
+++ b/tests/e2e/patched/test_activation_checkpointing.py
@@ -26,10 +26,15 @@ class TestActivationCheckpointing:
     E2E tests for activation checkpointing
     """
 
+    @pytest.mark.parametrize(
+        "gradient_checkpointing",
+        ["offload", "offload_disk"],
+    )
     def test_activation_checkpointing_offload(
         self,
         temp_dir,
         fix_checkpoint_after_test,  # pylint: disable=unused-argument,redefined-outer-name
+        gradient_checkpointing,
     ):
         # pylint: disable=duplicate-code
         cfg = DictDefault(
@@ -64,7 +69,7 @@ class TestActivationCheckpointing:
                 "sample_packing": True,
                 "bf16": True,
                 "save_safetensors": True,
-                "gradient_checkpointing": "offload",
+                "gradient_checkpointing": gradient_checkpointing,
             }
         )
 


### PR DESCRIPTION
This PR adds an option to offload activations to disk and prefetch them on the backwards pass right before they're needed. This should really only be used in place of the regular CPU offloading on resource constrained systems that are low on system RAM like Colab. see https://colab.research.google.com/drive/1MBHGHiOtRORFdoHEMZ6jFriMkRqJJIDv?usp=sharing where we are able to train Qwen3-8B w QLoRA @ 28K context