### PR TITLE
use state for wandb in callbacks

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -798,7 +798,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
         control: TrainerControl,
         **kwargs,  # pylint: disable=unused-argument
     ):
-        if is_main_process():
+        if state.is_world_process_zero:
             try:
                 # sync config to top level in run, cannot delete file right away because wandb schedules it to be synced even w/policy = 'now', so let OS delete it later.
                 with NamedTemporaryFile(


### PR DESCRIPTION
# Description
multi node report with wandb:

```
[rank8]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/trainer_callback.py", line 506, in on_train_begin
[rank8]:     return self.call_event("on_train_begin", args, state, control)
[rank8]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank8]:   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/trainer_callback.py", line 556, in call_event
[rank8]:     result = getattr(callback, event)(
[rank8]:              ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank8]:   File "/workspace/axolotl/src/axolotl/utils/callbacks/__init__.py", line 809, in on_train_begin
[rank8]:     f"config-{wandb.run.id}", type="axolotl-config"
[rank8]:               ^^^^^^^^^^^^
[rank8]: AttributeError: 'NoneType' object has no attribute 'id'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal logic for determining the main process when saving configuration files to WandB during training. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->