### PR TITLE
remove deprecated wandb env var

### DIFF
--- a/src/axolotl/utils/wandb_.py
+++ b/src/axolotl/utils/wandb_.py
@@ -16,6 +16,3 @@ def setup_wandb_env_vars(cfg: DictDefault):
     # Enable wandb if project name is present
     if cfg.wandb_project and len(cfg.wandb_project) > 0:
         cfg.use_wandb = True
-        os.environ.pop("WANDB_DISABLED", None)  # Remove if present
-    else:
-        os.environ["WANDB_DISABLED"] = "true"

--- a/tests/e2e/multigpu/patched/test_sp.py
+++ b/tests/e2e/multigpu/patched/test_sp.py
@@ -12,8 +12,6 @@ from axolotl.utils.dict import DictDefault
 
 from ...utils import check_tensorboard
 
-os.environ["WANDB_DISABLED"] = "true"
-
 
 class TestSequenceParallelism:
     """Test case for training with sequence parallelism enabled"""

--- a/tests/e2e/multigpu/patched/test_sp.py
+++ b/tests/e2e/multigpu/patched/test_sp.py
@@ -1,6 +1,5 @@
 """E2E tests for sequence parallelism"""
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/multigpu/solo/test_flex.py
+++ b/tests/e2e/multigpu/solo/test_flex.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu lora tinyllama
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/multigpu/solo/test_flex.py
+++ b/tests/e2e/multigpu/solo/test_flex.py
@@ -13,12 +13,8 @@ from transformers.testing_utils import get_torch_dist_unique_port
 from transformers.utils import is_torch_bf16_gpu_available
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.e2e.utils import check_tensorboard, require_torch_2_6_0
-
-LOG = get_logger("axolotl.tests.e2e.multigpu")
-os.environ["WANDB_DISABLED"] = "true"
 
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 

--- a/tests/e2e/multigpu/test_eval.py
+++ b/tests/e2e/multigpu/test_eval.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu eval
 """
 
-import os
 from pathlib import Path
 
 import yaml

--- a/tests/e2e/multigpu/test_eval.py
+++ b/tests/e2e/multigpu/test_eval.py
@@ -10,12 +10,8 @@ from accelerate.test_utils import execute_subprocess_async
 from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_tensorboard
-
-LOG = get_logger("axolotl.tests.e2e.multigpu")
-os.environ["WANDB_DISABLED"] = "true"
 
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 

--- a/tests/e2e/multigpu/test_gemma3.py
+++ b/tests/e2e/multigpu/test_gemma3.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu lora tinyllama
 """
 
-import os
 from pathlib import Path
 
 import pytest
@@ -12,12 +11,8 @@ from huggingface_hub import snapshot_download
 from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.e2e.utils import check_tensorboard
-
-LOG = get_logger("axolotl.tests.e2e.multigpu")
-os.environ["WANDB_DISABLED"] = "true"
 
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 

--- a/tests/e2e/multigpu/test_llama.py
+++ b/tests/e2e/multigpu/test_llama.py
@@ -14,12 +14,8 @@ from packaging import version
 from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.e2e.utils import check_tensorboard, require_torch_2_6_0
-
-LOG = get_logger("axolotl.tests.e2e.multigpu")
-os.environ["WANDB_DISABLED"] = "true"
 
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 

--- a/tests/e2e/multigpu/test_llama.py
+++ b/tests/e2e/multigpu/test_llama.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu lora tinyllama
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/multigpu/test_qwen2.py
+++ b/tests/e2e/multigpu/test_qwen2.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu qwen2
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/multigpu/test_qwen2.py
+++ b/tests/e2e/multigpu/test_qwen2.py
@@ -11,10 +11,6 @@ from accelerate.test_utils import execute_subprocess_async
 from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger("axolotl.tests.e2e.multigpu")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestMultiGPUQwen2:

--- a/tests/e2e/multigpu/test_ray.py
+++ b/tests/e2e/multigpu/test_ray.py
@@ -10,12 +10,8 @@ import yaml
 from accelerate.test_utils import execute_subprocess_async
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.e2e.utils import check_tensorboard, require_torch_lt_2_6_0
-
-LOG = get_logger(__name__)
-os.environ["WANDB_DISABLED"] = "true"
 
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 

--- a/tests/e2e/multigpu/test_ray.py
+++ b/tests/e2e/multigpu/test_ray.py
@@ -2,7 +2,6 @@
 E2E tests for multigpu post-training use Ray Train
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/patched/test_4d_multipack_llama.py
+++ b/tests/e2e/patched/test_4d_multipack_llama.py
@@ -2,7 +2,6 @@
 E2E tests for multipack fft llama using 4d attention masks
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/patched/test_4d_multipack_llama.py
+++ b/tests/e2e/patched/test_4d_multipack_llama.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class Test4dMultipackLlama(unittest.TestCase):

--- a/tests/e2e/patched/test_fa_xentropy.py
+++ b/tests/e2e/patched/test_fa_xentropy.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, check_tensorboard
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestFAXentropyLlama:

--- a/tests/e2e/patched/test_fa_xentropy.py
+++ b/tests/e2e/patched/test_fa_xentropy.py
@@ -2,8 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
-
 import pytest
 from transformers.utils import is_torch_bf16_gpu_available
 

--- a/tests/e2e/patched/test_falcon_samplepack.py
+++ b/tests/e2e/patched/test_falcon_samplepack.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestFalconPatched(unittest.TestCase):

--- a/tests/e2e/patched/test_falcon_samplepack.py
+++ b/tests/e2e/patched/test_falcon_samplepack.py
@@ -2,7 +2,6 @@
 E2E tests for falcon
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/patched/test_fused_llama.py
+++ b/tests/e2e/patched/test_fused_llama.py
@@ -13,12 +13,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 @pytest.mark.skip("FIXME, mostly underused functionality")

--- a/tests/e2e/patched/test_fused_llama.py
+++ b/tests/e2e/patched/test_fused_llama.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/patched/test_llama_s2_attention.py
+++ b/tests/e2e/patched/test_llama_s2_attention.py
@@ -2,7 +2,6 @@
 E2E tests for llama w/ S2 attn
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/patched/test_llama_s2_attention.py
+++ b/tests/e2e/patched/test_llama_s2_attention.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 @pytest.mark.skip(reason="FIXME?")

--- a/tests/e2e/patched/test_lora_llama_multipack.py
+++ b/tests/e2e/patched/test_lora_llama_multipack.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/patched/test_lora_llama_multipack.py
+++ b/tests/e2e/patched/test_lora_llama_multipack.py
@@ -13,12 +13,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestLoraLlama(unittest.TestCase):

--- a/tests/e2e/patched/test_mistral_samplepack.py
+++ b/tests/e2e/patched/test_mistral_samplepack.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestMistral(unittest.TestCase):

--- a/tests/e2e/patched/test_mistral_samplepack.py
+++ b/tests/e2e/patched/test_mistral_samplepack.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/patched/test_mixtral_samplepack.py
+++ b/tests/e2e/patched/test_mixtral_samplepack.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestMixtral(unittest.TestCase):

--- a/tests/e2e/patched/test_mixtral_samplepack.py
+++ b/tests/e2e/patched/test_mixtral_samplepack.py
@@ -2,7 +2,6 @@
 E2E tests for mixtral
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/patched/test_phi_multipack.py
+++ b/tests/e2e/patched/test_phi_multipack.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestPhiMultipack(unittest.TestCase):

--- a/tests/e2e/patched/test_phi_multipack.py
+++ b/tests/e2e/patched/test_phi_multipack.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/patched/test_resume.py
+++ b/tests/e2e/patched/test_resume.py
@@ -2,7 +2,6 @@
 E2E tests for resuming training
 """
 
-import os
 import re
 import subprocess
 

--- a/tests/e2e/patched/test_resume.py
+++ b/tests/e2e/patched/test_resume.py
@@ -13,12 +13,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, most_recent_subdir, require_torch_2_6_0
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestResumeLlama:

--- a/tests/e2e/patched/test_unsloth_qlora.py
+++ b/tests/e2e/patched/test_unsloth_qlora.py
@@ -11,12 +11,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, check_tensorboard
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 # pylint: disable=duplicate-code

--- a/tests/e2e/patched/test_unsloth_qlora.py
+++ b/tests/e2e/patched/test_unsloth_qlora.py
@@ -2,8 +2,6 @@
 e2e tests for unsloth qlora
 """
 
-import os
-
 import pytest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/solo/test_flex.py
+++ b/tests/e2e/solo/test_flex.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_tensorboard, require_torch_2_6_0, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestPackedFlex(unittest.TestCase):

--- a/tests/e2e/solo/test_flex.py
+++ b/tests/e2e/solo/test_flex.py
@@ -2,7 +2,6 @@
 E2E tests for packed training w/ flex attention
 """
 
-import os
 import unittest
 
 from transformers.utils import is_torch_bf16_gpu_available

--- a/tests/e2e/solo/test_relora_llama.py
+++ b/tests/e2e/solo/test_relora_llama.py
@@ -2,7 +2,6 @@
 E2E tests for relora llama
 """
 
-import os
 import unittest
 from pathlib import Path
 

--- a/tests/e2e/solo/test_relora_llama.py
+++ b/tests/e2e/solo/test_relora_llama.py
@@ -11,12 +11,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from ..utils import check_model_output_exists, check_tensorboard, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestReLoraLlama(unittest.TestCase):

--- a/tests/e2e/test_deepseekv3.py
+++ b/tests/e2e/test_deepseekv3.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.hf_offline_utils import enable_hf_offline
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestDeepseekV3:

--- a/tests/e2e/test_deepseekv3.py
+++ b/tests/e2e/test_deepseekv3.py
@@ -2,7 +2,6 @@
 E2E tests for deepseekv3
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/test_dpo.py
+++ b/tests/e2e/test_dpo.py
@@ -13,12 +13,8 @@ from axolotl.common.datasets import load_preference_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestDPOLlamaLora(unittest.TestCase):

--- a/tests/e2e/test_dpo.py
+++ b/tests/e2e/test_dpo.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 from pathlib import Path
 

--- a/tests/e2e/test_embeddings_lr.py
+++ b/tests/e2e/test_embeddings_lr.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, check_tensorboard, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestEmbeddingsLrScale(unittest.TestCase):

--- a/tests/e2e/test_embeddings_lr.py
+++ b/tests/e2e/test_embeddings_lr.py
@@ -2,7 +2,6 @@
 E2E tests for llama pretrain
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_evaluate.py
+++ b/tests/e2e/test_evaluate.py
@@ -1,6 +1,5 @@
 """E2E smoke test for evaluate CLI command"""
 
-import os
 from pathlib import Path
 
 import yaml

--- a/tests/e2e/test_evaluate.py
+++ b/tests/e2e/test_evaluate.py
@@ -9,8 +9,6 @@ from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
 
-os.environ["WANDB_DISABLED"] = "true"
-
 
 class TestE2eEvaluate:
     """Test cases for evaluate CLI"""

--- a/tests/e2e/test_falcon.py
+++ b/tests/e2e/test_falcon.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestFalcon(unittest.TestCase):

--- a/tests/e2e/test_falcon.py
+++ b/tests/e2e/test_falcon.py
@@ -2,7 +2,6 @@
 E2E tests for falcon
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/test_gemma2.py
+++ b/tests/e2e/test_gemma2.py
@@ -12,10 +12,6 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestGemma2:

--- a/tests/e2e/test_gemma2.py
+++ b/tests/e2e/test_gemma2.py
@@ -2,7 +2,6 @@
 E2E tests for gemma2
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/test_gemma3_text.py
+++ b/tests/e2e/test_gemma3_text.py
@@ -2,7 +2,6 @@
 E2E tests for gemma3_text
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/test_gemma3_text.py
+++ b/tests/e2e/test_gemma3_text.py
@@ -12,10 +12,6 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestGemma3Text:

--- a/tests/e2e/test_llama.py
+++ b/tests/e2e/test_llama.py
@@ -9,12 +9,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.e2e.utils import check_model_output_exists
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestLlama:

--- a/tests/e2e/test_llama.py
+++ b/tests/e2e/test_llama.py
@@ -2,8 +2,6 @@
 E2E tests for llama
 """
 
-import os
-
 from axolotl.cli.args import TrainerCliArgs
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train

--- a/tests/e2e/test_llama_pretrain.py
+++ b/tests/e2e/test_llama_pretrain.py
@@ -11,12 +11,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, check_tensorboard
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestPretrainLlama:

--- a/tests/e2e/test_llama_pretrain.py
+++ b/tests/e2e/test_llama_pretrain.py
@@ -2,8 +2,6 @@
 E2E tests for llama pretrain
 """
 
-import os
-
 import pytest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_llama_vision.py
+++ b/tests/e2e/test_llama_vision.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestLlamaVision(unittest.TestCase):

--- a/tests/e2e/test_lora_llama.py
+++ b/tests/e2e/test_lora_llama.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_lora_llama.py
+++ b/tests/e2e/test_lora_llama.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestLoraLlama(unittest.TestCase):

--- a/tests/e2e/test_mamba.py
+++ b/tests/e2e/test_mamba.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 import pytest

--- a/tests/e2e/test_mamba.py
+++ b/tests/e2e/test_mamba.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 @pytest.mark.skip(reason="skipping until upstreamed into transformers")

--- a/tests/e2e/test_mistral.py
+++ b/tests/e2e/test_mistral.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from transformers.utils import is_torch_bf16_gpu_available

--- a/tests/e2e/test_mistral.py
+++ b/tests/e2e/test_mistral.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestMistral(unittest.TestCase):

--- a/tests/e2e/test_mixtral.py
+++ b/tests/e2e/test_mixtral.py
@@ -2,7 +2,6 @@
 E2E tests for mixtral
 """
 
-import os
 import unittest
 
 import torch

--- a/tests/e2e/test_mixtral.py
+++ b/tests/e2e/test_mixtral.py
@@ -13,12 +13,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestMixtral(unittest.TestCase):

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -2,7 +2,6 @@
 E2E tests for custom optimizers using Llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, require_torch_2_5_1, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestCustomOptimizers(unittest.TestCase):

--- a/tests/e2e/test_packing_loss.py
+++ b/tests/e2e/test_packing_loss.py
@@ -12,12 +12,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_tensorboard, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestPackedLlama(unittest.TestCase):

--- a/tests/e2e/test_packing_loss.py
+++ b/tests/e2e/test_packing_loss.py
@@ -2,7 +2,6 @@
 E2E tests for packed training
 """
 
-import os
 import unittest
 
 from transformers.utils import is_torch_bf16_gpu_available

--- a/tests/e2e/test_phi.py
+++ b/tests/e2e/test_phi.py
@@ -2,7 +2,6 @@
 E2E tests for lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_phi.py
+++ b/tests/e2e/test_phi.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestPhi(unittest.TestCase):

--- a/tests/e2e/test_process_reward_model_smollm2.py
+++ b/tests/e2e/test_process_reward_model_smollm2.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, check_tensorboard, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestProcessRewardSmolLM2(unittest.TestCase):

--- a/tests/e2e/test_process_reward_model_smollm2.py
+++ b/tests/e2e/test_process_reward_model_smollm2.py
@@ -2,7 +2,6 @@
 E2E tests for process reward model w/ lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_qwen.py
+++ b/tests/e2e/test_qwen.py
@@ -2,7 +2,6 @@
 E2E tests for qwen
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/e2e/test_qwen.py
+++ b/tests/e2e/test_qwen.py
@@ -11,10 +11,6 @@ from accelerate.test_utils import execute_subprocess_async
 from transformers.testing_utils import get_torch_dist_unique_port
 
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger("axolotl.tests.qwen")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestE2eQwen:

--- a/tests/e2e/test_reward_model_smollm2.py
+++ b/tests/e2e/test_reward_model_smollm2.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, check_tensorboard, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestRewardModelLoraSmolLM2(unittest.TestCase):

--- a/tests/e2e/test_reward_model_smollm2.py
+++ b/tests/e2e/test_reward_model_smollm2.py
@@ -2,7 +2,6 @@
 E2E tests for reward model lora llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -10,12 +10,8 @@ from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from .utils import check_model_output_exists, with_temp_dir
-
-LOG = get_logger("axolotl.tests.e2e")
-os.environ["WANDB_DISABLED"] = "true"
 
 
 class TestCustomSchedulers(unittest.TestCase):

--- a/tests/e2e/test_schedulers.py
+++ b/tests/e2e/test_schedulers.py
@@ -2,7 +2,6 @@
 E2E tests for custom schedulers using Llama
 """
 
-import os
 import unittest
 
 from axolotl.cli.args import TrainerCliArgs

--- a/tests/integrations/test_liger.py
+++ b/tests/integrations/test_liger.py
@@ -10,6 +10,7 @@ from axolotl.utils.config import prepare_plugins, validate_config
 from axolotl.utils.dict import DictDefault
 
 
+# pylint: disable=duplicate-code
 @pytest.fixture(name="minimal_liger_cfg")
 def fixture_cfg():
     return DictDefault(

--- a/tests/integrations/test_liger.py
+++ b/tests/integrations/test_liger.py
@@ -9,11 +9,6 @@ import pytest
 from axolotl.utils.config import prepare_plugins, validate_config
 from axolotl.utils.dict import DictDefault
 
-# pylint: disable=duplicate-code
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger("axolotl.integrations.test_liger")
-
 
 @pytest.fixture(name="minimal_liger_cfg")
 def fixture_cfg():

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -12,14 +12,11 @@ from axolotl.loaders.utils import check_model_config
 from axolotl.utils import is_comet_available
 from axolotl.utils.config import validate_config
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 from axolotl.utils.mlflow_ import setup_mlflow_env_vars
 from axolotl.utils.schemas.config import AxolotlConfigWCapabilities
 from axolotl.utils.wandb_ import setup_wandb_env_vars
 
 warnings.filterwarnings("error")
-
-LOG = get_logger(__name__)
 
 
 @pytest.fixture(name="minimal_cfg")
@@ -1507,7 +1504,6 @@ class TestValidationWandb(BaseValidation):
         assert os.environ.get("WANDB_MODE", "") == "online"
         assert os.environ.get("WANDB_WATCH", "") == "false"
         assert os.environ.get("WANDB_LOG_MODEL", "") == "checkpoint"
-        assert os.environ.get("WANDB_DISABLED", "") != "true"
 
         os.environ.pop("WANDB_PROJECT", None)
         os.environ.pop("WANDB_NAME", None)
@@ -1516,16 +1512,12 @@ class TestValidationWandb(BaseValidation):
         os.environ.pop("WANDB_MODE", None)
         os.environ.pop("WANDB_WATCH", None)
         os.environ.pop("WANDB_LOG_MODEL", None)
-        os.environ.pop("WANDB_DISABLED", None)
 
     def test_wandb_set_disabled(self, minimal_cfg):
         cfg = DictDefault({}) | minimal_cfg
-
         new_cfg = validate_config(cfg)
-
         setup_wandb_env_vars(new_cfg)
-
-        assert os.environ.get("WANDB_DISABLED", "") == "true"
+        assert new_cfg.use_wandb is None
 
         cfg = (
             DictDefault(
@@ -1537,13 +1529,10 @@ class TestValidationWandb(BaseValidation):
         )
 
         new_cfg = validate_config(cfg)
-
         setup_wandb_env_vars(new_cfg)
-
-        assert os.environ.get("WANDB_DISABLED", "") != "true"
+        assert new_cfg.use_wandb is True
 
         os.environ.pop("WANDB_PROJECT", None)
-        os.environ.pop("WANDB_DISABLED", None)
 
 
 @pytest.mark.skipif(is_comet_available() is False, reason="comet_ml is not installed")

--- a/tests/prompt_strategies/messages/test_chat.py
+++ b/tests/prompt_strategies/messages/test_chat.py
@@ -7,9 +7,6 @@ import unittest
 
 from axolotl.prompt_strategies.messages.chat import load
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger(__name__, log_level="DEBUG")
 
 
 class TestMessagesChatLlama3:

--- a/tests/prompt_strategies/messages/test_chat.py
+++ b/tests/prompt_strategies/messages/test_chat.py
@@ -7,6 +7,9 @@ import unittest
 
 from axolotl.prompt_strategies.messages.chat import load
 from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__, log_level="DEBUG")
 
 
 class TestMessagesChatLlama3:

--- a/tests/prompt_strategies/test_chat_templates.py
+++ b/tests/prompt_strategies/test_chat_templates.py
@@ -12,9 +12,6 @@ from axolotl.prompt_strategies.chat_template import (
 from axolotl.prompters import IGNORE_TOKEN_ID
 from axolotl.utils.chat_templates import get_chat_template
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger(__name__)
 
 
 class TestAssistantChatTemplateLlama3:

--- a/tests/prompt_strategies/test_chat_templates.py
+++ b/tests/prompt_strategies/test_chat_templates.py
@@ -12,6 +12,9 @@ from axolotl.prompt_strategies.chat_template import (
 from axolotl.prompters import IGNORE_TOKEN_ID
 from axolotl.utils.chat_templates import get_chat_template
 from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
 
 
 class TestAssistantChatTemplateLlama3:

--- a/tests/prompt_strategies/test_chat_templates_advanced.py
+++ b/tests/prompt_strategies/test_chat_templates_advanced.py
@@ -17,8 +17,11 @@ from axolotl.prompt_strategies.chat_template import (
 )
 from axolotl.prompters import IGNORE_TOKEN_ID
 from axolotl.utils.chat_templates import get_chat_template
+from axolotl.utils.logging import get_logger
 
 from tests.hf_offline_utils import enable_hf_offline
+
+LOG = get_logger(__name__)
 
 PARAMETRIZE_KEYS = "tokenizer, chat_template, chat_template_jinja, eos_token"
 PARAMETRIZE_PARAMS = [

--- a/tests/prompt_strategies/test_chat_templates_advanced.py
+++ b/tests/prompt_strategies/test_chat_templates_advanced.py
@@ -17,11 +17,8 @@ from axolotl.prompt_strategies.chat_template import (
 )
 from axolotl.prompters import IGNORE_TOKEN_ID
 from axolotl.utils.chat_templates import get_chat_template
-from axolotl.utils.logging import get_logger
 
 from tests.hf_offline_utils import enable_hf_offline
-
-LOG = get_logger(__name__)
 
 PARAMETRIZE_KEYS = "tokenizer, chat_template, chat_template_jinja, eos_token"
 PARAMETRIZE_PARAMS = [

--- a/tests/prompt_strategies/test_chat_templates_thinking.py
+++ b/tests/prompt_strategies/test_chat_templates_thinking.py
@@ -10,11 +10,8 @@ from axolotl.prompt_strategies.chat_template import (
     load,
 )
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.hf_offline_utils import enable_hf_offline
-
-LOG = get_logger(__name__)
 
 
 @pytest.fixture(name="messages_w_reasoning")

--- a/tests/prompt_strategies/test_jinja_template_analyzer.py
+++ b/tests/prompt_strategies/test_jinja_template_analyzer.py
@@ -5,6 +5,9 @@ tests for jinja_template_analyzer
 import pytest
 
 from axolotl.prompt_strategies.jinja_template_analyzer import JinjaTemplateAnalyzer
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__, log_level="DEBUG")
 
 
 class TestJinjaTemplateAnalyzer:

--- a/tests/prompt_strategies/test_jinja_template_analyzer.py
+++ b/tests/prompt_strategies/test_jinja_template_analyzer.py
@@ -5,9 +5,6 @@ tests for jinja_template_analyzer
 import pytest
 
 from axolotl.prompt_strategies.jinja_template_analyzer import JinjaTemplateAnalyzer
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger(__name__, log_level="DEBUG")
 
 
 class TestJinjaTemplateAnalyzer:

--- a/tests/test_prompt_tokenizers.py
+++ b/tests/test_prompt_tokenizers.py
@@ -16,11 +16,8 @@ from axolotl.prompt_strategies.orpo.chat_template import load
 from axolotl.prompt_tokenizers import AlpacaPromptTokenizingStrategy
 from axolotl.prompters import AlpacaPrompter, PromptStyle
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.logging import get_logger
 
 from tests.hf_offline_utils import enable_hf_offline
-
-LOG = get_logger(__name__)
 
 test_data = {
     "multi_turn_sys": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

From `transformers` (https://github.com/huggingface/transformers/blob/0f41c41a463ddd447e4248f4b5f9eb6728e8191d/src/transformers/integrations/integration_utils.py#L102):

```
Using the WANDB_DISABLED environment variable is deprecated and will be removed in v5. Use the --report_to flag to control the integrations used for logging result (for instance --report_to none).
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed explicit disabling of Weights & Biases (wandb) via environment variables across the application and test suite.
  - Simplified wandb integration logic to rely on configuration settings rather than environment variables.
  - Cleaned up unused logger imports and instances in tests.
- **Tests**
  - Updated tests to assert on configuration attributes instead of environment variables for wandb integration.
  - Removed redundant logging and environment variable setup from test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->