### PR TITLE
feat: do not find turn indices if turn is not trainable

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -425,7 +425,10 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             LOG.debug(f"Should train: {should_train}")
 
             # turn not trainable, skip having to find the turn indices
-            if not should_train:
+            # unless last turn and train_on_eos/train_on_eot is all
+            if not should_train and (
+                self.train_on_eos != "all" and self.train_on_eot != "all"
+            ):
                 if index == len(turns) - 1:
                     LOG.warning(
                         "Last turn is not trainable, skipping having to find the turn indices. "
@@ -438,7 +441,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
             LOG.debug(f"Turn indices: start={turn_start_idx}, end={turn_end_idx}")
 
-            if turn_start_idx != -1 and turn_end_idx != -1:
+            if should_train and turn_start_idx != -1 and turn_end_idx != -1:
                 if train_detail:
                     token_offsets = self.prompter.get_offsets_for_train_detail(  # type: ignore
                         content, train_detail

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -424,11 +424,21 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
             LOG.debug(f"Should train: {should_train}")
 
+            # turn not trainable, skip having to find the turn indices
+            if not should_train:
+                if index == len(turns) - 1:
+                    LOG.warning(
+                        "Last turn is not trainable, skipping having to find the turn indices. "
+                        "This may cause incorrect last EOT/EOS token to be unmasked."
+                    )
+
+                continue
+
             turn_start_idx, turn_end_idx = self.find_turn(turns=turns, turn_idx=index)
 
             LOG.debug(f"Turn indices: start={turn_start_idx}, end={turn_end_idx}")
 
-            if should_train and turn_start_idx != -1 and turn_end_idx != -1:
+            if turn_start_idx != -1 and turn_end_idx != -1:
                 if train_detail:
                     token_offsets = self.prompter.get_offsets_for_train_detail(  # type: ignore
                         content, train_detail

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -433,6 +433,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                     LOG.warning(
                         "Last turn is not trainable, skipping having to find the turn indices. "
                         "This may cause incorrect last EOT/EOS token to be unmasked."
+                        "This is likely a dataset design issue. Please ensure last turn is trainable."
                     )
 
                 continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

We were wasting compute trying to find the turns for indices we won't even train on. This reduces at least 1/2 computations done per sample (assuming assistant turns make up to 50% cases).

Secondly, the only case where we need the indices is when `train_on_eot` / `train_on_eos` is set to ALL, so we will do full computation.

Introduces a new warning if the last turn is not trainable (which is unusual):
```
                        "Last turn is not trainable, skipping having to find the turn indices. "
                        "This may cause incorrect last EOT/EOS token to be unmasked."
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran on dummy dataset with benchmark below: https://github.com/axolotl-ai-cloud/axolotl/pull/2696#issuecomment-2893971301

Need eyes to double check.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of non-trainable chat turns to prevent unnecessary processing and potential masking issues, with warnings logged if skipping may affect the last turn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->