### PR TITLE
fix:add sample_packing_sequentially to trainer args

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -253,6 +253,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         training_arguments_kwargs["eval_sample_packing"] = bool(
             self.cfg.eval_sample_packing
         )
+        if self.cfg.sample_packing_sequentially is not None:
+            training_arguments_kwargs["sample_packing_sequentially"] = (
+                self.cfg.sample_packing_sequentially
+            )
         if self.cfg.sample_packing_bin_size is not None:
             training_arguments_kwargs["sample_packing_bin_size"] = (
                 self.cfg.sample_packing_bin_size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description


The `MultipackBatchSampler` of the base trainer uses the argument `sample_packing_sequentially` (see [here](https://github.com/axolotl-ai-cloud/axolotl/blob/35fdbce1022547158a5e451a11350513f4ac4385/src/axolotl/core/trainers/base.py#L116)), however its value is not updated [during the creation](https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/core/builders/causal.py#L247-L267) of the Trainer arguments (see [here](https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/core/builders/causal.py#L247-L267)). This results in the argument always using its [default value](https://github.com/v-dicicco/axolotl/blob/main/src/axolotl/core/training_args_base.py#L35-L39) of `False`.

This PR adds the `sample_packing_sequentially` option to the the Training Arguments.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `sample_packing_sequentially` configuration option in training settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->