### PR TITLE
add assertion for packing patch to _get_unpad_data

### DIFF
--- a/src/axolotl/monkeypatch/multipack.py
+++ b/src/axolotl/monkeypatch/multipack.py
@@ -42,6 +42,10 @@ def patch_for_multipack(model_type, model_name=None, has_remote_code=False):
     if has_remote_code:
         patch_remote(model_name)
     elif hasattr(transformers, "modeling_flash_attention_utils"):
+        # sanity check in case upstream api changes on this
+        assert hasattr(
+            transformers.modeling_flash_attention_utils, "_get_unpad_data"
+        ), "transformers api changed for _get_unpad_data for flash attention"
         transformers.modeling_flash_attention_utils._get_unpad_data = (  # pylint: disable=protected-access
             get_unpad_data
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Setting ourselves to catch changes earlier in case upstream removes this. The patch would normally silently pass even if this attribute didn't previously exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with a clear message if a required attribute is missing due to upstream changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->