### PR TITLE
build fa2 from source for base image with torch2.6 and cu124

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -6,10 +6,12 @@ on:
       - "main"
     paths:
       - 'Dockerfile-base'
+      - 'Dockerfile-uv-base'
       - '.github/workflows/base.yml'
   pull_request:
     paths:
       - 'Dockerfile-base'
+      - 'Dockerfile-uv-base'
       - '.github/workflows/base.yml'
   workflow_dispatch:
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - "main"
     paths:
-      - 'Dockerfile-base'
-      - 'Dockerfile-uv-base'
+      - 'docker/Dockerfile-base'
+      - 'docker/Dockerfile-uv-base'
       - '.github/workflows/base.yml'
   pull_request:
     paths:
-      - 'Dockerfile-base'
-      - 'Dockerfile-uv-base'
+      - 'docker/Dockerfile-base'
+      - 'docker/Dockerfile-uv-base'
       - '.github/workflows/base.yml'
   workflow_dispatch:
 

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -39,5 +39,5 @@ RUN git lfs install --skip-repo && \
     pip3 install -U --no-cache-dir pydantic==1.10.10
 
 RUN if [ "$PYTORCH_VERSION" = "2.6.0" ] && [ "$CUDA" = "124" ] ; then \
-        FLASH_ATTENTION_FORCE_BUILD="TRUE" pip3 install flash-attn==2.8.0.post2; \
+        FLASH_ATTENTION_FORCE_BUILD="TRUE" pip3 install --no-build-isolation flash-attn==2.8.0.post2; \
     fi

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -37,3 +37,7 @@ RUN git lfs install --skip-repo && \
     pip3 install awscli && \
     # The base image ships with `pydantic==1.8.2` which is not working
     pip3 install -U --no-cache-dir pydantic==1.10.10
+
+RUN if [ "$PYTORCH_VERSION" = "2.6.0" ] && [ "$CUDA" = "126" ] ; then \
+        FLASH_ATTENTION_FORCE_BUILD="TRUE" pip3 install flash-attn==2.8.0.post2; \
+    fi

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -38,6 +38,6 @@ RUN git lfs install --skip-repo && \
     # The base image ships with `pydantic==1.8.2` which is not working
     pip3 install -U --no-cache-dir pydantic==1.10.10
 
-RUN if [ "$PYTORCH_VERSION" = "2.6.0" ] && [ "$CUDA" = "126" ] ; then \
+RUN if [ "$PYTORCH_VERSION" = "2.6.0" ] && [ "$CUDA" = "124" ] ; then \
         FLASH_ATTENTION_FORCE_BUILD="TRUE" pip3 install flash-attn==2.8.0.post2; \
     fi


### PR DESCRIPTION
fa2 builds are broken when using torch 2.6.0 + cu124. let's build it from source on these base images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image build process to conditionally install the flash-attn package for specific PyTorch and CUDA versions.
  * Updated workflow triggers to include additional Dockerfile for automated testing on code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->