### PR TITLE
fix for iterable datasets and pickling

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -413,7 +413,8 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 or self.cfg.micro_batch_size > 1
             ):
                 return DataCollatorForSeq2Seq(self.tokenizer, **kwargs)
-            return None
+            if not (self.cfg.sample_packing and self.cfg.pretrain_multipack_attn):
+                return None
 
         if self.cfg.model_config_type == "mamba":
             return MambaDataCollator(tokenizer=self.tokenizer)

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -223,6 +223,8 @@ def execute_training(
             )
 
         LOG.info("Starting trainer...")
+        if cfg.bf16:
+            torch.set_default_dtype(torch.bfloat16)
         trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
 

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -224,10 +224,10 @@ def wrap_pretraining_dataset(
     remove_columns = []
     if dataset.features is None:
         for first_row in dataset:
-            remove_columns = first_row.keys()
+            remove_columns = list(first_row.keys())
             break
     else:
-        remove_columns = dataset.features.keys()
+        remove_columns = list(dataset.features.keys())
 
     dataset = dataset.map(
         encode,

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -267,6 +267,7 @@ def encode_packed_pretraining(
         batch_size=1,
         batch_max_len=batch_size * max_seq_length,
         drop_last=True,
+        num_processes=1,
     )
 
     chunked_data = defaultdict(list)

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -260,7 +260,7 @@ class MultipackBatchSampler(BatchSampler):
         lengths: np.ndarray,  # Sequence lengths
         packing_efficiency_estimate: float = 1.0,  # Initial efficiency estimate
         drop_last: bool = True,  # Whether to drop final batches (might be incomplete)
-        num_count_samples: int = 8,  # Number of times to estimate batch count
+        num_count_samples: int = 4,  # Number of times to estimate batch count
         sequential: bool = False,  # Whether to use sequential packing
         group_size: int = 100_000,  # Size of groups for parallel packing
         bin_size: int = 200,  # The max number of samples that can be packed in a single bin
@@ -335,12 +335,13 @@ class MultipackBatchSampler(BatchSampler):
             bins = [[indices[b_idx] for b_idx in bin_indices] for bin_indices in bins]
         else:
             # Use parallel packing
+            num_processes = self.num_processes or 1
             all_bins = pack_parallel(
                 lengths,
                 bin_capacity=self.batch_max_len,
                 group_size=self.group_size,
                 bin_size=self.bin_size,
-                num_processes=max(4, self.num_processes) if self.num_processes else 4,
+                num_processes=min(4, num_processes) if num_processes else 4,
                 safe_mode=self.safe_mode,
                 mp_start_method=self.mp_start_method,
             )

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -462,6 +462,20 @@ class TrainingValidationMixin:
 
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def pretrain_with_tps(cls, data):
+        if data.get("pretraining_dataset") and data.get(
+            "include_tokens_per_second", False
+        ):
+            # combining these would raise `TypeError: cannot pickle 'dict_keys' object`
+            # due to trying to count the number of tokens total in the dataset
+            raise ValueError(
+                "pretraining_dataset and include_tokens_per_second cannot be used together."
+            )
+
+        return data
+
 
 class LoRAValidationMixin:
     """Validation methods related to LoRA/QLoRA configuration."""

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -381,6 +381,7 @@ def process_pretraining_datasets_for_packing(
     if not skip_position_ids:
         train_dataset = train_dataset.map(
             add_position_ids,
+            batched=True,
             desc="Add position_id column (Pretraining Sample Packing)",
         )
     if drop_attention_mask:

--- a/tests/test_packed_pretraining.py
+++ b/tests/test_packed_pretraining.py
@@ -1,7 +1,6 @@
 """Module for testing streaming dataset sequence packing"""
 
 import functools
-import pickle
 import random
 import string
 
@@ -88,9 +87,6 @@ class TestPretrainingPacking:
             batch_size=cfg.micro_batch_size,
             seed=cfg.seed or 42,
         )
-
-        # make sure the dataset is pickleable
-        pickle.dumps(train_dataset)
 
         trainer_loader = DataLoader(
             train_dataset,

--- a/tests/test_packed_pretraining.py
+++ b/tests/test_packed_pretraining.py
@@ -1,6 +1,7 @@
 """Module for testing streaming dataset sequence packing"""
 
 import functools
+import pickle
 import random
 import string
 
@@ -87,6 +88,9 @@ class TestPretrainingPacking:
             batch_size=cfg.micro_batch_size,
             seed=cfg.seed or 42,
         )
+
+        # make sure the dataset is pickleable
+        pickle.dumps(train_dataset)
 
         trainer_loader = DataLoader(
             train_dataset,


### PR DESCRIPTION
ran into this issue with pretraining 

```
[rank1]:     ForkingPickler(file, protocol).dump(obj)                                                                                                                                                                                                          
[rank1]: TypeError: cannot pickle 'dict_keys' object 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility by ensuring columns to remove from datasets are always handled as lists, preventing potential downstream issues.
- **New Features**
  - Added a validation check to prevent using both pretraining datasets and tokens-per-second tracking simultaneously, providing clearer error messages for unsupported configurations.
- **Improvements**
  - Optimized dataset processing by enabling batched operations for position ID assignment.
  - Adjusted parallel processing limits during data packing to improve efficiency.
  - Set default tensor data type to bfloat16 during training when configured.
  - Enhanced data collator behavior to better support sample packing and multipack attention scenarios.
- **Tests**
  - Enhanced test coverage by verifying that the training dataset can be serialized, ensuring better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->