### PR TITLE
don't use include_tokens_per_second for GRPO

### DIFF
--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -58,8 +58,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             trainer_cls_args.extend(GRPOStrategy.set_trainer_args(self.cfg))
 
             trainer_kwargs.update(GRPOStrategy.set_trainer_kwargs(self.cfg))
-            if "include_tokens_per_second" in trainer_kwargs:
-                del trainer_kwargs["include_tokens_per_second"]
 
         elif self.cfg.rl in [RLType.DPO, RLType.IPO]:
             trainer_cls = DPOStrategy.get_trainer_class()

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -58,6 +58,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             trainer_cls_args.extend(GRPOStrategy.set_trainer_args(self.cfg))
 
             trainer_kwargs.update(GRPOStrategy.set_trainer_kwargs(self.cfg))
+            if "include_tokens_per_second" in trainer_kwargs:
+                del trainer_kwargs["include_tokens_per_second"]
 
         elif self.cfg.rl in [RLType.DPO, RLType.IPO]:
             trainer_cls = DPOStrategy.get_trainer_class()

--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -148,7 +148,7 @@ class GRPOStrategy:
 
     @classmethod
     def get_blocklist_args_kwargs(cls) -> list[str]:
-        return ["dataset_num_proc", "max_length"]
+        return ["dataset_num_proc", "max_length", "include_tokens_per_second"]
 
     @classmethod
     def get_reward_func(cls, reward_func_fqn: str) -> RewardFunc:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
 Fixes #2779 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where an unnecessary setting related to tokens per second was included for a specific reinforcement learning type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->