### PR TITLE
respect shuffle_merged_datasets for single dataset too

### DIFF
--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -526,7 +526,8 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
     if len(datasets) == 1:
         ds = datasets[0]
 
-        # Do not shuffle if curriculum sampling is enabled
+        # Do not shuffle if curriculum sampling is enabled or
+        # shuffle_merged_datasets is disabled
         if cfg.curriculum_sampling or not cfg.shuffle_merged_datasets:
             return ds
 

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -527,7 +527,7 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
         ds = datasets[0]
 
         # Do not shuffle if curriculum sampling is enabled
-        if cfg.curriculum_sampling:
+        if cfg.curriculum_sampling or not cfg.shuffle_merged_datasets:
             return ds
 
         return ds.shuffle(seed=cfg.seed)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
#2845 forced shuffling, but can have unexpected side effects when comparing newer to older experiments where we need a stable shuffle/split of train/test data. Fixes shuffle to respect shuffle_merged_datasets so we can disable the shuffle to repeat old experiments.

Trying to re-run a YAML with a single dataset results in different results because the eval split is now different.
<img width="1399" alt="Screenshot 2025-07-04 at 11 18 47 PM" src="https://github.com/user-attachments/assets/9bbe88cd-4a4a-435b-a243-e6a231c14ec1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset merging logic to prevent shuffling when curriculum sampling is enabled or when shuffling of merged datasets is disabled in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->