### PR TITLE
make sure log level is upper

### DIFF
--- a/src/axolotl/logging_config.py
+++ b/src/axolotl/logging_config.py
@@ -113,7 +113,7 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
     "loggers": {
         "axolotl": {
             "handlers": ["color_console"],
-            "level": os.getenv("AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL),
+            "level": os.getenv("AXOLOTL_LOG_LEVEL", DEFAULT_AXOLOTL_LOG_LEVEL).upper(),
             "propagate": False,
         },
     },


### PR DESCRIPTION
If AXOLOTL_LOG_LEVEL=debug, it doesn't correctly get upper()-ed

```
Traceback (most recent call last):
  File "/root/miniconda3/envs/py3.11/bin/axolotl", line 5, in <module>
    from axolotl.cli.main import main
  File "/workspace/axolotl/src/axolotl/cli/__init__.py", line 8, in <module>
    configure_logging()
  File "/workspace/axolotl/src/axolotl/logging_config.py", line 126, in configure_logging
    dictConfig(DEFAULT_LOGGING_CONFIG)
  File "/root/miniconda3/envs/py3.11/lib/python3.11/logging/config.py", line 823, in dictConfig
    dictConfigClass(config).configure()
  File "/root/miniconda3/envs/py3.11/lib/python3.11/logging/config.py", line 629, in configure
    raise ValueError('Unable to configure logger '
ValueError: Unable to configure logger 'axolotl'
````

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of log level configuration by ensuring the log level from environment variables is always treated as uppercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->