### PR TITLE
fix keyerror on load_in_8bit/load_in_4bit access in _set_quantization_config

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -575,6 +575,8 @@ class ModelLoader:
             if self.cfg.model_quantization_config_kwargs:
                 mxfp4_kwargs = self.cfg.model_quantization_config_kwargs
             self.model_kwargs["quantization_config"] = Mxfp4Config(**mxfp4_kwargs)
+            self.model_kwargs["load_in_8bit"] = None
+            self.model_kwargs["load_in_4bit"] = None
         else:
             self.model_kwargs["load_in_8bit"] = self.cfg.load_in_8bit
             self.model_kwargs["load_in_4bit"] = self.cfg.load_in_4bit

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -575,8 +575,6 @@ class ModelLoader:
             if self.cfg.model_quantization_config_kwargs:
                 mxfp4_kwargs = self.cfg.model_quantization_config_kwargs
             self.model_kwargs["quantization_config"] = Mxfp4Config(**mxfp4_kwargs)
-            self.model_kwargs["load_in_8bit"] = None
-            self.model_kwargs["load_in_4bit"] = None
         else:
             self.model_kwargs["load_in_8bit"] = self.cfg.load_in_8bit
             self.model_kwargs["load_in_4bit"] = self.cfg.load_in_4bit
@@ -614,7 +612,9 @@ class ModelLoader:
                 self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                     **self.model_config.quantization_config
                 )
-        elif self.cfg.adapter == "qlora" and self.model_kwargs["load_in_4bit"]:
+        elif self.cfg.adapter == "qlora" and self.model_kwargs.get(
+            "load_in_4bit", False
+        ):
             bnb_config = {
                 "load_in_4bit": True,
                 "llm_int8_threshold": 6.0,
@@ -640,7 +640,9 @@ class ModelLoader:
             self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                 **bnb_config,
             )
-        elif self.cfg.adapter == "lora" and self.model_kwargs["load_in_8bit"]:
+        elif self.cfg.adapter == "lora" and self.model_kwargs.get(
+            "load_in_8bit", False
+        ):
             bnb_config = {
                 "load_in_8bit": True,
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing errors when certain model configuration options are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->