### PR TITLE
Fix: shorten mem logs to 2 decimal places and renamed nd docs

### DIFF
--- a/docs/nd_parallelism.qmd
+++ b/docs/nd_parallelism.qmd
@@ -1,4 +1,6 @@
-# N-D Parallelism
+---
+title: "N-D Parallelism"
+---
 
 Axolotl enables training models at scale by composing different parallelism techniques. This is essential when:
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -567,10 +567,10 @@ class AxolotlTrainer(
             # Add memory usage
             try:
                 active, allocated, reserved = get_gpu_memory_usage()
-                logs["memory/max_memory_active"] = active
-                logs["memory/max_memory_allocated"] = allocated
-                logs["memory/device_memory_reserved"] = reserved
-            except (ValueError, FileNotFoundError):
+                logs["memory/max_memory_active(gib)"] = round(active, 2)
+                logs["memory/max_memory_allocated(gib)"] = round(allocated, 2)
+                logs["memory/device_memory_reserved(gib)"] = round(reserved, 2)
+            except (ValueError, TypeError, FileNotFoundError):
                 pass
 
         del self._stored_metrics[train_eval]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated document metadata for improved clarity without changing content.

* **Bug Fixes**
  * Improved GPU memory usage logging by rounding values to two decimal places and clarifying units in the log output.
  * Enhanced error handling when retrieving GPU memory usage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->