### PR TITLE
Register Plugins in Ray Workers

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -111,7 +111,8 @@ def ray_train_func(kwargs: dict):
 
     # Register plugins in Ray workers
     if cfg.get("plugins"):
-        from axolotl.cli.config import prepare_plugins, plugin_set_cfg
+        from axolotl.cli.config import plugin_set_cfg, prepare_plugins
+
         prepare_plugins(cfg)
         plugin_set_cfg(cfg)
 

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -109,6 +109,11 @@ def ray_train_func(kwargs: dict):
     # initialize accelerator before model instantiation
     Accelerator(gradient_accumulation_steps=cfg.gradient_accumulation_steps)
 
+    if cfg.get("plugins"):
+        from axolotl.cli.config import prepare_plugins, plugin_set_cfg
+        prepare_plugins(cfg)
+        plugin_set_cfg(cfg)
+
     kwargs["cfg"] = cfg
 
     do_train(**kwargs)

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -109,6 +109,7 @@ def ray_train_func(kwargs: dict):
     # initialize accelerator before model instantiation
     Accelerator(gradient_accumulation_steps=cfg.gradient_accumulation_steps)
 
+    # Register plugins in Ray workers
     if cfg.get("plugins"):
         from axolotl.cli.config import prepare_plugins, plugin_set_cfg
         prepare_plugins(cfg)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Updated train.py to register the plugins on the ray workers.

Currently, when running `axolotl train <yaml> --use-ray`, the ray workers did not have access to the additional functions provided by the atropos plugin. Ray launches a new process that does not register the plugins, since that is currently done within the `cli/config.py`.

<!--- Describe your changes in detail -->

## Motivation and Context

When running `axolotl train train-fft.yaml --use-ray` with the plugin-atropos, the ray workers did not have access to the atropos plugin since it launches a new process on each worker.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Launched `axolotl train train-fft.yaml --use-ray` using 2 nodes and was able to access the atropos-plugin specific functions from within all of the Ray workers.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ensured that plugins are now automatically prepared and configured on each Ray worker node before training begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->