### PR TITLE
upgrade peft==0.16.0 and datasets==4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ liger-kernel==0.6.0
 packaging==23.2
 
 huggingface_hub>=0.33.0
-peft==0.15.2
+peft==0.16.0
 transformers==4.53.2
 tokenizers>=0.21.1
 accelerate==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ peft==0.16.0
 transformers==4.53.2
 tokenizers>=0.21.1
 accelerate==1.8.1
-datasets==3.6.0
+datasets==4.0.0
 deepspeed>=0.17.0
 trl==0.19.1
 hf_xet==1.1.2

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -865,6 +865,7 @@ class OptimizationValidationMixin:
             and hasattr(self, "save_safetensors")
             and self.save_safetensors
             and self.fsdp_config.get("state_dict_type", "") == "SHARDED_STATE_DICT"
+            and str(getattr(self, "fsdp_version", "1")) != "2"
         ):
             raise ValueError(
                 "FSDP SHARDED_STATE_DICT not compatible with save_safetensors"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ from huggingface_hub.errors import LocalEntryNotFoundError
 from tokenizers import AddedToken
 from transformers import AutoTokenizer
 
+from axolotl.utils.dict import DictDefault
+
 from tests.hf_offline_utils import (
     enable_hf_offline,
     hf_offline_context,
@@ -537,6 +539,22 @@ def dataset_fozziethebeat_alpaca_messages_2k_dpo_test_rev_ea82cff(
         / "fozziethebeat__alpaca_messages_2k_dpo_test__rev_ea82cff"
     )
     return datasets.load_from_disk(ds_path)["train"]
+
+
+@pytest.fixture(name="min_base_cfg")
+def fixture_min_base_cfg():
+    return DictDefault(
+        base_model="HuggingFaceTB/SmolLM2-135M",
+        learning_rate=1e-3,
+        datasets=[
+            {
+                "path": "mhenrichsen/alpaca_2k_test",
+                "type": "alpaca",
+            },
+        ],
+        micro_batch_size=1,
+        gradient_accumulation_steps=1,
+    )
 
 
 # # pylint: disable=redefined-outer-name,unused-argument

--- a/tests/e2e/multigpu/test_llama.py
+++ b/tests/e2e/multigpu/test_llama.py
@@ -391,7 +391,10 @@ class TestMultiGPULlama:
 
     @pytest.mark.parametrize(
         "fsdp_state_dict_type",
-        ["FULL_STATE_DICT", "SHARDED_STATE_DICT"],
+        [
+            "FULL_STATE_DICT",
+            # "SHARDED_STATE_DICT",  # not supported since intermediate checkpoints fail with fsdp1
+        ],
     )
     def test_fsdp_packed(self, temp_dir, fsdp_state_dict_type):
         # pylint: disable=duplicate-code
@@ -413,7 +416,8 @@ class TestMultiGPULlama:
                     },
                 ],
                 "num_epochs": 1,
-                "max_steps": 2,
+                "max_steps": 3,
+                "save_steps": 2,
                 "micro_batch_size": 2,
                 "gradient_accumulation_steps": 2,
                 # "gradient_checkpointing": True,

--- a/tests/e2e/multigpu/test_llama.py
+++ b/tests/e2e/multigpu/test_llama.py
@@ -601,7 +601,7 @@ class TestMultiGPULlama:
                     "fsdp_use_orig_params": False,
                     "fsdp_cpu_ram_efficient_loading": True,
                     "fsdp_transformer_layer_cls_to_wrap": "LlamaDecoderLayer",
-                    "fsdp_state_dict_type": "SHARDED_STATE_DICT",
+                    "fsdp_state_dict_type": "FULL_STATE_DICT",
                     "fsdp_auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
                 },
                 "use_tensorboard": True,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -7,21 +7,16 @@ from axolotl.utils.dict import DictDefault
 
 
 @pytest.fixture(name="train_base_cfg")
-def fixture_train_base_cfg():
-    return DictDefault(
-        base_model="gpt2",
-        learning_rate=1e-3,
-        datasets=[
-            {
-                "path": "mhenrichsen/alpaca_2k_test",
-                "type": "alpaca",
-            },
-        ],
-        micro_batch_size=2,
-        gradient_accumulation_steps=4,
-        sequence_len=2048,
-        sample_packing=True,
-        num_epochs=1,
+def fixture_train_base_cfg(min_base_cfg):
+    return (
+        DictDefault(
+            micro_batch_size=2,
+            gradient_accumulation_steps=4,
+            sequence_len=2048,
+            sample_packing=True,
+            num_epochs=1,
+        )
+        | min_base_cfg
     )
 
 

--- a/tests/utils/schemas/validation/test_fsdp.py
+++ b/tests/utils/schemas/validation/test_fsdp.py
@@ -9,29 +9,13 @@ from axolotl.utils.config import validate_config
 from axolotl.utils.dict import DictDefault
 
 
-@pytest.fixture(name="fsdp_base_cfg")
-def fixture_fsdp_base_cfg():
-    return DictDefault(
-        base_model="gpt2",
-        learning_rate=1e-3,
-        datasets=[
-            {
-                "path": "mhenrichsen/alpaca_2k_test",
-                "type": "alpaca",
-            },
-        ],
-        micro_batch_size=1,
-        gradient_accumulation_steps=1,
-    )
-
-
 class TestFSDPValidation:
     """
     test class for pydantic fsdp validation
     """
 
-    def test_fsdp_version_in_fsdp_config(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp_version_in_fsdp_config(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "fsdp_version": 2,
             },
@@ -42,8 +26,8 @@ class TestFSDPValidation:
         assert cfg.fsdp_version == 2
         assert cfg.fsdp_config.fsdp_version is None
 
-    def test_fsdp_sharded_state_dict_safetensors(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp_sharded_state_dict_safetensors(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "fsdp_state_dict_type": "SHARDED_STATE_DICT",
             },
@@ -56,7 +40,7 @@ class TestFSDPValidation:
             validate_config(cfg)
 
         # test w/o prefix too
-        cfg = fsdp_base_cfg | DictDefault(
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "state_dict_type": "SHARDED_STATE_DICT",
             },
@@ -68,8 +52,8 @@ class TestFSDPValidation:
         ):
             validate_config(cfg)
 
-    def test_fsdp_offload_w_8bit_optim(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp_offload_w_8bit_optim(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "offload_params": True,
             },
@@ -81,8 +65,8 @@ class TestFSDPValidation:
         ):
             validate_config(cfg)
 
-    def test_fsdp2_w_8bit_optim(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp2_w_8bit_optim(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "offload_params": True,
             },
@@ -95,8 +79,8 @@ class TestFSDPValidation:
         ):
             validate_config(cfg)
 
-    def test_fsdp2_w_cpu_ram_efficient_loading(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp2_w_cpu_ram_efficient_loading(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             load_in_8bit=True,
             adapter="lora",
             fsdp_config={
@@ -110,8 +94,8 @@ class TestFSDPValidation:
         ):
             validate_config(cfg)
 
-    def test_fsdp_prefixes_removed(self, fsdp_base_cfg):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp_prefixes_removed(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
             fsdp_config={
                 "fsdp_version": 2,
                 "fsdp_auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
@@ -137,8 +121,8 @@ class TestFSDPValidation:
             "ipo",
         ],
     )
-    def test_fsdp2_dpo(self, fsdp_base_cfg, rl):
-        cfg = fsdp_base_cfg | DictDefault(
+    def test_fsdp2_dpo(self, min_base_cfg, rl):
+        cfg = min_base_cfg | DictDefault(
             fsdp_version=2,
             fsdp_config={
                 "reshard_after_forward": True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the versions of the `peft` package to 0.16.0 and the `datasets` package to 4.0.0.
* **Tests**
  * Introduced a new minimal base configuration fixture for testing.
  * Enhanced test configuration flexibility by merging base settings.
  * Streamlined test fixtures by replacing an older configuration with the new minimal base configuration.
  * Adjusted test parameters to focus on full state dict usage and updated training step settings.
* **Bug Fixes**
  * Improved validation to exempt FSDP version 2 from certain incompatibility errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->