### PR TITLE
use skip_move_to_device for all cases

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -845,6 +845,7 @@ class ModelLoader:
                 self.model._tp_size = self.cfg.tensor_parallel_size
                 self.model._device_mesh = self.model_kwargs["device_mesh"]
 
+        skip_move_to_device = True
         return skip_move_to_device
 
     def _set_z3_leaf_modules(self):

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -845,7 +845,9 @@ class ModelLoader:
                 self.model._tp_size = self.cfg.tensor_parallel_size
                 self.model._device_mesh = self.model_kwargs["device_mesh"]
 
-        skip_move_to_device = True
+        if self.cfg.experimental_skip_move_to_device is not None:
+            skip_move_to_device = self.cfg.experimental_skip_move_to_device
+
         return skip_move_to_device
 
     def _set_z3_leaf_modules(self):

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -62,6 +62,14 @@ class ModelInputConfig(BaseModel):
         json_schema_extra={"description": "Trust remote code for untrusted source"},
     )
 
+    experimental_skip_move_to_device: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Don't move the model to the device before sharding. "
+            "This is an experimental feature that may be included in the future as the default."
+        },
+    )
+
     @field_validator("trust_remote_code")
     @classmethod
     def hint_trust_remote_code(cls, trust_remote_code):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

WIP

multigpu tests https://github.com/axolotl-ai-cloud/axolotl/actions/runs/16738721812
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an experimental option to control whether models are moved to the device before sharding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->