### PR TITLE
TiledMLP support

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -152,7 +152,7 @@ class ModelLoader:
             A tuple with the loaded model and its LoRA configuration (if applicable).
         """
         # Initial setup and patches
-        self.patch_manager.apply_pre_model_load_patches()
+        self.patch_manager.apply_pre_model_load_patches(self.cfg.model_config_type)
         self._apply_pre_model_load_setup()
 
         # Build the model

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -152,7 +152,7 @@ class ModelLoader:
             A tuple with the loaded model and its LoRA configuration (if applicable).
         """
         # Initial setup and patches
-        self.patch_manager.apply_pre_model_load_patches(self.cfg.model_config_type)
+        self.patch_manager.apply_pre_model_load_patches()
         self._apply_pre_model_load_setup()
 
         # Build the model

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -248,7 +248,7 @@ class PatchManager:
         if self.cfg.tiled_mlp:
             from axolotl.monkeypatch.tiled_mlp import patch_tiled_mlp
 
-            patch_tiled_mlp(model_type)
+            patch_tiled_mlp(model_type, cfg_num_shards=self.cfg.tiled_mlp_num_shards)
 
     def _patch_attention(self):
         """Apply attention-specific patches based on model type."""

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -243,6 +243,7 @@ class PatchManager:
 
             patch_prepare_data_loader()
             patch_prepare_device_mesh(self.cfg.sequence_parallel_degree, self.cfg.fsdp)
+
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:
             from axolotl.monkeypatch.tiled_mlp import patch_tiled_mlp

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -47,7 +47,7 @@ class PatchManager:
         """Check if flash attention is installed."""
         return importlib.util.find_spec("flash_attn") is not None
 
-    def apply_pre_model_load_patches(self, model_type: str | None):
+    def apply_pre_model_load_patches(self):
         """Apply pre-model load patches based on config."""
         self._apply_flash_attention_patches()
         self._apply_chunked_cross_entropy_patch()
@@ -66,8 +66,7 @@ class PatchManager:
         self._apply_self_attention_lora_patch()
         self._apply_gemma3_conditional_generation_forward_patch()
         self._apply_sequence_parallel_patches()
-        if model_type:
-            self._apply_tiled_mlp(model_type)
+        self._apply_tiled_mlp(self.cfg.model_config_type)
 
     def apply_post_model_load_patches(self, model: PreTrainedModel):
         """Apply patches that require the model instance."""

--- a/src/axolotl/monkeypatch/tiled_mlp.py
+++ b/src/axolotl/monkeypatch/tiled_mlp.py
@@ -1,0 +1,72 @@
+import math
+
+import torch
+import torch.distributed as dist
+
+
+def patch_tiled_mlp(model_type):
+    from deepspeed.runtime.sequence_parallel.ulysses_sp import (
+        TiledMLP,
+        sequence_tiled_compute,
+    )
+
+    # def tiled_mlp_forward(self, x):
+    #     input_shape = x.shape
+    #     seqlen = input_shape[-2]
+    #     hidden = input_shape[-1]
+    #     num_shards = math.ceil(seqlen / hidden)
+    #     num_shards_tensor = torch.tensor(num_shards, device=x.device)
+    #     dist.all_reduce(num_shards_tensor, op=dist.ReduceOp.MAX)
+    #     num_shards = num_shards_tensor.item()
+    #
+    #     compute_params = [self.down_proj.weight, self.gate_proj.weight, self.up_proj.weight]
+    #
+    #     def mlp_forward(self_, hs):
+    #         return self_.down_proj(self_.act_fn(self_.gate_proj(hs)) * self_.up_proj(hs))
+    #
+    #     mlp_forward_compiled = torch.compile(mlp_forward)
+    #
+    #     down_res = TiledMLP.apply(
+    #         mlp_forward_compiled,
+    #         self,
+    #         x,
+    #         num_shards,
+    #         compute_params,
+    #     )
+    #     return down_res
+
+    def mlp_forward_sequence_tiled_compute(self, x):
+        kwargs_to_shard = dict(x=x)
+        kwargs_to_pass = dict(self=self)
+        grad_requiring_tensor_key = "x"
+        compute_params = [self.down_proj.weight, self.up_proj.weight]
+        seqlen = x.shape[1]
+        num_shards = 4
+
+        return sequence_tiled_compute(
+            mlp_forward_orig,
+            seqlen,
+            num_shards,
+            kwargs_to_shard,
+            kwargs_to_pass,
+            grad_requiring_tensor_key,
+            compute_params,
+            output_unshard_dimension=1,  # x
+            output_reduction=None,
+        )
+
+    try:
+        # Dynamically import the module and MLP class
+        module_path = f"transformers.models.{model_type}.modeling_{model_type}"
+        model_cls_prefix = "".join(
+            [part.capitalize() for part in model_type.split("_")]
+        )
+        module = __import__(module_path, fromlist=[f"{model_cls_prefix}MLP"])
+        mlp_cls = getattr(module, f"{model_cls_prefix}MLP")
+
+        mlp_cls.forward = mlp_forward_sequence_tiled_compute
+    except (ImportError, AttributeError) as e:
+        raise RuntimeError(
+            f"Could not import MLP class for model_type: {model_type}. "
+            f"Error: {str(e)}"
+        ) from e

--- a/src/axolotl/monkeypatch/tiled_mlp.py
+++ b/src/axolotl/monkeypatch/tiled_mlp.py
@@ -4,38 +4,8 @@ import torch
 import torch.distributed as dist
 
 
-def patch_tiled_mlp(model_type):
-    from deepspeed.runtime.sequence_parallel.ulysses_sp import (
-        SequenceTiledCompute,
-        TiledMLP,
-        sequence_tiled_compute,
-    )
-
-    # def tiled_mlp_forward(self, x):
-    #     input_shape = x.shape
-    #     seqlen = input_shape[-2]
-    #     hidden = input_shape[-1]
-    #     num_shards = math.ceil(seqlen / hidden)
-    #     num_shards_tensor = torch.tensor(num_shards, device=x.device)
-    #     dist.all_reduce(num_shards_tensor, op=dist.ReduceOp.MAX)
-    #     num_shards = num_shards_tensor.item()
-    #
-    #     compute_params = [self.down_proj.weight, self.gate_proj.weight, self.up_proj.weight]
-    #
-    #     def mlp_forward(self_, hs):
-    #         return self_.down_proj(self_.act_fn(self_.gate_proj(hs)) * self_.up_proj(hs))
-    #
-    #     mlp_forward_compiled = torch.compile(mlp_forward)
-    #
-    #     down_res = TiledMLP.apply(
-    #         mlp_forward_compiled,
-    #         self,
-    #         x,
-    #         num_shards,
-    #         compute_params,
-    #     )
-    #     return down_res
-
+def patch_tiled_mlp(model_type, use_original_mlp=False):
+    from deepspeed.runtime.sequence_parallel.ulysses_sp import TiledMLP
 
     try:
         # Dynamically import the module and MLP class
@@ -46,45 +16,35 @@ def patch_tiled_mlp(model_type):
         module = __import__(module_path, fromlist=[f"{model_cls_prefix}MLP"])
         mlp_cls = getattr(module, f"{model_cls_prefix}MLP")
 
-        mlp_forward_orig = mlp_cls.forward
+        if use_original_mlp:
+            mlp_forward = mlp_cls.forward
+        else:
+            def generic_mlp_forward(self_, hs):
+                return self_.down_proj(self_.act_fn(self_.gate_proj(hs)) * self_.up_proj(hs))
 
-        def mlp_forward_sequence_tiled_compute(self, x):
-            kwargs_to_shard = dict(x=x)
-            kwargs_to_pass = dict(self=self)
-            grad_requiring_tensor_key = "x"
+            mlp_forward = torch.compile(generic_mlp_forward)
+
+        def tiled_mlp_forward(self, x):
+            input_shape = x.shape
+            seqlen = input_shape[-2]
+            hidden = input_shape[-1]
+            num_shards = math.ceil(seqlen / hidden)
+            num_shards_tensor = torch.tensor(num_shards, device=x.device)
+            dist.all_reduce(num_shards_tensor, op=dist.ReduceOp.MAX)
+            num_shards = num_shards_tensor.item()
+
             compute_params = [self.down_proj.weight, self.gate_proj.weight, self.up_proj.weight]
-            seqlen = x.shape[1]
-            num_shards = 4
 
-            def mlp_forward_orig(self, x):
-                return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
-
-            return SequenceTiledCompute.apply(
-                mlp_forward_orig,
-                seqlen,
+            down_res = TiledMLP.apply(
+                mlp_forward,
+                self,
+                x,
                 num_shards,
-                keys_to_shard,
-                keys_to_pass,
-                grad_requiring_tensor_key,
                 compute_params,
-                output_unshard_dimension,
-                output_reduction,
-                *args_to_shard,
-                *args_to_pass,
             )
-            return sequence_tiled_compute(
-                mlp_forward_orig,
-                seqlen,
-                num_shards,
-                kwargs_to_shard,
-                kwargs_to_pass,
-                grad_requiring_tensor_key,
-                compute_params,
-                output_unshard_dimension=1,  # x
-                output_reduction=None,
-            )
+            return down_res
 
-        mlp_cls.forward = mlp_forward_sequence_tiled_compute
+        mlp_cls.forward = tiled_mlp_forward
     except (ImportError, AttributeError) as e:
         raise RuntimeError(
             f"Could not import MLP class for model_type: {model_type}. "

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -549,6 +549,18 @@ class AxolotlInputConfig(
         },
     )
 
+    tiled_mlp: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Whether to use ALST tiled mlp for memory efficient long context"
+        },
+    )
+
+    tiled_mlp_num_chunks: int | None = Field(
+        default=None,
+        json_schema_extra={"description": "Number of chunks to use for tiled mlp"},
+    )
+
     llama4_linearized_experts: bool | None = None
 
     deepspeed: str | dict[str, Any] | None = Field(

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -556,11 +556,6 @@ class AxolotlInputConfig(
         },
     )
 
-    tiled_mlp_num_chunks: int | None = Field(
-        default=None,
-        json_schema_extra={"description": "Number of chunks to use for tiled mlp"},
-    )
-
     llama4_linearized_experts: bool | None = None
 
     deepspeed: str | dict[str, Any] | None = Field(

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -556,6 +556,13 @@ class AxolotlInputConfig(
         },
     )
 
+    tiled_mlp_num_shards: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Number of shards to use for ALST tiled mlp. If unset, it will be set based on seqlen/hidden_size"
+        },
+    )
+
     llama4_linearized_experts: bool | None = None
 
     deepspeed: str | dict[str, Any] | None = Field(

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -476,6 +476,13 @@ class TrainingValidationMixin:
 
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_tiled_mlp_deepspeed(cls, data):
+        if data.get("tiled_mlp", False) and not data.get("deepspeed"):
+            raise ValueError("tiled_mlp requires deepspeed ZeRO to be enabled")
+        return data
+
 
 class LoRAValidationMixin:
     """Validation methods related to LoRA/QLoRA configuration."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Arctic Long Sequence Training (see https://www.snowflake.com/en/engineering-blog/arctic-long-sequence-training-multi-million-token-ai/) introduced TiledMLP into deepspeed to reduce the activation footprint of long sequences in the MLP modules.  This adds support for that via the `tiled_mlp: true` parameter in our YAML. This currently only works with deepspeed zero1 through zero3. Single GPU, DDP, and FSDP aren't supported with this currently.

When using bf16, there appears to be some numerical differences in train and eval loss as well as grad norm, which @stas00 is helping to pinpoint. In the meantime, it's worth adding as it significantly reduces VRAM requirements with the tradeoff of some reduced accuracy. 
<img width="1413" alt="Screenshot 2025-07-04 at 5 32 46 PM" src="https://github.com/user-attachments/assets/55365852-83c9-44c0-9c1e-100eb0457da0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for a memory-efficient "tiled MLP" option for long context models, configurable via a new setting.
* **Validation**
  * Added a check to ensure "tiled MLP" can only be enabled when DeepSpeed ZeRO is also enabled.
* **Bug Fixes**
  * Improved error messaging when required model components for tiled MLP are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->