### PR TITLE
gating _gather_outputs (causes increased vram usage)

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -219,6 +219,7 @@ def execute_training(
                     gradient_accumulation_steps=cfg.gradient_accumulation_steps,
                     ring_attn_func=cfg.ring_attn_func,
                     heads_k_stride=cfg.heads_k_stride,
+                    gather_outputs=cfg.rl is RLType.GRPO,
                 )
             )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Title. This gives back the original VRAM savings that we saw in the original implementation.

Possible follow-on items:
- Add checks for VRAM usage in smoke tests
- Add smoke tests for other, untested SP + trainer combos 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether outputs are gathered during sequence parallel training, based on the selected reinforcement learning type.

- **Documentation**
  - Updated descriptions to reflect the new option for gathering outputs during training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->