### PR TITLE
Fix: lora kernel pre-patch applied despite post-patch not applied

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -166,6 +166,17 @@ class PatchManager:
     def _apply_self_attention_lora_patch(self):
         """Apply self-attention LoRA patches if configured."""
         if self.cfg.lora_qkv_kernel or self.cfg.lora_o_kernel:
+            # Only patch if conditions are met
+            can_patch = (
+                self.cfg.lora_dropout == 0
+                if hasattr(self.cfg, "lora_dropout")
+                else True
+            )  # default to True if lora_dropout is not set
+
+            if not can_patch:
+                LOG.warning("Cannot patch self-attention - requires no dropout")
+                return
+
             from axolotl.monkeypatch.lora_kernels import patch_self_attn_lora
 
             patch_self_attn_lora(self.cfg)

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -178,15 +178,6 @@ def patch_self_attn_lora(cfg: DictDefault):
         AssertionError: If the required code blocks are not found in the attention
             implementation.
     """
-    # Only patch if conditions are met
-    can_patch = (
-        cfg.lora_dropout == 0 if hasattr(cfg, "lora_dropout") else True
-    )  # default to True if lora_dropout is not set
-
-    if not can_patch:
-        LOG.warning("Cannot patch self-attention - requires no dropout")
-        return
-
     attention_cls = get_attention_cls_from_config(cfg)
 
     # Check if already patched

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -179,7 +179,9 @@ def patch_self_attn_lora(cfg: DictDefault):
             implementation.
     """
     # Only patch if conditions are met
-    can_patch = cfg.lora_dropout == 0
+    can_patch = (
+        cfg.lora_dropout == 0 if hasattr(cfg, "lora_dropout") else True
+    )  # default to True if lora_dropout is not set
 
     if not can_patch:
         LOG.warning("Cannot patch self-attention - requires no dropout")

--- a/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
+++ b/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
@@ -546,7 +546,7 @@ def test_kernel_training_integration_dropout_non_zero():
     assert attention_cls.forward == original_forward_method
 
     # Load model
-    model, _ = load_model_and_tokenizer(cfg=cfg)
+    model, _, _ = load_model_and_tokenizer(cfg=cfg)
 
     # Apply apply_lora_kernel_patches
     apply_lora_kernel_patches(model, cfg)

--- a/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
+++ b/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
@@ -539,17 +539,23 @@ def test_kernel_training_integration_dropout_non_zero():
     # Store original state before patching
     original_forward_method = attention_cls.forward
 
+    # Load model
+    model, tokenizer, _ = load_model_and_tokenizer(cfg=cfg)
+
+    # We call modelloader as that's where the patches are applied
+    # despite the fact that we're not using it to load the model
+    model_loader = ModelLoader(cfg, tokenizer)
+
     # Apply patch
-    patch_self_attn_lora(cfg=cfg)
+    model_loader.patch_manager._apply_self_attention_lora_patch()  # pylint: disable=protected-access
 
     # Verify patch was not applied
     assert attention_cls.forward == original_forward_method
 
-    # Load model
-    model, _, _ = load_model_and_tokenizer(cfg=cfg)
-
     # Apply apply_lora_kernel_patches
-    apply_lora_kernel_patches(model, cfg)
+    model_loader.patch_manager._apply_lora_kernel_patch(  # pylint: disable=protected-access
+        model
+    )
 
     # Verify patch was not applied
     layers = get_layers(model)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Fix #2770 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Added test and manual run before/after to ensure error appears and got fixed

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of LoRA dropout by ensuring kernel patching is skipped when dropout is non-zero, with a warning logged for clarity.

- **Tests**
	- Added a new test to verify that self-attention kernel patching does not occur when LoRA dropout is set above zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->