### PR TITLE
handle refactor upstream for flash attention

### DIFF
--- a/src/axolotl/monkeypatch/ring_attn/patch.py
+++ b/src/axolotl/monkeypatch/ring_attn/patch.py
@@ -15,7 +15,13 @@ from typing import Optional
 import accelerate
 import torch
 import torch.distributed as dist
-from transformers.modeling_flash_attention_utils import _flash_supports_window_size
+
+try:
+    from transformers.modeling_flash_attention_utils import _flash_supports_window
+except ImportError:
+    from transformers.modeling_flash_attention_utils import (
+        _flash_supports_window_size as _flash_supports_window,
+    )
 
 from axolotl.monkeypatch.utils import get_cu_seqlens_from_pos_ids
 from axolotl.utils.logging import get_logger
@@ -106,7 +112,7 @@ def create_ring_flash_attention_forward(
 
         # Assuming 4D tensors, key_states.shape[1] is the key/value sequence length (source length).
         use_sliding_windows = (
-            _flash_supports_window_size
+            _flash_supports_window
             and sliding_window is not None
             and key_states.shape[1] > sliding_window
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
https://github.com/huggingface/transformers/pull/39474 breaks ring-attn import

error in ci against upstream main https://github.com/axolotl-ai-cloud/axolotl/actions/runs/16446775509/job/46480818447

```
src/axolotl/monkeypatch/ring_attn/patch.py:18: in <module>
    from transformers.modeling_flash_attention_utils import _flash_supports_window_size
E   ImportError: cannot import name '_flash_supports_window_size' from 'transformers.modeling_flash_attention_utils' (/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/transformers/modeling_flash_attention_utils.py)
```

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different versions of the transformers library when checking for Flash Attention sliding window support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->