### PR TITLE
remove unused field for chat_template.default for DPO training

### DIFF
--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -91,4 +91,4 @@ def default(
 
         return result
 
-    return transform_fn, {"remove_columns":[field_messages]}
+    return transform_fn, {"remove_columns": [field_messages]}

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -91,4 +91,4 @@ def default(
 
         return result
 
-    return transform_fn
+    return transform_fn, {"remove_columns":[field_messages]}

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -91,4 +91,4 @@ def default(
 
         return result
 
-    return transform_fn, {"remove_columns": [field_messages]}
+    return transform_fn, {"remove_columns":[field_messages]}

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -103,7 +103,7 @@ class TestAssistantDPOChatTemplateLlama3:
 
     def test_llama3_defaults(self, llama3_tokenizer, assistant_dataset):
         # pylint: disable=duplicate-code
-        transform_fn = default(
+        transform_fn, _ = default(
             DictDefault(
                 {
                     "chat_template": "llama3",
@@ -128,7 +128,7 @@ class TestAssistantDPOChatTemplateLlama3:
 
     def test_llama3_configured(self, llama3_tokenizer, custom_assistant_dataset):
         # pylint: disable=duplicate-code
-        transform_fn = default(
+        transform_fn, _ = default(
             DictDefault(
                 {
                     "chat_template": "llama3",
@@ -169,7 +169,7 @@ class TestAssistantDPOChatTemplatePhi3:
 
     def test_phi3_defaults(self, phi3_tokenizer, assistant_dataset):
         # pylint: disable=duplicate-code
-        transform_fn = default(
+        transform_fn, _ = default(
             DictDefault(
                 {
                     "chat_template": "tokenizer_default",
@@ -199,7 +199,7 @@ class TestAssistantDPOChatTemplateGemma:
 
     def test_gemma_defaults(self, gemma_tokenizer, assistant_dataset):
         # pylint: disable=duplicate-code
-        transform_fn = default(
+        transform_fn, _ = default(
             DictDefault(
                 {
                     "chat_template": "tokenizer_default",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -289,7 +289,10 @@ class TestDatasetPreparation:
         train_dataset, _ = load_prepare_preference_datasets(cfg)
 
         assert len(train_dataset) == 1800
-        assert "conversation" in train_dataset.features
+        assert "conversation" not in train_dataset.features
+        assert "chosen" in train_dataset.features
+        assert "rejected" in train_dataset.features
+        assert "prompt" in train_dataset.features
 
     @pytest.mark.skip(reason="TODO: fix hf hub offline to work with HF rate limits")
     @enable_hf_offline
@@ -348,7 +351,10 @@ class TestDatasetPreparation:
             train_dataset, _ = load_prepare_preference_datasets(cfg)
 
             assert len(train_dataset) == 1800
-            assert "conversation" in train_dataset.features
+            assert "conversation" not in train_dataset.features
+            assert "chosen" in train_dataset.features
+            assert "rejected" in train_dataset.features
+            assert "prompt" in train_dataset.features
 
     @enable_hf_offline
     @pytest.mark.skip("datasets bug with local datasets when offline")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

DPO trainer expects only prompt+chosen+rejected columns present in the final dataset. However, the `chat_template.default` implementation passes an extra column `messages` which causes validations to fail.

## Motivation and Context

Fixes issue #2415 

## How has this been tested?

Tested using sample config:

```yaml
rl: dpo

datasets:
  - path: "..../dataset.jsonl"
    chat_template: tokenizer_default
    type: chat_template.default
    field_messages: "messages"
    field_chosen: "chosen"
    field_rejected: "rejected"
    message_property_mappings:
      role: role
      content: content
    roles:
      user: [ "user" ]
      assistant: [ "assistant" ]
      system: [ "system" ]
```

then by running `axolotl preprocess` and `axolotl train` commands.

Without the fix, it fails with the following errors:

```
KeyError: "Invalid keys in the example: {'messages', 'prompt', 'rejected', 'chosen'}"
```

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The system now provides additional metadata indicating which columns should be removed during processing.
- **Bug Fixes**
  - Updated dataset tests to reflect correct feature presence and absence, improving data validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->