### PR TITLE
revert renaming of deepspeed stage3 args that use auto

### DIFF
--- a/deepspeed_configs/zero3.json
+++ b/deepspeed_configs/zero3.json
@@ -7,9 +7,9 @@
     "reduce_bucket_size": "auto",
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": "auto"

--- a/deepspeed_configs/zero3.json
+++ b/deepspeed_configs/zero3.json
@@ -5,11 +5,11 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "prefetch_bucket_size": "auto",
-    "param_persistence_threshold": "auto",
-    "max_live_parameters": 0,
-    "max_reuse_distance": 0,
-    "gather_16bit_weights_on_model_save": true
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 0,
+    "stage3_max_reuse_distance": 0,
+    "stage3_gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": "auto"

--- a/deepspeed_configs/zero3_bf16.json
+++ b/deepspeed_configs/zero3_bf16.json
@@ -7,9 +7,9 @@
     "reduce_bucket_size": "auto",
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16.json
+++ b/deepspeed_configs/zero3_bf16.json
@@ -5,11 +5,11 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "prefetch_bucket_size": "auto",
-    "param_persistence_threshold": "auto",
-    "max_live_parameters": 0,
-    "max_reuse_distance": 0,
-    "gather_16bit_weights_on_model_save": true
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 0,
+    "stage3_max_reuse_distance": 0,
+    "stage3_gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_all.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_all.json
@@ -15,11 +15,11 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "prefetch_bucket_size": "auto",
-    "param_persistence_threshold": "auto",
-    "max_live_parameters": 0,
-    "max_reuse_distance": 0,
-    "gather_16bit_weights_on_model_save": true
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 0,
+    "stage3_max_reuse_distance": 0,
+    "stage3_gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_all.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_all.json
@@ -17,9 +17,9 @@
     "reduce_bucket_size": "auto",
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_params.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_params.json
@@ -13,9 +13,9 @@
     "reduce_bucket_size": "auto",
     "stage3_prefetch_bucket_size": "auto",
     "stage3_param_persistence_threshold": "auto",
-    "stage3_max_live_parameters": 0,
-    "stage3_max_reuse_distance": 0,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "max_live_parameters": 0,
+    "max_reuse_distance": 0,
+    "gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true

--- a/deepspeed_configs/zero3_bf16_cpuoffload_params.json
+++ b/deepspeed_configs/zero3_bf16_cpuoffload_params.json
@@ -11,11 +11,11 @@
     "contiguous_gradients": true,
     "sub_group_size": 0,
     "reduce_bucket_size": "auto",
-    "prefetch_bucket_size": "auto",
-    "param_persistence_threshold": "auto",
-    "max_live_parameters": 0,
-    "max_reuse_distance": 0,
-    "gather_16bit_weights_on_model_save": true
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 0,
+    "stage3_max_reuse_distance": 0,
+    "stage3_gather_16bit_weights_on_model_save": true
   },
   "bf16": {
     "enabled": true


### PR DESCRIPTION
Reverts axolotl-ai-cloud/axolotl#2956

Repro: `axolotl train examples/llama-3/lora-1b.yml  --deepspeed deepspeed_configs/zero3_bf16.json`

```
ValueError: `zero_optimization.prefetch_bucket_size` not found in kwargs. Please specify `zero_optimization.prefetch_bucket_size` without `auto` (set to correct value) in the DeepSpeed config file or pass it in kwargs.
```

Reason: Transformers was actually the one handling the `auto` values https://github.com/huggingface/transformers/blob/37f8b0b53512e6aae0cfd15746c133c101783178/src/transformers/integrations/deepspeed.py#L207-L220 and hardcodes the key.

Solution: I found that reverting the PR and using the `stage3_gather_16bit_weights_on_model_save` does not seem to have the error mentioned in the linked PR.

Alternative solution: patch the upstream transformers function / add our own plugin to the trainer to update the value for auto for these keys.

Our deepspeed: 0.17.2 (latest release)

Reported at: https://discord.com/channels/1104757954588196865/1104757955204743201/1396910875230605486 by `Sicarius` and validated by `Keaton`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration files to rename certain optimization parameter keys for improved clarity. No changes to parameter values or overall structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->