### PR TITLE
don't check dataset labels during preprocess for GRPO

### DIFF
--- a/src/axolotl/common/datasets.py
+++ b/src/axolotl/common/datasets.py
@@ -122,7 +122,7 @@ def load_preference_datasets(
             math.ceil(len(train_dataset) * cfg.num_epochs / cfg.batch_size)
         )
 
-    if (cli_args and cli_args.debug) or cfg.debug:
+    if ((cli_args and cli_args.debug) or cfg.debug) and cfg.rl != "grpo":
         LOG.info("check_dataset_labels...")
 
         num_examples = cli_args.debug_num_examples if cli_args else 1

--- a/src/axolotl/common/datasets.py
+++ b/src/axolotl/common/datasets.py
@@ -122,7 +122,7 @@ def load_preference_datasets(
             math.ceil(len(train_dataset) * cfg.num_epochs / cfg.batch_size)
         )
 
-    if ((cli_args and cli_args.debug) or cfg.debug) and cfg.rl != "grpo":
+    if ((cli_args and cli_args.debug) or cfg.debug) and cfg.rl != RLType.ORPO:
         LOG.info("check_dataset_labels...")
 
         num_examples = cli_args.debug_num_examples if cli_args else 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted debug label checking for datasets to cases where the RL type is not "ORPO," reducing unnecessary log output in specific configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->