### PR TITLE
fix: remove unnecessary movement of eval logits to cpu

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -215,10 +215,6 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 self.cfg.auto_find_batch_size
             )
 
-        training_arguments_kwargs["eval_accumulation_steps"] = (
-            self.cfg.gradient_accumulation_steps
-        )
-
         training_arguments_kwargs["load_best_model_at_end"] = (
             (
                 self.cfg.load_best_model_at_end is not False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Edit: See https://github.com/axolotl-ai-cloud/axolotl/pull/2824#issuecomment-3002851516

---

There has been reports about eval taking more vram than training. I suspect it's this config which we set to grad accu. Would love some tests for this!

This config does not seem to be running mini-batches as we think?

https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments.eval_accumulation_steps

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed explicit setting of the "eval_accumulation_steps" parameter in training configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->