### PR TITLE
update training args check for new defaults

### DIFF
--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -281,7 +281,7 @@ class TestHFRLTrainerBuilder:
         # Other settings
         assert training_arguments.dataloader_num_workers == 1
         assert training_arguments.dataloader_pin_memory is True
-        assert training_arguments.gradient_checkpointing is False
+        assert training_arguments.gradient_checkpointing is True
 
     def test_dpo_training_arguments(self, dpo_cfg, model, tokenizer):
         builder = HFRLTrainerBuilder(dpo_cfg, model, tokenizer)

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -281,7 +281,9 @@ class TestHFRLTrainerBuilder:
         # Other settings
         assert training_arguments.dataloader_num_workers == 1
         assert training_arguments.dataloader_pin_memory is True
-        assert training_arguments.gradient_checkpointing is True
+
+        # TODO(wing): restore once trl releases 0.22.0
+        # assert training_arguments.gradient_checkpointing is True
 
     def test_dpo_training_arguments(self, dpo_cfg, model, tokenizer):
         builder = HFRLTrainerBuilder(dpo_cfg, model, tokenizer)


### PR DESCRIPTION
https://github.com/huggingface/trl/pull/3510 updated gradient_checkpointing defaults, which we need to account for in some tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for the default state of the gradient checkpointing setting in RLHF trainer builder tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->