### PR TITLE
Add validation for TP with models with tied embeddings

### DIFF
--- a/src/axolotl/loaders/utils.py
+++ b/src/axolotl/loaders/utils.py
@@ -131,10 +131,14 @@ def check_model_config(cfg: DictDefault, model_config: PretrainedConfig):
             f"Please include [{lora_modules_to_save_joined}] in `lora_modules_to_save`."
         )
 
-    if cfg.tensor_parallel_size > 1 and model_config.get("tie_word_embeddings", False):
+    if (
+        cfg.tensor_parallel_size > 1
+        and hasattr(model_config, "tie_word_embeddings")
+        and model_config.tie_word_embeddings
+    ):
         raise ValueError(
-            "Tensor parallelism is incompatible with `tie_word_embeddings`. "
-            "Please use a model without `tie_word_embeddings`. or disable tensor parallelism."
+            "Tensor parallelism is incompatible with models configured with `tie_word_embeddings` enabled. "
+            "Please use a model without `tie_word_embeddings`, or disable tensor parallelism."
         )
 
 

--- a/src/axolotl/loaders/utils.py
+++ b/src/axolotl/loaders/utils.py
@@ -131,6 +131,12 @@ def check_model_config(cfg: DictDefault, model_config: PretrainedConfig):
             f"Please include [{lora_modules_to_save_joined}] in `lora_modules_to_save`."
         )
 
+    if cfg.tensor_parallel_size > 1 and model_config.get("tie_word_embeddings", False):
+        raise ValueError(
+            "Tensor parallelism is incompatible with `tie_word_embeddings`. "
+            "Please use a model without `tie_word_embeddings`. or disable tensor parallelism."
+        )
+
 
 def load_model_config(cfg: DictDefault) -> PretrainedConfig | addict.Dict:
     """Loads and configures a model configuration from HuggingFace or local sources.

--- a/src/axolotl/loaders/utils.py
+++ b/src/axolotl/loaders/utils.py
@@ -132,7 +132,8 @@ def check_model_config(cfg: DictDefault, model_config: PretrainedConfig):
         )
 
     if (
-        cfg.tensor_parallel_size > 1
+        cfg.tensor_parallel_size
+        and cfg.tensor_parallel_size > 1
         and hasattr(model_config, "tie_word_embeddings")
         and model_config.tie_word_embeddings
     ):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Tensor Parallelism doesn't work with models with tied embeddings, so let's error sooner .

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation check to prevent enabling tensor parallelism with models that use tied word embeddings. Users will now receive an explicit error message if this unsupported configuration is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->