### PR TITLE
Print slowest durations for tests

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -80,9 +80,9 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -v -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/
-          pytest -v tests/patched/
-          pytest -v tests/cli/
+          pytest -v --durations=10 -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/
+          pytest -v --durations=10 tests/patched/
+          pytest -v --durations=10 tests/cli/
 
       - name: cleanup pip cache
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,9 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -v -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/ --cov=axolotl --cov-report=xml
-          pytest -v tests/patched/ --cov=axolotl --cov-append --cov-report=xml
-          pytest -v tests/cli/ --cov=axolotl --cov-append --cov-report=xml
+          pytest -v --durations=10 -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/ --cov=axolotl --cov-report=xml
+          pytest -v --durations=10 tests/patched/ --cov=axolotl --cov-append --cov-report=xml
+          pytest -v --durations=10 tests/cli/ --cov=axolotl --cov-append --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -175,9 +175,9 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -v -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/
-          pytest -v tests/patched/
-          pytest -v tests/cli/
+          pytest -v --durations=10 -n8 --dist loadfile --ignore=tests/e2e/ --ignore=tests/patched/ --ignore=tests/cli/ tests/
+          pytest -v --durations=10 tests/patched/
+          pytest -v --durations=10 tests/cli/
 
       - name: cleanup pip cache
         run: |


### PR DESCRIPTION
This should help with moitoring excessively slow tests and allow us to bring down CI time. For example:
```bash
============================= slowest 10 durations =============================
0.94s call     tests/cli/test_cli_evaluate.py::TestEvaluateCommand::test_evaluate_basic_execution_no_accelerate
0.87s setup    tests/cli/test_cli_evaluate.py::TestEvaluateCommand::test_evaluate_cli_validation
0.28s call     tests/cli/test_cli_train.py::TestTrainCommand::test_train_basic_execution_no_accelerate
0.26s call     tests/cli/test_cli_train.py::TestTrainCommand::test_train_cli_overrides
0.11s call     tests/cli/test_cli_evaluate.py::TestEvaluateCommand::test_evaluate_cli_overrides
0.08s call     tests/cli/test_cli_inference.py::test_inference_basic
0.07s call     tests/cli/test_cli_merge_lora.py::test_merge_lora_nonexistent_lora_dir
0.07s call     tests/cli/test_cli_inference.py::test_inference_gradio
0.04s teardown tests/cli/test_cli_preprocess.py::test_preprocess_config_not_found
0.04s teardown tests/cli/test_cli_evaluate.py::TestEvaluateCommand::test_evaluate_cli_validation
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflows to report the 10 slowest tests in nightly and standard test runs, improving visibility into test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->