### PR TITLE
fixed the lora_target_modules syntax inside examples/qwen2-vl/lora-7b.yaml

### DIFF
--- a/examples/qwen2-vl/lora-7b.yaml
+++ b/examples/qwen2-vl/lora-7b.yaml
@@ -25,7 +25,7 @@ pad_to_sequence_len: false
 lora_r: 32
 lora_alpha: 16
 lora_dropout: 0.05
-lora_target_modules: 'model.layers.[\d]+.(mlp|cross_attn|self_attn).(up|down|gate|q|k|v|o)_proj'
+lora_target_modules: 'model.language_model.layers.[\d]+.(mlp|cross_attn|self_attn).(up|down|gate|q|k|v|o)_proj'
 
 wandb_project:
 wandb_entity:


### PR DESCRIPTION


# Description

Single edit to a single line, so that you can successfully run with this config file. 

Specifically, the lora_target_modules line missed out ".language_model", leading to errors. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Tested using base axolotl fine tuning setup. No more `[rank0]: ValueError: Target modules model.layers.[\d]+.(mlp|cross_attn|self_attn).(up|down|gate|q|k|v|o)_proj not found in the base model. Please check the target modules and try again.`

## Social Handles (Optional)

x.com/cummins_tweets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to adjust which model components are targeted during training or fine-tuning. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->