### PR TITLE
fix: num_items_in_batch wrong type in kd trainer loss

### DIFF
--- a/src/axolotl/integrations/kd/trainer.py
+++ b/src/axolotl/integrations/kd/trainer.py
@@ -74,6 +74,9 @@ class AxolotlKDTrainer(AxolotlTrainer):
         target_token_ids_for_loss = target_token_ids[..., 1:, :].contiguous()
         target_mask_for_loss = target_mask[..., 1:, :].contiguous()
 
+        if num_items_in_batch is None:
+            num_items_in_batch = -1
+
         if self.args.kd_zscore_base_temp:
             loss_kd = topk_kd_loss_with_zscore(
                 shift_logits,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Maybe closes #2682 

The `loss` function is JIT compiled and expects `num_items_in_batch` as integer. This PR fixes it being passed as None.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Reported working by reporter at https://github.com/axolotl-ai-cloud/axolotl/issues/2682#issuecomment-2914622507

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
