### PR TITLE
fix: catch httperror from ratelimiting hf when checking user token

### DIFF
--- a/src/axolotl/cli/checks.py
+++ b/src/axolotl/cli/checks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from accelerate.commands.config import config_args
 from huggingface_hub import HfApi
 from huggingface_hub.utils import LocalTokenNotFoundError
+from requests import HTTPError
 
 from axolotl.utils.logging import get_logger
 
@@ -44,5 +45,10 @@ def check_user_token() -> bool:
     except LocalTokenNotFoundError:
         LOG.warning(
             "Error verifying HuggingFace token. Remember to log in using `huggingface-cli login` and get your access token from https://huggingface.co/settings/tokens if you want to use gated models or datasets."
+        )
+        return False
+    except HTTPError:
+        LOG.warning(
+            "Error accessing HuggingFace. This may be due to a network issue or rate limiting."
         )
         return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

We need to catch HTTP error when calling the check user token.

User reported as follows

```
File "/home/redacted/axolotl/venv/lib/python3.10/site-packages/huggingface_hub/utils/_http.py", line 406, in hf_raise_for_status
[rank120]:     response.raise_for_status()
[rank120]:   File "/home/redacted/axolotl/venv/lib/python3.10/site-packages/requests/models.py", line 1024, in raise_for_status
[rank120]:     raise HTTPError(http_error_msg, response=self)
[rank120]: requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/whoami-v2
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during HuggingFace token verification to better manage network issues or rate limiting, ensuring clearer warnings and more robust operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->