### PR TITLE
use exec instead of subprocess to make ctrl+c nicer for cli

### DIFF
--- a/src/axolotl/cli/main.py
+++ b/src/axolotl/cli/main.py
@@ -123,9 +123,9 @@ def train(
     _launcher = None if kwargs.get("use_ray") else launcher
 
     # Process each configuration
-    for cfg_file, num_permutations in generate_config_files(config, sweep):
+    for cfg_file, is_group in generate_config_files(config, sweep):
         try:
-            use_exec = num_permutations == 1
+            use_exec = is_group is not True
             launch_training(cfg_file, _launcher, cloud, kwargs, launcher_args, use_exec)
         except subprocess.CalledProcessError as exc:
             LOG.error(f"Failed to train/fine-tune config '{cfg_file}': {exc}")

--- a/src/axolotl/cli/main.py
+++ b/src/axolotl/cli/main.py
@@ -125,8 +125,8 @@ def train(
     # Process each configuration
     for cfg_file, num_permutations in generate_config_files(config, sweep):
         try:
-            exec_ = num_permutations == 1
-            launch_training(cfg_file, _launcher, cloud, kwargs, launcher_args, exec_)
+            use_exec = num_permutations == 1
+            launch_training(cfg_file, _launcher, cloud, kwargs, launcher_args, use_exec)
         except subprocess.CalledProcessError as exc:
             LOG.error(f"Failed to train/fine-tune config '{cfg_file}': {exc}")
             if not sweep:

--- a/src/axolotl/cli/main.py
+++ b/src/axolotl/cli/main.py
@@ -123,9 +123,10 @@ def train(
     _launcher = None if kwargs.get("use_ray") else launcher
 
     # Process each configuration
-    for cfg_file in generate_config_files(config, sweep):
+    for cfg_file, num_permutations in generate_config_files(config, sweep):
         try:
-            launch_training(cfg_file, _launcher, cloud, kwargs, launcher_args)
+            exec_ = num_permutations == 1
+            launch_training(cfg_file, _launcher, cloud, kwargs, launcher_args, exec_)
         except subprocess.CalledProcessError as exc:
             LOG.error(f"Failed to train/fine-tune config '{cfg_file}': {exc}")
             if not sweep:

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -64,10 +64,20 @@ def build_command(base_cmd: list[str], options: dict[str, Any]) -> list[str]:
     return cmd
 
 
-def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str, int]]:
-    """Generate list of configuration files to process."""
+def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str, bool]]:
+    """
+    Generate list of configuration files to process.
+
+    Args:
+        config: Base configuration file
+        sweep: Sweep configuration file
+
+    Yields:
+        Tuple of configuration file name and whether this is a group of configurations
+    """
+
     if not sweep:
-        yield config, 1
+        yield config, False
         return
 
     # Load sweep and base configurations
@@ -78,7 +88,7 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
 
     # Generate all possible configurations
     permutations = generate_sweep_configs(base_config, sweep_config)
-    num_permutations = len(permutations)
+    is_group = len(permutations) > 1
     for permutation in permutations:
         # pylint: disable=consider-using-with
         temp_file = tempfile.NamedTemporaryFile(
@@ -89,7 +99,7 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
         )
         yaml.dump(permutation, temp_file)
         temp_file.close()
-        yield temp_file.name, num_permutations
+        yield temp_file.name, is_group
 
 
 def launch_training(

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -98,7 +98,7 @@ def launch_training(
     cloud: str | None,
     kwargs: dict,
     launcher_args: list[str] | None = None,
-    exec_: bool = False,
+    use_exec: bool = False,
 ) -> None:
     """Execute training with the given configuration."""
     launcher_args = launcher_args or []
@@ -107,9 +107,9 @@ def launch_training(
         _launch_cloud_training(cloud, cfg_file, launcher, kwargs, launcher_args)
     elif launcher:
         if launcher == "accelerate":
-            _launch_accelerate_training(cfg_file, kwargs, launcher_args, exec_)
+            _launch_accelerate_training(cfg_file, kwargs, launcher_args, use_exec)
         elif launcher == "torchrun":
-            _launch_torchrun_training(cfg_file, kwargs, launcher_args, exec_)
+            _launch_torchrun_training(cfg_file, kwargs, launcher_args, use_exec)
         elif launcher == "python":
             _launch_python_training(cfg_file, kwargs)
 
@@ -141,7 +141,7 @@ def _launch_accelerate_training(
     cfg_file: str,
     kwargs: dict,
     launcher_args: list[str] | None = None,
-    exec_: bool = False,
+    use_exec: bool = False,
 ) -> None:
     """Execute training via accelerate launcher."""
     launcher_args = launcher_args or []
@@ -166,7 +166,7 @@ def _launch_accelerate_training(
         base_cmd.append(cfg_file)
 
     cmd = build_command(base_cmd, kwargs)
-    if exec_:
+    if use_exec:
         os.execvpe(cmd[0], cmd, os.environ)  # nosec B606
     else:
         subprocess.run(cmd, check=True)  # nosec B603
@@ -176,7 +176,7 @@ def _launch_torchrun_training(
     cfg_file: str,
     kwargs: dict,
     launcher_args: list[str] | None = None,
-    exec_: bool = False,
+    use_exec: bool = False,
 ) -> None:
     """Execute training via torchrun launcher."""
     launcher_args = launcher_args or []
@@ -189,7 +189,7 @@ def _launch_torchrun_training(
         base_cmd.append(cfg_file)
 
     cmd = build_command(base_cmd, kwargs)
-    if exec_:
+    if use_exec:
         os.execvpe(cmd[0], cmd, os.environ)  # nosec B606
     else:
         subprocess.run(cmd, check=True)  # nosec B603

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess  # nosec
+import sys
 import tempfile
 from typing import Any, Iterator, Literal
 
@@ -177,6 +178,9 @@ def _launch_accelerate_training(
 
     cmd = build_command(base_cmd, kwargs)
     if use_exec:
+        # make sure to flush stdout and stderr before replacing the process
+        sys.stdout.flush()
+        sys.stderr.flush()
         os.execvpe(cmd[0], cmd, os.environ)  # nosec B606
     else:
         subprocess.run(cmd, check=True)  # nosec B603
@@ -200,6 +204,9 @@ def _launch_torchrun_training(
 
     cmd = build_command(base_cmd, kwargs)
     if use_exec:
+        # make sure to flush stdout and stderr before replacing the process
+        sys.stdout.flush()
+        sys.stderr.flush()
         os.execvpe(cmd[0], cmd, os.environ)  # nosec B606
     else:
         subprocess.run(cmd, check=True)  # nosec B603

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -65,7 +65,8 @@ class BaseCliTest:
             if train:
                 expected.append("--shard=False")
 
-            assert mock.call_args.args[0] == expected
+            assert mock.call_args.args[0] == "accelerate"
+            assert mock.call_args.args[1] == expected
             assert mock.call_args.kwargs == {"check": True}
             assert result.exit_code == 0
 

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -47,7 +47,7 @@ class BaseCliTest:
         config_path = tmp_path / "config.yml"
         config_path.write_text(valid_test_config)
 
-        with patch("subprocess.run") as mock:
+        with patch("os.execvpe") as mock:
             result = cli_runner.invoke(cli, [command, str(config_path)])
 
             assert mock.called

--- a/tests/cli/test_cli_train.py
+++ b/tests/cli/test_cli_train.py
@@ -85,7 +85,7 @@ class TestTrainCommand(BaseCliTest):
         config_path = tmp_path / "config.yml"
         config_path.write_text(valid_test_config)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with patch("os.execvpe") as mock_subprocess:
             result = cli_runner.invoke(
                 cli,
                 [
@@ -104,7 +104,7 @@ class TestTrainCommand(BaseCliTest):
             mock_subprocess.assert_called_once()
 
             # Verify launcher args are passed to torchrun
-            called_cmd = mock_subprocess.call_args.args[0]
+            called_cmd = mock_subprocess.call_args.args[1]
             assert called_cmd[0] == "torchrun"
             assert "--nproc_per_node=2" in called_cmd
             assert "--nnodes=1" in called_cmd
@@ -118,7 +118,7 @@ class TestTrainCommand(BaseCliTest):
         config_path = tmp_path / "config.yml"
         config_path.write_text(valid_test_config)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with patch("os.execvpe") as mock_subprocess:
             result = cli_runner.invoke(
                 cli,
                 [
@@ -137,7 +137,8 @@ class TestTrainCommand(BaseCliTest):
             mock_subprocess.assert_called_once()
 
             # Verify launcher args are passed to accelerate
-            called_cmd = mock_subprocess.call_args.args[0]
+            assert mock_subprocess.call_args.args[0] == "accelerate"
+            called_cmd = mock_subprocess.call_args.args[1]
             assert called_cmd[0] == "accelerate"
             assert called_cmd[1] == "launch"
             assert "--config_file=accelerate_config.yml" in called_cmd
@@ -152,7 +153,7 @@ class TestTrainCommand(BaseCliTest):
         config_path = tmp_path / "config.yml"
         config_path.write_text(valid_test_config)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with patch("os.execvpe") as mock_subprocess:
             result = cli_runner.invoke(
                 cli,
                 [
@@ -170,7 +171,8 @@ class TestTrainCommand(BaseCliTest):
             mock_subprocess.assert_called_once()
 
             # Verify no launcher args contamination
-            called_cmd = mock_subprocess.call_args.args[0]
+            assert mock_subprocess.call_args.args[0] == "accelerate"
+            called_cmd = mock_subprocess.call_args.args[1]
             assert called_cmd[0] == "accelerate"
             assert called_cmd[1] == "launch"
             # Should not contain any extra launcher args
@@ -186,7 +188,7 @@ class TestTrainCommand(BaseCliTest):
         config_path = tmp_path / "config.yml"
         config_path.write_text(valid_test_config)
 
-        with patch("subprocess.run") as mock_subprocess:
+        with patch("os.execvpe") as mock_subprocess:
             result = cli_runner.invoke(
                 cli,
                 [
@@ -207,7 +209,8 @@ class TestTrainCommand(BaseCliTest):
             assert result.exit_code == 0
             mock_subprocess.assert_called_once()
 
-            called_cmd = mock_subprocess.call_args.args[0]
+            assert mock_subprocess.call_args.args[0] == "torchrun"
+            called_cmd = mock_subprocess.call_args.args[1]
             # Verify launcher args
             assert "--nproc_per_node=8" in called_cmd
             # Verify axolotl args are also present


### PR DESCRIPTION
right now, when training from the cli, if you ctrl+c to stop the training, it just ends up dumping a call stack forever requiring pkill to stop the processes. This PR swaps the subprocess with an exec to replace the running process with the training process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved training command to better handle multiple configuration sets.
  * Added an option to replace the current process when launching training for more efficient execution.

* **Refactor**
  * Enhanced configuration generation and training launch processes to support the new execution mode.

* **Tests**
  * Updated CLI tests to reflect changes in training process execution method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->