### PR TITLE
fix deprecate deepspeed stage3_gather_16bit_weights_on_model_save arg

### DIFF
--- a/deepspeed_configs/zero3.json
+++ b/deepspeed_configs/zero3.json
@@ -9,7 +9,7 @@
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 0,
     "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": "auto"

--- a/deepspeed_configs/zero3.json
+++ b/deepspeed_configs/zero3.json
@@ -5,10 +5,10 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
-    "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
+    "prefetch_bucket_size": "auto",
+    "param_persistence_threshold": "auto",
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
     "gather_16bit_weights_on_model_save": true
   },
   "bf16": {

--- a/deepspeed_configs/zero3_bf16.json
+++ b/deepspeed_configs/zero3_bf16.json
@@ -9,7 +9,7 @@
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 0,
     "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16.json
+++ b/deepspeed_configs/zero3_bf16.json
@@ -5,10 +5,10 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
-    "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
+    "prefetch_bucket_size": "auto",
+    "param_persistence_threshold": "auto",
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
     "gather_16bit_weights_on_model_save": true
   },
   "bf16": {

--- a/deepspeed_configs/zero3_bf16_cpuoffload_all.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_all.json
@@ -15,10 +15,10 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
-    "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
+    "prefetch_bucket_size": "auto",
+    "param_persistence_threshold": "auto",
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
     "gather_16bit_weights_on_model_save": true
   },
   "bf16": {

--- a/deepspeed_configs/zero3_bf16_cpuoffload_all.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_all.json
@@ -19,7 +19,7 @@
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 0,
     "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_params.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_params.json
@@ -15,7 +15,7 @@
     "stage3_param_persistence_threshold": "auto",
     "stage3_max_live_parameters": 0,
     "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_params.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_params.json
@@ -11,10 +11,10 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
-    "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
+    "prefetch_bucket_size": "auto",
+    "param_persistence_threshold": "auto",
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
     "gather_16bit_weights_on_model_save": true
   },
   "bf16": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The latest version of Deepspeed would give the error `Extra inputs are not permitted`, changing this arg name seems to fix the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration files by renaming keys related to optimization settings for clarity. No changes to functionality or configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->