### PR TITLE
Dion optimizer support

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -284,6 +284,7 @@ website:
             - docs/sequence_parallelism.qmd
             - docs/gradient_checkpointing.qmd
             - docs/nd_parallelism.qmd
+            - docs/optimizers.qmd
 
         - section: "Troubleshooting"
           contents:

--- a/docs/nd_parallelism.qmd
+++ b/docs/nd_parallelism.qmd
@@ -1,5 +1,5 @@
 ---
-title: "N-D Parallelism"
+title: "N-D Parallelism (Beta)"
 ---
 
 Axolotl enables training models at scale by composing different parallelism techniques. This is essential when:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -1,0 +1,18 @@
+---
+title: Optimizers
+description: Configuring optimizers
+---
+
+### Dion Optimizer
+
+Microsoft's Dion (DIstributed OrthoNormalization) optimizer is a scalable and communication-efficient
+orthonormalizing optimizer that uses low-rank approximations to reduce gradient communication.
+
+Usage:
+
+```yaml
+optimizer: dion
+dion_lr: 0.01
+dion_momentum: 0.95
+lr: 0.00001  # learning rate for embeddings and parameters that fallback to AdamW
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,6 @@ torchao==0.12.0
 schedulefree==1.4.1
 
 axolotl-contribs-lgpl==0.0.6
-axolotl-contribs-mit==0.0.3
+axolotl-contribs-mit==0.0.4
 
 mistral-common==1.8.3

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -532,15 +532,15 @@ class TrainerBuilderBase(abc.ABC):
             "include_tokens_per_second",
             "weight_decay",
             "seed",
+            "dion_momentum",
+            "dion_rank_fraction",
+            "dion_rank_multiple_of",
         ]:
             if hasattr(self.cfg, arg) and getattr(self.cfg, arg) is not None:
                 training_args_kwargs[arg] = getattr(self.cfg, arg)
 
         arg_map = {
             "dion_learning_rate": "dion_lr",
-            "dion_momentum": "dion_mu",
-            "dion_rank_fraction": "dion_rank_fraction",
-            "dion_rank_multiple_of": "dion_rank_multiple_of",
         }
         for kwarg, cfg_arg in arg_map.items():
             if hasattr(self.cfg, cfg_arg) and getattr(self.cfg, cfg_arg) is not None:

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -278,6 +278,8 @@ class TrainerBuilderBase(abc.ABC):
                     if self.cfg.optimizer == "dion_8bit"
                     else DionOptimizerFactory
                 )
+                optimizer_kwargs["dion_lr"] = training_args_kwargs["dion_learning_rate"]
+                optimizer_kwargs["dion_mu"] = training_args_kwargs["dion_momentum"]
                 optimizer_kwargs.update(adam_kwargs)
                 partial_state = PartialState()
                 optimizer_kwargs["device_mesh"] = partial_state.device_mesh
@@ -533,6 +535,16 @@ class TrainerBuilderBase(abc.ABC):
         ]:
             if hasattr(self.cfg, arg) and getattr(self.cfg, arg) is not None:
                 training_args_kwargs[arg] = getattr(self.cfg, arg)
+
+        arg_map = {
+            "dion_learning_rate": "dion_lr",
+            "dion_momentum": "dion_mu",
+            "dion_rank_fraction": "dion_rank_fraction",
+            "dion_rank_multiple_of": "dion_rank_multiple_of",
+        }
+        for kwarg, cfg_arg in arg_map.items():
+            if hasattr(self.cfg, cfg_arg) and getattr(self.cfg, cfg_arg) is not None:
+                training_args_kwargs[kwarg] = getattr(self.cfg, cfg_arg)
 
         training_args_kwargs["per_device_train_batch_size"] = self.cfg.micro_batch_size
         training_args_kwargs["average_tokens_across_devices"] = False

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -267,17 +267,12 @@ class TrainerBuilderBase(abc.ABC):
 
                 optimizer_cls = MuonOptimizerFactory
                 optimizer_kwargs.update(adam_kwargs)
-            elif self.cfg.optimizer in ["dion", "dion_8bit"]:
+            elif self.cfg.optimizer == "dion":
                 from axolotl.contribs.mit.dion import (  # pylint: disable=no-name-in-module
-                    Dion8bitOptimizerFactory,
                     DionOptimizerFactory,
                 )
 
-                optimizer_cls = (
-                    Dion8bitOptimizerFactory
-                    if self.cfg.optimizer == "dion_8bit"
-                    else DionOptimizerFactory
-                )
+                optimizer_cls = DionOptimizerFactory
                 optimizer_kwargs["dion_lr"] = training_args_kwargs["dion_learning_rate"]
                 optimizer_kwargs["dion_mu"] = training_args_kwargs["dion_momentum"]
                 optimizer_kwargs.update(adam_kwargs)

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -267,6 +267,20 @@ class TrainerBuilderBase(abc.ABC):
 
                 optimizer_cls = MuonOptimizerFactory
                 optimizer_kwargs.update(adam_kwargs)
+            elif self.cfg.optimizer in ["dion", "dion_8bit"]:
+                from axolotl.contribs.mit.dion import (  # pylint: disable=no-name-in-module
+                    Dion8bitOptimizerFactory,
+                    DionOptimizerFactory,
+                )
+
+                optimizer_cls = (
+                    Dion8bitOptimizerFactory
+                    if self.cfg.optimizer == "dion_8bit"
+                    else DionOptimizerFactory
+                )
+                optimizer_kwargs.update(adam_kwargs)
+                partial_state = PartialState()
+                optimizer_kwargs["device_mesh"] = partial_state.device_mesh
             elif self.cfg.optimizer == "optimi_adamw":
                 from optimi import AdamW
 

--- a/src/axolotl/core/training_args_base.py
+++ b/src/axolotl/core/training_args_base.py
@@ -243,3 +243,18 @@ class AxolotlTrainingMixins:
     )
 
     # end of multi-modal section
+
+    dion_learning_rate: float | None = field(
+        default=None,
+        metadata={"help": "The learning rate for Dion"},
+    )
+    dion_momentum: float | None = field(
+        default=None,
+        metadata={"help": "The momentum for Dion"},
+    )
+    dion_rank_fraction: float | None = field(
+        default=None,
+    )
+    dion_rank_multiple_of: int | None = field(
+        default=None,
+    )

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -79,6 +79,8 @@ class CustomSupportedOptimizers(str, Enum):
     adopt_adamw = "adopt_adamw"
     came_pytorch = "came_pytorch"
     muon = "muon"
+    dion = "dion"
+    dion_8bit = "dion_8bit"
 
 
 class RingAttnFunc(str, Enum):

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -80,7 +80,6 @@ class CustomSupportedOptimizers(str, Enum):
     came_pytorch = "came_pytorch"
     muon = "muon"
     dion = "dion"
-    dion_8bit = "dion_8bit"
 
 
 class RingAttnFunc(str, Enum):

--- a/src/axolotl/utils/schemas/training.py
+++ b/src/axolotl/utils/schemas/training.py
@@ -138,6 +138,26 @@ class HyperparametersConfig(BaseModel):
     adam_beta3: float | None = Field(
         default=None, json_schema_extra={"description": "only used for CAME Optimizer"}
     )
+
+    dion_lr: float | None = Field(
+        default=None, json_schema_extra={"description": "Dion Optimizer learning rate"}
+    )
+    dion_momentum: float | None = Field(
+        default=None, json_schema_extra={"description": "Dion Optimizer momentum"}
+    )
+    dion_rank_fraction: float | None = Field(
+        default=1.0,
+        json_schema_extra={
+            "description": "Dion Optimizer: r/d fraction for low-rank approximation. Used to compute the low-rank dimension."
+        },
+    )
+    dion_rank_multiple_of: int | None = Field(
+        default=1,
+        json_schema_extra={
+            "description": "Dion Optimizer: Round up the low-rank dimension to a multiple of this number. This may be useful to ensure even sharding."
+        },
+    )
+
     max_grad_norm: float | None = Field(
         default=None, json_schema_extra={"description": "Gradient clipping max norm"}
     )

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -171,7 +171,6 @@ class TestCustomOptimizers(unittest.TestCase):
                 "model_type": "AutoModelForCausalLM",
                 "tokenizer_type": "AutoTokenizer",
                 "sequence_len": 1024,
-                "load_in_8bit": True,
                 "val_set_size": 0.0,
                 "special_tokens": {
                     "pad_token": "<|endoftext|>",

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -159,8 +159,9 @@ class TestCustomOptimizers(unittest.TestCase):
 
         _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
-        assert "Muon" in trainer.optimizer.optimizer.__class__.__name__ @ with_temp_dir
+        assert "Muon" in trainer.optimizer.optimizer.__class__.__name__
 
+    @with_temp_dir
     @require_torch_2_7_0
     def test_dion(self, temp_dir):
         # pylint: disable=duplicate-code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Adds support for https://github.com/microsoft/dion via the contribs integration
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "Dion" optimizer with configurable learning rate, momentum, rank fraction, and rank multiple.
  * Expanded supported custom optimizers to include "Dion".
  * Enhanced parameter filtering for weight decay in optimizers.
* **Tests**
  * Added end-to-end test validating training with the "Dion" optimizer.
* **Documentation**
  * Added detailed documentation for the "Dion" optimizer and updated sidebar navigation.
  * Updated "N-D Parallelism" documentation heading to indicate beta status.
* **Chores**
  * Updated dependency version for `axolotl-contribs-mit` to 0.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->