### PR TITLE
Make De-duplication Multi-threaded and Happen Only During Pre-processing

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -341,7 +341,9 @@ def load_tokenized_prepared_datasets(
                 LOG.debug("NOT shuffling merged datasets")
 
         if cfg.dataset_exact_deduplication:
-            _, _, dataset = deduplicate_and_log_datasets(dataset=dataset, num_proc=cfg.dataset_processes)
+            _, _, dataset = deduplicate_and_log_datasets(
+                dataset=dataset, num_proc=cfg.dataset_processes
+            )
 
         if not cfg.skip_prepare_dataset:
             dataset = drop_long_seq_in_dataset(dataset, cfg)

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -340,6 +340,9 @@ def load_tokenized_prepared_datasets(
             else:
                 LOG.debug("NOT shuffling merged datasets")
 
+        if cfg.dataset_exact_deduplication:
+            _, _, dataset = deduplicate_and_log_datasets(dataset=dataset, num_proc=cfg.dataset_processes)
+
         if not cfg.skip_prepare_dataset:
             dataset = drop_long_seq_in_dataset(dataset, cfg)
 
@@ -438,8 +441,7 @@ def load_prepare_datasets(
         )
         train_fingerprint = md5(to_hash_train)
         test_fingerprint = md5(to_hash_test)
-        if cfg.dataset_exact_deduplication:
-            _, _, dataset = deduplicate_and_log_datasets(dataset=dataset)
+
         dataset = dataset.train_test_split(
             test_size=val_set_size,
             shuffle=False,
@@ -451,16 +453,10 @@ def load_prepare_datasets(
         train_dataset = dataset["train"]
         eval_dataset = dataset["test"]
     elif split == "test":
-        if cfg.dataset_exact_deduplication:
-            _, eval_dataset, _ = deduplicate_and_log_datasets(eval_dataset=dataset)
-        else:
-            eval_dataset = dataset
+        eval_dataset = dataset
         train_dataset = None
     else:
-        if cfg.dataset_exact_deduplication:
-            train_dataset, _, _ = deduplicate_and_log_datasets(train_dataset=dataset)
-        else:
-            train_dataset = dataset
+        train_dataset = dataset
         eval_dataset = None
     return train_dataset, eval_dataset, prompters
 

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -94,7 +94,9 @@ def deduplicate_dataset(
     other_hashes = set()
     if other_dataset is not None:
         other_hashed = other_dataset.map(
-            compute_row_hash, remove_columns=other_dataset.column_names, num_proc=num_proc
+            compute_row_hash,
+            remove_columns=other_dataset.column_names,
+            num_proc=num_proc
         )
         other_hashes = set(other_hashed["row_hash"])
         del other_hashed

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -69,39 +69,41 @@ def sha256(to_hash: str, encoding: str = "utf-8") -> str:
     return hashlib.sha256(to_hash.encode(encoding)).hexdigest()
 
 
-def deduplicate_dataset(
-    dataset: Dataset, seen_hashes: dict[str, list[int]], other_dataset: Dataset = None
-) -> Dataset:
-    unique_indices = []
+def compute_row_hash(example):
+    return {"row_hash": sha256(str(example))}
 
-    for idx, row in enumerate(dataset):
-        row_hash = sha256(str(row))  # Using SHA256 for collision resistance.
-        if row_hash not in seen_hashes:
-            seen_hashes[row_hash] = [idx]
-            unique_indices.append(idx)
-        else:
-            # Check for collision by looking up the original dataset indices
-            original_indices = seen_hashes[row_hash]
-            is_duplicate = False
-            for original_idx in original_indices:
-                if (
-                    not idx == original_idx
-                    and original_idx < len(dataset)
-                    and str(dataset[original_idx]) == str(row)
-                ):
-                    is_duplicate = True
-                    break
-                # Check in the other dataset if provided
-                if other_dataset is not None:
-                    if original_idx < len(other_dataset) and str(
-                        other_dataset[original_idx]
-                    ) == str(row):
-                        is_duplicate = True
-                        break
-            if not is_duplicate:
-                seen_hashes[row_hash].append(idx)
-                unique_indices.append(idx)
-                continue
+
+def deduplicate_dataset(
+    dataset: Dataset,
+    other_dataset: Dataset = None,
+    num_proc: int = None,
+) -> Dataset:
+    hashes, other_hashes, seen_hashes, unique_indices = [], [], set(), set()
+
+    if dataset is not None:
+        hashed = dataset.map(
+            compute_row_hash,
+            batched=False,
+            num_proc=num_proc,
+            remove_columns=[],
+        )
+        hashes = hashed["row_hash"]
+
+    if other_dataset is not None:
+        other_hashed = other_dataset.map(
+            compute_row_hash,
+            batched=False,
+            num_proc=num_proc,
+            remove_columns=[],
+        )
+        other_hashes = set(other_hashed["row_hash"])
+
+    for idx, hash in enumerate(hashes):
+        if hash in seen_hashes or hash in other_hashes:
+            continue
+        seen_hashes.add(hash)
+        unique_indices.add(idx)
+
     return dataset.select(unique_indices)
 
 
@@ -110,6 +112,7 @@ def deduplicate_and_log_datasets(
     train_dataset: Dataset = None,
     eval_dataset: Dataset = None,
     dataset: Dataset = None,
+    num_proc: int = None,
 ) -> tuple[Dataset, Dataset, Dataset]:
     """
     Deduplicates train, eval, and an optional dataset if provided, logging original and new sizes.
@@ -117,43 +120,25 @@ def deduplicate_and_log_datasets(
     Returns:
         tuple: Deduplicated train, eval, and additional datasets.
     """
-    seen_hashes: dict[str, list[int]] = {}
-
     # Handle cases where datasets are None
     if train_dataset is not None:
-        LOG.info(
-            f"Starting deduplication for train dataset. Original size: {len(train_dataset)}"
-        )
-        train_dataset = deduplicate_dataset(
-            dataset=train_dataset, seen_hashes=seen_hashes
-        )
-        LOG.info(
-            f"Deduplication complete for train dataset. New size: {len(train_dataset)}"
-        )
+        LOG.info(f"Starting deduplication for train dataset. Original size: {len(train_dataset)}")
+        train_dataset = deduplicate_dataset(dataset=train_dataset, num_proc=num_proc)
+        LOG.info(f"Deduplication complete for train dataset. New size: {len(train_dataset)}")
     else:
         LOG.info("Train dataset is None. Skipping deduplication.")
 
     if eval_dataset is not None:
-        LOG.info(
-            f"Starting deduplication for eval dataset. Original size: {len(eval_dataset)}"
-        )
-        eval_dataset = deduplicate_dataset(
-            dataset=eval_dataset, seen_hashes=seen_hashes, other_dataset=train_dataset
-        )
-        LOG.info(
-            f"Deduplication complete for eval dataset. New size: {len(eval_dataset)}"
-        )
+        LOG.info(f"Starting deduplication for eval dataset. Original size: {len(eval_dataset)}")
+        eval_dataset = deduplicate_dataset(dataset=eval_dataset, other_dataset=train_dataset, num_proc=num_proc)
+        LOG.info(f"Deduplication complete for eval dataset. New size: {len(eval_dataset)}")
     else:
         LOG.info("Eval dataset is None. Skipping deduplication.")
 
     if dataset is not None and (eval_dataset is None and train_dataset is None):
-        LOG.info(
-            f"Starting deduplication for combined dataset. Original size: {len(dataset)}"
-        )
-        dataset = deduplicate_dataset(dataset=dataset, seen_hashes=seen_hashes)
-        LOG.info(
-            f"Deduplication complete for combined dataset. New size: {len(dataset)}"
-        )
+        LOG.info(f"Starting deduplication for combined dataset. Original size: {len(dataset)}")
+        dataset = deduplicate_dataset(dataset=dataset, num_proc=num_proc)
+        LOG.info(f"Deduplication complete for combined dataset. New size: {len(dataset)}")
 
     return train_dataset, eval_dataset, dataset
 

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -77,25 +77,21 @@ def compute_row_hash(example):
 def deduplicate_dataset(
     dataset: Dataset,
     other_dataset: Dataset = None,
-    num_proc: int = None,
+    num_proc: Optional[int] = None,
 ) -> Dataset:
     hashes, other_hashes, seen_hashes, unique_indices = [], set(), set(), set()
 
     if dataset is not None:
         hashed = dataset.map(
             compute_row_hash,
-            batched=False,
             num_proc=num_proc,
-            remove_columns=[],
         )
         hashes = hashed["row_hash"]
 
     if other_dataset is not None:
         other_hashed = other_dataset.map(
             compute_row_hash,
-            batched=False,
             num_proc=num_proc,
-            remove_columns=[],
         )
         other_hashes = set(other_hashed["row_hash"])
 

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -90,7 +90,7 @@ def deduplicate_dataset(
 
     if other_dataset is not None:
         other_hashed = other_dataset.map(
-            compute_row_hash, remove_columns=dataset.column_names, num_proc=num_proc
+            compute_row_hash, remove_columns=other_dataset.column_names, num_proc=num_proc
         )
         other_hashes = set(other_hashed["row_hash"])
         del other_hashed

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -96,7 +96,7 @@ def deduplicate_dataset(
         other_hashed = other_dataset.map(
             compute_row_hash,
             remove_columns=other_dataset.column_names,
-            num_proc=num_proc
+            num_proc=num_proc,
         )
         other_hashes = set(other_hashed["row_hash"])
         del other_hashed

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -9,6 +9,7 @@ import huggingface_hub
 import numpy as np
 import requests
 from datasets import Dataset, IterableDataset
+from typing import Optional
 
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
@@ -78,7 +79,7 @@ def deduplicate_dataset(
     other_dataset: Dataset = None,
     num_proc: int = None,
 ) -> Dataset:
-    hashes, other_hashes, seen_hashes, unique_indices = [], [], set(), set()
+    hashes, other_hashes, seen_hashes, unique_indices = [], set(), set(), set()
 
     if dataset is not None:
         hashed = dataset.map(
@@ -98,10 +99,10 @@ def deduplicate_dataset(
         )
         other_hashes = set(other_hashed["row_hash"])
 
-    for idx, hash in enumerate(hashes):
-        if hash in seen_hashes or hash in other_hashes:
+    for idx, row_hash in enumerate(hashes):
+        if row_hash in seen_hashes or row_hash in other_hashes:
             continue
-        seen_hashes.add(hash)
+        seen_hashes.add(row_hash)
         unique_indices.add(idx)
 
     return dataset.select(unique_indices)
@@ -112,7 +113,7 @@ def deduplicate_and_log_datasets(
     train_dataset: Dataset = None,
     eval_dataset: Dataset = None,
     dataset: Dataset = None,
-    num_proc: int = None,
+    num_proc: Optional[int] = None,
 ) -> tuple[Dataset, Dataset, Dataset]:
     """
     Deduplicates train, eval, and an optional dataset if provided, logging original and new sizes.

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -82,18 +82,26 @@ def deduplicate_dataset(
     hashes, other_hashes, seen_hashes, unique_indices = [], set(), set(), set()
 
     if dataset is not None:
-        hashed = dataset.map(compute_row_hash, num_proc=num_proc)
+        hashed = dataset.map(
+            compute_row_hash, remove_columns=dataset.column_names, num_proc=num_proc
+        )
         hashes = hashed["row_hash"]
+        del hashed
 
     if other_dataset is not None:
-        other_hashed = other_dataset.map(compute_row_hash, num_proc=num_proc)
+        other_hashed = other_dataset.map(
+            compute_row_hash, remove_columns=dataset.column_names, num_proc=num_proc
+        )
         other_hashes = set(other_hashed["row_hash"])
+        del other_hashed
 
     for idx, row_hash in enumerate(hashes):
         if row_hash in seen_hashes or row_hash in other_hashes:
             continue
         seen_hashes.add(row_hash)
         unique_indices.add(idx)
+
+    del hashes, other_hashes, seen_hashes
 
     return dataset.select(unique_indices)
 

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -3,13 +3,13 @@
 import functools
 import hashlib
 import time
+from typing import Optional
 from enum import Enum
 
 import huggingface_hub
 import numpy as np
 import requests
 from datasets import Dataset, IterableDataset
-from typing import Optional
 
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -3,8 +3,8 @@
 import functools
 import hashlib
 import time
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
 import huggingface_hub
 import numpy as np
@@ -82,17 +82,11 @@ def deduplicate_dataset(
     hashes, other_hashes, seen_hashes, unique_indices = [], set(), set(), set()
 
     if dataset is not None:
-        hashed = dataset.map(
-            compute_row_hash,
-            num_proc=num_proc,
-        )
+        hashed = dataset.map(compute_row_hash, num_proc=num_proc)
         hashes = hashed["row_hash"]
 
     if other_dataset is not None:
-        other_hashed = other_dataset.map(
-            compute_row_hash,
-            num_proc=num_proc,
-        )
+        other_hashed = other_dataset.map(compute_row_hash, num_proc=num_proc)
         other_hashes = set(other_hashed["row_hash"])
 
     for idx, row_hash in enumerate(hashes):
@@ -119,23 +113,37 @@ def deduplicate_and_log_datasets(
     """
     # Handle cases where datasets are None
     if train_dataset is not None:
-        LOG.info(f"Starting deduplication for train dataset. Original size: {len(train_dataset)}")
+        LOG.info(
+            f"Starting deduplication for train dataset. Original size: {len(train_dataset)}"
+        )
         train_dataset = deduplicate_dataset(dataset=train_dataset, num_proc=num_proc)
-        LOG.info(f"Deduplication complete for train dataset. New size: {len(train_dataset)}")
+        LOG.info(
+            f"Deduplication complete for train dataset. New size: {len(train_dataset)}"
+        )
     else:
         LOG.info("Train dataset is None. Skipping deduplication.")
 
     if eval_dataset is not None:
-        LOG.info(f"Starting deduplication for eval dataset. Original size: {len(eval_dataset)}")
-        eval_dataset = deduplicate_dataset(dataset=eval_dataset, other_dataset=train_dataset, num_proc=num_proc)
-        LOG.info(f"Deduplication complete for eval dataset. New size: {len(eval_dataset)}")
+        LOG.info(
+            f"Starting deduplication for eval dataset. Original size: {len(eval_dataset)}"
+        )
+        eval_dataset = deduplicate_dataset(
+            dataset=eval_dataset, other_dataset=train_dataset, num_proc=num_proc
+        )
+        LOG.info(
+            f"Deduplication complete for eval dataset. New size: {len(eval_dataset)}"
+        )
     else:
         LOG.info("Eval dataset is None. Skipping deduplication.")
 
     if dataset is not None and (eval_dataset is None and train_dataset is None):
-        LOG.info(f"Starting deduplication for combined dataset. Original size: {len(dataset)}")
+        LOG.info(
+            f"Starting deduplication for combined dataset. Original size: {len(dataset)}"
+        )
         dataset = deduplicate_dataset(dataset=dataset, num_proc=num_proc)
-        LOG.info(f"Deduplication complete for combined dataset. New size: {len(dataset)}")
+        LOG.info(
+            f"Deduplication complete for combined dataset. New size: {len(dataset)}"
+        )
 
     return train_dataset, eval_dataset, dataset
 


### PR DESCRIPTION
Uses only the SHA256 hash. Collision is too unlikely to be worth checking for.

262K samples de-duped in ~4 minutes. Previously it took ~15 minutes to de-dupe 162K samples. So roughly 6x faster, or even faster if you count it de-duping multiple times before.

```
[2025-06-01 06:26:34,020] [INFO] [axolotl.utils.data.utils.deduplicate_and_log_datasets:132] [PID:74277] [RANK:0] Train dataset is None. Skipping deduplication.
[2025-06-01 06:26:34,020] [INFO] [axolotl.utils.data.utils.deduplicate_and_log_datasets:145] [PID:74277] [RANK:0] Eval dataset is None. Skipping deduplication.
[2025-06-01 06:26:34,020] [INFO] [axolotl.utils.data.utils.deduplicate_and_log_datasets:148] [PID:74277] [RANK:0] Starting deduplication for combined dataset. Original size: 262437
Map (num_proc=12): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 262437/262437 [03:45<00:00, 1163.76 examples/s]
[2025-06-01 06:30:20,862] [INFO] [axolotl.utils.data.utils.deduplicate_and_log_datasets:152] [PID:74277] [RANK:0] Deduplication complete for combined dataset. New size: 258523
```

Resolves #2719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved dataset deduplication with faster, parallel processing using hash-based methods.
	- Deduplication now occurs once immediately after dataset merging, reducing redundant steps.
- **Chores**
	- Simplified dataset preparation workflow for better consistency and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->