### PR TITLE
Fix logging import in evaluate.py (#2782)

### DIFF
--- a/src/axolotl/evaluate.py
+++ b/src/axolotl/evaluate.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import torch
-from accelerate.logging import get_logger
 from datasets import Dataset
 from transformers.trainer import Trainer
 
@@ -18,6 +17,7 @@ from axolotl.train import (
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.distributed import cleanup_distributed
 from axolotl.utils.trainer import setup_trainer
+from axolotl.utils.logging import get_logger
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_dir = os.path.join(project_root, "src")

--- a/src/axolotl/evaluate.py
+++ b/src/axolotl/evaluate.py
@@ -16,8 +16,8 @@ from axolotl.train import (
 )
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.distributed import cleanup_distributed
-from axolotl.utils.trainer import setup_trainer
 from axolotl.utils.logging import get_logger
+from axolotl.utils.trainer import setup_trainer
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_dir = os.path.join(project_root, "src")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Changed the import in `src/axolotl/evaluate.py` to be identical to `src/axolotl/train.py`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[Issue 2782](https://github.com/axolotl-ai-cloud/axolotl/issues/2782)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran `axolotl evaluate config.yml`, and verified that the logs are now outputted.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal logging utility source. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->