### PR TITLE
Eval on training begin instead of after step 1

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -32,7 +32,7 @@ from axolotl.monkeypatch.relora import ReLoRACallback
 from axolotl.processing_strategies import get_processing_strategy
 from axolotl.utils import is_comet_available, is_mlflow_available
 from axolotl.utils.callbacks import (
-    EvalFirstStepCallback,
+    EvalOnTrainingBeginCallback,
     LossWatchDogCallback,
     SaveBetterTransformerModelCallback,
     bench_eval_callback_factory,
@@ -63,7 +63,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
 
     def get_callbacks(self):
         callbacks = super().get_callbacks()
-        callbacks.append(EvalFirstStepCallback())
+        callbacks.append(EvalOnTrainingBeginCallback())
 
         if self.cfg.relora_steps:
             callbacks.append(ReLoRACallback(self.cfg))

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -53,11 +53,11 @@ IGNORE_INDEX = -100
 LOG = get_logger(__name__)
 
 
-class EvalFirstStepCallback(
+class EvalOnTrainingBeginCallback(
     TrainerCallback
 ):  # pylint: disable=too-few-public-methods disable=unused-argument
     """
-    Callback to trigger evals on the first step
+    Callback to trigger evals before training begins
     """
 
     def on_step_end(
@@ -67,7 +67,7 @@ class EvalFirstStepCallback(
         control: TrainerControl,
         **kwargs,
     ):
-        if args.eval_strategy == IntervalStrategy.STEPS and state.global_step == 1:
+        if args.eval_strategy == IntervalStrategy.STEPS and state.global_step == 0:
             control.should_evaluate = True
         return control
 

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -60,16 +60,9 @@ class EvalOnTrainingBeginCallback(
     Callback to trigger evals before training begins
     """
 
-    def on_step_end(
-        self,
-        args: TrainingArguments,
-        state: TrainerState,
-        control: TrainerControl,
-        **kwargs,
-    ):
-        if args.eval_strategy == IntervalStrategy.STEPS and state.global_step == 0:
+    def on_train_begin(self, args, state, control, **kwargs):
+        if args.eval_strategy == IntervalStrategy.STEPS:
             control.should_evaluate = True
-        return control
 
 
 class SaveBetterTransformerModelCallback(


### PR DESCRIPTION
Current implementation evaluates after step 1, which makes doesn't make sense, because the first eval is to establish a baseline.

Changed to run before training starts instead of step 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Evaluation now runs before training begins instead of after the first step, enhancing the accuracy of initial model assessment.

- **Documentation**
  - Clarified when evaluation is triggered during the training process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->