### PR TITLE
Fix: tokenize stall due to not shuffling dataset

### DIFF
--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -527,10 +527,10 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
         ds = datasets[0]
 
         # Do not shuffle if curriculum sampling is enabled
-        if not cfg.curriculum_sampling:
-            return ds.shuffle(seed=cfg.seed)
+        if cfg.curriculum_sampling:
+            return ds
 
-        return ds
+        return ds.shuffle(seed=cfg.seed)
 
     LOG.info("Merging datasets...")
     merged_dataset = concatenate_datasets(datasets)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -524,7 +524,13 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
         Merged dataset.
     """
     if len(datasets) == 1:
-        return datasets[0]
+        ds = datasets[0]
+
+        # Do not shuffle if curriculum sampling is enabled
+        if not cfg.curriculum_sampling:
+            return ds.shuffle(seed=cfg.seed)
+
+        return ds
 
     LOG.info("Merging datasets...")
     merged_dataset = concatenate_datasets(datasets)

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -537,6 +537,11 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
 
     if cfg.shuffle_merged_datasets:
         LOG.debug("Shuffling merged datasets...")
+        if cfg.curriculum_sampling:
+            LOG.warning(
+                "Shuffling merged datasets with curriculum sampling is not recommended. "
+                "This will randomize the order of samples."
+            )
         merged_dataset = merged_dataset.shuffle(seed=cfg.seed)
     else:
         LOG.debug("Not shuffling merged datasets.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

This has been reported by a few folks where the tokenization will slow to a crawl at the last few percentage.

`Gifted Gummy Bee` and `Teknium` have discovered & verified that shuffling the datasets fixes this issue. The suspected cause was that it helps move around the larger samples more "evenly". Since we did not shuffle single dataset, this PR changes that, except if curriculum sampling is enabled.

Credits to both of them for the fix.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dataset merging behavior to respect curriculum sampling settings, ensuring datasets are not shuffled when curriculum sampling is enabled.
  * Added warnings when shuffling is used alongside curriculum sampling to inform users of potential issues with sample order.

* **Bug Fixes**
  * Prevented unintended shuffling of datasets when curriculum sampling is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->