### PR TITLE
fix(deepspeed): deepspeed config not being set for z3

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -556,11 +556,18 @@ class ModelLoader:
         if self.cfg.low_cpu_mem_usage:
             self.model_kwargs["low_cpu_mem_usage"] = True
 
-    def _configure_zero3_memory_efficient_loading(self):
-        """Set the deepspeed config to load the model into RAM first before moving
-        to VRAM.
+    def _configure_zero3_memory_efficient_loading(
+        self,
+    ) -> HfTrainerDeepSpeedConfig | None:
+        """
+        Set the deepspeed config to load the model into RAM first before moving to VRAM.
 
-        We need to return `hf_ds_cfg` as it needs to exist before model loading.
+        IMPORTANT
+        ==========
+
+        We need to return `hf_ds_cfg` as it needs to exist before model loading for zero3.
+        HfTrainerDeepSpeedConfig is a class that is used to configure the DeepSpeed training.
+        It is not passed anywhere the model loading function, just need to exist.
         """
         hf_ds_cfg = None
 
@@ -625,7 +632,8 @@ class ModelLoader:
                 if "device_map" in self.model_kwargs:
                     del self.model_kwargs["device_map"]
 
-            self._configure_zero3_memory_efficient_loading()
+            # Please don't remove underscore binding without reading the fn docstring.
+            _ = self._configure_zero3_memory_efficient_loading()
 
             # Load model with random initialization if specified
             if self.cfg.random_init_weights:
@@ -695,7 +703,8 @@ class ModelLoader:
                     if "device_map" in self.model_kwargs:
                         del self.model_kwargs["device_map"]
 
-                self._configure_zero3_memory_efficient_loading()
+                # Please don't remove underscore binding without reading the fn docstring.
+                _ = self._configure_zero3_memory_efficient_loading()
 
                 self.model = self.auto_model_loader.from_pretrained(
                     self.base_model,

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -567,7 +567,7 @@ class ModelLoader:
 
         We need to return `hf_ds_cfg` as it needs to exist before model loading for zero3.
         HfTrainerDeepSpeedConfig is a class that is used to configure the DeepSpeed training.
-        It is not passed anywhere the model loading function, just need to exist.
+        It is not passed anywhere in the model loading function, just need to exist.
         """
         hf_ds_cfg = None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Loss may be 0 and grad norm nan for deepspeed zero3 with llama3/gemma3.

Thanks for `Keaton` for report and helping run repro between commits to verify the issue.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Loss appear properly and no dtype deepspeed z3 optimizer error.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved documentation for memory-efficient model loading with DeepSpeed Zero Stage 3, providing clearer guidance and warnings for users.

- **Refactor**
  - Enhanced method signatures and internal handling to clarify behavior and ensure correct configuration during model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->