### PR TITLE
don't create a reference model if grpo beta is 0.0

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -115,8 +115,11 @@ def setup_reference_model(
             LOG.debug("Passing model_ref: None to RL trainer")
             model_ref = None  # explicit setting to None
         else:
+            reference_model: bool = True
+            if cfg.rl == RLType.GRPO and cfg.trl.beta == 0:
+                reference_model = False
             # load the model again for model_ref/baseline
-            model_loader = ModelLoader(cfg, tokenizer, reference_model=True)
+            model_loader = ModelLoader(cfg, tokenizer, reference_model=reference_model)
             model_ref, _ = model_loader.load()
     return model_ref
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

see https://github.com/huggingface/trl/blob/23ea671c5e7c83031c617171741ceabbf3fe18cc/trl/trainer/grpo_trainer.py#L726-L728

We can save memory here if not doing kl-divergence

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reference model loading during reinforcement learning training, ensuring the reference model is not loaded when using GRPO RL type with a beta value of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->