### PR TITLE
Add num_proc to fix data set slow processing issue

### DIFF
--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -72,6 +72,7 @@ def map_dataset(cfg, data_set, ds_transform_fn, tokenizer, **map_kwargs):
     data_set = data_set.map(
         ds_transform_fn,
         desc="Mapping RL Dataset",
+        num_proc=cfg.dataset_processes,
         **map_kwargs,
     )
 


### PR DESCRIPTION
# Description
I am using axolotl for DPO training and I found that data processing is very slow. Adding num_proc to the map function would help.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced dataset processing speed by enabling parallel processing based on your configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->