### PR TITLE
Deduplicate Only During Pre-Processing

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -340,6 +340,9 @@ def load_tokenized_prepared_datasets(
             else:
                 LOG.debug("NOT shuffling merged datasets")
 
+        if cfg.dataset_exact_deduplication:
+            _, _, dataset = deduplicate_and_log_datasets(dataset=dataset)
+
         if not cfg.skip_prepare_dataset:
             dataset = drop_long_seq_in_dataset(dataset, cfg)
 
@@ -438,8 +441,7 @@ def load_prepare_datasets(
         )
         train_fingerprint = md5(to_hash_train)
         test_fingerprint = md5(to_hash_test)
-        if cfg.dataset_exact_deduplication:
-            _, _, dataset = deduplicate_and_log_datasets(dataset=dataset)
+
         dataset = dataset.train_test_split(
             test_size=val_set_size,
             shuffle=False,
@@ -451,16 +453,10 @@ def load_prepare_datasets(
         train_dataset = dataset["train"]
         eval_dataset = dataset["test"]
     elif split == "test":
-        if cfg.dataset_exact_deduplication:
-            _, eval_dataset, _ = deduplicate_and_log_datasets(eval_dataset=dataset)
-        else:
-            eval_dataset = dataset
+        eval_dataset = dataset
         train_dataset = None
     else:
-        if cfg.dataset_exact_deduplication:
-            train_dataset, _, _ = deduplicate_and_log_datasets(train_dataset=dataset)
-        else:
-            train_dataset = dataset
+        train_dataset = dataset
         eval_dataset = None
     return train_dataset, eval_dataset, prompters
 


### PR DESCRIPTION
Resolves #2719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved dataset deduplication by centralizing the deduplication process, ensuring it occurs only once after datasets are merged and optionally shuffled.
  - Simplified internal workflow for handling datasets, reducing redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->