### PR TITLE
fix:kd_distillation key_error logprobs

### DIFF
--- a/src/axolotl/integrations/kd/chat_template.py
+++ b/src/axolotl/integrations/kd/chat_template.py
@@ -286,7 +286,9 @@ class ChatTemplateStrategyWithKDv2(ChatTemplateStrategyWithKD):
     def _tokenize_single_prompt(self, prompt):
         logprobs = prompt.pop(self.logprobs_field)
         target_token_ids = prompt.pop("target_token_ids")
-        base_tokenized = super(ChatTemplateStrategyWithKD, self)._tokenize_single_prompt(prompt)
+        base_tokenized = super(
+            ChatTemplateStrategyWithKD, self
+        )._tokenize_single_prompt(prompt)
         if logprobs is not None:
             base_tokenized[self.logprobs_field] = logprobs
         if target_token_ids is not None:

--- a/src/axolotl/integrations/kd/chat_template.py
+++ b/src/axolotl/integrations/kd/chat_template.py
@@ -286,10 +286,12 @@ class ChatTemplateStrategyWithKDv2(ChatTemplateStrategyWithKD):
     def _tokenize_single_prompt(self, prompt):
         logprobs = prompt.pop(self.logprobs_field)
         target_token_ids = prompt.pop("target_token_ids")
-        tokenized_prompt = super()._tokenize_single_prompt(prompt)
-        tokenized_prompt[self.logprobs_field] = logprobs
-        tokenized_prompt["target_token_ids"] = target_token_ids
-        tokenized_prompt = self.transform_logprobs(tokenized_prompt)
+        base_tokenized = super(ChatTemplateStrategyWithKD, self)._tokenize_single_prompt(prompt)
+        if logprobs is not None:
+            base_tokenized[self.logprobs_field] = logprobs
+        if target_token_ids is not None:
+            base_tokenized["target_token_ids"] = target_token_ids
+        tokenized_prompt = self.transform_logprobs(base_tokenized)
 
         return tokenized_prompt
 

--- a/src/axolotl/integrations/kd/chat_template.py
+++ b/src/axolotl/integrations/kd/chat_template.py
@@ -284,16 +284,12 @@ class ChatTemplateStrategyWithKDv2(ChatTemplateStrategyWithKD):
         return sample
 
     def _tokenize_single_prompt(self, prompt):
-        logprobs = prompt.pop(self.logprobs_field)
-        target_token_ids = prompt.pop("target_token_ids")
-        base_tokenized = super(
-            ChatTemplateStrategyWithKD, self
-        )._tokenize_single_prompt(prompt)
-        if logprobs is not None:
-            base_tokenized[self.logprobs_field] = logprobs
+        target_token_ids = prompt.get("target_token_ids", None)
+
+        tokenized_prompt = super()._tokenize_single_prompt(prompt)
+
         if target_token_ids is not None:
-            base_tokenized["target_token_ids"] = target_token_ids
-        tokenized_prompt = self.transform_logprobs(base_tokenized)
+            tokenized_prompt["target_token_ids"] = target_token_ids
 
         return tokenized_prompt
 


### PR DESCRIPTION
key error log_probs 
# Description
log_probs getting popped twice once in child ``` ChatTemplateStrategyWithKDv2 ``` class and second in parent class 
same with target_token_ids
parent class ``` ChatTemplateStrategyWithKD ``` calling ``` transform_logprobs ```
of child expecting dict

added a bypass to avoid calling ``` transform_logprobs ``` of child 
and saving log_probs and target_token_ids if not none 

## Motivation and Context
#2978 

## How has this been tested?
similar config file as presented in the issue  was able to reproduce the issue 
with dataset 
```
{"conversation": [{"role": "user", "content": "Hello, how are you?"}, {"role": "assistant", "content": "I'm doing great, thank you for asking!"}], "logprobs": [[-0.1, -0.5], [-0.2, -0.8]], "target_token_ids": [[123, 456], [789, 101]]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional fields in chat prompt tokenization to prevent issues when certain data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->