### PR TITLE
feat(dataset): Individual shuffling of datasets before merging

### DIFF
--- a/.runpod/README.md
+++ b/.runpod/README.md
@@ -119,14 +119,15 @@ datasets:
 
 ## Dataset Processing
 
-| Option                        | Default                    | Description                       |
-| ----------------------------- | -------------------------- | --------------------------------- |
-| `dataset_prepared_path`       | `"data/last_run_prepared"` | Path for prepared dataset         |
-| `push_dataset_to_hub`         | `""`                       | Push dataset to HF hub            |
-| `dataset_processes`           | `4`                        | Number of preprocessing processes |
-| `dataset_keep_in_memory`      | `false`                    | Keep dataset in memory            |
-| `shuffle_merged_datasets`     | `true`                     | Shuffle merged datasets           |
-| `dataset_exact_deduplication` | `true`                     | Deduplicate datasets              |
+| Option                            | Default                    | Description                         |
+| --------------------------------- | -------------------------- | ----------------------------------- |
+| `dataset_prepared_path`           | `"data/last_run_prepared"` | Path for prepared dataset           |
+| `push_dataset_to_hub`             | `""`                       | Push dataset to HF hub              |
+| `dataset_processes`               | `4`                        | Number of preprocessing processes   |
+| `dataset_keep_in_memory`          | `false`                    | Keep dataset in memory              |
+| `shuffle_merged_datasets`         | `true`                     | Shuffle merged datasets             |
+| `shuffle_before_merging_datasets` | `false`                    | Shuffle each dataset before merging |
+| `dataset_exact_deduplication`     | `true`                     | Deduplicate datasets                |
 
 ## LoRA Configuration
 

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -543,6 +543,12 @@ def merge_datasets(datasets: list[Dataset], cfg: DictDefault) -> Dataset:
 
         return ds.shuffle(seed=cfg.seed)
 
+    # If enabled, shuffle each dataset independently before merging.
+    # This allows curriculum learning strategies to be applied at the dataset level.
+    if cfg.shuffle_before_merging_datasets:
+        LOG.info("Shuffling each dataset individually before merging...")
+        datasets = [ds.shuffle(seed=cfg.seed) for ds in datasets]
+
     LOG.info("Merging datasets...")
     merged_dataset = concatenate_datasets(datasets)
 

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -179,6 +179,12 @@ class AxolotlInputConfig(
             "description": "If false, the datasets will not be shuffled and will keep their original order in `datasets`. The same applies to the `test_datasets` option and the `pretraining_dataset` option. Default is true."
         },
     )
+    shuffle_before_merging_datasets: bool | None = Field(
+        default=False,
+        json_schema_extra={
+            "description": "If true, each dataset in `datasets` will be shuffled before merging. This allows curriculum learning strategies to be applied at the dataset level. Default is false."
+        },
+    )
     dataset_prepared_path: str | None = Field(
         default=None,
         json_schema_extra={


### PR DESCRIPTION
✨ Individual shuffling of datasets before merging

# Description

This PR introduces a new configuration option `shuffle_before_merging_datasets` to enable per-dataset shuffling before datasets are merged. When enabled, each dataset is independently shuffled using the specified random seed. This enables curriculum learning at the dataset level by preserving inter-dataset order while allowing intra-dataset shuffling during training.

# Motivation and Context

This change is motivated by the need to support curriculum-aware dataset handling. Shuffling a fully merged dataset can break important training pipeline structure — for example, when aiming to train in two phases, such as 50% of IFT data followed by 50% of reasoning data. By shuffling each dataset individually before merging, we retain the ability to design dataset-level learning progressions (inter-dataset order) while still allowing shuffling within each dataset (intra-dataset shuffling).

This does not alter the behavior when `shuffle_before_merging_datasets ` is not enabled and only one dataset is provided, so it's fully backward-compatible.

# How has this been tested?
This feature was validated using a toy setup with two datasets (`ds_1`, `ds_2`), each containing two files. Each file has two examples with distinguishable user prompts for visual inspection.

ds_1/
├── 1_1.jsonl
├── 1_2.jsonl

ds_2/
├── 2_1.jsonl
├── 2_2.jsonl

Each `.jsonl` file contains:
```json
{
  "conversations": [
    {
      "role": "user",
      "content": "<ds_number>_<file_number>_<sample_number>"
    },
    {
      "role": "assistant",
      "content": "<sample_number>"
    }
  ]
}
```

#### Example config (Axolotl)

```yaml
shuffle_before_merging_datasets: false
datasets:
  - path: ds_1
    ds_type: json
    type: chat_template
    field_messages: conversations
    data_files:
      - 1_1.jsonl
      - 1_2.jsonl

  - path: ds_2
    ds_type: json
    type: chat_template
    field_messages: conversations
    data_files:
      - 2_1.jsonl
      - 2_2.jsonl
```

#### Results (only user prompt)
- Without shuffling (shuffle_before_merging_datasets: false)
```
1_1_1
1_1_2
1_2_1
1_2_2
2_1_1
2_1_2
2_2_1
2_2_2
```

- With shuffling (shuffle_before_merging_datasets: true)
```
1_2_2
1_1_1
1_2_1
1_1_2
2_1_2
2_2_1
2_2_2
2_1_1
```


# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🧠 New feature (non-breaking change that adds functionality)  
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] 🔧 Refactor (non-breaking change that improves structure or readability)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

# Social Handles (Optional)

@N1colAIs - X (twitter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to shuffle each dataset before merging, allowing for more flexible dataset processing strategies.

* **Documentation**
  * Updated documentation to describe the new shuffle option and improved table formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->