### PR TITLE
add validation around cce + chunked_ce

### DIFF
--- a/src/axolotl/integrations/cut_cross_entropy/args.py
+++ b/src/axolotl/integrations/cut_cross_entropy/args.py
@@ -50,3 +50,4 @@ class CutCrossEntropyArgs(BaseModel):
                 "Cut Cross Entropy does not support chunked cross entropy. "
                 "Please set `chunked_cross_entropy` to `False` or disable Cut Cross Entropy."
             )
+        return data

--- a/src/axolotl/integrations/cut_cross_entropy/args.py
+++ b/src/axolotl/integrations/cut_cross_entropy/args.py
@@ -41,3 +41,12 @@ class CutCrossEntropyArgs(BaseModel):
             )
 
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_chunked_cross_entropy_not_set(cls, data):
+        if data.get("chunked_cross_entropy"):
+            raise ValueError(
+                "Cut Cross Entropy does not support chunked cross entropy. "
+                "Please set `chunked_cross_entropy` to `False` or disable Cut Cross Entropy."
+            )


### PR DESCRIPTION
# Description

since these two patch the same forward, they don't compose together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent enabling chunked cross entropy when using Cut Cross Entropy, ensuring users receive a clear error message if an incompatible configuration is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->