### PR TITLE
improve handling of file lock when content is empty

### DIFF
--- a/src/axolotl/utils/data/lock.py
+++ b/src/axolotl/utils/data/lock.py
@@ -46,7 +46,8 @@ class FileLockLoader:
     def _increment_counter(self):
         """Safely increment the process counter."""
         if self.counter_path.exists():
-            count = int(self.counter_path.read_text().strip())
+            counter_content = self.counter_path.read_text().strip()
+            count = int(counter_content) if counter_content else 0
         else:
             count = 0
         self.counter_path.write_text(str(count + 1))
@@ -54,10 +55,11 @@ class FileLockLoader:
     def cleanup(self):
         """Clean up ready flag when last process is done."""
         with FileLock(str(self.lock_file_path)):
-            count = int(self.counter_path.read_text().strip())
+            counter_content = self.counter_path.read_text().strip()
+            count = int(counter_content) if counter_content else 0
             count -= 1
 
-            if count == 0:
+            if count <= 0:
                 # Last process cleans everything up
                 self.ready_flag_path.unlink(missing_ok=True)
                 self.counter_path.unlink(missing_ok=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
 Fixes #2951 

I think what's happening is the file contents are empty, so parsing as an int gives a similar error:

```
>>> int("")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: ''
```

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or invalid process counter files to prevent errors.
  * Enhanced cleanup logic to ensure proper execution even when the process counter is zero or negative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->