### PR TITLE
fix dist state init before deepspeed setup

### DIFF
--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -32,7 +32,7 @@ from transformers import PreTrainedModel, Trainer
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
 
-LOG = get_logger(__name__)
+LOG = get_logger(__name__, use_environ=True)
 
 if TYPE_CHECKING:
     from axolotl.common.datasets import TrainDatasetMeta


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

before:

```
[rank0]: Traceback (most recent call last):                                                                           [rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main                                                    [rank0]:   File "<frozen runpy>", line 88, in _run_code                                                               [rank0]:   File "/workspace/axolotl/src/axolotl/cli/train.py", line 121, in <module>                                  
[rank0]:     fire.Fire(do_cli)                                                                                        
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/fire/core.py", line 135, in Fire           [rank0]:     component_trace = _Fire(component, args, parsed_flag_args, context, name)                                [rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^            
[rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/fire/core.py", line 468, in _Fire          
[rank0]:     component, remaining_args = _CallAndUpdateTrace(                                                         
[rank0]:                                 ^^^^^^^^^^^^^^^^^^^^                                                         [rank0]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace                                                                                                                  [rank0]:     component = fn(*varargs, **kwargs)                                                                       [rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^            
[rank0]:   File "/workspace/axolotl/src/axolotl/cli/train.py", line 70, in do_cli                                     
[rank0]:     parsed_cfg = load_cfg(config, **kwargs)                                                                  [rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                  [rank0]:   File "/workspace/axolotl/src/axolotl/cli/config.py", line 227, in load_cfg                                 [rank0]:     prepare_optim_env(cfg)               
[rank0]:   File "/workspace/axolotl/src/axolotl/utils/trainer.py", line 583, in prepare_optim_env                     
[rank0]:     setup_deepspeed_env(cfg, stage=stage)                                                                    [rank0]:   File "/workspace/axolotl/src/axolotl/utils/trainer.py", line 527, in setup_deepspeed_env                   [rank0]:     raise RuntimeError(                                                                                      [rank0]: RuntimeError: Distributed State already initialized before Deepspeed setup
```

after: ✅ 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated logger configuration to better support environment-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->