### PR TITLE
don't use tokenizer parallelism when using packing

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -609,6 +609,9 @@ def prepare_opinionated_env(cfg):
     if cfg.qlora_sharded_model_loading:
         # model loading is forked after the tokenizer
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    if cfg.sample_packing:
+        # multipack parallel packing sampler defaults to using fork
+        os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 def setup_trainer(


### PR DESCRIPTION
When using packing, the stderr gets spammed with

```
stderr: To disable this warning, you can either:                                                       
stderr:         - Avoid using `tokenizers` before the fork if possible                                 
stderr:         - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)         
stderr: huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled tokenizer parallelism when sample packing is enabled to prevent potential conflicts during multiprocessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->