### PR TITLE
fix xformers version for python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,9 @@ def parse_requirements(extras_require_map):
                 extras_require_map["vllm"] = ["vllm>=0.9.0"]
             elif (major, minor) >= (2, 6):
                 _install_requires.pop(_install_requires.index(xformers_version))
-                _install_requires.append(
-                    "xformers==0.0.29.post2"
-                )  # vllm needs post2 w torch 2.6
+                _install_requires.append("xformers==0.0.29.post3")
+                # since we only support 2.6.0+cu126
+                _dependency_links.append("https://download.pytorch.org/whl/cu126")
                 extras_require_map["vllm"] = ["vllm==0.8.5.post1"]
             elif (major, minor) >= (2, 5):
                 _install_requires.pop(_install_requires.index(xformers_version))


### PR DESCRIPTION
Since we're only supporting cu126 for torch 2.6.0, we need to use the post3 release and manually specify the index url to install from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the required version of the `xformers` package for compatibility with PyTorch 2.6.
  * Added support for CUDA 12.6 wheels.

* **Documentation**
  * Clarified comments to indicate support for PyTorch 2.6.0+cu126 only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->