### PR TITLE
Make Axolotl Print Dataset Name Before Processing

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -484,7 +484,7 @@ def get_dataset_wrapper(
     }
 
     LOG.info(
-        f"Loading dataset with base_type: {d_base_type} and prompt_style: {d_prompt_style}"
+        f"Loading dataset: {config_dataset['path']} with base_type: {d_base_type} and prompt_style: {d_prompt_style}"
     )
 
     if (


### PR DESCRIPTION
When a config has many datasets and one of them has an error which breaks things it is annoying to figure out which one it is. This simply adds the name before that would happen, so you can immediately tell which set caused it.

Resolves #2667.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved log messages to display the dataset path along with additional dataset details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->