### PR TITLE
Fix: Prevents merging of tool arguments during preprocessing

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -378,12 +378,20 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         """
         Public method that can handle either a single prompt or a batch of prompts.
         """
+        def _remove_none_values(obj):
+            if hasattr(obj, "items"):
+                return {k: _remove_none_values(v) for k, v in obj.items() if v is not None}
+            elif isinstance(obj, list):
+                return [_remove_none_values(elem) for elem in obj]
+            return obj
 
         if not self.is_prompt_batched(prompt) or not self.supports_batched:
             return self._tokenize_single_prompt(prompt)
 
         res = defaultdict(lambda: [])
         feature_names = list(prompt.keys())
+
+        prompt = _remove_none_values(prompt)
 
         # Process each prompt individually
         for row in zip(*prompt.values()):

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -388,14 +388,13 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 return [_remove_none_values(elem) for elem in obj]
             return obj
 
+        prompt = _remove_none_values(prompt)
+
         if not self.is_prompt_batched(prompt) or not self.supports_batched:
-            prompt = _remove_none_values(prompt)
             return self._tokenize_single_prompt(prompt)
 
         res = defaultdict(lambda: [])
         feature_names = list(prompt.keys())
-
-        prompt = _remove_none_values(prompt)
 
         # Process each prompt individually
         for row in zip(*prompt.values()):

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -378,14 +378,18 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         """
         Public method that can handle either a single prompt or a batch of prompts.
         """
+
         def _remove_none_values(obj):
             if hasattr(obj, "items"):
-                return {k: _remove_none_values(v) for k, v in obj.items() if v is not None}
-            elif isinstance(obj, list):
+                return {
+                    k: _remove_none_values(v) for k, v in obj.items() if v is not None
+                }
+            if isinstance(obj, list):
                 return [_remove_none_values(elem) for elem in obj]
             return obj
 
         if not self.is_prompt_batched(prompt) or not self.supports_batched:
+            prompt = _remove_none_values(prompt)
             return self._tokenize_single_prompt(prompt)
 
         res = defaultdict(lambda: [])

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -380,6 +380,11 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         """
 
         def _remove_none_values(obj):
+            """
+            Remove null from a dictionary-like obj or list.
+            These can appear due to Dataset loading causing schema merge.
+            See https://github.com/axolotl-ai-cloud/axolotl/pull/2909
+            """
             if hasattr(obj, "items"):
                 return {
                     k: _remove_none_values(v) for k, v in obj.items() if v is not None

--- a/tests/prompt_strategies/test_chat_template_ds_schema_unification.py
+++ b/tests/prompt_strategies/test_chat_template_ds_schema_unification.py
@@ -1,0 +1,75 @@
+"""
+Tests for chat template prompt strategy with schema unification for none fields
+"""
+
+import json
+
+import pytest
+from datasets import Dataset
+from transformers import AutoTokenizer
+
+from axolotl.prompt_strategies.chat_template import StrategyLoader
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.fixture(name="messages_w_tools")
+def fixture_messages_w_tools():
+    jsons = """
+{"messages":[{"role":"user","content":"move to (0, 1)"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"move","arguments":{"x":0,"y":1}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
+{"messages":[{"role":"user","content":"turn 270 degree"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"turn","arguments":{"theta": 270}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
+{"messages":[{"role":"user","content":"jump high"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"invalid_prompt","arguments":{"message": "jump is not a valid action"}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
+    """.strip().split(
+        "\n"
+    )
+    rows = [json.loads(row) for row in jsons]
+    return Dataset.from_list(rows)
+
+
+@pytest.fixture(name="qwen3_tokenizer")
+def qwen3_tokenizer_fixture(
+    download_qwen3_half_billion_model,
+):  # pylint: disable=unused-argument
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+
+    return tokenizer
+
+
+@pytest.fixture(name="qwen3_prompt_strategy")
+def qwen3_chat_template_strategy(qwen3_tokenizer):
+    cfg = DictDefault(
+        sequence_len=2048,
+        chat_template="qwen3",
+        eot_tokens=["<|im_end|>"],
+    )
+    ds_cfg = DictDefault(
+        type="chat_template",
+    )
+    load = StrategyLoader()
+    strat = load(qwen3_tokenizer, cfg, ds_cfg)
+    return strat
+
+
+class TestSchemaUnification:
+    """
+    Test class on handling null fields for tool calling
+    """
+
+    def test_schema_unification_single_prompt(
+        self, messages_w_tools, qwen3_prompt_strategy, qwen3_tokenizer
+    ):
+        for row in messages_w_tools:
+            inputs = qwen3_prompt_strategy.tokenize_prompt(row)
+            decoded = qwen3_tokenizer.decode(inputs["input_ids"])
+            tool_call = decoded.split("<tool_call>")[-1].split("</tool_call>")[0]
+            assert '"message": null' not in tool_call
+            assert '"theta": null' not in tool_call
+
+    def test_schema_unification_batched(
+        self, messages_w_tools, qwen3_prompt_strategy, qwen3_tokenizer
+    ):
+        rows = messages_w_tools.map(qwen3_prompt_strategy.tokenize_prompt, batched=True)
+        for row in rows:
+            decoded = qwen3_tokenizer.decode(row["input_ids"])
+            tool_call = decoded.split("<tool_call>")[-1].split("</tool_call>")[0]
+            assert '"message": null' not in tool_call
+            assert '"theta": null' not in tool_call


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR modifies the data preprocessing logic for tool calls. It resolves an issue where arguments from multiple tools were being merged during preprocessing, causing unnecessary fields to be populated with null values.

This change reforms the structure of tool_calls within the preprocessed data. By removing extraneous null arguments, each tool call in the training data now strictly adheres to its own schema, ensuring it matches the format expected by standard chat templates.

## Motivation and Context

### Problem: 
The current logic merges the function signatures of all available tools, likely due to the schema unification behavior of Hugging Face's datasets.load_dataset with JSON files. (See [HF Docs on JSON loading](https://huggingface.co/docs/datasets/loading#json)).
<br>

### Impact: 
This results in training data where tool_calls contain extraneous arguments with null values.
A model fine-tuned on this data performs poorly when used for inference with standard chat templates (e.g., in vLLM), as there is a mismatch between the training format and the expected inference format.
<br>

### Example:
```json
{"messages":[{"role":"user","content":"move to (0, 1)"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"move","arguments":{"x":0,"y":1}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
{"messages":[{"role":"user","content":"turn 270 degree"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"turn","arguments":{"theta": 270}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
{"messages":[{"role":"user","content":"jump high"},{"role":"assistant","content":"","tool_calls":[{"function":{"name":"invalid_prompt","arguments":{"message": "jump is not a valid action"}}}]}],"tools":[{"type":"function","function":{"name":"move","description":"Move to a given location measured in meters","parameters":{"type":"object","properties":{"x":{"type":"number","description":"The x coordinate of the location, negative values are to the left, positive values are to the right"},"y":{"type":"number","description":"The y coordinate of the location, negative values are backward, positive values are forward"}},"required":["x","y"]}}},{"type":"function","function":{"name":"turn","description":"Turn the robot to a given direction","parameters":{"type":"object","properties":{"theta":{"type":"integer","description":"The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}},"required":["theta"]}}},{"type":"function","function":{"name":"invalid_prompt","description":"call when the user's prompt is invalid","parameters":{"type":"object","properties":{"message":{"type":"string","description":"why the prompt is invalid"}},"required":["message"]}}}],"add_generation_prompt":false}
```

Applying the chat template to the data above produces the following result (first column)
``` text
<|im_start|>system
# Tools

You may call one or more functions to assist with the user query.

You are provided with function signatures within <tools></tools> XML tags:
<tools>
{"type": "function", "function": {"name": "move", "description": "Move to a given location measured in meters", "parameters": {"type": "object", "properties": {"x": {"type": "number", "description": "The x coordinate of the location, negative values are to the left, positive values are to the right"}, "y": {"type": "number", "description": "The y coordinate of the location, negative values are backward, positive values are forward"}}, "required": ["x", "y"]}}}
{"type": "function", "function": {"name": "turn", "description": "Turn the robot to a given direction", "parameters": {"type": "object", "properties": {"theta": {"type": "integer", "description": "The angle to turn to, in degrees, positive values are counter-clockwise, negative values are clockwise"}}, "required": ["theta"]}}}
{"type": "function", "function": {"name": "invalid_prompt", "description": "call when the user's prompt is invalid", "parameters": {"type": "object", "properties": {"message": {"type": "string", "description": "why the prompt is invalid"}}, "required": ["message"]}}}
</tools>

For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
<tool_call>
{"name": <function-name>, "arguments": <args-json-object>}
</tool_call><|im_end|>
<|im_start|>user
move to (0, 1)<|im_end|>
<|im_start|>assistant
<think>

</think>

<tool_call>
{"name": "move", "arguments": {"x": 0, "y": 1}}
</tool_call><|im_end|>
```
<br>

axolotl preprocess --debug makes following output

* Before this PR (contains "theta": null and "message" null)
``` text
(User prompt and tool tokens omitted.)
(-100, 198) <|im_start|>(-100, 151644) assistant(-100, 77091) 
(-100, 198) <think>(-100, 151667) 

(-100, 271) </think>(-100, 151668) 

(-100, 271) <tool_call>(151657, 151657) 
(198, 198) {"(4913, 4913) name(606, 606) ":(788, 788)  "(330, 330) move(3397, 3397) ",(497, 497)  "(330, 330) arguments(16370, 16370) ":(788, 788)  {"(5212, 5212) x(87, 87) ":(788, 788)  (220, 220) 0(15, 15) ,(11, 11)  "(330, 330) y(88, 88) ":(788, 788)  (220, 220) 1(16, 16) ,(11, 11)  "(330, 330) theta(15976, 15976) ":(788, 788)  null(845, 845) ,(11, 11)  "(330, 330) message(1994, 1994) ":(788, 788)  null(845, 845) }}
(11248, 11248) </tool_call>(151658, 151658) <|im_end|>(151645, 151645) 
(-100, 198)
```

* After this PR (Correct arguments for "move" tool)
``` text
(User prompt and tool tokens omitted.)
(-100, 198) <|im_start|>(-100, 151644) assistant(-100, 77091) 
(-100, 198) <think>(-100, 151667) 

(-100, 271) </think>(-100, 151668) 

(-100, 271) <tool_call>(151657, 151657) 
(198, 198) {"(4913, 4913) name(606, 606) ":(788, 788)  "(330, 330) move(3397, 3397) ",(497, 497)  "(330, 330) arguments(16370, 16370) ":(788, 788)  {"(5212, 5212) x(87, 87) ":(788, 788)  (220, 220) 0(15, 15) ,(11, 11)  "(330, 330) y(88, 88) ":(788, 788)  (220, 220) 1(16, 16) }}
(11248, 11248) </tool_call>(151658, 151658) <|im_end|>(151645, 151645) 
(-100, 198)
```

## How has this been tested?

This change was evaluated using the qwen3-1.7b model with vLLM for inference. 
The results are as follows:

Before fine-tuning: 55.5% accuracy
After fine-tuning (before this PR): 29.8% (Performance degraded)
After fine-tuning (this PR): 90.3% (Performance improved)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt processing by filtering out any entries with missing values before tokenization, ensuring cleaner serialized outputs.  
* **Tests**
  * Added tests to verify that optional fields are correctly omitted in tool call outputs, preventing null values in serialized chat prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->