### PR TITLE
allow custom trainer_cls to be defined as a module reference in the YAML

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -43,6 +43,7 @@ from axolotl.utils.collators import (
     V2BatchSamplerDataCollatorForSeq2Seq,
 )
 from axolotl.utils.collators.mm_chat import MultiModalChatDataCollator
+from axolotl.utils.import_helper import get_cls_from_module_str
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
@@ -136,6 +137,11 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             return AxolotlRewardTrainer
         if self.cfg.process_reward_model:
             return AxolotlPRMTrainer
+
+        if self.cfg.trainer_cls:
+            # override the trainer cls
+            return get_cls_from_module_str(self.cfg.trainer_cls)
+
         return AxolotlTrainer
 
     def build(self, total_num_steps):

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -140,7 +140,14 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.trainer_cls:
             # override the trainer cls
-            return get_cls_from_module_str(self.cfg.trainer_cls)
+            try:
+                trainer_cls = get_cls_from_module_str(self.cfg.trainer_cls)
+                LOG.debug(f"Using custom trainer class: {self.cfg.trainer_cls}")
+                return trainer_cls
+            except (ImportError, AttributeError, ValueError) as e:
+                raise ValueError(
+                    f"Failed to load custom trainer class '{self.cfg.trainer_cls}': {e}"
+                ) from e
 
         return AxolotlTrainer
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -75,7 +75,13 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.trainer_cls:
             # override the trainer cls
-            trainer_cls = get_cls_from_module_str(self.cfg.trainer_cls)
+            try:
+                trainer_cls = get_cls_from_module_str(self.cfg.trainer_cls)
+                LOG.debug(f"Using custom trainer class: {self.cfg.trainer_cls}")
+            except (ImportError, AttributeError, ValueError) as e:
+                raise ValueError(
+                    f"Failed to load custom trainer class '{self.cfg.trainer_cls}': {e}"
+                ) from e
 
         return trainer_cls, trainer_cls_args
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -15,6 +15,7 @@ from axolotl.core.trainers.grpo import GRPOStrategy
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders.utils import ensure_dtype
 from axolotl.utils.callbacks.qat import QATCallback
+from axolotl.utils.import_helper import get_cls_from_module_str
 from axolotl.utils.logging import get_logger
 from axolotl.utils.schemas.enums import RLType
 
@@ -71,6 +72,10 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             trainer_cls = AxolotlCPOTrainer
         else:
             raise ValueError(f"Unsupported RL: {self.cfg.rl}")
+
+        if self.cfg.trainer_cls:
+            # override the trainer cls
+            trainer_cls = get_cls_from_module_str(self.cfg.trainer_cls)
 
         return trainer_cls, trainer_cls_args
 

--- a/src/axolotl/utils/import_helper.py
+++ b/src/axolotl/utils/import_helper.py
@@ -7,7 +7,22 @@ import importlib
 
 def get_cls_from_module_str(module_str: str):
     # use importlib to dynamically load the reward function from the module
-    module_name = module_str.split(".")[-1]
-    mod = importlib.import_module(".".join(module_str.split(".")[:-1]))
-    mod_cls = getattr(mod, module_name)
-    return mod_cls
+    if not isinstance(module_str, str) or not module_str.strip():
+        raise ValueError("module_str must be a non-empty string")
+
+    parts = module_str.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"Invalid module string format: {module_str}")
+
+    try:
+        cls_name = parts[-1]
+        module_path = ".".join(parts[:-1])
+        mod = importlib.import_module(module_path)
+        mod_cls = getattr(mod, cls_name)
+        return mod_cls
+    except ImportError as e:
+        raise ImportError(f"Failed to import module '{module_path}': {e}") from e
+    except AttributeError as e:
+        raise AttributeError(
+            f"Class '{cls_name}' not found in module '{module_path}': {e}"
+        ) from e

--- a/src/axolotl/utils/import_helper.py
+++ b/src/axolotl/utils/import_helper.py
@@ -1,0 +1,13 @@
+"""
+Helper for importing modules from strings
+"""
+
+import importlib
+
+
+def get_cls_from_module_str(module_str: str):
+    # use importlib to dynamically load the reward function from the module
+    module_name = module_str.split(".")[-1]
+    mod = importlib.import_module(".".join(module_str.split(".")[:-1]))
+    mod_cls = getattr(mod, module_name)
+    return mod_cls

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -110,6 +110,13 @@ class AxolotlInputConfig(
         },
     )
 
+    trainer_cls: str | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "module to custom trainer class to use for training"
+        },
+    )
+
     rl: RLType | None = Field(
         default=None,
         json_schema_extra={

--- a/tests/utils/test_import_helper.py
+++ b/tests/utils/test_import_helper.py
@@ -2,9 +2,36 @@
 test cases for axolotl.utils.import_helper
 """
 
+import pytest
+
 from axolotl.utils.import_helper import get_cls_from_module_str
 
 
 def test_get_cls_from_module_str():
     cls = get_cls_from_module_str("axolotl.core.trainers.base.AxolotlTrainer")
     assert cls.__name__ == "AxolotlTrainer"
+
+
+def test_get_cls_from_module_str_empty_string():
+    with pytest.raises(ValueError, match="module_str must be a non-empty string"):
+        get_cls_from_module_str("")
+
+
+def test_get_cls_from_module_str_whitespace_only():
+    with pytest.raises(ValueError, match="module_str must be a non-empty string"):
+        get_cls_from_module_str("   ")
+
+
+def test_get_cls_from_module_str_invalid_format():
+    with pytest.raises(ValueError, match="Invalid module string format"):
+        get_cls_from_module_str("single_part")
+
+
+def test_get_cls_from_module_str_nonexistent_module():
+    with pytest.raises(ImportError, match="Failed to import module"):
+        get_cls_from_module_str("nonexistent.module.Class")
+
+
+def test_get_cls_from_module_str_nonexistent_class():
+    with pytest.raises(AttributeError, match="Class 'NonExistentClass' not found"):
+        get_cls_from_module_str("axolotl.core.trainers.base.NonExistentClass")

--- a/tests/utils/test_import_helper.py
+++ b/tests/utils/test_import_helper.py
@@ -1,0 +1,10 @@
+"""
+test cases for axolotl.utils.import_helper
+"""
+
+from axolotl.utils.import_helper import get_cls_from_module_str
+
+
+def test_get_cls_from_module_str():
+    cls = get_cls_from_module_str("axolotl.core.trainers.base.AxolotlTrainer")
+    assert cls.__name__ == "AxolotlTrainer"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This allows users to extend the `AxolotlTrainer` in file/module without the extra complexity of a custom plugin

for example, create a `my_trainer.py` with:
```python
from axolotl.core.trainers.base import AxolotlTrainer

class MyTrainer(AxolotlTrainer):
    def training_step(self, model, inputs):
        # TODO do something before the training step
        return super().training_step(model, inputs)
```

and then in your yaml, you can use:
```yaml
trainer_cls: my_trainer.MyTrainer
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom trainer class via configuration, allowing advanced users to override the default trainer by providing a module path string.
* **Documentation**
  * Updated configuration schema with a new optional field for specifying a custom trainer class.
* **Tests**
  * Added tests to verify dynamic import functionality for custom trainer classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->