### PR TITLE
cu126-torch271 for cloud docker image should be tagged with main-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,6 @@ jobs:
             python_version: "3.11"
             pytorch: 2.6.0
             axolotl_extras:
-            is_latest: true
           - cuda: 126
             cuda_version: 12.6.3
             python_version: "3.11"
@@ -98,6 +97,7 @@ jobs:
             python_version: "3.11"
             pytorch: 2.7.1
             axolotl_extras:
+            is_latest: true
           - cuda: 128
             cuda_version: 12.8.1
             python_version: "3.11"


### PR DESCRIPTION
# Description
 in the release notes of v0.11.0 we promised that the "latest" tag for images would be 2.7.1, but we never actually did that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration to mark a different environment as the "latest" for Docker image tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->