### PR TITLE
Fix don't preview docs for contributors

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Netlify Publish
         uses: nwtgck/actions-netlify@v3.0
-        if: ${{ secrets.NETLIFY_AUTH_TOKEN != '' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         id: netlify
         with:
           publish-dir: './_site'
@@ -68,7 +68,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Update PR with preview link
-        if: ${{ steps.netlify.outcome == 'success' && secrets.NETLIFY_AUTH_TOKEN != '' }}
+        if: ${{ steps.netlify.outcome == 'success' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/index.qmd
+++ b/index.qmd
@@ -4,6 +4,8 @@
 # toc-expand: 2
 ---
 
+
+test test
 ```{python}
 #|output: asis
 #|echo: false


### PR DESCRIPTION
We can instead check against the source repo of the PR, as the current solution is failing with https://github.com/axolotl-ai-cloud/axolotl/actions/runs/16645612239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two lines of text ("test test") before the Python code block in the documentation.

* **Chores**
  * Updated workflow conditions to restrict Netlify deployments to pull requests from the same repository and simplified preview link update logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->