### PR TITLE
feat: add call method to mistral tokenizer wrapper

### DIFF
--- a/tests/prompt_strategies/test_chat_templates_mistral.py
+++ b/tests/prompt_strategies/test_chat_templates_mistral.py
@@ -754,10 +754,12 @@ def test_magistral_tokenizer_call_method(
     magistral_tokenizer: "HFMistralTokenizer", llama3_tokenizer: "PreTrainedTokenizer"
 ):
     """Test the __call__ method behavior matches HuggingFace standards"""
+    from copy import deepcopy
+
     import numpy as np
     import torch
 
-    hf_tokenizer = llama3_tokenizer
+    hf_tokenizer = deepcopy(llama3_tokenizer)
     hf_tokenizer.pad_token = hf_tokenizer.eos_token
 
     test_text = "Hello, how are you?"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Add `__call__` to HFMistralTokenizer, with similar signature to PretrainedTokenizer.__call__.

We try to minimize what we support for now to basic call for np/pt format with padding and truncation until necessary to expand.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Added tests to compare against HF tokenizer.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tokenizer usability by allowing direct tokenization of input text with flexible options for padding, truncation, and output formats.  
* **Tests**
  * Added comprehensive tests to verify the new tokenizer behavior, including support for single and batch inputs, output formats, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->