### PR TITLE
fix: move memory usage log to trainer.log

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -36,7 +36,6 @@ from axolotl.monkeypatch.trainer.lr import patch_trainer_get_lr
 from axolotl.utils import is_comet_available, is_mlflow_available
 from axolotl.utils.callbacks import (
     GCCallback,
-    GPUStatsCallback,
     SaveAxolotlConfigtoWandBCallback,
     SaveModelOnFirstStepCallback,
 )
@@ -140,8 +139,6 @@ class TrainerBuilderBase(abc.ABC):
             )
         if self.cfg.save_first_step:
             callbacks.append(SaveModelOnFirstStepCallback())
-
-        callbacks.append(GPUStatsCallback(cfg=self.cfg))
 
         if self.cfg.profiler_steps:
             callbacks.append(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

With current callback, there is a desync that occurs after an eval.

```
Tried to log to step 199 that is less than the current step 200. Steps must be monotonically increasing, so this data will be ignored. See https://wandb.me/define-metric to log data out of order.
```

In this PR, the logs are appended before they are propagated to the callback handlers. An alternative solution tried was modifying the `logs` in a callback but that callback is likely executed after a metric handler like wandb is called, so it has almost no effect.

Side effect of this PR, the logs are now printed:
```
{'loss': 1.6104, 'grad_norm': 2.421875, 'learning_rate': 0.00013268753144081652, 'memory/max_memory_active': 12.16070032119751, 'memory/max_memory_allocated': 12.16070032119751, 'memory/device_memory_reserved': 12.32421875, 'epoch': 0.46}
```
<img width="1354" height="96" alt="image" src="https://github.com/user-attachments/assets/aa050c28-4e29-42c0-9a0e-55c8a7600934" />

Wandb also rewrites names of the log to include `train/`. https://github.com/huggingface/transformers/blob/a5923d4de7df2fbd1f373dfcfe983216b79b6937/src/transformers/integrations/integration_utils.py#L631

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU memory usage logging directly to training logs, allowing users to monitor memory usage during training.

* **Removals**
  * Removed the GPU memory stats callback; GPU memory statistics are now integrated into the main training logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->