### PR TITLE
Support --lora-on-cpu flag for DPO model merging

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -712,6 +712,10 @@ class ModelLoader:
                 # Please don't remove underscore binding without reading the fn docstring.
                 _ = self._configure_zero3_memory_efficient_loading()
 
+                if self.cfg.lora_on_cpu:
+                    self.model_kwargs["max_memory"] = {"cpu": "256GiB"}
+                    self.model_kwargs["device_map"] = {"": "cpu"}
+
                 self.model = self.auto_model_loader.from_pretrained(
                     self.base_model,
                     config=self.model_config,


### PR DESCRIPTION
The `lora_on_cpu` flag allows you to e.g. merge a LoRA and a model even when there isn't enough GPU VRAM by handling the LoRA part exclusively on CPU. This patch enables this for DPO based merging as well.

# Description

Check for the presence of the `lora_on_cpu` option in the DPO loader code, and use when set.

## Motivation and Context

Without this, you either need to have enough VRAM to fit everything, or not use the GPU at all for the merge process. This allows you to use the available VRAM while still spilling over into CPU RAM.

## How has this been tested?

I've used it to perform merges of DPO training runs using `axolotl merge-lora` and tested the resulting models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Added an option to load the model entirely on CPU when a specific configuration flag is set, allowing for large memory allocation on CPU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(note: the above summary is wrong -- we could always load the model entirely on CPU simply by doing `CUDA_VISIBLE_DEVICES= axolotl merge-lora [...]`)