### PR TITLE
[Draft] Token-weighted datasets: Control up/down-sampling of multiple datasets

### DIFF
--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -243,7 +243,7 @@ def _load_split(cfg: DictDefault, split: Literal["train", "test"]) -> Dataset:
                 LOG.warning(f"Dropped {dropped} long samples from dataset index {i}")
 
     # Merge datasets
-    dataset = merge_datasets(split_datasets, cfg)
+    dataset = merge_datasets(split_datasets, cfg, datasets_configs)
 
     if not cfg.skip_prepare_dataset:
         # Save preprocessed dataset

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -331,7 +331,7 @@ def _load_raw_datasets(
         prompters.append(dataset_prompter)
 
     # Merge datasets
-    dataset = merge_datasets(datasets, cfg)
+    dataset = merge_datasets(datasets, cfg, datasets_configs)
 
     if not cfg.skip_prepare_dataset:
         dataset = drop_long_seq_in_dataset(dataset, cfg)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -597,8 +597,15 @@ def _merge_datasets_with_token_weighting(
         tok_cnt = original_token_counts[i]
         target_tok = max(1, int(weight * total_original_tokens))
         
+        if target_tok > tok_cnt:
+            effective_operation = "upsampling"
+        elif target_tok < tok_cnt:
+            effective_operation = "downsampling"
+        else:
+            effective_operation = "unchanged"
+        
         LOG.info(f"Dataset '{dataset_name}': {tok_cnt:,} → {target_tok:,} tokens "
-                f"(weight={weight:.3f}, strategy={strategy})")
+                f"(weight={weight:.3f}, {effective_operation})")
 
         if strategy == "upsample":
             if target_tok <= tok_cnt:

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -630,6 +630,14 @@ def _merge_datasets_with_token_weighting(
             )
             weighted_parts.append(ds)
 
+    LOG.info("Weighted dataset parts before concatenation:")
+    total_weighted_tokens = 0
+    for i, part in enumerate(weighted_parts):
+        part_tokens = _count_tokens(part)
+        total_weighted_tokens += part_tokens
+        LOG.info(f"  Part {i+1}: {part_tokens:,} tokens ({len(part):,} samples)")
+    LOG.info(f"Total tokens in weighted parts: {total_weighted_tokens:,}")
+
     merged = concatenate_datasets(weighted_parts)
     
     final_tokens = _count_tokens(merged)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -651,6 +651,16 @@ def _merge_datasets_with_token_weighting(
     LOG.info(f"Final merged dataset: {final_tokens:,} tokens ({len(merged):,} samples)")
     LOG.info(f"Token count change: {total_original_tokens:,} → {final_tokens:,} "
             f"({final_tokens/total_original_tokens:.2f}x)")
+    
+    LOG.info("Final weight verification:")
+    for i, (ds, d_cfg) in enumerate(zip(datasets, datasets_configs)):
+        dataset_name = getattr(d_cfg, "path", f"dataset_{i}")
+        original_weight = float(getattr(d_cfg, "weight", 1.0) or 1.0)
+        target_tokens = max(1, int(original_weight * total_original_tokens))
+        actual_weight = target_tokens / final_tokens if final_tokens > 0 else 0
+        
+        LOG.info(f"  {dataset_name}: requested={original_weight:.3f}, "
+                f"achieved≈{actual_weight:.3f} ({target_tokens:,}/{final_tokens:,} tokens)")
 
     if cfg.shuffle_merged_datasets:
         merged = merged.shuffle(seed=cfg.seed)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -541,7 +541,7 @@ def _validate_weights(datasets_configs) -> None:
     weights = []
     for d_cfg in datasets_configs:
         weight = getattr(d_cfg, "weight", 1.0)
-        if not (0.0 <= weight <= 1.0):
+        if not 0.0 <= weight <= 1.0:
             raise ValueError(
                 f"Dataset weight must be between 0.0 and 1.0, got {weight} "
                 f"for dataset {getattr(d_cfg, 'path', '<unknown>')}"

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -513,18 +513,140 @@ def generate_dataset_hash_from_config(
     return str(md5(config_str))
 
 
-def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
-    """Merge multiple datasets into one with optional shuffling.
+def _count_tokens(ds: Dataset, sample_size: int = 2048) -> int:
+    """
+    Return the *exact* number of tokens if the dataset is small enough,
+    otherwise estimate it from a random sample (saves RAM for huge corpora).
+    """
+    if len(ds) <= sample_size:
+        return sum(len(ids) for ids in ds["input_ids"])
+
+    sample = ds.shuffle(seed=42).select(range(sample_size))
+    avg_len = sum(len(ids) for ids in sample["input_ids"]) / sample_size
+    return int(avg_len * len(ds))
+
+
+def _has_token_weighting(datasets_configs) -> bool:
+    """Check if any dataset has non-default weight or weight_strategy."""
+    for d_cfg in datasets_configs:
+        weight = getattr(d_cfg, "weight", 1.0)
+        strategy = getattr(d_cfg, "weight_strategy", "upsample")
+        if weight != 1.0 or strategy != "upsample":
+            return True
+    return False
+
+
+def _validate_weights(datasets_configs) -> None:
+    """Validate that weights are between 0.0-1.0 and sum to 1.0."""
+    weights = []
+    for d_cfg in datasets_configs:
+        weight = getattr(d_cfg, "weight", 1.0)
+        if not (0.0 <= weight <= 1.0):
+            raise ValueError(
+                f"Dataset weight must be between 0.0 and 1.0, got {weight} "
+                f"for dataset {getattr(d_cfg, 'path', '<unknown>')}"
+            )
+        weights.append(weight)
+    
+    weight_sum = sum(weights)
+    if abs(weight_sum - 1.0) > 1e-6:  # Allow for small floating point errors
+        raise ValueError(
+            f"Dataset weights must sum to 1.0, got {weight_sum}. "
+            f"Weights: {weights}"
+        )
+
+
+def _merge_datasets_with_token_weighting(
+    datasets: list[Dataset],
+    datasets_configs: list,
+    cfg: DictDefault,
+) -> Dataset:
+    """
+    Merge several HF datasets into one, honouring per-dataset weights *in tokens*.
+    """
+    from math import floor
+    
+    LOG.info("Merging datasets with token-based weighting...")
+    
+    _validate_weights(datasets_configs)
+
+    weighted_parts: list[Dataset] = []
+
+    for ds, d_cfg in zip(datasets, datasets_configs):
+        weight = float(getattr(d_cfg, "weight", 1.0) or 1.0)
+        strategy = getattr(d_cfg, "weight_strategy", "upsample").lower()
+
+        if weight == 1.0 and len(datasets) == 1:
+            weighted_parts.append(ds)
+            continue
+
+        tok_cnt = _count_tokens(ds)
+        target_tok = max(1, int(tok_cnt * weight))
+
+        if strategy == "upsample":
+            repeats = max(1, floor(target_tok / tok_cnt))
+            weighted_parts.extend([ds] * repeats)
+
+            remaining_tok = target_tok - repeats * tok_cnt
+            if remaining_tok:
+                avg_len = max(1, tok_cnt // len(ds))
+                n_extra = min(len(ds), int(remaining_tok / avg_len) + 1)
+
+                extra = ds.shuffle(seed=cfg.seed).select(range(n_extra))
+                weighted_parts.append(extra)
+
+        elif strategy == "downsample":
+            if weight >= 1:
+                LOG.warning(
+                    f"Ignoring downsample weight ≥1 for dataset "
+                    f"{getattr(d_cfg, 'path', '<unknown>')}."
+                )
+                weighted_parts.append(ds)
+                continue
+
+            target_tok = max(1, int(tok_cnt * weight))
+            avg_len = max(1, tok_cnt // len(ds))
+            n_keep = max(1, int(target_tok / avg_len))
+
+            sampled = ds.shuffle(seed=cfg.seed).select(range(n_keep))
+            weighted_parts.append(sampled)
+        else:
+            LOG.warning(
+                f"Unknown weight_strategy '{strategy}' "
+                f"for dataset {getattr(d_cfg, 'path', '<unknown>')}. "
+                "Using dataset without weighting."
+            )
+            weighted_parts.append(ds)
+
+    merged = concatenate_datasets(weighted_parts)
+
+    if cfg.shuffle_merged_datasets:
+        merged = merged.shuffle(seed=cfg.seed)
+
+    return merged
+
+
+def merge_datasets(
+    datasets: list[Dataset], 
+    cfg: DictDefault, 
+    datasets_configs: list | None = None
+) -> Dataset:
+    """Merge multiple datasets into one with optional token-based weighting.
 
     Args:
         datasets: List of datasets to merge.
         cfg: Configuration object containing shuffle settings.
+        datasets_configs: Optional list of dataset configurations for token weighting.
 
     Returns:
         Merged dataset.
     """
     if len(datasets) == 1:
         return datasets[0]
+
+    # Check if token weighting should be used
+    if datasets_configs and _has_token_weighting(datasets_configs):
+        return _merge_datasets_with_token_weighting(datasets, datasets_configs, cfg)
 
     LOG.info("Merging datasets...")
     merged_dataset = concatenate_datasets(datasets)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -547,12 +547,11 @@ def _validate_weights(datasets_configs) -> None:
                 f"for dataset {getattr(d_cfg, 'path', '<unknown>')}"
             )
         weights.append(weight)
-    
+
     weight_sum = sum(weights)
     if abs(weight_sum - 1.0) > 1e-6:  # Allow for small floating point errors
         raise ValueError(
-            f"Dataset weights must sum to 1.0, got {weight_sum}. "
-            f"Weights: {weights}"
+            f"Dataset weights must sum to 1.0, got {weight_sum}. " f"Weights: {weights}"
         )
 
 
@@ -565,9 +564,9 @@ def _merge_datasets_with_token_weighting(
     Merge several HF datasets into one, honouring per-dataset weights *in tokens*.
     """
     from math import floor
-    
+
     LOG.info("Merging datasets with token-based weighting...")
-    
+
     _validate_weights(datasets_configs)
 
     weighted_parts: list[Dataset] = []
@@ -627,9 +626,7 @@ def _merge_datasets_with_token_weighting(
 
 
 def merge_datasets(
-    datasets: list[Dataset], 
-    cfg: DictDefault, 
-    datasets_configs: list | None = None
+    datasets: list[Dataset], cfg: DictDefault, datasets_configs: list | None = None
 ) -> Dataset:
     """Merge multiple datasets into one with optional token-based weighting.
 

--- a/src/axolotl/utils/schemas/datasets.py
+++ b/src/axolotl/utils/schemas/datasets.py
@@ -60,6 +60,8 @@ class SFTDataset(BaseModel):
     drop_system_message: bool | None = None
     trust_remote_code: bool | None = False
     revision: str | None = None
+    weight: float | None = 1.0
+    weight_strategy: str | None = "upsample"
 
     @model_validator(mode="before")
     @classmethod
@@ -127,6 +129,8 @@ class DPODataset(BaseModel):
     data_files: list[str] | None = None
     revision: str | None = None
     field_messages: str | None = None
+    weight: float | None = 1.0
+    weight_strategy: str | None = "upsample"
 
 
 class StepwiseSupervisedDataset(BaseModel):
@@ -139,6 +143,8 @@ class StepwiseSupervisedDataset(BaseModel):
     step_separator: str | None = None
     max_completion_length: int | None = None
     train_on_last_step_only: bool | None = None
+    weight: float | None = 1.0
+    weight_strategy: str | None = "upsample"
 
 
 class UserDefinedKTOType(BaseModel):
@@ -161,6 +167,8 @@ class KTODataset(BaseModel):
     data_files: list[str] | None = None
     trust_remote_code: bool | None = False
     revision: str | None = None
+    weight: float | None = 1.0
+    weight_strategy: str | None = "upsample"
 
 
 DatasetConfig = SFTDataset | DPODataset | KTODataset | StepwiseSupervisedDataset

--- a/tests/test_token_weighting.py
+++ b/tests/test_token_weighting.py
@@ -1,0 +1,213 @@
+"""Test token weighting functionality for dataset merging."""
+
+import pytest
+from datasets import Dataset
+from axolotl.utils.data.shared import merge_datasets, _validate_weights, _has_token_weighting
+from axolotl.utils.dict import DictDefault
+
+
+def create_sample_datasets():
+    """Create sample datasets with input_ids for testing."""
+    ds1 = Dataset.from_list([
+        {"input_ids": [1, 2, 3, 4, 5]},  # 5 tokens
+        {"input_ids": [6, 7, 8]},        # 3 tokens
+    ])  # Total: 8 tokens
+    
+    ds2 = Dataset.from_list([
+        {"input_ids": [9, 10, 11, 12]},  # 4 tokens
+        {"input_ids": [13, 14]},         # 2 tokens
+    ])  # Total: 6 tokens
+    
+    return [ds1, ds2]
+
+
+def create_cfg():
+    """Basic configuration for testing."""
+    return DictDefault({
+        "seed": 42,
+        "shuffle_merged_datasets": True
+    })
+
+
+class TestTokenWeighting:
+    """Test token weighting functionality."""
+
+    def test_backward_compatibility_no_weights(self):
+        """Test that merge_datasets works without weights (backward compatibility)."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        result = merge_datasets(sample_datasets, cfg)
+        assert len(result) == 4  # 2 + 2 samples
+        assert "input_ids" in result.features
+
+    def test_backward_compatibility_default_weights(self):
+        """Test that default weights (1.0) don't trigger token weighting."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 1.0, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 1.0, "weight_strategy": "upsample"})
+        ]
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) == 4  # Should be same as no weighting
+
+    def test_token_weighting_validation_sum_to_one(self):
+        """Test that weights must sum to 1.0."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.7, "path": "dataset1"}),
+            DictDefault({"weight": 0.4, "path": "dataset2"})  # Sum = 1.1
+        ]
+        
+        with pytest.raises(ValueError, match="Dataset weights must sum to 1.0"):
+            merge_datasets(sample_datasets, cfg, datasets_configs)
+
+    def test_token_weighting_validation_range(self):
+        """Test that weights must be between 0.0 and 1.0."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 1.5, "path": "dataset1"}),  # Invalid
+            DictDefault({"weight": 0.5, "path": "dataset2"})
+        ]
+        
+        with pytest.raises(ValueError, match="Dataset weight must be between 0.0 and 1.0"):
+            merge_datasets(sample_datasets, cfg, datasets_configs)
+
+    def test_token_weighting_equal_weights(self):
+        """Test token weighting with equal weights."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.5, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 0.5, "weight_strategy": "upsample"})
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_token_weighting_unequal_weights(self):
+        """Test token weighting with unequal weights."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.8, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 0.2, "weight_strategy": "upsample"})
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_downsample_strategy(self):
+        """Test downsample strategy."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.3, "weight_strategy": "downsample"}),
+            DictDefault({"weight": 0.7, "weight_strategy": "upsample"})
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_single_dataset_with_weights(self):
+        """Test that single dataset bypasses weighting logic."""
+        cfg = create_cfg()
+        single_dataset = [Dataset.from_list([{"input_ids": [1, 2, 3]}])]
+        datasets_configs = [DictDefault({"weight": 0.5})]
+        
+        result = merge_datasets(single_dataset, cfg, datasets_configs)
+        assert len(result) == 1
+
+    def test_has_token_weighting_detection(self):
+        """Test _has_token_weighting helper function."""
+        configs1 = [DictDefault({"weight": 1.0, "weight_strategy": "upsample"})]
+        assert not _has_token_weighting(configs1)
+        
+        configs2 = [DictDefault({"weight": 0.5, "weight_strategy": "upsample"})]
+        assert _has_token_weighting(configs2)
+        
+        configs3 = [DictDefault({"weight": 1.0, "weight_strategy": "downsample"})]
+        assert _has_token_weighting(configs3)
+
+    def test_validate_weights_helper(self):
+        """Test _validate_weights helper function."""
+        configs1 = [
+            DictDefault({"weight": 0.3}),
+            DictDefault({"weight": 0.7})
+        ]
+        _validate_weights(configs1)  # Should not raise
+        
+        configs2 = [
+            DictDefault({"weight": 0.3}),
+            DictDefault({"weight": 0.8})
+        ]
+        with pytest.raises(ValueError):
+            _validate_weights(configs2)
+
+    def test_zero_weight_validation(self):
+        """Test that zero weights are allowed."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.0, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 1.0, "weight_strategy": "upsample"})
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_unknown_weight_strategy(self):
+        """Test handling of unknown weight strategy."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.5, "weight_strategy": "unknown_strategy", "path": "dataset1"}),
+            DictDefault({"weight": 0.5, "weight_strategy": "upsample", "path": "dataset2"})
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_downsample_with_weight_greater_than_one(self):
+        """Test downsample strategy with weight >= 1 (should be ignored)."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 1.2, "weight_strategy": "downsample", "path": "dataset1"}),
+            DictDefault({"weight": -0.2, "weight_strategy": "upsample", "path": "dataset2"})  # This will cause validation error
+        ]
+        
+        with pytest.raises(ValueError, match="Dataset weight must be between 0.0 and 1.0"):
+            merge_datasets(sample_datasets, cfg, datasets_configs)
+
+    def test_floating_point_precision_weights(self):
+        """Test that small floating point errors in weight sum are tolerated."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.1, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 0.9000000000000001, "weight_strategy": "upsample"})  # Sum slightly > 1.0
+        ]
+        
+        result = merge_datasets(sample_datasets, cfg, datasets_configs)
+        assert len(result) > 0
+        assert "input_ids" in result.features
+
+    def test_large_floating_point_error_weights(self):
+        """Test that large floating point errors in weight sum are caught."""
+        sample_datasets = create_sample_datasets()
+        cfg = create_cfg()
+        datasets_configs = [
+            DictDefault({"weight": 0.1, "weight_strategy": "upsample"}),
+            DictDefault({"weight": 0.95, "weight_strategy": "upsample"})  # Sum = 1.05, too large
+        ]
+        
+        with pytest.raises(ValueError, match="Dataset weights must sum to 1.0"):
+            merge_datasets(sample_datasets, cfg, datasets_configs)

--- a/tests/test_token_weighting.py
+++ b/tests/test_token_weighting.py
@@ -2,31 +2,36 @@
 
 import pytest
 from datasets import Dataset
-from axolotl.utils.data.shared import merge_datasets, _validate_weights, _has_token_weighting
+from axolotl.utils.data.shared import (
+    _has_token_weighting,
+    _validate_weights,
+    merge_datasets,
+)
 from axolotl.utils.dict import DictDefault
 
 
 def create_sample_datasets():
     """Create sample datasets with input_ids for testing."""
-    ds1 = Dataset.from_list([
-        {"input_ids": [1, 2, 3, 4, 5]},  # 5 tokens
-        {"input_ids": [6, 7, 8]},        # 3 tokens
-    ])  # Total: 8 tokens
-    
-    ds2 = Dataset.from_list([
-        {"input_ids": [9, 10, 11, 12]},  # 4 tokens
-        {"input_ids": [13, 14]},         # 2 tokens
-    ])  # Total: 6 tokens
+    ds1 = Dataset.from_list(
+        [
+            {"input_ids": [1, 2, 3, 4, 5]},  # 5 tokens
+            {"input_ids": [6, 7, 8]},  # 3 tokens
+        ]
+    )  # Total: 8 tokens
+
+    ds2 = Dataset.from_list(
+        [
+            {"input_ids": [9, 10, 11, 12]},  # 4 tokens
+            {"input_ids": [13, 14]},  # 2 tokens
+        ]
+    )  # Total: 6 tokens
     
     return [ds1, ds2]
 
 
 def create_cfg():
     """Basic configuration for testing."""
-    return DictDefault({
-        "seed": 42,
-        "shuffle_merged_datasets": True
-    })
+    return DictDefault({"seed": 42, "shuffle_merged_datasets": True})
 
 
 class TestTokenWeighting:

--- a/tests/test_token_weighting.py
+++ b/tests/test_token_weighting.py
@@ -46,7 +46,7 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 1.0, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 1.0, "weight_strategy": "upsample"})
+            DictDefault({"weight": 1.0, "weight_strategy": "upsample"}),
         ]
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) == 4  # Should be same as no weighting
@@ -57,9 +57,9 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.7, "path": "dataset1"}),
-            DictDefault({"weight": 0.4, "path": "dataset2"})  # Sum = 1.1
+            DictDefault({"weight": 0.4, "path": "dataset2"}),  # Sum = 1.1
         ]
-        
+
         with pytest.raises(ValueError, match="Dataset weights must sum to 1.0"):
             merge_datasets(sample_datasets, cfg, datasets_configs)
 
@@ -69,10 +69,12 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 1.5, "path": "dataset1"}),  # Invalid
-            DictDefault({"weight": 0.5, "path": "dataset2"})
+            DictDefault({"weight": 0.5, "path": "dataset2"}),
         ]
-        
-        with pytest.raises(ValueError, match="Dataset weight must be between 0.0 and 1.0"):
+
+        with pytest.raises(
+            ValueError, match="Dataset weight must be between 0.0 and 1.0"
+        ):
             merge_datasets(sample_datasets, cfg, datasets_configs)
 
     def test_token_weighting_equal_weights(self):
@@ -81,9 +83,9 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.5, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 0.5, "weight_strategy": "upsample"})
+            DictDefault({"weight": 0.5, "weight_strategy": "upsample"}),
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -94,9 +96,9 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.8, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 0.2, "weight_strategy": "upsample"})
+            DictDefault({"weight": 0.2, "weight_strategy": "upsample"}),
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -107,9 +109,9 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.3, "weight_strategy": "downsample"}),
-            DictDefault({"weight": 0.7, "weight_strategy": "upsample"})
+            DictDefault({"weight": 0.7, "weight_strategy": "upsample"}),
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -119,7 +121,7 @@ class TestTokenWeighting:
         cfg = create_cfg()
         single_dataset = [Dataset.from_list([{"input_ids": [1, 2, 3]}])]
         datasets_configs = [DictDefault({"weight": 0.5})]
-        
+
         result = merge_datasets(single_dataset, cfg, datasets_configs)
         assert len(result) == 1
 
@@ -127,10 +129,10 @@ class TestTokenWeighting:
         """Test _has_token_weighting helper function."""
         configs1 = [DictDefault({"weight": 1.0, "weight_strategy": "upsample"})]
         assert not _has_token_weighting(configs1)
-        
+
         configs2 = [DictDefault({"weight": 0.5, "weight_strategy": "upsample"})]
         assert _has_token_weighting(configs2)
-        
+
         configs3 = [DictDefault({"weight": 1.0, "weight_strategy": "downsample"})]
         assert _has_token_weighting(configs3)
 

--- a/tests/test_token_weighting.py
+++ b/tests/test_token_weighting.py
@@ -136,16 +136,10 @@ class TestTokenWeighting:
 
     def test_validate_weights_helper(self):
         """Test _validate_weights helper function."""
-        configs1 = [
-            DictDefault({"weight": 0.3}),
-            DictDefault({"weight": 0.7})
-        ]
+        configs1 = [DictDefault({"weight": 0.3}), DictDefault({"weight": 0.7})]
         _validate_weights(configs1)  # Should not raise
-        
-        configs2 = [
-            DictDefault({"weight": 0.3}),
-            DictDefault({"weight": 0.8})
-        ]
+
+        configs2 = [DictDefault({"weight": 0.3}), DictDefault({"weight": 0.8})]
         with pytest.raises(ValueError):
             _validate_weights(configs2)
 
@@ -155,9 +149,9 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.0, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 1.0, "weight_strategy": "upsample"})
+            DictDefault({"weight": 1.0, "weight_strategy": "upsample"}),
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -167,10 +161,18 @@ class TestTokenWeighting:
         sample_datasets = create_sample_datasets()
         cfg = create_cfg()
         datasets_configs = [
-            DictDefault({"weight": 0.5, "weight_strategy": "unknown_strategy", "path": "dataset1"}),
-            DictDefault({"weight": 0.5, "weight_strategy": "upsample", "path": "dataset2"})
+            DictDefault(
+                {
+                    "weight": 0.5,
+                    "weight_strategy": "unknown_strategy",
+                    "path": "dataset1",
+                }
+            ),
+            DictDefault(
+                {"weight": 0.5, "weight_strategy": "upsample", "path": "dataset2"}
+            ),
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -180,11 +182,17 @@ class TestTokenWeighting:
         sample_datasets = create_sample_datasets()
         cfg = create_cfg()
         datasets_configs = [
-            DictDefault({"weight": 1.2, "weight_strategy": "downsample", "path": "dataset1"}),
-            DictDefault({"weight": -0.2, "weight_strategy": "upsample", "path": "dataset2"})  # This will cause validation error
+            DictDefault(
+                {"weight": 1.2, "weight_strategy": "downsample", "path": "dataset1"}
+            ),
+            DictDefault(
+                {"weight": -0.2, "weight_strategy": "upsample", "path": "dataset2"}
+            ),  # This will cause validation error
         ]
-        
-        with pytest.raises(ValueError, match="Dataset weight must be between 0.0 and 1.0"):
+
+        with pytest.raises(
+            ValueError, match="Dataset weight must be between 0.0 and 1.0"
+        ):
             merge_datasets(sample_datasets, cfg, datasets_configs)
 
     def test_floating_point_precision_weights(self):
@@ -193,9 +201,11 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.1, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 0.9000000000000001, "weight_strategy": "upsample"})  # Sum slightly > 1.0
+            DictDefault(
+                {"weight": 0.9000000000000001, "weight_strategy": "upsample"}
+            ),  # Sum slightly > 1.0
         ]
-        
+
         result = merge_datasets(sample_datasets, cfg, datasets_configs)
         assert len(result) > 0
         assert "input_ids" in result.features
@@ -206,8 +216,10 @@ class TestTokenWeighting:
         cfg = create_cfg()
         datasets_configs = [
             DictDefault({"weight": 0.1, "weight_strategy": "upsample"}),
-            DictDefault({"weight": 0.95, "weight_strategy": "upsample"})  # Sum = 1.05, too large
+            DictDefault(
+                {"weight": 0.95, "weight_strategy": "upsample"}
+            ),  # Sum = 1.05, too large
         ]
-        
+
         with pytest.raises(ValueError, match="Dataset weights must sum to 1.0"):
             merge_datasets(sample_datasets, cfg, datasets_configs)


### PR DESCRIPTION
# Description

Preprocessing is often a hurdle that requires a lot of care especially when preprocessing before axolotl touches the datasets. Weighting datasets is a feature I consider essential to finetuning a single model for multiple tasks. To achieve this, you would like to control the token distribution which this PR allows.

This implementation is co-authored by me and Devin. I made the initial prototype of the weighting and asked Devin to do the integration work and testing.

Closes #1508 

## How has this been tested?

A good number of tests have been implemented to verify this implementation, but further manual testing is required to ensure the behavior is correct and as expected. Especially around when to upsample and when to downsample. One assumption that I made during the implementation is that we want the weights to sum to 1 as its otherwise hard to control exactly what happens.

Outputs from one of the tests:

```
Running merge_datasets with token weighting (0.7, 0.3)...

INFO:axolotl.utils.data.shared:Merging datasets with token-based weighting...
INFO:axolotl.utils.data.shared:Dataset 'dataset1.jsonl': 13 tokens (2 samples)
INFO:axolotl.utils.data.shared:Dataset 'dataset2.jsonl': 11 tokens (2 samples)
INFO:axolotl.utils.data.shared:Total original tokens across all datasets: 24
INFO:axolotl.utils.data.shared:Dataset 'dataset1.jsonl': 13 → 16 tokens (weight=0.700, upsampling)
INFO:axolotl.utils.data.shared:Dataset 'dataset2.jsonl': 11 → 7 tokens (weight=0.300, downsampling)
INFO:axolotl.utils.data.shared:Weighted dataset parts before concatenation:
INFO:axolotl.utils.data.shared:  Part 1: 13 tokens (2 samples)
INFO:axolotl.utils.data.shared:  Part 2: 5 tokens (1 samples)
INFO:axolotl.utils.data.shared:  Part 3: 7 tokens (1 samples)
INFO:axolotl.utils.data.shared:Total tokens in weighted parts: 25
INFO:axolotl.utils.data.shared:Final merged dataset: 25 tokens (4 samples)
INFO:axolotl.utils.data.shared:Token count change: 24 → 25 (1.04x)
INFO:axolotl.utils.data.shared:Final weight verification:
INFO:axolotl.utils.data.shared:  dataset1.jsonl: requested=0.700, achieved≈0.640 (16/25 tokens)
INFO:axolotl.utils.data.shared:  dataset2.jsonl: requested=0.300, achieved≈0.280 (7/25 tokens)

=== Summary ===
Final merged dataset: 4 samples
Total tokens in result: 25
```

## My Nits

- Validation of weighting could probably be implemented somewhere else.
- Logging is verbose which is nice for testing and validation, but should consider how to slim this down.
- A working example config should be provided so users can see how this works in a real example.
- Add documentation of the new parameters.