### PR TITLE
fix(log): suppress warning if we enabled skip prepare

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -308,7 +308,7 @@ def _load_raw_datasets(
 ) -> tuple[Dataset, list[Prompter | None]]:
     """Load, process, merge, and save raw datasets."""
     LOG.info("Loading raw datasets...", main_process_only=False)
-    if not cfg.is_preprocess:
+    if not cfg.is_preprocess and not cfg.skip_prepare_dataset:
         LOG.warning(
             "Processing datasets during training can lead to VRAM instability. Please "
             "pre-process your dataset using `axolotl preprocess path/to/config.yml`."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

This warns in vision sft mode which is incorrect.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning messages during training by refining the conditions under which they are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->