### PR TITLE
make the initial call to tokenizer.pad not spam the console

### DIFF
--- a/src/axolotl/integrations/liger/args.py
+++ b/src/axolotl/integrations/liger/args.py
@@ -53,3 +53,12 @@ class LigerArgs(BaseModel):
             )
             data["liger_glu_activation"] = data.pop("liger_swiglu")
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_tiled_mlp_conflict(cls, data):
+        if data.get("liger_glu_activation") is True and data.get("tiled_mlp") is True:
+            raise ValueError(
+                "You cannot have both `liger_glu_activation` and `tiled_mlp` set."
+            )
+        return data

--- a/src/axolotl/loaders/tokenizer.py
+++ b/src/axolotl/loaders/tokenizer.py
@@ -295,4 +295,8 @@ def load_tokenizer(cfg: DictDefault) -> PreTrainedTokenizer:
         LOG.info(
             "No Chat template selected. Consider adding a chat template for easier inference."
         )
+
+    # make the tokenizer.pad call quieter 🤐
+    tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
+
     return tokenizer

--- a/src/axolotl/loaders/tokenizer.py
+++ b/src/axolotl/loaders/tokenizer.py
@@ -297,6 +297,7 @@ def load_tokenizer(cfg: DictDefault) -> PreTrainedTokenizer:
         )
 
     # make the tokenizer.pad call quieter 🤐
-    tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
+    if hasattr(tokenizer, "deprecation_warnings"):
+        tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
 
     return tokenizer

--- a/src/axolotl/monkeypatch/tiled_mlp.py
+++ b/src/axolotl/monkeypatch/tiled_mlp.py
@@ -7,6 +7,9 @@ import torch
 import torch.distributed as dist
 
 from axolotl.utils.callbacks.models import get_causal_lm_model_cls_prefix
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
 
 
 def patch_tiled_mlp(model_type, use_original_mlp=False, cfg_num_shards=None):
@@ -63,6 +66,10 @@ def patch_tiled_mlp(model_type, use_original_mlp=False, cfg_num_shards=None):
 
         mlp_cls.forward = tiled_mlp_forward
         mlp_cls._compute_params = []  # pylint: disable=protected-access
+        LOG.info(
+            f"Successfully monkey-patched TiledMLP for model_type: {model_type}",
+            main_process_only=True,
+        )
     except (ImportError, AttributeError) as e:
         raise RuntimeError(
             f"Could not import MLP class for model_type: {model_type}. "

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -3,7 +3,6 @@
 # pylint: disable=too-many-boolean-expressions
 
 import json
-import logging
 import tempfile
 from pathlib import Path
 
@@ -13,11 +12,12 @@ from pydantic import (
 )
 from transformers.utils.import_utils import is_torch_npu_available
 
+from axolotl.utils.logging import get_logger
 from axolotl.utils.schemas.enums import ChatTemplate, RingAttnFunc, RLType
 
 # pylint: disable=too-many-lines
 
-LOG = logging.getLogger(__name__)
+LOG = get_logger(__name__)
 
 SUPPORTED_METRICS = {"sacrebleu", "comet", "ter", "chrf", "perplexity"}
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -116,7 +116,8 @@ class DatasetValidationMixin:
             and not data.get("eval_table_size")
         ):
             LOG.info(
-                "explicitly setting `eval_sample_packing` to match `sample_packing`"
+                "explicitly setting `eval_sample_packing` to match `sample_packing`",
+                main_process_only=True,
             )
             data["eval_sample_packing"] = True
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

When training starts, we pad but the tokenizer usually gets called in fork/multiprocess so it spams the console with

```
Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.
```

This PR sets a variable so the check doesn't emit the mesage

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed deprecation warnings related to padding on fast tokenizers, reducing unnecessary warning messages for users.
* **New Features**
  * Added validation to prevent incompatible configuration options from being enabled simultaneously.
* **Improvements**
  * Enhanced logging to provide clearer informational messages while limiting output to the main process in distributed environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->