### PR TITLE
feat(doc): note lora kernel incompat with RLHF

### DIFF
--- a/docs/lora_optims.qmd
+++ b/docs/lora_optims.qmd
@@ -84,6 +84,10 @@ lora_qkv_kernel: true
 lora_o_kernel: true
 ```
 
+::: {.callout-note}
+Currently, LoRA kernels are not supported for RLHF training, only SFT.
+:::
+
 ## Requirements
 
 - One or more NVIDIA or AMD GPUs (in order to use the Triton kernels)

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1050,7 +1050,7 @@ class AxolotlInputConfig(
         ):
             if data.get("adapter") == "lora" and data.get("load_in_8bit"):
                 raise ValueError(
-                    "lora_mlp_kernel, lora_mlp_kernel, and lora_mlp_kernel are not compatible with 8-bit LoRA"
+                    "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with 8-bit LoRA"
                 )
         return data
 
@@ -1063,7 +1063,7 @@ class AxolotlInputConfig(
             or data.get("lora_o_kernel")
         ) and data.get("rl"):
             raise ValueError(
-                "lora_mlp_kernel, lora_mlp_kernel, and lora_mlp_kernel are not compatible with RL at the moment."
+                "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with RL at the moment."
             )
         return data
 

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1042,7 +1042,7 @@ class AxolotlInputConfig(
 
     @model_validator(mode="before")
     @classmethod
-    def check_lora_8bit(cls, data):
+    def check_lora_kernel_8bit(cls, data):
         if (
             data.get("lora_mlp_kernel")
             or data.get("lora_qkv_kernel")
@@ -1052,6 +1052,19 @@ class AxolotlInputConfig(
                 raise ValueError(
                     "lora_mlp_kernel, lora_mlp_kernel, and lora_mlp_kernel are not compatible with 8-bit LoRA"
                 )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_lora_kernel_rl(cls, data):
+        if (
+            data.get("lora_mlp_kernel")
+            or data.get("lora_qkv_kernel")
+            or data.get("lora_o_kernel")
+        ) and data.get("rl"):
+            raise ValueError(
+                "lora_mlp_kernel, lora_mlp_kernel, and lora_mlp_kernel are not compatible with RL at the moment."
+            )
         return data
 
     @model_validator(mode="before")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

>  Error 2: Model must be a PeftModelForCausalLM when enabling LoRa kernel patches. Since Gemma3 is not inherited from PeftModelForCausalLM, how can i use these monkey patches?

- from discord

Let's add to doc about this limitation for now. Should we add validation too?

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a note clarifying that LoRA kernels currently support only Supervised Fine-Tuning (SFT) and are not compatible with Reinforcement Learning with Human Feedback (RLHF) training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->