### PR TITLE
Allow Liger with GraniteMoE

### DIFF
--- a/src/axolotl/integrations/liger/__init__.py
+++ b/src/axolotl/integrations/liger/__init__.py
@@ -175,6 +175,16 @@ class LigerPlugin(BasePlugin):
                 rms_norm=cfg.liger_rms_norm,
                 layer_norm=cfg.liger_layer_norm,
             )
+        elif cfg.model_config_type == "granitemoe":
+            from liger_kernel.transformers import apply_liger_kernel_to_granite
+
+            apply_liger_kernel_to_granite(
+                rope=cfg.liger_rope,
+                cross_entropy=cfg.liger_cross_entropy,
+                fused_linear_cross_entropy=cfg.liger_fused_linear_cross_entropy,
+                rms_norm=cfg.liger_rms_norm,
+                swiglu=cfg.liger_glu_activation,
+            )
         else:
             logging.warning(
                 f"Unsupported model config type: {cfg.model_config_type}. Liger not applied."


### PR DESCRIPTION
Doesn't seem to be included in `MODEL_TYPE_TO_APPLY_LIGER_FN`, and might not apply to *everything* in the MoE, but it does apply correctly and memory usage is lower. Would make sense to do a PR upstream, but this should work for now.

Doesn't support `liger_fused_linear_cross_entropy`

# Memory before/during loading & training
![Granite-3 1-Earthen-v0 3-3B-A800M-QLoRA - No Liger](https://github.com/user-attachments/assets/adb50c75-b71b-43f2-b005-ae946a767233)
![Granite-3 1-Earthen-v0 3-3B-A800M-QLoRA - Liger](https://github.com/user-attachments/assets/92840fa5-511e-4c99-a72a-1f7f1a3436b2)

# Config used to test
```yaml
# Model checkpointing config
output_dir: ./output

# Model architecture config
base_model: ibm-granite/granite-3.1-3b-a800m-instruct
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

# Mixed precision training config
bf16: true
fp16: false
tf32: false

# Model loading config
load_in_8bit: false
load_in_4bit: true
strict: false

# Sequence config
sequence_len: 8192
min_sample_len: 256
sample_packing: true
eval_sample_packing: true
pad_to_sequence_len: true
train_on_inputs: false
group_by_length: false

# LoRA adapter config
adapter: qlora
lora_r: 16
lora_alpha: 16
lora_dropout: 0.125
lora_target_linear: true
embeddings_skip_upcast: true

# Training hyperparameters
num_epochs: 1
gradient_accumulation_steps: 1
micro_batch_size: 1
eval_batch_size: 1
warmup_steps: 0
optimizer: came_pytorch
optim_args:
  enable_stochastic_rounding: true
  enable_cautious: true
  enable_8bit: true
lr_scheduler: rex
learning_rate: 2.5e-7
cosine_min_lr_ratio: 0.05
weight_decay: 0.01
max_grad_norm: 0.5
logging_steps: 1

# Model optimization
gradient_checkpointing: offload
sdp_attention: true
plugins:
  - axolotl.integrations.liger.LigerPlugin
liger_rope: true
liger_rms_norm: true
liger_layer_norm: true
liger_glu_activation: true
liger_cross_entropy: true
lora_mlp_kernel: false
lora_qkv_kernel: false
lora_o_kernel: false

# Debug config
debug: true
seed: 42

# Token config
special_tokens:
  bos_token: "<|end_of_text|>"
  eos_token: "<|end_of_text|>"
  pad_token: "<|end_of_text|>"
tokens:
```