### PR TITLE
move the plugin post trainer create to the setup trainer

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -526,6 +526,9 @@ def setup_model_and_trainer(cfg: DictDefault, dataset_meta: TrainDatasetMeta) ->
         peft_config=peft_config,
     )
 
+    plugin_manager = PluginManager.get_instance()
+    plugin_manager.post_trainer_create(cfg, trainer)
+
     return (
         trainer,
         model,
@@ -557,9 +560,6 @@ def train(
         processor,
     ) = setup_model_and_trainer(cfg, dataset_meta)
 
-    plugin_manager = PluginManager.get_instance()
-    plugin_manager.post_trainer_create(cfg, trainer)
-
     # Handle untrained tokens if configured
     safe_serialization = cfg.save_safetensors is True
     train_dataset = dataset_meta.train_dataset
@@ -582,6 +582,7 @@ def train(
     if not cfg.use_ray:
         cleanup_distributed()
 
+    plugin_manager = PluginManager.get_instance()
     plugin_manager.post_train(cfg, model)
 
     return model, tokenizer, trainer

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -228,6 +228,9 @@ def execute_training(
         #     torch.set_default_dtype(torch.bfloat16)
         trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
+        plugin_manager = PluginManager.get_instance()
+        plugin_manager.post_train(cfg, trainer.model)
+
 
 def save_trained_model(
     cfg: DictDefault,
@@ -581,8 +584,5 @@ def train(
     create_model_card(cfg, trainer)
     if not cfg.use_ray:
         cleanup_distributed()
-
-    plugin_manager = PluginManager.get_instance()
-    plugin_manager.post_train(cfg, model)
 
     return model, tokenizer, trainer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Moving the plugin setup to setup trainer makes it so calling trainer.train() is all that needs to be done after. (e.g. colab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the training workflow by reorganizing internal plugin-related operations for better process management. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->