### PR TITLE
add 2.7.0 torch images back to support vlllm

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -50,6 +50,13 @@ jobs:
             cuda_version: 12.6.3
             cudnn_version: ""
             python_version: "3.11"
+            pytorch: 2.7.0
+            torch_cuda_arch_list: "7.0 7.5 8.0 8.6 8.7 8.9 9.0+PTX"
+            dockerfile: "Dockerfile-base"
+          - cuda: "126"
+            cuda_version: 12.6.3
+            cudnn_version: ""
+            python_version: "3.11"
             pytorch: 2.7.1
             torch_cuda_arch_list: "7.0 7.5 8.0 8.6 8.7 8.9 9.0+PTX"
             dockerfile: "Dockerfile-base"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,11 @@ jobs:
           - cuda: 126
             cuda_version: 12.6.3
             python_version: "3.11"
+            pytorch: 2.7.0
+            axolotl_extras: vllm
+          - cuda: 126
+            cuda_version: 12.6.3
+            python_version: "3.11"
             pytorch: 2.7.1
             axolotl_extras:
           - cuda: 128
@@ -93,6 +98,11 @@ jobs:
             pytorch: 2.6.0
             axolotl_extras:
             is_latest: true
+          - cuda: 126
+            cuda_version: 12.6.3
+            python_version: "3.11"
+            pytorch: 2.7.0
+            axolotl_extras:
           - cuda: 126
             cuda_version: 12.6.3
             python_version: "3.11"

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ def parse_requirements(extras_require_map):
 
             if (major, minor) >= (2, 7):
                 _install_requires.pop(_install_requires.index(xformers_version))
-                # _install_requires.append("xformers==0.0.29.post3")  # xformers seems to be hard pinned to 2.6.0
-                extras_require_map["vllm"] = ["vllm==0.8.5.post1"]
+                _install_requires.append("xformers==0.0.31.post1")
+                extras_require_map["vllm"] = ["vllm>=0.9.0"]
             elif (major, minor) >= (2, 6):
                 _install_requires.pop(_install_requires.index(xformers_version))
                 _install_requires.append(


### PR DESCRIPTION
vllm is pinned to torch==2.7.0, so we can't ship them with our torch 2.7.1 images. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded build configurations to include support for PyTorch 2.7.0 with CUDA 12.6.3 and Python 3.11 in automated workflows.
  * Updated package requirements to use `xformers==0.0.31.post1` for PyTorch 2.7+ and set `vllm` to require version 0.9.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->