### PR TITLE
use dynamic finetuning with chunked cross entropy

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -153,9 +153,12 @@ class PatchManager:
             from axolotl.monkeypatch.loss.chunked import patch_chunked_ce_loss_fn
 
             if self.cfg.chunked_cross_entropy_num_chunks:
-                patch_chunked_ce_loss_fn(self.cfg.chunked_cross_entropy_num_chunks)
+                patch_chunked_ce_loss_fn(
+                    self.cfg.chunked_cross_entropy_num_chunks,
+                    use_dft=self.cfg.use_dynamic_finetuning,
+                )
             else:
-                patch_chunked_ce_loss_fn()
+                patch_chunked_ce_loss_fn(use_dft=self.cfg.use_dynamic_finetuning)
 
     def _apply_fsdp_patches(self):
         """Apply patches for FSDP configurations."""

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -664,6 +664,13 @@ class AxolotlInputConfig(
         },
     )
 
+    use_dynamic_finetuning: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Whether to use dynamic fine-tuning for scaled SFT gradients."
+        },
+    )
+
     chunked_cross_entropy: bool | None = Field(
         default=None,
         json_schema_extra={


### PR DESCRIPTION
# Description

paper: https://arxiv.org/abs/2508.05629

support DFT, but requires chunked_cross_entropy since we implement it there.

```yaml
use_dynamic_finetuning: true
chunked_cross_entropy: true
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional setting to enable dynamic fine-tuning that adapts loss weighting during training, integrated with chunked cross-entropy.

- Validation
  - Introduced pre-run checks requiring chunked cross-entropy when dynamic fine-tuning is enabled, with clear error messages for misconfiguration.
  - Added a guard preventing incompatible combinations of parameter offload and specific 8-bit/4-bit optimizers in FSDP2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->