### PR TITLE
TiledMLP support for FSDP2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 ## 🎉 Latest Updates
 
+- 2025/07: TiledMLP support for single-GPU to multi-GPU training with DDP, DeepSpeed and FSDP support has been added to support Arctic Long Sequence Training. (ALST). See [examples](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/alst) for using ALST with Axolotl!
 - 2025/06: Magistral with mistral-common tokenizer support has been added to Axolotl. See [examples](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/magistral) to start training your own Magistral models with Axolotl!
 - 2025/05: Quantization Aware Training (QAT) support has been added to Axolotl. Explore the [docs](https://docs.axolotl.ai/docs/qat.html) to learn more!
 - 2025/04: Llama 4 support has been added in Axolotl. See [examples](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/llama-4) to start training your own Llama 4 models with Axolotl's linearized version!

--- a/examples/alst/README.md
+++ b/examples/alst/README.md
@@ -1,0 +1,9 @@
+# Arctic Long Sequence Training (ALST)
+
+Artic Long Sequence Training (ALST) is a technique for training long context models using a variety of optimization
+techniques. It is a combination of:
+- TiledMLP: Leverage tiling over the sequence dimension on MLP layers to reduce memory usage
+- Tiled Loss: Using optimized loss functions like Liger-Kernel or Cut Cross Entropy to reduce memory usage
+- Activation Offloading: Offload activations to CPU RAM to reduce memory usage
+
+For more information, you can check out the ALST paper [here](https://www.arxiv.org/abs/2506.13996).

--- a/examples/alst/llama3-8b-deepspeed-alst.yaml
+++ b/examples/alst/llama3-8b-deepspeed-alst.yaml
@@ -1,0 +1,53 @@
+base_model: meta-llama/Llama-3.1-8B
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+datasets:
+  - path: togethercomputer/Long-Data-Collections
+    type: completion
+    field: text
+    data_files:
+      - pretrain/rp_sub.jsonl.zst
+  - path: princeton-nlp/TextbookChapters
+    type: completion
+    field: chapter
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.0
+output_dir: ./outputs/out
+
+sequence_len: 500_000
+min_sample_len: 200_000
+sample_packing: true
+
+tiled_mlp: true
+sequence_parallel_degree: 8
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+gradient_accumulation_steps: 1
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 2e-5
+
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+activation_offloading: legacy
+
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_steps: 100
+saves_per_epoch: 1
+evals_per_epoch: 2
+weight_decay: 0.0
+special_tokens:
+  pad_token: <|end_of_text|>
+
+deepspeed: deepspeed_configs/zero3_bf16_cpuoffload_all.json
+
+# save_first_step: true  # uncomment this to validate checkpoint saving works with your config

--- a/examples/alst/llama3-8b-fsdp2-alst.yaml
+++ b/examples/alst/llama3-8b-fsdp2-alst.yaml
@@ -20,7 +20,7 @@ min_sample_len: 200_000
 sample_packing: true
 
 tiled_mlp: true
-sequence_parallel_degree: 8
+context_parallel_size: 8
 plugins:
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
 

--- a/examples/alst/llama3-8b-fsdp2-alst.yaml
+++ b/examples/alst/llama3-8b-fsdp2-alst.yaml
@@ -1,0 +1,59 @@
+base_model: meta-llama/Llama-3.1-8B
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+datasets:
+  - path: togethercomputer/Long-Data-Collections
+    type: completion
+    field: text
+    data_files:
+      - pretrain/rp_sub.jsonl.zst
+  - path: princeton-nlp/TextbookChapters
+    type: completion
+    field: chapter
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.0
+output_dir: ./outputs/out
+
+sequence_len: 500_000
+min_sample_len: 200_000
+sample_packing: true
+
+tiled_mlp: true
+sequence_parallel_degree: 8
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+gradient_accumulation_steps: 1
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 2e-5
+
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+activation_offloading: legacy
+
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_steps: 100
+saves_per_epoch: 1
+evals_per_epoch: 2
+weight_decay: 0.0
+special_tokens:
+  pad_token: <|end_of_text|>
+
+fsdp_version: 2
+fsdp_config:
+  offload_params: false  # offloading is currently not compatible with SP + torchao optimizer
+  state_dict_type: SHARDED_STATE_DICT
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: LlamaDecoderLayer
+  reshard_after_forward: true
+
+# save_first_step: true  # uncomment this to validate checkpoint saving works with your config

--- a/src/axolotl/integrations/liger/args.py
+++ b/src/axolotl/integrations/liger/args.py
@@ -57,8 +57,12 @@ class LigerArgs(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_tiled_mlp_conflict(cls, data):
-        if data.get("liger_glu_activation") is True and data.get("tiled_mlp") is True:
+        if (
+            data.get("liger_glu_activation") is True
+            and data.get("tiled_mlp") is True
+            and not data.get("tiled_mlp_use_original_mlp")
+        ):
             raise ValueError(
-                "You cannot have both `liger_glu_activation` and `tiled_mlp` set."
+                "You cannot have both `liger_glu_activation` and `tiled_mlp` set without `tiled_mlp_use_original_mlp: true`."
             )
         return data

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -162,6 +162,7 @@ class ModelLoader:
 
         # Build the model
         PLUGIN_MANAGER.pre_model_load(self.cfg)
+        self.patch_manager.apply_post_plugin_pre_model_load_patches()
         skip_move_to_device = self._build_model()
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
 

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -272,13 +272,23 @@ class PatchManager:
 
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:
-            from axolotl.monkeypatch.tiled_mlp import patch_tiled_mlp
-
-            patch_tiled_mlp(
-                model_type,
-                use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
-                cfg_num_shards=self.cfg.tiled_mlp_num_shards,
+            from axolotl.monkeypatch.tiled_mlp import (
+                patch_tiled_mlp_deepspeed,
+                patch_tiled_mlp_fsdp,
             )
+
+            if self.cfg.deepspeed:
+                patch_tiled_mlp_deepspeed(
+                    model_type,
+                    use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
+                    cfg_num_shards=self.cfg.tiled_mlp_num_shards,
+                )
+            if self.cfg.fsdp:
+                patch_tiled_mlp_fsdp(
+                    model_type,
+                    use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
+                    cfg_num_shards=self.cfg.tiled_mlp_num_shards,
+                )
 
     def _patch_attention(self):
         """Apply attention-specific patches based on model type."""

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -66,6 +66,9 @@ class PatchManager:
         self._apply_self_attention_lora_patch()
         self._apply_gemma3_conditional_generation_forward_patch()
         self._apply_sequence_parallel_patches()
+
+    def apply_post_plugin_pre_model_load_patches(self):
+        """Apply post plugin-pre_model_load load patches based on config."""
         self._apply_tiled_mlp(self.cfg.model_config_type)
 
     def apply_post_model_load_patches(self, model: PreTrainedModel):
@@ -274,21 +277,13 @@ class PatchManager:
         if self.cfg.tiled_mlp:
             from axolotl.monkeypatch.tiled_mlp import (
                 patch_tiled_mlp,
-                patch_tiled_mlp_deepspeed,
             )
 
-            if self.cfg.deepspeed:
-                patch_tiled_mlp_deepspeed(
-                    model_type,
-                    use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
-                    cfg_num_shards=self.cfg.tiled_mlp_num_shards,
-                )
-            else:
-                patch_tiled_mlp(
-                    model_type,
-                    use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
-                    cfg_num_shards=self.cfg.tiled_mlp_num_shards,
-                )
+            patch_tiled_mlp(
+                model_type,
+                use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
+                cfg_num_shards=self.cfg.tiled_mlp_num_shards,
+            )
 
     def _patch_attention(self):
         """Apply attention-specific patches based on model type."""

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -273,8 +273,8 @@ class PatchManager:
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:
             from axolotl.monkeypatch.tiled_mlp import (
+                patch_tiled_mlp,
                 patch_tiled_mlp_deepspeed,
-                patch_tiled_mlp_fsdp,
             )
 
             if self.cfg.deepspeed:
@@ -283,8 +283,8 @@ class PatchManager:
                     use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
                     cfg_num_shards=self.cfg.tiled_mlp_num_shards,
                 )
-            if self.cfg.fsdp:
-                patch_tiled_mlp_fsdp(
+            else:
+                patch_tiled_mlp(
                     model_type,
                     use_original_mlp=self.cfg.tiled_mlp_use_original_mlp,
                     cfg_num_shards=self.cfg.tiled_mlp_num_shards,

--- a/src/axolotl/monkeypatch/tiled_mlp/__init__.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/__init__.py
@@ -3,11 +3,11 @@ TiledMLP monkey patches
 """
 
 from .patch import (
+    patch_tiled_mlp,
     patch_tiled_mlp_deepspeed,
-    patch_tiled_mlp_fsdp,
 )
 
 __all__ = [
     "patch_tiled_mlp_deepspeed",
-    "patch_tiled_mlp_fsdp",
+    "patch_tiled_mlp",
 ]

--- a/src/axolotl/monkeypatch/tiled_mlp/__init__.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/__init__.py
@@ -1,0 +1,13 @@
+"""
+TiledMLP monkey patches
+"""
+
+from .patch import (
+    patch_tiled_mlp_deepspeed,
+    patch_tiled_mlp_fsdp,
+)
+
+__all__ = [
+    "patch_tiled_mlp_deepspeed",
+    "patch_tiled_mlp_fsdp",
+]

--- a/src/axolotl/monkeypatch/tiled_mlp/__init__.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/__init__.py
@@ -4,10 +4,8 @@ TiledMLP monkey patches
 
 from .patch import (
     patch_tiled_mlp,
-    patch_tiled_mlp_deepspeed,
 )
 
 __all__ = [
-    "patch_tiled_mlp_deepspeed",
     "patch_tiled_mlp",
 ]

--- a/src/axolotl/monkeypatch/tiled_mlp/fsdp.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/fsdp.py
@@ -1,0 +1,136 @@
+"""
+TiledMLP support for FSDP
+"""
+
+import threading
+from typing import List
+
+import torch
+
+
+class TiledMLPFSDP(torch.autograd.Function):
+    """
+    TiledMLP implementation for FSDP using gradient hooks
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        fn,
+        self,
+        x,
+        shards,
+        compute_params,
+    ) -> torch.Tensor:
+        ctx.fn = fn
+        ctx.self = self
+        ctx.shards = shards
+        ctx.compute_params = [p for p in compute_params if p.requires_grad]
+        ctx.save_for_backward(x)
+
+        x_shards = list(torch.chunk(x, chunks=shards, dim=1))
+        with torch.no_grad():
+            output_shards = [fn(self, x_shard) for x_shard in x_shards]
+        output_unsharded = torch.cat(output_shards, dim=1)
+
+        return output_unsharded
+
+    @staticmethod
+    def backward(ctx, *grads) -> torch.Tensor:
+        fn = ctx.fn
+        (x,) = ctx.saved_tensors
+        self = ctx.self
+        shards = ctx.shards
+        compute_params = ctx.compute_params
+
+        x_requires_grad = x.requires_grad
+        x = x.detach()
+        x.requires_grad_(x_requires_grad)
+
+        incoming_grad = grads[0]
+        x_grad = torch.zeros_like(x)
+        x_shards = list(torch.chunk(x, chunks=shards, dim=1))
+
+        # Create a gradient accumulator for parameters
+        grad_accumulator = GradientAccumulator(compute_params, shards)
+
+        shard_step = x_shards[0].numel()
+        for i, x_shard in enumerate(x_shards):
+            x_shard.requires_grad_(x_requires_grad)
+
+            shard_offset = i * shard_step
+            x_shard.grad = (
+                x_grad.view(-1)
+                .narrow(0, shard_offset, x_shard.numel())
+                .view_as(x_shard)
+            )
+            incoming_grad_shard = (
+                incoming_grad.view(-1)
+                .narrow(0, shard_offset, x_shard.numel())
+                .view_as(x_shard)
+            )
+
+            # Install hooks for this shard
+            is_last_shard = i + 1 == shards
+            grad_accumulator.install_hooks(is_last_shard)
+
+            with torch.enable_grad():
+                output = fn(self, x_shard)
+            torch.autograd.backward(output, incoming_grad_shard)
+
+        # Clean up hooks
+        grad_accumulator.cleanup()
+
+        return (None, None, x_grad, None, None)
+
+
+class GradientAccumulator:
+    """
+    Manual gradient accumulator for TiledMLP using parameter hooks
+    """
+
+    def __init__(self, params: List[torch.nn.Parameter], total_shards: int):
+        self.params = params
+        self.total_shards = total_shards
+        self.accumulated_grads = {}
+        self.hooks = []
+        self.lock = threading.Lock()
+
+        # Initialize accumulated gradients
+        for param in self.params:
+            if param.grad is not None:
+                self.accumulated_grads[param] = param.grad.clone()
+                param.grad = None
+            else:
+                self.accumulated_grads[param] = torch.zeros_like(param)
+
+    def install_hooks(self, is_last_shard: bool):
+        """Install gradient hooks that accumulate gradients and only assign on last shard"""
+
+        def create_hook(param):
+            def hook(grad):
+                with self.lock:
+                    if param in self.accumulated_grads:
+                        self.accumulated_grads[param] += grad
+                    else:
+                        self.accumulated_grads[param] = grad.clone()
+
+                    # Only assign the accumulated gradient on the last shard
+                    if is_last_shard:
+                        param.grad = self.accumulated_grads[param]
+                        return self.accumulated_grads[param]
+                    return None
+
+            return hook
+
+        # Install hooks on all parameters
+        for param in self.params:
+            if param.requires_grad:
+                hook = param.register_hook(create_hook(param))
+                self.hooks.append(hook)
+
+    def cleanup(self):
+        """Remove all installed hooks"""
+        for hook in self.hooks:
+            hook.remove()
+        self.hooks.clear()

--- a/src/axolotl/monkeypatch/tiled_mlp/patch.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/patch.py
@@ -8,12 +8,11 @@ import torch
 import torch.distributed as dist
 from deepspeed.runtime.sequence_parallel.ulysses_sp import TiledMLP
 
+from axolotl.monkeypatch.tiled_mlp.fsdp import TiledMLPFSDP
 from axolotl.utils.callbacks.models import get_causal_lm_model_cls_prefix
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
-
-from .fsdp import TiledMLPFSDP
 
 
 def patch_tiled_mlp_distributed(

--- a/src/axolotl/monkeypatch/tiled_mlp/patch.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/patch.py
@@ -6,9 +6,9 @@ from functools import partial
 
 import torch
 import torch.distributed as dist
-from deepspeed.runtime.sequence_parallel.ulysses_sp import TiledMLP
+from deepspeed.runtime.sequence_parallel.ulysses_sp import TiledMLP as DeepSpeedTiledMLP
 
-from axolotl.monkeypatch.tiled_mlp.fsdp import TiledMLPFSDP
+from axolotl.monkeypatch.tiled_mlp.base import TiledMLP
 from axolotl.utils.callbacks.models import get_causal_lm_model_cls_prefix
 from axolotl.utils.logging import get_logger
 
@@ -81,5 +81,5 @@ def patch_tiled_mlp_distributed(
         ) from e
 
 
-patch_tiled_mlp_deepspeed = partial(patch_tiled_mlp_distributed, TiledMLP)
-patch_tiled_mlp_fsdp = partial(patch_tiled_mlp_distributed, TiledMLPFSDP)
+patch_tiled_mlp_deepspeed = partial(patch_tiled_mlp_distributed, DeepSpeedTiledMLP)
+patch_tiled_mlp = partial(patch_tiled_mlp_distributed, TiledMLP)

--- a/src/axolotl/monkeypatch/tiled_mlp/patch.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/patch.py
@@ -60,7 +60,10 @@ def patch_tiled_mlp(model_type, use_original_mlp=True, cfg_num_shards=None):
             if not self._tiled_mlp_dist_impl:
                 if (
                     self._compute_params
-                    and hasattr(self._compute_params[0], "param_idx_in_group")
+                    and any(
+                        hasattr(p, "ds_param") or hasattr(p, "param_idx_in_group")
+                        for p in self._compute_params
+                    )
                 ) or os.environ.get("ACCELERATE_USE_DEEPSPEED", "false") == "true":
                     self._tiled_mlp_dist_impl = DeepSpeedTiledMLP
                 else:

--- a/src/axolotl/monkeypatch/tiled_mlp/patch.py
+++ b/src/axolotl/monkeypatch/tiled_mlp/patch.py
@@ -61,7 +61,7 @@ def patch_tiled_mlp(model_type, use_original_mlp=True, cfg_num_shards=None):
                 if (
                     self._compute_params
                     and any(
-                        hasattr(p, "ds_param") or hasattr(p, "param_idx_in_group")
+                        hasattr(p, "ds_id") or hasattr(p, "param_idx_in_group")
                         for p in self._compute_params
                     )
                 ) or os.environ.get("ACCELERATE_USE_DEEPSPEED", "false") == "true":

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -867,6 +867,11 @@ class GCCallback(TrainerCallback):
         torch.cuda.empty_cache()
         gc.collect()
 
+    def on_train_begin(
+        self, args, state, control, **kwargs  # pylint: disable=unused-argument
+    ):
+        self._gc()
+
     def on_step_begin(
         self, args, state, control, **kwargs  # pylint: disable=unused-argument
     ):

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -870,7 +870,8 @@ class GCCallback(TrainerCallback):
     def on_step_begin(
         self, args, state, control, **kwargs  # pylint: disable=unused-argument
     ):
-        if self.next_gc_on_begin_step == state.global_step:
+        # pylint: disable=consider-using-in
+        if self.next_gc_on_begin_step == state.global_step or state.global_step == 0:
             self._gc()
 
     def on_step_end(

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -597,7 +597,7 @@ class AxolotlInputConfig(
     )
 
     tiled_mlp_use_original_mlp: bool | None = Field(
-        default=None,
+        default=True,
         json_schema_extra={
             "description": "Whether to use original mlp for ALST tiled mlp. Otherwise uses a generic MLP based on llama."
         },

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -519,9 +519,11 @@ class TrainingValidationMixin:
         n_gpu = 0
         if capabilities and capabilities.get("n_gpu", 0) >= 1:
             n_gpu = capabilities.get("n_gpu", 0)
-        if data.get("tiled_mlp", False) and (n_gpu > 1 and not data.get("deepspeed")):
+        if data.get("tiled_mlp", False) and (
+            n_gpu > 1 and not data.get("deepspeed") and not data.get("fsdp_config")
+        ):
             raise ValueError(
-                "tiled_mlp requires deepspeed ZeRO to be enabled for multi-gpu"
+                "tiled_mlp requires single GPU, FSDP, or deepspeed ZeRO to be enabled for multi-gpu"
             )
         return data
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -512,21 +512,6 @@ class TrainingValidationMixin:
 
         return data
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_tiled_mlp_deepspeed(cls, data):
-        capabilities = data.get("capabilities")
-        n_gpu = 0
-        if capabilities and capabilities.get("n_gpu", 0) >= 1:
-            n_gpu = capabilities.get("n_gpu", 0)
-        if data.get("tiled_mlp", False) and (
-            n_gpu > 1 and not data.get("deepspeed") and not data.get("fsdp_config")
-        ):
-            raise ValueError(
-                "tiled_mlp requires single GPU, FSDP, or deepspeed ZeRO to be enabled for multi-gpu"
-            )
-        return data
-
 
 class LoRAValidationMixin:
     """Validation methods related to LoRA/QLoRA configuration."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Use manual gradient accumulation with parameter hooks to work with FSDP2. I didn't test with FSDP1, but I expect it should work with that also. 
@sfc-gh-sbekman

WandB: https://wandb.ai/axolotl-ai/tiledmlp-fsdp2?nw=nwuserwingaxolotl

<img width="951" height="679" alt="Screenshot 2025-07-19 at 1 30 11 PM" src="https://github.com/user-attachments/assets/4c23fa87-5de0-46db-91bd-8010895781cb" />

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new tiled multi-layer perceptron (TiledMLP) supporting distributed and single GPU training, with advanced gradient accumulation for mixed precision scenarios.
  * Added a new patch application step between plugin initialization and model loading to enhance model setup.
  * Added example configurations and documentation for Arctic Long Sequence Training (ALST) with Llama 3 8B models using DeepSpeed and FSDP.

* **Improvements**
  * Enhanced garbage collection during training to trigger at the very start and at step zero.
  * Updated tiled MLP patch to default to using the original MLP implementation and dynamically select DeepSpeed support when applicable.
  * Refined conflict validation to allow tiled MLP usage when explicitly configured to use the original MLP.
  * Changed default configuration to enable original MLP usage for tiled MLP by default.

* **Removals**
  * Removed the validation check that enforced DeepSpeed usage with tiled MLP in multi-GPU setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->