### PR TITLE
prevent usage of low bit ao optimizers with configurations that use parameter groups

### DIFF
--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -880,12 +880,13 @@ class OptimizationValidationMixin:
 
         return self
 
+    @model_validator(mode="after")
     def lr_groups_ao_optimizer(self):
         if (
-            self.args.loraplus_lr_ratio is not None
-            or self.args.embedding_lr_scale is not None
-            or self.args.embedding_lr is not None
-            or self.args.lr_groups is not None
+            self.loraplus_lr_ratio is not None
+            or self.embedding_lr_scale is not None
+            or self.embedding_lr is not None
+            or self.lr_groups is not None
         ) and self.optimizer.value in ["adamw_torch_8bit", "adamw_torch_4bit"]:
             # TODO(wing): remove this once ao>0.12.0
             # requires https://github.com/pytorch/ao/pull/2606 in an ao release

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -886,7 +886,7 @@ class OptimizationValidationMixin:
             or self.args.embedding_lr_scale is not None
             or self.args.embedding_lr is not None
             or self.args.lr_groups is not None
-        ) and self.optimizer in ["torch_adamw_8bit", "torch_adamw_4bit"]:
+        ) and self.optimizer.value in ["adamw_torch_8bit", "adamw_torch_4bit"]:
             # TODO(wing): remove this once ao>0.12.0
             # requires https://github.com/pytorch/ao/pull/2606 in an ao release
             raise ValueError(

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -880,6 +880,22 @@ class OptimizationValidationMixin:
 
         return self
 
+    def lr_groups_ao_optimizer(self):
+        if (
+            self.args.loraplus_lr_ratio is not None
+            or self.args.embedding_lr_scale is not None
+            or self.args.embedding_lr is not None
+            or self.args.lr_groups is not None
+        ) and self.optimizer in ["torch_adamw_8bit", "torch_adamw_4bit"]:
+            # TODO(wing): remove this once ao>0.12.0
+            # requires https://github.com/pytorch/ao/pull/2606 in an ao release
+            raise ValueError(
+                "lr groups (`loraplus_lr_ratio`, `embedding_lr_scale`, `embedding_lr`, `lr_groups`) are not "
+                "supported with ao low-bit optimizers until ao>0.12.0. "
+                "Please refer to https://github.com/pytorch/ao/pull/2606."
+            )
+        return self
+
     @model_validator(mode="before")
     @classmethod
     def check_tensor_parallel_size_update_ds_json(cls, data):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Using configurations that create lr parameter groups passed to the optimizers result in :
```
RuntimeError: lr was changed to a non-Tensor object. If you want to update lr, please use optim.param_groups[0]['lr'].fill_(new_lr)
```
see https://github.com/pytorch/ao/issues/2574

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent the use of learning rate groups with unsupported AO low-bit optimizers, ensuring users are notified of incompatible configuration choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->