### PR TITLE
Fix: logging on py310

### DIFF
--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -14,7 +14,7 @@ This guide covers all the ways you can install and set up Axolotl for your envir
 ## Requirements {#sec-requirements}
 
 - NVIDIA GPU (Ampere architecture or newer for `bf16` and Flash Attention) or AMD GPU
-- Python ≥3.10
+- Python ≥3.11
 - PyTorch ≥2.5.1
 
 ## Installation Methods {#sec-installation-methods}
@@ -153,7 +153,7 @@ We recommend using WSL2 (Windows Subsystem for Linux) or Docker.
 
 ### Conda/Pip venv {#sec-conda}
 
-1. Install Python ≥3.10
+1. Install Python ≥3.11
 2. Install PyTorch: https://pytorch.org/get-started/locally/
 3. Install Axolotl:
    ```{.bash}

--- a/src/axolotl/logging_config.py
+++ b/src/axolotl/logging_config.py
@@ -25,12 +25,18 @@ class AxolotlOrWarnErrorFilter(logging.Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.axolotl_level = logging.getLevelNamesMapping()[
-            os.getenv("AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL)
-        ]
-        self.other_level = logging.getLevelNamesMapping()[
-            os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL)
-        ]
+        axolotl_log_level = os.getenv("AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL)
+        other_log_level = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL)
+
+        try:
+            # py311+ only
+            level_mapping = logging.getLevelNamesMapping()
+            self.axolotl_level = level_mapping[axolotl_log_level]
+            self.other_level = level_mapping[other_log_level]
+        except AttributeError:
+            # For py311-, use getLevelName directly
+            self.axolotl_level = logging.getLevelName(axolotl_log_level)
+            self.other_level = logging.getLevelName(other_log_level)
 
     def filter(self, record: LogRecord) -> bool:
         # General filter

--- a/src/axolotl/logging_config.py
+++ b/src/axolotl/logging_config.py
@@ -25,8 +25,10 @@ class AxolotlOrWarnErrorFilter(logging.Filter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        axolotl_log_level = os.getenv("AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL)
-        other_log_level = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL)
+        axolotl_log_level = os.getenv(
+            "AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL
+        ).upper()
+        other_log_level = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
 
         try:
             # py311+ only
@@ -34,7 +36,7 @@ class AxolotlOrWarnErrorFilter(logging.Filter):
             self.axolotl_level = level_mapping[axolotl_log_level]
             self.other_level = level_mapping[other_log_level]
         except AttributeError:
-            # For py311-, use getLevelName directly
+            # For py310, use getLevelName directly
             self.axolotl_level = logging.getLevelName(axolotl_log_level)
             self.other_level = logging.getLevelName(other_log_level)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Reported on Discord by Caitlyn and artem , the `logging.logging.getLevelNamesMapping` was added in 311 https://docs.python.org/3/library/logging.html#logging.getLevelNamesMapping

This PR adds a try catch to handle for Py310. However, we would now recommend Py311 as that's where we test

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to require Python ≥3.11 (previously ≥3.10).

- **Bug Fixes**
  - Improved logging configuration to ensure compatibility with both Python 3.11+ and earlier Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->