### PR TITLE
Autocomplete axolotl CLI

### DIFF
--- a/.axolotl-complete.bash
+++ b/.axolotl-complete.bash
@@ -10,8 +10,11 @@ _axolotl_completions() {
         return 0
     fi
 
-    # If the previous word was "train" or "preprocess"
-    if [[ "$prev" == "train" || "$prev" == "preprocess" ]]; then
+    # Commands that should complete with directories and YAML files
+    local yaml_commands=("merge-sharded-fsdp-weights" "quantize" "vllm-serve" "evaluate" "inference" "merge-lora" "preprocess" "train")
+
+    # Check if previous word is in our list
+    if [[ " ${yaml_commands[*]} " =~ " $prev " ]]; then
         # Complete with directories and YAML files
         COMPREPLY=($(compgen -d -- "$cur"))  # directories
         COMPREPLY+=($(compgen -f -X "!*.yaml" -- "$cur"))  # .yaml files

--- a/.axolotl-complete.bash
+++ b/.axolotl-complete.bash
@@ -1,0 +1,26 @@
+_axolotl_completions() {
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # If we're completing the first argument (the command)
+    if [[ $COMP_CWORD -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "delinearize-llama4 fetch lm-eval merge-sharded-fsdp-weights quantize vllm-serve evaluate inference merge-lora preprocess train" -- "$cur"))
+        return 0
+    fi
+
+    # If the previous word was "train" or "preprocess"
+    if [[ "$prev" == "train" || "$prev" == "preprocess" ]]; then
+        # Complete with directories and YAML files
+        COMPREPLY=($(compgen -d -- "$cur"))  # directories
+        COMPREPLY+=($(compgen -f -X "!*.yaml" -- "$cur"))  # .yaml files
+        COMPREPLY+=($(compgen -f -X "!*.yml" -- "$cur"))   # .yml files
+        return 0
+    fi
+
+    # Default: no completion
+    return 0
+}
+
+complete -F _axolotl_completions axolotl

--- a/.axolotl-complete.bash
+++ b/.axolotl-complete.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 _axolotl_completions() {
     local cur prev
     COMPREPLY=()
@@ -6,7 +8,7 @@ _axolotl_completions() {
 
     # If we're completing the first argument (the command)
     if [[ $COMP_CWORD -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "delinearize-llama4 fetch lm-eval merge-sharded-fsdp-weights quantize vllm-serve evaluate inference merge-lora preprocess train" -- "$cur"))
+        mapfile -t COMPREPLY < <(compgen -W "delinearize-llama4 fetch lm-eval merge-sharded-fsdp-weights quantize vllm-serve evaluate inference merge-lora preprocess train" -- "$cur")
         return 0
     fi
 
@@ -17,7 +19,7 @@ _axolotl_completions() {
     if [[ " ${yaml_commands[*]} " =~ (^|[[:space:]])$prev($|[[:space:]]) ]]; then
         # Use filename completion which handles directories properly
         compopt -o filenames
-        COMPREPLY=($(compgen -f -- "$cur"))
+        mapfile -t COMPREPLY < <(compgen -f -- "$cur")
 
         # Filter to only include directories and YAML files
         local -a filtered=()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,10 +31,11 @@ RUN if [ "$AXOLOTL_EXTRAS" != "" ] ; then \
     pip install pytest && \
     pip cache purge
 
-# fix so that git fetch/pull from remote works
+# fix so that git fetch/pull from remote works with shallow clone
 RUN git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && \
     git config --get remote.origin.fetch && \
     git config --global credential.helper store
 
 COPY .axolotl-complete.bash /root/.axolotl-complete.bash
-RUN echo 'source /root/.axolotl-complete.bash' >> ~/.bashrc
+RUN chmod +x /root/.axolotl-complete.bash && \
+    echo 'source /root/.axolotl-complete.bash' >> ~/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,3 +35,6 @@ RUN if [ "$AXOLOTL_EXTRAS" != "" ] ; then \
 RUN git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && \
     git config --get remote.origin.fetch && \
     git config --global credential.helper store
+
+COPY .axolotl-complete.bash /root/.axolotl-complete.bash
+RUN echo 'source /root/.axolotl-complete.bash' >> ~/.bashrc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I had tried using `click`'s recommendation for autocompletion @ https://click.palletsprojects.com/en/stable/shell-completion/, but the responsiveness is too slow because it executes the CLI and ends up loading up torch. This whole step is high latency and feels terrible to use so I decided to simply statically setup the autocompletion with the current commands. 

Also, only for preprocess and train, it will autocomplete any directories and yaml/yml files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Bash tab completion for the Axolotl CLI, providing context-sensitive command and file suggestions.
  * Bash completion is now automatically enabled when using the Axolotl CLI inside the Docker container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->