### PR TITLE
Fix: do not call preprocess in multimodal or pretraining case

### DIFF
--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -51,6 +51,10 @@ description: Frequently asked questions
 >   pad_token: "..."
 > ```
 
+**Q: `IterableDataset error` or `KeyError: 'input_ids'` when using `preprocess` CLI**
+
+> A: This is because you may be using `preprocess` CLI with `pretraining_dataset:` or `skip_prepare_dataset: true` respectively. Please use `axolotl train` CLI directly instead as these datasets are prepared on demand.
+
 ### Chat templates
 
 **Q: `jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'content' / 'role' / ____`**

--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -36,7 +36,7 @@ def do_preprocess(cfg: DictDefault, cli_args: PreprocessCliArgs) -> None:
     check_user_token()
 
     for key in ["skip_prepare_dataset", "pretraining_dataset"]:
-        if key in cfg and cfg[key]:
+        if cfg.get("key"):
             raise ValueError(
                 f"You have set `{key}:`. `preprocess` is not needed. Run the `axolotl train` CLI directly instead."
             )

--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -35,6 +35,11 @@ def do_preprocess(cfg: DictDefault, cli_args: PreprocessCliArgs) -> None:
     check_accelerate_default_config()
     check_user_token()
 
+    if cfg.skip_prepare_dataset:
+        raise ValueError(
+            "You have set `skip_prepare_dataset: true`. Preprocessing is not needed. Run the `axolotl train` CLI directly instead."
+        )
+
     if not cfg.dataset_prepared_path:
         msg = (
             Fore.RED

--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -35,10 +35,11 @@ def do_preprocess(cfg: DictDefault, cli_args: PreprocessCliArgs) -> None:
     check_accelerate_default_config()
     check_user_token()
 
-    if cfg.skip_prepare_dataset:
-        raise ValueError(
-            "You have set `skip_prepare_dataset: true`. Preprocessing is not needed. Run the `axolotl train` CLI directly instead."
-        )
+    for key in ["skip_prepare_dataset", "pretraining_dataset"]:
+        if key in cfg and cfg[key]:
+            raise ValueError(
+                f"You have set `{key}:`. `preprocess` is not needed. Run the `axolotl train` CLI directly instead."
+            )
 
     if not cfg.dataset_prepared_path:
         msg = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Add clear error when users run preprocess as they may be confused for `IterableDataset error` (from discord https://discord.com/channels/1104757954588196865/1111279858136383509/1390314265658921000) or `KeyError: 'input_ids'` from https://github.com/axolotl-ai-cloud/axolotl/issues/2856

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation to prevent running preprocessing with incompatible configuration flags, guiding users to use the training command directly.
* **Documentation**
  * Added an FAQ entry explaining common errors related to preprocessing and advising on the correct usage of the training command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->