### PR TITLE
text diffusion training plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v0.12.12
     hooks:
     -   id: ruff
-        args: [--fix]
+        args: [--fix, --select, I]
     -   id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.1

--- a/examples/colab-notebooks/colab-axolotl-example.ipynb
+++ b/examples/colab-notebooks/colab-axolotl-example.ipynb
@@ -176,8 +176,8 @@
     }
    ],
    "source": [
-    "from axolotl.utils.dict import DictDefault\n",
     "from axolotl.cli.config import load_cfg\n",
+    "from axolotl.utils.dict import DictDefault\n",
     "\n",
     "# Axolotl provides full control and transparency over model and training configuration\n",
     "config = DictDefault(\n",

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -10,14 +10,14 @@ pretraining_dataset:
 
 plugins:
   - diffusion.DiffusionPlugin
-noise_schedule: cosine
-min_mask_ratio: 0.15
-max_mask_ratio: 0.85
-eps: 5e-4
-importance_weighting: true
-mask_token_id: 128002
-generate_samples: true
-generation_interval: 10
+diffusion_noise_schedule: cosine
+diffusion_min_mask_ratio: 0.15
+diffusion_max_mask_ratio: 0.85
+diffusion_eps: 5e-4
+diffusion_importance_weighting: true
+diffusion_mask_token_id: 128002
+diffusion_generate_samples: true
+diffusion_generation_interval: 10
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -15,7 +15,7 @@ plugins:
 noise_schedule: "cosine"
 min_mask_ratio: 0.15
 max_mask_ratio: 0.85
-num_diffusion_steps: 2000
+num_diffusion_steps: 128
 eps: 5e-4
 importance_weighting: true
 

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -2,29 +2,27 @@ base_model: meta-llama/Llama-3.2-1B
 # Automatically upload checkpoint and final model to HF
 # hub_model_id: username/custom_model_name
 
-# Dataset configuration for pretraining
-datasets:
+pretraining_dataset:
   - path: wikitext
     name: wikitext-103-raw-v1
     type: completion
     field: text
-val_set_size: 0.001
 
 plugins:
   - diffusion.DiffusionPlugin
-noise_schedule: "cosine"
+noise_schedule: cosine
 min_mask_ratio: 0.15
 max_mask_ratio: 0.85
-num_diffusion_steps: 128
 eps: 5e-4
 importance_weighting: true
 mask_token_id: 128002
+generate_samples: true
+generation_interval: 10
 
 output_dir: ./outputs/model-out
 
 sequence_len: 512
-sample_packing: false
-eval_sample_packing: false
+sample_packing: true
 
 gradient_accumulation_steps: 8
 micro_batch_size: 4
@@ -42,12 +40,10 @@ resume_from_checkpoint:
 logging_steps: 1
 sdp_attention: true
 
-warmup_steps: 500
+warmup_steps: 1000
 
 save_strategy: steps
-eval_strategy: steps
 save_steps: 1000
-eval_steps: 1000
 
 special_tokens:
   pad_token: "<|end_of_text|>"

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -22,8 +22,8 @@ importance_weighting: true
 output_dir: ./outputs/model-out
 
 sequence_len: 512
-sample_packing: true
-eval_sample_packing: true
+sample_packing: false
+eval_sample_packing: false
 
 gradient_accumulation_steps: 8
 micro_batch_size: 4
@@ -51,8 +51,8 @@ eval_steps: 1000
 special_tokens:
   pad_token: "<|end_of_text|>"
 
-wandb_project:
-wandb_entity:
+wandb_project: diffusion-plugin
+wandb_entity: axolotl-ai
 wandb_watch:
 wandb_name:
 wandb_log_model:

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -9,7 +9,7 @@ pretraining_dataset:
     field: text
 
 plugins:
-  - diffusion.DiffusionPlugin
+  - axolotl.integrations.diffusion.DiffusionPlugin
 diffusion_noise_schedule: cosine
 diffusion_min_mask_ratio: 0.15
 diffusion_max_mask_ratio: 0.85

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -40,7 +40,7 @@ resume_from_checkpoint:
 logging_steps: 1
 sdp_attention: true
 
-warmup_steps: 1000
+warmup_ratio: 0.1
 
 save_strategy: steps
 save_steps: 1000

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -18,6 +18,7 @@ max_mask_ratio: 0.85
 num_diffusion_steps: 128
 eps: 5e-4
 importance_weighting: true
+mask_token_id: 128002
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -34,7 +34,7 @@ lr_scheduler: cosine
 learning_rate: 3e-4
 
 bf16: auto
-tf32: false
+tf32: true
 
 gradient_checkpointing: true
 resume_from_checkpoint:
@@ -51,8 +51,8 @@ eval_steps: 1000
 special_tokens:
   pad_token: "<|end_of_text|>"
 
-wandb_project: diffusion-plugin
-wandb_entity: axolotl-ai
+wandb_project:
+wandb_entity:
 wandb_watch:
 wandb_name:
 wandb_log_model:

--- a/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-pretrain.yaml
@@ -1,0 +1,60 @@
+base_model: meta-llama/Llama-3.2-1B
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+# Dataset configuration for pretraining
+datasets:
+  - path: wikitext
+    name: wikitext-103-raw-v1
+    type: completion
+    field: text
+val_set_size: 0.001
+
+plugins:
+  - diffusion.DiffusionPlugin
+noise_schedule: "cosine"
+min_mask_ratio: 0.15
+max_mask_ratio: 0.85
+num_diffusion_steps: 2000
+eps: 5e-4
+importance_weighting: true
+
+output_dir: ./outputs/model-out
+
+sequence_len: 512
+sample_packing: true
+eval_sample_packing: true
+
+gradient_accumulation_steps: 8
+micro_batch_size: 4
+max_steps: 10000
+
+optimizer: adamw_8bit
+lr_scheduler: cosine
+learning_rate: 3e-4
+
+bf16: auto
+tf32: false
+
+gradient_checkpointing: true
+resume_from_checkpoint:
+logging_steps: 1
+sdp_attention: true
+
+warmup_steps: 500
+
+save_strategy: steps
+eval_strategy: steps
+save_steps: 1000
+eval_steps: 1000
+
+special_tokens:
+  pad_token: "<|end_of_text|>"
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+# save_first_step: true  # uncomment this to validate checkpoint saving works with your config

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -1,0 +1,55 @@
+base_model: meta-llama/Llama-3.2-1B
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+datasets:
+  - path: teknium/GPT4-LLM-Cleaned
+    type: alpaca
+val_set_size: 0.05
+
+plugins:
+  - diffusion.DiffusionPlugin
+noise_schedule: "linear"
+min_mask_ratio: 0.1
+max_mask_ratio: 0.9
+num_diffusion_steps: 1000
+eps: 1e-3
+importance_weighting: true
+
+output_dir: ./outputs/model-out
+
+sequence_len: 512
+sample_packing: true
+eval_sample_packing: true
+
+gradient_accumulation_steps: 4
+micro_batch_size: 4
+num_epochs: 1
+
+optimizer: adamw_8bit
+lr_scheduler: cosine
+learning_rate: 1e-5
+
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+resume_from_checkpoint:
+logging_steps: 1
+sdp_attention: true
+
+save_strategy: steps
+eval_strategy: steps
+save_steps: 500
+eval_steps: 500
+
+special_tokens:
+  pad_token: "<|end_of_text|>"
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+# save_first_step: true  # uncomment this to validate checkpoint saving works with your config

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -9,13 +9,13 @@ val_set_size: 0.05
 
 plugins:
   - diffusion.DiffusionPlugin
-noise_schedule: cosine
-min_mask_ratio: 0.1
-max_mask_ratio: 0.9
-num_diffusion_steps: 128
-eps: 1e-3
-importance_weighting: true
-mask_token_id: 128002
+diffusion_noise_schedule: cosine
+diffusion_min_mask_ratio: 0.1
+diffusion_max_mask_ratio: 0.9
+diffusion_num_diffusion_steps: 128
+diffusion_eps: 1e-3
+diffusion_importance_weighting: true
+diffusion_mask_token_id: 128002
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -39,7 +39,7 @@ resume_from_checkpoint:
 logging_steps: 1
 sdp_attention: true
 
-warmup_steps: 1000
+warmup_steps: 0.1
 
 save_strategy: steps
 eval_strategy: steps

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -8,7 +8,7 @@ datasets:
 val_set_size: 0.05
 
 plugins:
-  - diffusion.DiffusionPlugin
+  - axolotl.integrations.diffusion.DiffusionPlugin
 diffusion_noise_schedule: cosine
 diffusion_min_mask_ratio: 0.1
 diffusion_max_mask_ratio: 0.9

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -12,7 +12,7 @@ plugins:
 noise_schedule: "linear"
 min_mask_ratio: 0.1
 max_mask_ratio: 0.9
-num_diffusion_steps: 1000
+num_diffusion_steps: 128
 eps: 1e-3
 importance_weighting: true
 

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -9,7 +9,7 @@ val_set_size: 0.05
 
 plugins:
   - diffusion.DiffusionPlugin
-noise_schedule: "linear"
+noise_schedule: cosine
 min_mask_ratio: 0.1
 max_mask_ratio: 0.9
 num_diffusion_steps: 128
@@ -38,6 +38,8 @@ gradient_checkpointing: true
 resume_from_checkpoint:
 logging_steps: 1
 sdp_attention: true
+
+warmup_steps: 1000
 
 save_strategy: steps
 eval_strategy: steps

--- a/examples/llama-3/diffusion-3.2-1b-sft.yaml
+++ b/examples/llama-3/diffusion-3.2-1b-sft.yaml
@@ -15,6 +15,7 @@ max_mask_ratio: 0.9
 num_diffusion_steps: 128
 eps: 1e-3
 importance_weighting: true
+mask_token_id: 128002
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion/pretrain-1b.yaml
+++ b/examples/llama-3/diffusion/pretrain-1b.yaml
@@ -20,7 +20,7 @@ diffusion:
   importance_weighting: true
   mask_token_id: 128002
   generate_samples: true
-  generation_interval: 10
+  generation_interval: 250
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion/pretrain-1b.yaml
+++ b/examples/llama-3/diffusion/pretrain-1b.yaml
@@ -15,6 +15,7 @@ diffusion:
   noise_schedule: cosine
   min_mask_ratio: 0.15
   max_mask_ratio: 0.85
+  num_diffusion_steps: 128
   eps: 5e-4
   importance_weighting: true
   mask_token_id: 128002

--- a/examples/llama-3/diffusion/pretrain-1b.yaml
+++ b/examples/llama-3/diffusion/pretrain-1b.yaml
@@ -30,21 +30,17 @@ sample_packing: true
 gradient_accumulation_steps: 8
 micro_batch_size: 4
 max_steps: 10000
+warmup_ratio: 0.1
 
 optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 3e-4
+sdp_attention: true
 
 bf16: auto
 tf32: true
 
-gradient_checkpointing: true
-resume_from_checkpoint:
 logging_steps: 1
-sdp_attention: true
-
-warmup_ratio: 0.1
-
 save_strategy: steps
 save_steps: 1000
 

--- a/examples/llama-3/diffusion/pretrain-1b.yaml
+++ b/examples/llama-3/diffusion/pretrain-1b.yaml
@@ -10,14 +10,16 @@ pretraining_dataset:
 
 plugins:
   - axolotl.integrations.diffusion.DiffusionPlugin
-diffusion_noise_schedule: cosine
-diffusion_min_mask_ratio: 0.15
-diffusion_max_mask_ratio: 0.85
-diffusion_eps: 5e-4
-diffusion_importance_weighting: true
-diffusion_mask_token_id: 128002
-diffusion_generate_samples: true
-diffusion_generation_interval: 10
+
+diffusion:
+  noise_schedule: cosine
+  min_mask_ratio: 0.15
+  max_mask_ratio: 0.85
+  eps: 5e-4
+  importance_weighting: true
+  mask_token_id: 128002
+  generate_samples: true
+  generation_interval: 10
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion/sft-1b.yaml
+++ b/examples/llama-3/diffusion/sft-1b.yaml
@@ -18,6 +18,8 @@ diffusion:
   eps: 1e-3
   importance_weighting: true
   mask_token_id: 128002
+  generate_samples: true
+  generation_interval: 10
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion/sft-1b.yaml
+++ b/examples/llama-3/diffusion/sft-1b.yaml
@@ -9,13 +9,15 @@ val_set_size: 0.05
 
 plugins:
   - axolotl.integrations.diffusion.DiffusionPlugin
-diffusion_noise_schedule: cosine
-diffusion_min_mask_ratio: 0.1
-diffusion_max_mask_ratio: 0.9
-diffusion_num_diffusion_steps: 128
-diffusion_eps: 1e-3
-diffusion_importance_weighting: true
-diffusion_mask_token_id: 128002
+
+diffusion:
+  noise_schedule: cosine
+  min_mask_ratio: 0.1
+  max_mask_ratio: 0.9
+  num_diffusion_steps: 128
+  eps: 1e-3
+  importance_weighting: true
+  mask_token_id: 128002
 
 output_dir: ./outputs/model-out
 

--- a/examples/llama-3/diffusion/sft-1b.yaml
+++ b/examples/llama-3/diffusion/sft-1b.yaml
@@ -19,7 +19,7 @@ diffusion:
   importance_weighting: true
   mask_token_id: 128002
   generate_samples: true
-  generation_interval: 10
+  generation_interval: 250
 
 output_dir: ./outputs/model-out
 
@@ -29,7 +29,7 @@ eval_sample_packing: true
 
 gradient_accumulation_steps: 4
 micro_batch_size: 4
-num_epochs: 1
+max_steps: 10000
 
 optimizer: adamw_8bit
 lr_scheduler: cosine

--- a/examples/llama-3/diffusion/sft-1b.yaml
+++ b/examples/llama-3/diffusion/sft-1b.yaml
@@ -29,7 +29,8 @@ eval_sample_packing: true
 
 gradient_accumulation_steps: 4
 micro_batch_size: 4
-max_steps: 10000
+num_epochs: 1
+warmup_steps: 0.1
 
 optimizer: adamw_8bit
 lr_scheduler: cosine
@@ -40,15 +41,11 @@ tf32: true
 
 gradient_checkpointing: true
 resume_from_checkpoint:
-logging_steps: 1
 sdp_attention: true
 
-warmup_steps: 0.1
-
-save_strategy: steps
-eval_strategy: steps
-save_steps: 500
-eval_steps: 500
+logging_steps: 1
+save_strategy: best
+eval_strategy: epoch
 
 special_tokens:
   pad_token: "<|end_of_text|>"

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -9,7 +9,7 @@ from typing import Union
 import fire
 import torch
 import transformers
-from colorama import Fore, Style, init as colorama_init
+from colorama import Fore, Style
 from transformers import GenerationConfig, TextIteratorStreamer, TextStreamer
 
 from axolotl.cli.args import InferenceCliArgs
@@ -20,13 +20,11 @@ from axolotl.cli.utils.diffusion import (
     run_diffusion,
 )
 from axolotl.integrations.base import PluginManager
-from axolotl.integrations.diffusion import DiffusionPlugin
 from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
-colorama_init(autoreset=True)
 
 
 def get_multi_line_input() -> str:
@@ -83,7 +81,7 @@ def do_inference(
     # Detect diffusion mode
     plugin_manager = PluginManager.get_instance()
     is_diffusion = any(
-        isinstance(plugin, DiffusionPlugin)
+        plugin.__class__.__name__ == "DiffusionPlugin"
         for plugin in plugin_manager.plugins.values()
     )
 

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -19,6 +19,8 @@ from axolotl.cli.utils.diffusion import (
     parse_commands,
     run_diffusion,
 )
+from axolotl.integrations.base import PluginManager
+from axolotl.integrations.diffusion import DiffusionPlugin
 from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
@@ -78,11 +80,11 @@ def do_inference(
 
     model = model.to(cfg.device, dtype=cfg.torch_dtype)
 
-    # Detect diffusion mode from plugins
-    plugins = cfg.get("plugins") or []
+    # Detect diffusion mode
+    plugin_manager = PluginManager.get_instance()
     is_diffusion = any(
-        isinstance(p, str) and p == "axolotl.integrations.diffusion.DiffusionPlugin"
-        for p in plugins
+        isinstance(plugin, DiffusionPlugin)
+        for plugin in plugin_manager.plugins.values()
     )
 
     if is_diffusion:

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -9,17 +9,16 @@ from typing import Union
 import fire
 import torch
 import transformers
-from transformers import GenerationConfig, TextIteratorStreamer, TextStreamer
 from colorama import Fore, Style, init as colorama_init
-
-from axolotl.cli.utils.diffusion import (
-    run_diffusion,
-    parse_commands,
-)
+from transformers import GenerationConfig, TextIteratorStreamer, TextStreamer
 
 from axolotl.cli.args import InferenceCliArgs
 from axolotl.cli.config import load_cfg
 from axolotl.cli.utils import load_model_and_tokenizer
+from axolotl.cli.utils.diffusion import (
+    parse_commands,
+    run_diffusion,
+)
 from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -81,12 +81,7 @@ def do_inference(
     # Detect diffusion mode from plugins
     plugins = cfg.get("plugins") or []
     is_diffusion = any(
-        isinstance(p, str)
-        and (
-            p == "axolotl.integrations.diffusion.DiffusionPlugin"
-            or p.endswith("diffusion.DiffusionPlugin")
-            or "diffusion" in p
-        )
+        isinstance(p, str) and p == "axolotl.integrations.diffusion.DiffusionPlugin"
         for p in plugins
     )
 

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -50,9 +50,9 @@ def do_inference(
     cli_args: InferenceCliArgs,
 ):
     """
-    Runs inference on the command line in a loop. User input is accepted, a chat template
-    is (optionally) applied, and the model specified in the `axolotl` config is used to
-    generate completions according to a default generation config.
+    Runs inference on the command line in a loop. User input is accepted, a chat
+    template is (optionally) applied, and the model specified in the `axolotl` config is
+    used to generate completions according to a default generation config.
 
     Args:
         cfg: Dictionary mapping `axolotl` config keys to values.
@@ -89,12 +89,6 @@ def do_inference(
         )
         for p in plugins
     )
-
-    # Print diffusion commands once at startup
-    if is_diffusion:
-        print("Commands:")
-        print(":complete N -> completion mode with N tokens (default 64)")
-        print(":mask R     -> random masking with ratio R (0.0–1.0)")
 
     if is_diffusion:
         print("=" * 80)
@@ -188,7 +182,7 @@ def do_inference(
                 if masked_text is not None and mask_ratio is not None:
                     print(f"Masked ({mask_ratio:.1%}):\n{masked_text}\n")
                 if generated_ids is not None:
-                    # Compute style label per position (avoid nested closures for clarity)
+                    # Compute per-token style
                     styles: list[str] = []
                     for i, tid in enumerate(generated_ids):
                         if i in masked_positions:
@@ -225,9 +219,7 @@ def do_inference(
                             out_parts.append(Fore.RED + chunk_text + Style.RESET_ALL)
                         else:
                             if style_name == "dim":
-                                out_parts.append(
-                                    Style.DIM + chunk_text + Style.RESET_ALL
-                                )
+                                out_parts.append(Style.DIM + chunk_text + Style.RESET_ALL)
                             else:
                                 out_parts.append(chunk_text)
                     print("Generated:\n" + "".join(out_parts))

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -219,7 +219,9 @@ def do_inference(
                             out_parts.append(Fore.RED + chunk_text + Style.RESET_ALL)
                         else:
                             if style_name == "dim":
-                                out_parts.append(Style.DIM + chunk_text + Style.RESET_ALL)
+                                out_parts.append(
+                                    Style.DIM + chunk_text + Style.RESET_ALL
+                                )
                             else:
                                 out_parts.append(chunk_text)
                     print("Generated:\n" + "".join(out_parts))

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -1,0 +1,242 @@
+"""Helpers for diffusion-mode inference in CLI and Gradio."""
+
+from __future__ import annotations
+
+
+from axolotl.utils.dict import DictDefault
+
+# Import diffusion generator (backwards compatible alias)
+try:  # pragma: no cover - thin wrapper
+    from axolotl.integrations.diffusion.generation import (
+        generate as diffusion_generate,
+    )
+except Exception:  # pragma: no cover
+    diffusion_generate = None  # type: ignore
+
+
+def parse_commands(text: str):
+    """
+    Parse leading diffusion commands.
+
+    Supported at start of input (can be chained):
+      :complete N  -> completion mode with N tokens (default 64)
+      :mask R      -> random masking with ratio R in [0, 1]
+    """
+    tokens = text.strip().split()
+    i = 0
+    mode = "random"
+    completion_tokens = 0
+    target_mask_ratio = None
+    consumed = 0
+    while i < len(tokens) and tokens[i].startswith(":"):
+        cmd = tokens[i]
+        i += 1
+        consumed = i
+        if cmd == ":complete":
+            mode = "completion"
+            if i < len(tokens):
+                try:
+                    completion_tokens = int(tokens[i])
+                    i += 1
+                    consumed = i
+                except Exception:
+                    completion_tokens = 64
+            else:
+                completion_tokens = 64
+        elif cmd == ":mask":
+            mode = "random"
+            if i < len(tokens):
+                try:
+                    target_mask_ratio = float(tokens[i])
+                    i += 1
+                    consumed = i
+                except Exception:
+                    target_mask_ratio = None
+        else:
+            i -= 1
+            consumed = i
+            break
+
+    cleaned = " ".join(tokens[consumed:])
+    return mode, completion_tokens, target_mask_ratio, cleaned
+
+
+def infer_mask_token_id(tokenizer, cfg: DictDefault) -> int:
+    """Infer mask token id from tokenizer/config, preferring a saved diffusion token."""
+    mts = cfg.get("mask_token_str")
+    if mts:
+        try:
+            tid = tokenizer.convert_tokens_to_ids(mts)
+            unk_id = getattr(tokenizer, "unk_token_id", None)
+            specials = (getattr(tokenizer, "all_special_tokens", []) or []) + (
+                getattr(tokenizer, "additional_special_tokens", []) or []
+            )
+            if (
+                isinstance(tid, int)
+                and tid >= 0
+                and (unk_id is None or tid != unk_id)
+                and mts in specials
+            ):
+                return tid
+        except Exception:  # pragma: no cover
+            pass
+    mid = cfg.get("mask_token_id")
+    if isinstance(mid, int):
+        try:
+            if 0 <= mid < len(tokenizer):
+                return mid
+        except Exception:  # pragma: no cover
+            pass
+    specials = (getattr(tokenizer, "all_special_tokens", []) or []) + (
+        getattr(tokenizer, "additional_special_tokens", []) or []
+    )
+
+    def _ok(s: str) -> bool:
+        low = s.lower()
+        if any(
+            bad in low
+            for bad in [
+                "im_start",
+                "im_end",
+                "bos",
+                "eos",
+                "pad",
+                "system",
+                "assistant",
+                "user",
+            ]
+        ):
+            return False
+        return ("diffusion" in low) or ("mask" in low)
+
+    for s in specials:
+        if _ok(s):
+            token_id = tokenizer.convert_tokens_to_ids(s)
+            unk_id = getattr(tokenizer, "unk_token_id", None)
+            if (
+                isinstance(token_id, int)
+                and token_id >= 0
+                and (unk_id is None or token_id != unk_id)
+            ):
+                return token_id
+
+    return getattr(tokenizer, "unk_token_id", 0) or 0
+
+
+def run_diffusion(
+    *,
+    model,
+    tokenizer,
+    cfg: DictDefault,
+    prompt: str,
+    chat_template_str: str | None,
+    mode: str = "random",
+    target_mask_ratio: float | None = None,
+    completion_tokens: int = 0,
+):
+    """Run a single diffusion generation and return a structured result dict."""
+    if chat_template_str:
+        batch = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            return_tensors="pt",
+            add_special_tokens=True,
+            add_generation_prompt=True,
+            chat_template=chat_template_str,
+            tokenize=True,
+            return_dict=True,
+        )
+    else:
+        batch = tokenizer(prompt, return_tensors="pt", add_special_tokens=True)
+
+    steps = cfg.get("generation_steps") or cfg.get("num_diffusion_steps") or 128
+    temperature = cfg.get("generation_temperature", 0.0)
+    mask_token_id = infer_mask_token_id(tokenizer, cfg)
+
+    seq = batch["input_ids"].to(cfg.device)
+    gen_mode = "random" if mode == "mask" else "completion"
+    comp_tokens = int(completion_tokens) if gen_mode == "completion" else 0
+
+    result = diffusion_generate(
+        model,
+        tokenizer,
+        original_sequence=seq[:1],
+        num_diffusion_steps=int(steps),
+        temperature=float(temperature),
+        mask_token_id=int(mask_token_id),
+        mode=gen_mode,  # type: ignore[arg-type]
+        completion_tokens=comp_tokens,
+        target_mask_ratio=target_mask_ratio,
+    )
+
+    masked_text = result.get("masked") if isinstance(result, dict) else None
+    mask_ratio = result.get("mask_ratio") if isinstance(result, dict) else None
+    generated_ids = result.get("generated_ids") if isinstance(result, dict) else None
+    masked_positions = (
+        set(result.get("masked_positions") or []) if isinstance(result, dict) else set()
+    )
+    orig_ids = seq[0].detach().cpu().tolist()
+
+    return {
+        "masked_text": masked_text,
+        "mask_ratio": mask_ratio,
+        "generated_ids": generated_ids,
+        "masked_positions": masked_positions,
+        "orig_ids": orig_ids,
+    }
+
+
+def render_html(
+    generated_ids: list[int] | None,
+    orig_ids: list[int],
+    masked_positions: set[int],
+    tokenizer,
+) -> str:
+    """Render HTML with colored spans for diffusion correctness visualization."""
+    if not generated_ids:
+        return "<pre>Generated: (no output)</pre>"
+
+    def _style_for(i: int, tid: int) -> str:
+        if i in masked_positions:
+            if i < len(orig_ids) and tid == orig_ids[i]:
+                return "green"
+            if i < len(orig_ids):
+                return "red"
+            return "normal"
+        same = i < len(orig_ids) and tid == orig_ids[i]
+        return "dim" if same else "normal"
+
+    spans: list[tuple[str, int, int]] = []
+    if generated_ids:
+        cur = _style_for(0, generated_ids[0])
+        start = 0
+        for i in range(1, len(generated_ids)):
+            s = _style_for(i, generated_ids[i])
+            if s != cur:
+                spans.append((cur, start, i))
+                cur, start = s, i
+        spans.append((cur, start, len(generated_ids)))
+
+    html_parts = []
+    for style_name, a, b in spans:
+        txt = tokenizer.decode(generated_ids[a:b], skip_special_tokens=False)
+        if style_name == "green":
+            html_parts.append(f'<span style="color:#2e7d32">{txt}</span>')
+        elif style_name == "red":
+            html_parts.append(f'<span style="color:#c62828">{txt}</span>')
+        elif style_name == "dim":
+            html_parts.append(f'<span style="opacity:0.6">{txt}</span>')
+        else:
+            html_parts.append(txt)
+    legend = (
+        '<div style="font-size:0.9em;margin-bottom:4px">'
+        '<span style="color:#2e7d32">correct</span>, '
+        '<span style="color:#c62828">incorrect</span>, '
+        '<span style="opacity:0.6">unchanged</span>'
+        "</div>"
+    )
+    return (
+        legend
+        + '<pre style="white-space:pre-wrap">Generated:\n'
+        + "".join(html_parts)
+        + "</pre>"
+    )

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -72,13 +72,15 @@ def infer_mask_token_id(tokenizer, cfg: DictDefault) -> int:
                 return tid
         except Exception:  # pragma: no cover
             pass
-    mid = cfg.get("mask_token_id")
-    if isinstance(mid, int):
+
+    mask_token_id = cfg.get("mask_token_id")
+    if isinstance(mask_token_id, int):
         try:
-            if 0 <= mid < len(tokenizer):
-                return mid
+            if 0 <= mask_token_id < len(tokenizer):
+                return mask_token_id
         except Exception:  # pragma: no cover
             pass
+
     specials = (getattr(tokenizer, "all_special_tokens", []) or []) + (
         getattr(tokenizer, "additional_special_tokens", []) or []
     )

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from axolotl.integrations.diffusion.generation import generate
-from axolotl.integrations.diffusion.utils import resolve_mask_token_id
+from axolotl.integrations.diffusion import generate, resolve_mask_token_id
 from axolotl.utils.dict import DictDefault
 
 

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -2,11 +2,92 @@
 
 from __future__ import annotations
 
+from colorama import Fore, Style
+
 from axolotl.integrations.diffusion import generate, resolve_mask_token_id
 from axolotl.utils.dict import DictDefault
 
 
-def parse_commands(text: str):
+def diffusion_inference(
+    model,
+    tokenizer,
+    cfg,
+    prompt: str,
+    chat_template_str: str | None = None,
+):
+    """Diffusion inference helper method."""
+    mode = "random"
+    completion_tokens = 0
+    target_mask_ratio = None
+    mode, completion_tokens, target_mask_ratio, cleaned = _parse_commands(prompt)
+
+    if cleaned:
+        prompt = cleaned
+
+    info = _run_diffusion(
+        model=model,
+        tokenizer=tokenizer,
+        cfg=cfg,
+        prompt=prompt,
+        chat_template_str=chat_template_str,
+        mode=mode,
+        target_mask_ratio=target_mask_ratio,
+        completion_tokens=completion_tokens,
+    )
+    masked_text = info["masked_text"]
+    mask_ratio = info["mask_ratio"]
+    generated_ids = info["generated_ids"]
+    masked_positions = info["masked_positions"]
+    orig_ids = info["orig_ids"]
+
+    # Display with masked preview and colored diff
+    if masked_text is not None and mask_ratio is not None:
+        print(f"Masked ({mask_ratio:.1%}):\n{masked_text}\n")
+    if generated_ids is not None:
+        # Compute per-token style
+        styles: list[str] = []
+        for i, tid in enumerate(generated_ids):
+            if i in masked_positions:
+                if i < len(orig_ids) and tid == orig_ids[i]:
+                    styles.append("green")  # correct fill
+                elif i < len(orig_ids):
+                    styles.append("red")  # incorrect fill
+                else:
+                    styles.append("normal")  # appended
+            else:
+                same = i < len(orig_ids) and tid == orig_ids[i]
+                styles.append("dim" if same else "normal")
+
+        # Group contiguous spans by style
+        styled_spans: list[tuple[str, int, int]] = []
+        if generated_ids:
+            current_style = styles[0]
+            start = 0
+            for i in range(1, len(generated_ids)):
+                s = styles[i]
+                if s != current_style:
+                    styled_spans.append((current_style, start, i))
+                    current_style, start = s, i
+            styled_spans.append((current_style, start, len(generated_ids)))
+
+        out_parts = []
+        for style_name, a, b in styled_spans:
+            chunk_text = tokenizer.decode(generated_ids[a:b], skip_special_tokens=False)
+            if style_name == "green":
+                out_parts.append(Fore.GREEN + chunk_text + Style.RESET_ALL)
+            elif style_name == "red":
+                out_parts.append(Fore.RED + chunk_text + Style.RESET_ALL)
+            else:
+                if style_name == "dim":
+                    out_parts.append(Style.DIM + chunk_text + Style.RESET_ALL)
+                else:
+                    out_parts.append(chunk_text)
+        print("Generated:\n" + "".join(out_parts))
+    else:
+        print("Generated:\n(no output)")
+
+
+def _parse_commands(text: str):
     """
     Parse leading diffusion commands.
 
@@ -53,7 +134,7 @@ def parse_commands(text: str):
     return mode, completion_tokens, target_mask_ratio, cleaned
 
 
-def run_diffusion(
+def _run_diffusion(
     *,
     model,
     tokenizer,

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gradio as gr
+import torch
 from colorama import Fore, Style
 
 from axolotl.integrations.diffusion import generate, resolve_mask_token_id

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -81,15 +81,15 @@ def run_diffusion(
     mask_token_id = resolve_mask_token_id(tokenizer, cfg, allow_add=False)
 
     seq = batch["input_ids"].to(cfg.device)
-    gen_mode = "random" if mode == "mask" else "completion"
+    gen_mode = "completion" if mode == "completion" else "random"
     comp_tokens = int(completion_tokens) if gen_mode == "completion" else 0
 
     result = generate(
         model,
         tokenizer,
         original_sequence=seq[:1],
-        num_diffusion_steps=cfg.diffusion_num_diffusion_steps,
-        temperature=cfg.diffusion_generation_temperature,
+        num_diffusion_steps=cfg.diffusion.num_diffusion_steps,
+        temperature=cfg.diffusion.generation_temperature,
         mask_token_id=int(mask_token_id),
         mode=gen_mode,  # type: ignore[arg-type]
         completion_tokens=comp_tokens,

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from axolotl.integrations.diffusion.generation import generate as diffusion_generate
-from axolotl.utils.dict import DictDefault
 from axolotl.integrations.diffusion.utils import resolve_mask_token_id
+from axolotl.utils.dict import DictDefault
 
 
 def parse_commands(text: str):

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -2,16 +2,8 @@
 
 from __future__ import annotations
 
-
+from axolotl.integrations.diffusion.generation import generate as diffusion_generate
 from axolotl.utils.dict import DictDefault
-
-# Import diffusion generator (backwards compatible alias)
-try:  # pragma: no cover - thin wrapper
-    from axolotl.integrations.diffusion.generation import (
-        generate as diffusion_generate,
-    )
-except Exception:  # pragma: no cover
-    diffusion_generate = None  # type: ignore
 
 
 def parse_commands(text: str):

--- a/src/axolotl/cli/utils/diffusion.py
+++ b/src/axolotl/cli/utils/diffusion.py
@@ -84,8 +84,12 @@ def run_diffusion(
     else:
         batch = tokenizer(prompt, return_tensors="pt", add_special_tokens=True)
 
-    steps = cfg.get("generation_steps") or cfg.get("num_diffusion_steps") or 128
-    temperature = cfg.get("generation_temperature", 0.0)
+    steps = (
+        cfg.get("diffusion_generation_steps")
+        or cfg.get("diffusion_num_diffusion_steps")
+        or 128
+    )
+    temperature = cfg.get("diffusion_generation_temperature", 0.0)
     mask_token_id = infer_mask_token_id(tokenizer, cfg)
 
     seq = batch["input_ids"].to(cfg.device)

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -36,6 +36,7 @@ from axolotl.utils.callbacks import (
 )
 from axolotl.utils.callbacks.lisa import lisa_callback_factory
 from axolotl.utils.callbacks.qat import QATCallback
+from axolotl.utils.callbacks.tokens_per_second import TokensPerSecondCallback
 from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.collators import (
     BatchSamplerDataCollatorForSeq2Seq,
@@ -43,7 +44,6 @@ from axolotl.utils.collators import (
     MambaDataCollator,
     V2BatchSamplerDataCollatorForSeq2Seq,
 )
-from axolotl.utils.callbacks.tokens_per_second import TokensPerSecondCallback
 from axolotl.utils.collators.mm_chat import MultiModalChatDataCollator
 from axolotl.utils.import_helper import get_cls_from_module_str
 from axolotl.utils.logging import get_logger

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -7,15 +7,11 @@ from pathlib import Path
 from typing import Type, Union
 
 import transformers
-<<<<<<< HEAD
-from transformers import DataCollatorWithFlattening, EarlyStoppingCallback
-=======
 from transformers import (
     DataCollatorWithFlattening,
     EarlyStoppingCallback,
     Trainer,
 )
->>>>>>> d8b63804 (cleanup)
 from trl.trainer.utils import RewardDataCollatorWithPadding
 
 from axolotl.core.builders.base import TrainerBuilderBase

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -7,7 +7,15 @@ from pathlib import Path
 from typing import Type, Union
 
 import transformers
+<<<<<<< HEAD
 from transformers import DataCollatorWithFlattening, EarlyStoppingCallback
+=======
+from transformers import (
+    DataCollatorWithFlattening,
+    EarlyStoppingCallback,
+    Trainer,
+)
+>>>>>>> d8b63804 (cleanup)
 from trl.trainer.utils import RewardDataCollatorWithPadding
 
 from axolotl.core.builders.base import TrainerBuilderBase
@@ -391,18 +399,11 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 **data_collator_kwargs,
             )
         sig = inspect.signature(trainer_cls)
-
-        # Check if trainer class inherits from transformers.Trainer
-        # If so, we should pass the tokenizer/processing_class even if not in direct signature
-        from transformers import Trainer as HFTrainer
-
-        if "processing_class" in sig.parameters:
+        if "processing_class" in sig.parameters or issubclass(trainer_cls, Trainer):
             trainer_kwargs["processing_class"] = self.tokenizer
         elif "tokenizer" in sig.parameters:
             trainer_kwargs["tokenizer"] = self.tokenizer
-        elif issubclass(trainer_cls, HFTrainer):
-            # For subclasses of transformers.Trainer, try processing_class first (newer HF versions)
-            trainer_kwargs["processing_class"] = self.tokenizer
+
         if (
             trainer_cls not in [AxolotlRewardTrainer, AxolotlPRMTrainer]
             and self.cfg.datasets is not None

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -27,12 +27,12 @@ from axolotl.monkeypatch.relora import ReLoRACallback
 from axolotl.processing_strategies import get_processing_strategy
 from axolotl.utils import is_comet_available, is_mlflow_available
 from axolotl.utils.callbacks import (
+    LossWatchDogCallback,
+    SaveBetterTransformerModelCallback,
     bench_eval_callback_factory,
     causal_lm_bench_eval_callback_factory,
     colab_inference_post_train_callback,
     log_prediction_callback_factory,
-    LossWatchDogCallback,
-    SaveBetterTransformerModelCallback,
 )
 from axolotl.utils.callbacks.lisa import lisa_callback_factory
 from axolotl.utils.callbacks.qat import QATCallback

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -391,10 +391,18 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 **data_collator_kwargs,
             )
         sig = inspect.signature(trainer_cls)
+
+        # Check if trainer class inherits from transformers.Trainer
+        # If so, we should pass the tokenizer/processing_class even if not in direct signature
+        from transformers import Trainer as HFTrainer
+
         if "processing_class" in sig.parameters:
             trainer_kwargs["processing_class"] = self.tokenizer
         elif "tokenizer" in sig.parameters:
             trainer_kwargs["tokenizer"] = self.tokenizer
+        elif issubclass(trainer_cls, HFTrainer):
+            # For subclasses of transformers.Trainer, try processing_class first (newer HF versions)
+            trainer_kwargs["processing_class"] = self.tokenizer
         if (
             trainer_cls not in [AxolotlRewardTrainer, AxolotlPRMTrainer]
             and self.cfg.datasets is not None

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -89,7 +89,9 @@ class AxolotlTrainer(
 
         super().__init__(*_args, **kwargs)
         self.train_data_collator = self.data_collator
-        self._stored_metrics = defaultdict(lambda: defaultdict(list))
+        self._stored_metrics = defaultdict(
+            lambda: defaultdict(lambda: {"values": [], "reduction": "mean"})
+        )
         if self.args.orpo_alpha:
             self.loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
 
@@ -585,9 +587,26 @@ class AxolotlTrainer(
         """
         # logs either has 'loss' or 'eval_loss'
         train_eval = "train" if "loss" in logs else "eval"
-        # Add averaged stored metrics to logs
-        for key, metrics in self._stored_metrics[train_eval].items():
-            logs[key] = torch.tensor(metrics).mean().item()
+
+        # Add reduced stored metrics to logs
+        for key, metric_data in self._stored_metrics[train_eval].items():
+            values = torch.tensor(metric_data["values"])
+            reduction_type = metric_data["reduction"]
+
+            if reduction_type == "mean":
+                logs[key] = values.mean().item()
+            elif reduction_type == "min":
+                logs[key] = values.min().item()
+            elif reduction_type == "max":
+                logs[key] = values.max().item()
+            elif reduction_type == "sum":
+                logs[key] = values.sum().item()
+            else:
+                raise NotImplementedError(
+                    "Metric reduction must be one of [mean, min, max]"
+                )
+
+            logs[key] = round(logs[key], 4)
 
         if is_main_process():
             # Add memory usage
@@ -611,10 +630,27 @@ class AxolotlTrainer(
         return super().log(logs, start_time)
 
     def store_metrics(
-        self, metrics: dict[str, float], train_eval: Literal["train", "eval"] = "train"
+        self,
+        metrics: dict[str, float] | dict[str, tuple[int | float, str]],
+        train_eval: Literal["train", "eval"] = "train",
+        reduction: Literal["mean", "min", "max", "sum"] = "mean",
     ) -> None:
+        """
+        Store metrics with specified reduction type.
+
+        Args:
+            metrics: Dictionary of metric names to values, or metric names to (value,
+                reduction_type) tuples.
+            train_eval: Whether this is for training or evaluation.
+        """
         for key, value in metrics.items():
-            self._stored_metrics[train_eval][key].append(value)
+            if isinstance(value, tuple):
+                metric_value, metric_reduction = value
+            else:
+                metric_value, metric_reduction = value, reduction
+
+            self._stored_metrics[train_eval][key]["values"].append(metric_value)
+            self._stored_metrics[train_eval][key]["reduction"] = metric_reduction
 
     def _save_checkpoint(self, model, trial, **kwargs):
         # make sure the checkpoint dir exists, since trainer is flakey

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -643,12 +643,12 @@ class AxolotlTrainer(
         """
         for key, value in metrics.items():
             if isinstance(value, tuple):
-                value, reduction = value  # type: ignore[assignment]
+                value, _reduction = value  # type: ignore[assignment]
             else:
-                value, reduction = value, reduction
+                value, _reduction = value, reduction
 
             self._stored_metrics[train_eval][key]["values"].append(value)
-            self._stored_metrics[train_eval][key]["reduction"] = reduction
+            self._stored_metrics[train_eval][key]["reduction"] = _reduction
 
     def _save_checkpoint(self, model, trial, **kwargs):
         # make sure the checkpoint dir exists, since trainer is flakey

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -603,7 +603,7 @@ class AxolotlTrainer(
                 logs[key] = values.sum().item()
             else:
                 raise NotImplementedError(
-                    "Metric reduction must be one of [mean, min, max]"
+                    "Metric reduction must be one of [mean, min, max, sum]"
                 )
 
             logs[key] = round(logs[key], 4)

--- a/src/axolotl/integrations/base.py
+++ b/src/axolotl/integrations/base.py
@@ -142,7 +142,7 @@ class BasePlugin:
             model: The loaded model.
         """
 
-    def get_trainer_cls(self, cfg: DictDefault) -> Trainer | None:
+    def get_trainer_cls(self, cfg: DictDefault) -> type[Trainer] | None:
         """Returns a custom class for the trainer.
 
         Args:

--- a/src/axolotl/integrations/config.py
+++ b/src/axolotl/integrations/config.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, List, Type
 
 from axolotl.utils.schemas.config import (
     AxolotlConfigWCapabilities as AxolotlConfigWCapabilitiesBase,
+    AxolotlInputConfig as AxolotlInputConfigBase,
 )
-from axolotl.utils.schemas.config import AxolotlInputConfig as AxolotlInputConfigBase
 
 
 def merge_input_args():

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -53,8 +53,9 @@ model_type: llama
 # Standard Axolotl configuration
 datasets:
   - path: your_dataset
-    type: completion  # or conversation
+    ...
 
+# Other config
 sequence_len: 1024
 micro_batch_size: 8
 gradient_accumulation_steps: 4
@@ -85,31 +86,16 @@ The plugin uses native 4D attention masks to:
 
 Loss is computed only on masked tokens with (optional) importance weighting:
 
-```
+```python
 loss = sum(cross_entropy(pred, target) / p_mask) / total_tokens
 ```
-
-## Performance Tips
-
-### Memory Optimization
-- Bidirectional attention uses more memory than causal attention
-- Consider reducing `micro_batch_size` if you encounter OOM errors
-- Consider using gradient checkpointing, torch.compile,
-
-### Training Stability
-- Start with `noise_schedule: linear` for more predictable behavior
-- Enable `importance_weighting: true` for better gradient scaling
-
-### Convergence
-- Monitor the `diffusion_loss` and `diffusion_accuracy` metrics
-- Expect different loss curves compared to standard language modeling
 
 ## Sample Generation
 
 When `generate_samples: true`, the plugin generates samples during training:
 
 ```
-📝 Sample 1:
+Sample 1:
    Original (45 tokens): The quick brown fox jumps over the lazy dog...
    Masked (18/45 tokens, 40.0%): The [MASK] [MASK] fox [MASK] over [MASK] lazy [MASK]...
    Generated: The quick brown fox jumps over the lazy dog...
@@ -136,4 +122,4 @@ The plugin adds several metrics to track diffusion training:
 ## References
 
 - [LLaDA Paper](https://arxiv.org/abs/2404.10406)
-- [Axolotl Documentation](https://github.com/OpenAccess-AI-Collective/axolotl)
+- [Axolotl Documentation](https://docs.axolotl.ai/)

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -33,7 +33,7 @@ plugins:
 noise_schedule: "linear"  # or "cosine"
 min_mask_ratio: 0.1
 max_mask_ratio: 0.9
-num_diffusion_steps: 1000
+num_diffusion_steps: 128
 eps: 1e-3
 importance_weighting: true
 

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -1,13 +1,13 @@
 # Diffusion LM Training Plugin for Axolotl
 
-This plugin enables diffusion language model training using the LLaDA (Large Language
-And Diffusion Assistant) approach within the Axolotl framework.
+This plugin enables diffusion language model training using an approach inspired by
+LLaDA (Large Language Diffusion Models) within Axolotl.
 
 ## Overview
 
 LLaDA is a diffusion-based approach to language model training that uses:
 - **Random token masking** during training instead of next-token prediction
-- **Bidirectional attention** to allow the model to see the full context
+- **Bidirectional attention** to allow the model to attend to the full context
 - **Importance weighting** based on masking probabilities for stable training
 
 This approach can lead to more robust language models with better understanding of
@@ -20,24 +20,37 @@ your training config.
 
 ## Quickstart
 
+1. Install Axolotl: [docs](https://docs.axolotl.ai/docs/installation.html)
+2. Train with an example config (Llama‑3.2 1B):
+   - Pretrain: `axolotl train examples/llama-3/diffusion-3.2-1b-pretrain.yaml`
+   - SFT: `axolotl train examples/llama-3/diffusion-3.2-1b-sft.yaml`
+
 ### Basic Configuration
 
-Add the following to your Axolotl configuration YAML:
+You may also modify your existing configs to enable / customize diffusion training.
+
+Add the following to your Axolotl config:
 
 ```yaml
 # Enable diffusion LM training plugin
 plugins:
   - axolotl.integrations.diffusion.DiffusionPlugin
+```
 
-# Diffusion-specific configuration (prefixed)
+And, optionally (though these have good defaults):
+
+```yaml
 diffusion_noise_schedule: linear  # or "cosine"
 diffusion_min_mask_ratio: 0.1
 diffusion_max_mask_ratio: 0.9
 diffusion_num_diffusion_steps: 128
 diffusion_eps: 1e-3
 diffusion_importance_weighting: true
-# For non-Llama tokenizers, set this to a valid id (e.g., pad/eos)
-diffusion_mask_token_id: 128002
+
+# Mask token (training auto-adds if missing, avoid pad/eos)
+diffusion_mask_token_str: "<|diffusion_mask|>"
+# Or use an existing special token id (e.g., 128002 for Llama-3.x)
+# diffusion_mask_token_id: 128002
 
 # Sample generation during training (optional)
 diffusion_generate_samples: true
@@ -46,21 +59,6 @@ diffusion_num_generation_samples: 3
 diffusion_generation_steps: 128
 diffusion_generation_temperature: 0.0
 diffusion_generation_max_length: 100
-
-# Model configuration
-base_model: meta-llama/Llama-3.2-1B
-model_type: llama
-
-# Standard Axolotl configuration
-datasets:
-  - path: your_dataset
-    ...
-
-# Other config
-sequence_len: 1024
-micro_batch_size: 8
-gradient_accumulation_steps: 4
-learning_rate: 3e-4
 ```
 
 ## Supported Models
@@ -72,17 +70,10 @@ create an [issue](https://github.com/axolotl-ai-cloud/axolotl/issues) or open a
 ## How It Works
 
 ### Random Masking
-During training, tokens are randomly masked based on a sampled timestep:
+During training, tokens are randomly masked:
 - Sample timestep `t` uniformly from [0, 1]
 - Calculate masking probability: `p = (1 - eps) * t + eps`
 - Randomly mask tokens with probability `p`
-
-### Bidirectional Attention
-The plugin uses native 4D attention masks to:
-- Enable bidirectional attention without patches
-- Allow all tokens to attend to all other tokens
-- Maintain proper padding masks
-- Work with modern `transformers` models out of the box
 
 ### Diffusion Loss
 
@@ -94,7 +85,7 @@ loss = sum(cross_entropy(pred, target) / p_mask) / total_tokens
 
 ## Sample Generation
 
-When `generate_samples: true`, the plugin generates samples during training:
+When `diffusion_generate_samples: true`, the plugin generates samples during training:
 
 ```
 Sample 1:
@@ -111,8 +102,10 @@ Diffusion inference is integrated into the standard Axolotl CLI. Use the same co
 you trained with and run:
 
 ```
-axolotl inference --config path/to/your-config.yaml
+axolotl inference path/to/your-config.yaml
 ```
+
+Optionally, pass `--gradio` to use a simple web interface.
 
 Interactive controls (prefix the prompt with commands):
 - `:complete N` → completion mode with N new masked tokens appended (default 64)
@@ -134,15 +127,8 @@ Masked (40.0%):
 The [MASK] brown [MASK] jumps over the [MASK] dog
 
 Generated:
-The quick brown fox jumps over the lazy dog
+The quick brown fox jumps over the loud dog
 ```
-
-Notes:
-- The CLI renders per‑token correctness in color (green/red/dim) against the original
-  sequence for masked positions.
-- Inference reuses `diffusion_mask_token_id` from your config. It will not add new
-  tokens or resize embeddings during inference. If the id is missing or invalid, it
-  falls back to the tokenizer's `unk_token_id`.
 
 ## Metrics and Monitoring
 
@@ -165,3 +151,4 @@ The plugin adds (or modifies) several metrics to track diffusion training:
 
 - [LLaDA Paper](https://arxiv.org/abs/2404.10406)
 - [Axolotl Documentation](https://docs.axolotl.ai/)
+- [API reference for plugin](https://docs.axolotl.ai/docs/api/integrations.diffusion.args.html#axolotl.integrations.diffusion.args)

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -15,19 +15,18 @@ bidirectional context.
 
 ## Installation
 
-The plugin is included with Axolotl. To use it, simply add the plugin configuration to
-your training config.
+The plugin is included with Axolotl. See our
+[installation docs](https://docs.axolotl.ai/docs/installation.html).
 
 ## Quickstart
 
-1. Install Axolotl: [docs](https://docs.axolotl.ai/docs/installation.html)
-2. Train with an example config (Llama‑3.2 1B):
+Train with an example config (Llama‑3.2 1B):
    - Pretrain: `axolotl train examples/llama-3/diffusion-3.2-1b-pretrain.yaml`
    - SFT: `axolotl train examples/llama-3/diffusion-3.2-1b-sft.yaml`
 
 ### Basic Configuration
 
-You may also modify your existing configs to enable / customize diffusion training.
+You can also modify your existing configs to enable / customize diffusion training.
 
 Add the following to your Axolotl config:
 
@@ -37,28 +36,29 @@ plugins:
   - axolotl.integrations.diffusion.DiffusionPlugin
 ```
 
-And, optionally (though these have good defaults):
+And, configure the nested `diffusion` block (defaults shown):
 
 ```yaml
-diffusion_noise_schedule: linear  # or "cosine"
-diffusion_min_mask_ratio: 0.1
-diffusion_max_mask_ratio: 0.9
-diffusion_num_diffusion_steps: 128
-diffusion_eps: 1e-3
-diffusion_importance_weighting: true
+diffusion:
+  noise_schedule: linear  # or "cosine"
+  min_mask_ratio: 0.1
+  max_mask_ratio: 0.9
+  num_diffusion_steps: 128
+  eps: 1e-3
+  importance_weighting: true
 
-# Mask token (training auto-adds if missing, avoid pad/eos)
-diffusion_mask_token_str: "<|diffusion_mask|>"
-# Or use an existing special token id (e.g., 128002 for Llama-3.x)
-# diffusion_mask_token_id: 128002
+  # Mask token (training auto-adds if missing, avoid pad/eos)
+  mask_token_str: "<|diffusion_mask|>"
+  # Or use an existing special token id (e.g., 128002 for Llama-3.x)
+  # mask_token_id: 128002
 
-# Sample generation during training (optional)
-diffusion_generate_samples: true
-diffusion_generation_interval: 100
-diffusion_num_generation_samples: 3
-diffusion_generation_steps: 128
-diffusion_generation_temperature: 0.0
-diffusion_generation_max_length: 100
+  # Sample generation during training (optional)
+  generate_samples: true
+  generation_interval: 100
+  num_generation_samples: 3
+  generation_steps: 128
+  generation_temperature: 0.0
+  generation_max_length: 100
 ```
 
 ## Supported Models
@@ -85,7 +85,7 @@ loss = sum(cross_entropy(pred, target) / p_mask) / total_tokens
 
 ## Sample Generation
 
-When `diffusion_generate_samples: true`, the plugin generates samples during training:
+When `diffusion.generate_samples: true`, the plugin generates samples during training:
 
 ```
 Sample 1:

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -1,0 +1,117 @@
+# Diffusion LM Training Plugin for Axolotl
+
+This plugin enables diffusion language model training using the LLaDA (Large Language
+And Diffusion Assistant) approach within the Axolotl framework.
+
+## Overview
+
+LLaDA is a diffusion-based approach to language model training that uses:
+- **Random token masking** during training instead of next-token prediction
+- **Bidirectional attention** to allow the model to see the full context
+- **Importance weighting** based on masking probabilities for stable training
+
+This approach can lead to more robust language models with better understanding of
+bidirectional context.
+
+## Installation
+
+The plugin is included with Axolotl. To use it, simply add the plugin configuration to
+your training config.
+
+## Quickstart
+
+### Basic Configuration
+
+Add the following to your Axolotl configuration YAML:
+
+```yaml
+# Enable diffusion LM training plugin
+plugins:
+  - diffusion.DiffusionPlugin
+
+# Diffusion-specific configuration
+noise_schedule: "linear"  # or "cosine"
+min_mask_ratio: 0.1
+max_mask_ratio: 0.9
+num_diffusion_steps: 1000
+eps: 1e-3
+importance_weighting: true
+
+# Model configuration
+base_model: meta-llama/Llama-3.2-1B
+model_type: llama
+
+# Standard Axolotl configuration
+datasets:
+  - path: your_dataset
+    type: completion  # or conversation
+
+sequence_len: 1024
+micro_batch_size: 8
+gradient_accumulation_steps: 4
+learning_rate: 3e-4
+```
+
+## Supported Models
+
+Any models that support 4D attention masks should work out of the box. If not, please
+create an [issue](https://github.com/axolotl-ai-cloud/axolotl/issues)!
+
+## How It Works
+
+### Random Masking
+During training, tokens are randomly masked based on a sampled timestep:
+- Sample timestep `t` uniformly from [0, 1]
+- Calculate masking probability: `p = (1 - eps) * t + eps`
+- Randomly mask tokens with probability `p`
+
+### Bidirectional Attention
+The plugin uses native 4D attention masks to:
+- Enable bidirectional attention without patches
+- Allow all tokens to attend to all other tokens
+- Maintain proper padding masks
+- Work with modern `transformers` models out of the box
+
+### Diffusion Loss
+
+Loss is computed only on masked tokens with (optional) importance weighting:
+
+```
+loss = sum(cross_entropy(pred, target) / p_mask) / total_tokens
+```
+
+## Performance Tips
+
+### Memory Optimization
+- Bidirectional attention uses more memory than causal attention
+- Consider reducing `micro_batch_size` if you encounter OOM errors
+- Consider using gradient checkpointing, torch.compile,
+
+### Training Stability
+- Start with `noise_schedule: "linear"` for more predictable behavior
+- Enable `importance_weighting` for better gradient scaling
+
+### Convergence
+- Monitor the `diffusion_loss` and `diffusion_accuracy` metrics
+- Expect different loss curves compared to standard language modeling
+
+## Metrics and Monitoring
+
+The plugin adds several metrics to track diffusion training:
+
+- `train/diffusion_loss`: Weighted diffusion loss
+- `train/diffusion_accuracy`: Accuracy on masked tokens
+- `train/diffusion_mask_ratio`: Average fraction of tokens masked
+- `train/diffusion_num_masked_tokens`: Number of tokens masked
+- `train/diffusion_avg_p_mask`: Average masking probability
+- `train/diffusion_ce_loss`: Unweighted cross-entropy loss
+- `train/diffusion_importance_weight_avg`: Average importance weight
+
+## Limitations
+
+- No flash attention support
+
+## References
+
+- [LLaDA Paper](https://arxiv.org/abs/2404.10406)
+- [Axolotl Documentation](https://github.com/OpenAccess-AI-Collective/axolotl)

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -36,6 +36,7 @@ max_mask_ratio: 0.9
 num_diffusion_steps: 128
 eps: 1e-3
 importance_weighting: true
+# For non-Llama tokenizers, set this to a valid id (e.g., pad/eos)
 mask_token_id: 128002
 
 # Sample generation (optional)
@@ -102,6 +103,42 @@ Sample 1:
 ```
 
 Samples are logged to console and wandb (if enabled).
+
+## Inference
+
+After training, you can run lightweight reverse-diffusion on your model using the
+helper script `scripts/diffusion_infer.py`.
+
+Examples:
+
+- Provide your own texts:
+
+```
+python scripts/diffusion_infer.py \
+  --model /path/to/checkpoint \
+  --texts "The quick brown fox" "In a hole in the ground" \
+  --steps 32 --max-length 64 --num-samples 2
+```
+
+- Sample from a dataset:
+
+```
+python scripts/diffusion_infer.py \
+  --model /path/to/checkpoint \
+  --dataset mhenrichsen/alpaca_2k_test \
+  --dataset-field text --steps 32 --num-samples 2
+```
+
+Key options:
+- `--steps`: diffusion steps (lower for faster, e.g., 32)
+- `--num-samples`: number of samples to generate
+- `--mask-token-id`: token used for masking. Defaults to a Llama-3.2 id (128002). For
+  other models, prefer an existing reserved special token (e.g., a token containing
+  "reserved"/"mask"), or `unk_token_id`. Avoid using `pad`/`eos` if possible.
+
+Note: During training, if `mask_token_id` is unset or out-of-range for the tokenizer's
+vocabulary, Axolotl tries to auto-select a suitable id in this order:
+reserved special → other additional special → unk → pad → eos → vocab_size-1 → 0.
 
 ## Metrics and Monitoring
 

--- a/src/axolotl/integrations/diffusion/README.md
+++ b/src/axolotl/integrations/diffusion/README.md
@@ -27,15 +27,24 @@ Add the following to your Axolotl configuration YAML:
 ```yaml
 # Enable diffusion LM training plugin
 plugins:
-  - diffusion.DiffusionPlugin
+  - axolotl.integrations.diffusion.DiffusionPlugin
 
 # Diffusion-specific configuration
-noise_schedule: "linear"  # or "cosine"
+noise_schedule: linear  # or "cosine"
 min_mask_ratio: 0.1
 max_mask_ratio: 0.9
 num_diffusion_steps: 128
 eps: 1e-3
 importance_weighting: true
+mask_token_id: 128002
+
+# Sample generation (optional)
+generate_samples: true
+generation_interval: 100
+num_generation_samples: 3
+generation_steps: 128
+generation_temperature: 0.0
+generation_max_length: 100
 
 # Model configuration
 base_model: meta-llama/Llama-3.2-1B
@@ -88,24 +97,37 @@ loss = sum(cross_entropy(pred, target) / p_mask) / total_tokens
 - Consider using gradient checkpointing, torch.compile,
 
 ### Training Stability
-- Start with `noise_schedule: "linear"` for more predictable behavior
-- Enable `importance_weighting` for better gradient scaling
+- Start with `noise_schedule: linear` for more predictable behavior
+- Enable `importance_weighting: true` for better gradient scaling
 
 ### Convergence
 - Monitor the `diffusion_loss` and `diffusion_accuracy` metrics
 - Expect different loss curves compared to standard language modeling
 
+## Sample Generation
+
+When `generate_samples: true`, the plugin generates samples during training:
+
+```
+📝 Sample 1:
+   Original (45 tokens): The quick brown fox jumps over the lazy dog...
+   Masked (18/45 tokens, 40.0%): The [MASK] [MASK] fox [MASK] over [MASK] lazy [MASK]...
+   Generated: The quick brown fox jumps over the lazy dog...
+```
+
+Samples are logged to console and wandb (if enabled).
+
 ## Metrics and Monitoring
 
 The plugin adds several metrics to track diffusion training:
 
-- `train/diffusion_loss`: Weighted diffusion loss
-- `train/diffusion_accuracy`: Accuracy on masked tokens
-- `train/diffusion_mask_ratio`: Average fraction of tokens masked
-- `train/diffusion_num_masked_tokens`: Number of tokens masked
-- `train/diffusion_avg_p_mask`: Average masking probability
-- `train/diffusion_ce_loss`: Unweighted cross-entropy loss
-- `train/diffusion_importance_weight_avg`: Average importance weight
+- `train/loss`: Weighted diffusion loss
+- `train/accuracy`: Accuracy on masked tokens
+- `train/mask_ratio`: Average fraction of tokens masked
+- `train/num_masked_tokens`: Number of tokens masked
+- `train/avg_p_mask`: Average masking probability
+- `train/ce_loss`: Unweighted cross-entropy loss
+- `train/importance_weight_avg`: Average importance weight
 
 ## Limitations
 

--- a/src/axolotl/integrations/diffusion/__init__.py
+++ b/src/axolotl/integrations/diffusion/__init__.py
@@ -1,8 +1,4 @@
-"""
-Diffusion LM training plugin for Axolotl.
-
-This plugin enables diffusion language model training using the LLaDA approach.
-"""
+"""Diffusion LM training plugin init."""
 
 from .args import DiffusionArgs
 from .plugin import DiffusionPlugin

--- a/src/axolotl/integrations/diffusion/__init__.py
+++ b/src/axolotl/integrations/diffusion/__init__.py
@@ -1,6 +1,17 @@
 """Diffusion LM training plugin init."""
 
 from .args import DiffusionArgs
+from .callbacks import DiffusionGenerationCallback
+from .generation import generate
 from .plugin import DiffusionPlugin
+from .trainer import DiffusionTrainer
+from .utils import resolve_mask_token_id
 
-__all__ = ["DiffusionArgs", "DiffusionPlugin"]
+__all__ = [
+    "DiffusionArgs",
+    "DiffusionPlugin",
+    "DiffusionTrainer",
+    "generate",
+    "resolve_mask_token_id",
+    "DiffusionGenerationCallback",
+]

--- a/src/axolotl/integrations/diffusion/__init__.py
+++ b/src/axolotl/integrations/diffusion/__init__.py
@@ -1,6 +1,6 @@
 """Diffusion LM training plugin init."""
 
-from .args import DiffusionArgs
+from .args import DiffusionArgs, DiffusionConfig
 from .callbacks import DiffusionGenerationCallback
 from .generation import generate
 from .plugin import DiffusionPlugin
@@ -14,4 +14,5 @@ __all__ = [
     "generate",
     "resolve_mask_token_id",
     "DiffusionGenerationCallback",
+    "DiffusionConfig",
 ]

--- a/src/axolotl/integrations/diffusion/__init__.py
+++ b/src/axolotl/integrations/diffusion/__init__.py
@@ -1,0 +1,10 @@
+"""
+Diffusion LM training plugin for Axolotl.
+
+This plugin enables diffusion language model training using the LLaDA approach.
+"""
+
+from .args import DiffusionArgs
+from .plugin import DiffusionPlugin
+
+__all__ = ["DiffusionArgs", "DiffusionPlugin"]

--- a/src/axolotl/integrations/diffusion/__init__.py
+++ b/src/axolotl/integrations/diffusion/__init__.py
@@ -5,7 +5,7 @@ from .callbacks import DiffusionGenerationCallback
 from .generation import generate
 from .plugin import DiffusionPlugin
 from .trainer import DiffusionTrainer
-from .utils import resolve_mask_token_id
+from .utils import create_bidirectional_attention_mask, resolve_mask_token_id
 
 __all__ = [
     "DiffusionArgs",
@@ -13,6 +13,7 @@ __all__ = [
     "DiffusionTrainer",
     "generate",
     "resolve_mask_token_id",
+    "create_bidirectional_attention_mask",
     "DiffusionGenerationCallback",
     "DiffusionConfig",
 ]

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -49,9 +49,9 @@ class DiffusionArgs(BaseModel):
     diffusion_mask_token_str: str | None = Field(
         default=None,
         description=(
-            "Token string to use as a mask. If `mask_token_id` is invalid or unset, "
-            "this token will be ensured to exist as an additional special token and "
-            "used. If absent, a default '<|diffusion_mask|>' will be added."
+            "Token string to use as a mask. If `diffusion_mask_token_id` is invalid "
+            "or unset, this token will be ensured to exist as an additional special "
+            "token and used. If absent, a default '<|diffusion_mask|>' will be added."
         ),
     )
 

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -27,8 +27,6 @@ class DiffusionArgs(BaseModel):
     num_diffusion_steps: int = Field(
         default=128, ge=1, description="Number of diffusion timesteps"
     )
-
-    # Forward process config
     eps: float = Field(
         default=1e-3,
         ge=0.0,

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -46,5 +46,27 @@ class DiffusionArgs(BaseModel):
         description=(
             "Token ID to use for masking. Default is 128002 "
             "(<|reserved_special_token_0|> for Llama 3.2)"
-        )
+        ),
+    )
+
+    # Sample generation config
+    generate_samples: bool = Field(
+        default=True, description="Enable sample generation during training"
+    )
+    generation_interval: int = Field(
+        default=100, ge=1, description="Generate samples every N steps"
+    )
+    num_generation_samples: int = Field(
+        default=3, ge=1, description="Number of samples to generate each time"
+    )
+    generation_steps: int = Field(
+        default=128, ge=1, description="Number of diffusion steps for generation"
+    )
+    generation_temperature: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Temperature for generation sampling (0.0 = deterministic)",
+    )
+    generation_max_length: int = Field(
+        default=100, ge=1, description="Maximum sequence length for generation"
     )

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -9,25 +9,25 @@ class DiffusionArgs(BaseModel):
     """Arguments for diffusion LM training plugin."""
 
     # Noise schedule config
-    noise_schedule: Literal["linear", "cosine"] = Field(
+    diffusion_noise_schedule: Literal["linear", "cosine"] = Field(
         default="linear", description="Type of noise schedule for diffusion training"
     )
-    min_mask_ratio: float = Field(
+    diffusion_min_mask_ratio: float = Field(
         default=0.1,
         ge=0.0,
         le=1.0,
         description="Minimum masking ratio for diffusion noise schedule",
     )
-    max_mask_ratio: float = Field(
+    diffusion_max_mask_ratio: float = Field(
         default=0.9,
         ge=0.0,
         le=1.0,
         description="Maximum masking ratio for diffusion noise schedule",
     )
-    num_diffusion_steps: int = Field(
+    diffusion_num_diffusion_steps: int = Field(
         default=128, ge=1, description="Number of diffusion timesteps"
     )
-    eps: float = Field(
+    diffusion_eps: float = Field(
         default=1e-3,
         ge=0.0,
         le=1.0,
@@ -35,18 +35,18 @@ class DiffusionArgs(BaseModel):
     )
 
     # Training config
-    importance_weighting: bool = Field(
+    diffusion_importance_weighting: bool = Field(
         default=True,
         description="Apply importance weighting to loss based on masking probability",
     )
-    mask_token_id: int | None = Field(
+    diffusion_mask_token_id: int | None = Field(
         default=None,
         description=(
             "Token ID to use for masking. Unset by default; can use one of the "
             "tokenizer's special tokens here."
         ),
     )
-    mask_token_str: str | None = Field(
+    diffusion_mask_token_str: str | None = Field(
         default=None,
         description=(
             "Token string to use as a mask. If `mask_token_id` is invalid or unset, "
@@ -56,23 +56,23 @@ class DiffusionArgs(BaseModel):
     )
 
     # Sample generation config
-    generate_samples: bool = Field(
+    diffusion_generate_samples: bool = Field(
         default=True, description="Enable sample generation during training"
     )
-    generation_interval: int = Field(
+    diffusion_generation_interval: int = Field(
         default=100, ge=1, description="Generate samples every N steps"
     )
-    num_generation_samples: int = Field(
+    diffusion_num_generation_samples: int = Field(
         default=3, ge=1, description="Number of samples to generate each time"
     )
-    generation_steps: int = Field(
+    diffusion_generation_steps: int = Field(
         default=128, ge=1, description="Number of diffusion steps for generation"
     )
-    generation_temperature: float = Field(
+    diffusion_generation_temperature: float = Field(
         default=0.0,
         ge=0.0,
         description="Temperature for generation sampling (0.0 = deterministic)",
     )
-    generation_max_length: int = Field(
+    diffusion_generation_max_length: int = Field(
         default=100, ge=1, description="Maximum sequence length for generation"
     )

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -43,5 +43,8 @@ class DiffusionArgs(BaseModel):
     )
     mask_token_id: int = Field(
         default=128002,
-        description="Token ID to use for masking. Default is 128002 (<|reserved_special_token_0|> for Llama 3.2)",
+        description=(
+            "Token ID to use for masking. Default is 128002 "
+            "(<|reserved_special_token_0|> for Llama 3.2)"
+        )
     )

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -41,3 +41,7 @@ class DiffusionArgs(BaseModel):
         default=True,
         description="Apply importance weighting to loss based on masking probability",
     )
+    mask_token_id: int = Field(
+        default=128002,
+        description="Token ID to use for masking. Default is 128002 (<|reserved_special_token_0|> for Llama 3.2)",
+    )

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -1,8 +1,10 @@
 """Config args for diffusion LM training."""
 
+from __future__ import annotations
+
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class DiffusionArgs(BaseModel):
@@ -76,3 +78,11 @@ class DiffusionArgs(BaseModel):
     diffusion_generation_max_length: int = Field(
         default=100, ge=1, description="Maximum sequence length for generation"
     )
+
+    @model_validator(mode="after")
+    def _validate_mask_ratios(self) -> DiffusionArgs:
+        if self.diffusion_min_mask_ratio > self.diffusion_max_mask_ratio:
+            raise ValueError(
+                "diffusion_min_mask_ratio must be ≤ diffusion_max_mask_ratio"
+            )
+        return self

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -25,7 +25,7 @@ class DiffusionArgs(BaseModel):
         description="Maximum masking ratio for diffusion noise schedule",
     )
     num_diffusion_steps: int = Field(
-        default=1000, ge=1, description="Number of diffusion timesteps"
+        default=128, ge=1, description="Number of diffusion timesteps"
     )
 
     # Forward process config

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -1,4 +1,4 @@
-"""Configuration arguments for diffusion LM training."""
+"""Config args for diffusion LM training."""
 
 from typing import Literal
 
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 class DiffusionArgs(BaseModel):
     """Arguments for diffusion LM training plugin."""
 
-    # Noise schedule configuration
+    # Noise schedule config
     noise_schedule: Literal["linear", "cosine"] = Field(
         default="linear", description="Type of noise schedule for diffusion training"
     )
@@ -28,7 +28,7 @@ class DiffusionArgs(BaseModel):
         default=1000, ge=1, description="Number of diffusion timesteps"
     )
 
-    # Forward process parameters
+    # Forward process config
     eps: float = Field(
         default=1e-3,
         ge=0.0,
@@ -36,7 +36,7 @@ class DiffusionArgs(BaseModel):
         description="Epsilon value for minimum masking probability in forward process",
     )
 
-    # Training configuration
+    # Training config
     importance_weighting: bool = Field(
         default=True,
         description="Apply importance weighting to loss based on masking probability",

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -1,0 +1,43 @@
+"""Configuration arguments for diffusion LM training."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class DiffusionArgs(BaseModel):
+    """Arguments for diffusion LM training plugin."""
+
+    # Noise schedule configuration
+    noise_schedule: Literal["linear", "cosine"] = Field(
+        default="linear", description="Type of noise schedule for diffusion training"
+    )
+    min_mask_ratio: float = Field(
+        default=0.1,
+        ge=0.0,
+        le=1.0,
+        description="Minimum masking ratio for diffusion noise schedule",
+    )
+    max_mask_ratio: float = Field(
+        default=0.9,
+        ge=0.0,
+        le=1.0,
+        description="Maximum masking ratio for diffusion noise schedule",
+    )
+    num_diffusion_steps: int = Field(
+        default=1000, ge=1, description="Number of diffusion timesteps"
+    )
+
+    # Forward process parameters
+    eps: float = Field(
+        default=1e-3,
+        ge=0.0,
+        le=1.0,
+        description="Epsilon value for minimum masking probability in forward process",
+    )
+
+    # Training configuration
+    importance_weighting: bool = Field(
+        default=True,
+        description="Apply importance weighting to loss based on masking probability",
+    )

--- a/src/axolotl/integrations/diffusion/args.py
+++ b/src/axolotl/integrations/diffusion/args.py
@@ -39,11 +39,19 @@ class DiffusionArgs(BaseModel):
         default=True,
         description="Apply importance weighting to loss based on masking probability",
     )
-    mask_token_id: int = Field(
-        default=128002,
+    mask_token_id: int | None = Field(
+        default=None,
         description=(
-            "Token ID to use for masking. Default is 128002 "
-            "(<|reserved_special_token_0|> for Llama 3.2)"
+            "Token ID to use for masking. Unset by default; can use one of the "
+            "tokenizer's special tokens here."
+        ),
+    )
+    mask_token_str: str | None = Field(
+        default=None,
+        description=(
+            "Token string to use as a mask. If `mask_token_id` is invalid or unset, "
+            "this token will be ensured to exist as an additional special token and "
+            "used. If absent, a default '<|diffusion_mask|>' will be added."
         ),
     )
 

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -95,7 +95,7 @@ class DiffusionGenerationCallback(TrainerCallback):
                 f"\tMasked ({masked_tokens}/{total_tokens} tokens, "
                 f"{mask_ratio:.1%}): {masked}"
             )
-            # Colorize per-token diff (same as CLI)
+
             try:
                 gen_ids = sample_data.get("generated_ids")
                 orig_ids = sample_data.get("orig_ids")
@@ -142,7 +142,7 @@ class DiffusionGenerationCallback(TrainerCallback):
                     logger.info("\tGenerated:\n%s", "".join(parts))
                 else:
                     logger.info(f"\tGenerated: {generated}")
-            except Exception:  # pragma: no cover
+            except Exception:
                 logger.info(f"\tGenerated: {generated}")
 
         logger.info("=" * 60)

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -36,9 +36,9 @@ class DiffusionGenerationCallback(TrainerCallback):
         """Generate samples at specified intervals."""
         if (
             state.global_step > 0
-            and state.global_step % self.trainer.cfg.diffusion_generation_interval == 0
+            and state.global_step % self.trainer.cfg.diffusion.generation_interval == 0
         ):
-            if not self.trainer.state.is_world_process_zero():
+            if not self.trainer.state.is_world_process_zero:
                 return
 
             # Use eval dataloader if available, otherwise use train dataloader
@@ -52,15 +52,16 @@ class DiffusionGenerationCallback(TrainerCallback):
                 dataloader = self.trainer.get_train_dataloader()
 
             # Generate samples
+            diffusion_cfg = self.trainer.cfg.diffusion
             samples = generate_samples(
                 model=self.trainer.model,
                 tokenizer=self.trainer.processing_class,
                 dataloader=dataloader,
-                num_generation_samples=self.trainer.cfg.diffusion_num_generation_samples,
-                max_length=self.trainer.cfg.diffusion_generation_max_length,
-                num_diffusion_steps=self.trainer.cfg.diffusion_generation_steps,
-                temperature=self.trainer.cfg.diffusion_generation_temperature,
-                mask_token_id=self.trainer.cfg.diffusion_mask_token_id,
+                num_generation_samples=diffusion_cfg.num_generation_samples,
+                max_length=diffusion_cfg.generation_max_length,
+                num_diffusion_steps=diffusion_cfg.generation_steps,
+                temperature=diffusion_cfg.generation_temperature,
+                mask_token_id=diffusion_cfg.mask_token_id,
             )
 
             # Log samples

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -40,7 +40,7 @@ class DiffusionGenerationCallback(TrainerCallback):
         """Generate samples at specified intervals."""
         if (
             state.global_step > 0
-            and state.global_step % self.trainer.cfg.generation_interval == 0
+            and state.global_step % self.trainer.cfg.diffusion_generation_interval == 0
         ):
             # Use eval dataloader if available, otherwise use train dataloader
             dataloader = None
@@ -57,11 +57,11 @@ class DiffusionGenerationCallback(TrainerCallback):
                 model=self.trainer.model,
                 tokenizer=self.trainer.processing_class,
                 dataloader=dataloader,
-                num_generation_samples=self.trainer.cfg.num_generation_samples,
-                max_length=self.trainer.cfg.generation_max_length,
-                num_diffusion_steps=self.trainer.cfg.generation_steps,
-                temperature=self.trainer.cfg.generation_temperature,
-                mask_token_id=self.trainer.cfg.mask_token_id,
+                num_generation_samples=self.trainer.cfg.diffusion_num_generation_samples,
+                max_length=self.trainer.cfg.diffusion_generation_max_length,
+                num_diffusion_steps=self.trainer.cfg.diffusion_generation_steps,
+                temperature=self.trainer.cfg.diffusion_generation_temperature,
+                mask_token_id=self.trainer.cfg.diffusion_mask_token_id,
             )
 
             # Log samples

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -8,13 +8,9 @@ from colorama import Fore, Style
 from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
 from transformers.training_args import TrainingArguments
 
-from axolotl.utils.logging import get_logger
-
 from .generation import generate_samples
 
-LOG = get_logger(__name__)
-
-# Simple logger for readable sample generation
+# Simpler logger for more readable sample generation
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     handler = logging.StreamHandler(sys.stdout)
@@ -30,7 +26,6 @@ class DiffusionGenerationCallback(TrainerCallback):
     def __init__(self, trainer):
         self.trainer = trainer
 
-    # pylint: disable=unused-argument
     def on_step_end(
         self,
         args: TrainingArguments,
@@ -147,7 +142,7 @@ class DiffusionGenerationCallback(TrainerCallback):
 
         logger.info("=" * 60)
 
-        if self.trainer.cfg.use_wandb and self.trainer.state.is_world_process_zero:
+        if self.trainer.cfg.use_wandb:
             if wandb.run is not None:
                 wandb.log(
                     {

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -1,0 +1,115 @@
+"""Callbacks for diffusion training."""
+
+import wandb
+from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
+from transformers.training_args import TrainingArguments
+
+from axolotl.utils.logging import get_logger
+
+from .generation import generate_samples
+
+LOG = get_logger(__name__)
+
+
+class DiffusionGenerationCallback(TrainerCallback):
+    """Callback for generating samples during diffusion training."""
+
+    def __init__(self, trainer):
+        self.trainer = trainer
+
+    # pylint: disable=unused-argument
+    def on_step_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        """Generate samples at specified intervals."""
+        # Only generate samples at the specified interval and after step 0
+        if (
+            state.global_step > 0
+            and state.global_step % self.trainer.config.generation_interval == 0
+            and hasattr(self.trainer, "eval_dataset")
+            and self.trainer.eval_dataset is not None
+        ):
+
+            LOG.info(
+                f"Generating {self.trainer.config.num_generation_samples} samples at step {state.global_step}..."
+            )
+
+            # Create a simple dataloader from eval dataset for sampling
+            eval_dataloader = self.trainer.get_eval_dataloader()
+
+            # Generate samples
+            samples = generate_samples(
+                model=self.trainer.model,
+                tokenizer=self.trainer.tokenizer,
+                val_dataloader=eval_dataloader,
+                num_generation_samples=self.trainer.config.num_generation_samples,
+                max_length=self.trainer.config.generation_max_length,
+                num_diffusion_steps=self.trainer.config.generation_steps,
+                temperature=self.trainer.config.generation_temperature,
+                mask_token_id=self.trainer.config.mask_token_id,
+            )
+
+            # Log samples
+            self._log_samples(samples, state.global_step)
+
+    def _log_samples(self, samples: list, step: int):
+        """Log generated samples."""
+        if not samples:
+            return
+
+        LOG.info("=" * 60)
+        LOG.info("GENERATED SAMPLES")
+        LOG.info("=" * 60)
+
+        for i, sample_data in enumerate(samples, 1):
+            original = sample_data["original"]
+            masked = sample_data["masked"]
+            generated = sample_data["generated"]
+            mask_ratio = sample_data["mask_ratio"]
+            masked_tokens = sample_data["masked_tokens"]
+            total_tokens = sample_data["total_tokens"]
+
+            LOG.info(f"\nSample {i}:")
+            LOG.info(f"\tOriginal ({total_tokens} tokens): {original}")
+            LOG.info(
+                f"\tMasked ({masked_tokens}/{total_tokens} tokens, "
+                f"{mask_ratio:.1%}): {masked}"
+            )
+            LOG.info(f"\tGenerated: {generated}")
+
+        LOG.info("=" * 60)
+
+        if self.trainer.config.use_wandb and self.trainer.state.is_world_process_zero:
+            if wandb.run is not None:
+                wandb.log(
+                    {
+                        "generated_samples": wandb.Table(
+                            columns=[
+                                "step",
+                                "original",
+                                "masked",
+                                "generated",
+                                "mask_ratio",
+                                "masked_tokens",
+                                "total_tokens",
+                            ],
+                            data=[
+                                [
+                                    step,
+                                    sample["original"],
+                                    sample["masked"],
+                                    sample["generated"],
+                                    f"{sample['mask_ratio']:.1%}",
+                                    sample["masked_tokens"],
+                                    sample["total_tokens"],
+                                ]
+                                for sample in samples
+                            ],
+                        )
+                    },
+                    step=step,
+                )

--- a/src/axolotl/integrations/diffusion/callbacks.py
+++ b/src/axolotl/integrations/diffusion/callbacks.py
@@ -38,8 +38,7 @@ class DiffusionGenerationCallback(TrainerCallback):
             state.global_step > 0
             and state.global_step % self.trainer.cfg.diffusion_generation_interval == 0
         ):
-            # Only the main process generates / logs samples
-            if not getattr(self.trainer.state, "is_world_process_zero", True):
+            if not self.trainer.state.is_world_process_zero():
                 return
 
             # Use eval dataloader if available, otherwise use train dataloader

--- a/src/axolotl/integrations/diffusion/generation.py
+++ b/src/axolotl/integrations/diffusion/generation.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Any, List, Optional, Literal
+from typing import Any, List, Literal, Optional
 
 import torch
 

--- a/src/axolotl/integrations/diffusion/generation.py
+++ b/src/axolotl/integrations/diffusion/generation.py
@@ -1,12 +1,13 @@
 """Sample generation utilities for diffusion training."""
 
-import logging
 import re
 from typing import Any, List, Literal, Optional
 
 import torch
 
-logger = logging.getLogger(__name__)
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
 
 
 def generate_samples(
@@ -40,11 +41,11 @@ def generate_samples(
         List of dictionaries with original text, masked text, and generated text
     """
     if dataloader is None:
-        logger.warning("No validation dataloader provided, cannot generate samples")
+        LOG.warning("No validation dataloader provided, cannot generate samples")
         return []
 
     unwrapped_model = model.module if hasattr(model, "module") else model
-    was_training = unwrapped_model.training
+    training = unwrapped_model.training
     unwrapped_model.eval()
 
     # Resolve device robustly (some modules don't expose `.device`)
@@ -60,7 +61,7 @@ def generate_samples(
     sampled_sequences = _sample_sequences_from_dataloader(
         dataloader, num_generation_samples, max_length, device
     )
-    logger.info(f"Sampled {len(sampled_sequences)} sequences from validation dataset")
+    LOG.info(f"Sampled {len(sampled_sequences)} sequences from validation dataset")
 
     # Generate samples using reverse diffusion process
     with torch.no_grad():
@@ -79,7 +80,7 @@ def generate_samples(
             generations.append(generation_result)
 
     # Restore prior training state
-    if was_training:
+    if training:
         unwrapped_model.train()
     else:
         unwrapped_model.eval()

--- a/src/axolotl/integrations/diffusion/generation.py
+++ b/src/axolotl/integrations/diffusion/generation.py
@@ -203,6 +203,11 @@ def generate(
         final_ids = None
 
     try:
+        orig_ids_for_render = original_sequence[0].detach().cpu().tolist()
+    except Exception:  # pragma: no cover
+        orig_ids_for_render = None
+
+    try:
         if masked_indices is not None:
             masked_positions = (
                 torch.where(masked_indices[0])[0].detach().cpu().tolist()
@@ -214,7 +219,7 @@ def generate(
     except Exception:  # pragma: no cover
         masked_positions = []
 
-    return {
+    result = {
         "original": original_text,
         "masked": masked_text,
         "generated": generated_text,
@@ -223,11 +228,14 @@ def generate(
         "total_tokens": total_tokens,
         "generated_ids": final_ids,
         "masked_positions": masked_positions,
+        "orig_ids": orig_ids_for_render,
         "formatted": (
             f"Original: '{original_text}' → Masked: '{masked_text}' "
             f"({mask_ratio:.1%}) → Generated: '{generated_text}'"
         ),
     }
+
+    return result
 
 
 # Backwards compatibility for older imports

--- a/src/axolotl/integrations/diffusion/generation.py
+++ b/src/axolotl/integrations/diffusion/generation.py
@@ -285,31 +285,18 @@ def generate(
             mask_token_id,
             attention_mask,
         )
-
-    # Get final generated text
     generated_text = tokenizer.decode(sequence[0].cpu(), skip_special_tokens=True)
 
-    # Collect diagnostic info for richer UIs
-    try:
-        final_ids = sequence[0].detach().cpu().tolist()
-    except Exception:
-        final_ids = None
-
-    try:
-        orig_ids_for_render = original_sequence[0].detach().cpu().tolist()
-    except Exception:
-        orig_ids_for_render = None
-
-    try:
-        if masked_indices is not None:
-            masked_positions = (
-                torch.where(masked_indices[0])[0].detach().cpu().tolist()
-                if masked_indices.ndim == 2
-                else []
-            )
-        else:
-            masked_positions = []
-    except Exception:
+    # Collect diagnostic info
+    final_ids = sequence[0].detach().cpu().tolist()
+    orig_ids_for_render = original_sequence[0].detach().cpu().tolist()
+    if masked_indices is not None:
+        masked_positions = (
+            torch.where(masked_indices[0])[0].detach().cpu().tolist()
+            if masked_indices.ndim == 2
+            else []
+        )
+    else:
         masked_positions = []
 
     result = {
@@ -356,7 +343,7 @@ def _diffusion_step(
     num_diffusion_steps: int,
     temperature: float,
     mask_token_id: int,
-    attention_mask: Optional[torch.Tensor] = None,
+    attention_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Perform a single diffusion step with remasking."""
     # Only process if there are masked tokens remaining

--- a/src/axolotl/integrations/diffusion/generation.py
+++ b/src/axolotl/integrations/diffusion/generation.py
@@ -1,0 +1,267 @@
+"""Sample generation utilities for diffusion training."""
+
+import logging
+from typing import Any, List, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def generate_samples(
+    model: torch.nn.Module,
+    tokenizer: Any,
+    val_dataloader: Optional[Any] = None,
+    num_generation_samples: int = 3,
+    max_length: int = 100,
+    num_diffusion_steps: int = 128,
+    temperature: float = 0.0,
+    mask_token_id: int = 32000,
+) -> List[dict]:
+    """
+    Generate text samples using the diffusion model by randomly masking sequences
+    from the validation dataset and running the reverse diffusion process.
+
+    Args:
+        model: The wrapped or unwrapped model
+        tokenizer: Tokenizer for encoding/decoding
+        val_dataloader: Validation dataloader (for sampling sequences)
+        num_generation_samples: Number of samples to generate
+        max_length: Maximum length of sequences to use
+        num_diffusion_steps: Number of diffusion steps for generation
+        temperature: Temperature for sampling (0.0 = deterministic)
+        mask_token_id: Token ID used for masking
+
+    Returns:
+        List of dictionaries with original text, masked text, and generated text
+    """
+    if val_dataloader is None:
+        logger.warning("No validation dataloader provided, cannot generate samples")
+        return []
+
+    # Get the actual model (unwrap if needed)
+    unwrapped_model = model.module if hasattr(model, "module") else model
+    unwrapped_model.eval()
+    generations = []
+
+    # Sample sequences from validation dataset
+    sampled_sequences = _sample_sequences_from_dataloader(
+        val_dataloader, num_generation_samples, max_length, unwrapped_model.device
+    )
+    logger.info(f"Sampled {len(sampled_sequences)} sequences from validation dataset")
+
+    # Generate samples using reverse diffusion process
+    with torch.no_grad():
+        for original_sequence in sampled_sequences:
+            generation_result = _generate(
+                unwrapped_model,
+                tokenizer,
+                original_sequence,
+                num_diffusion_steps,
+                temperature,
+                mask_token_id,
+            )
+            generations.append(generation_result)
+
+    unwrapped_model.train()
+    return generations
+
+
+def _sample_sequences_from_dataloader(
+    val_dataloader: Any, num_samples: int, max_length: int, device: torch.device
+) -> List[torch.Tensor]:
+    """Sample sequences from validation dataloader."""
+    sampled_sequences = []
+    sample_count = 0
+
+    # Add randomness by skipping a random number of batches
+    skip_batches = torch.randint(0, 6, (1,)).item()
+    batch_count = 0
+
+    for batch in val_dataloader:
+        # Skip some batches for variety
+        if batch_count < skip_batches:
+            batch_count += 1
+            continue
+
+        if sample_count >= num_samples:
+            break
+
+        batch_count += 1
+        input_ids = batch["input_ids"]
+        attention_mask = batch.get("attention_mask")
+
+        # Randomly sample from sequences in this batch
+        batch_indices = torch.randperm(input_ids.size(0)).tolist()
+
+        for i in batch_indices:
+            if sample_count >= num_samples:
+                break
+
+            # Get actual sequence length (non-padded)
+            if attention_mask is not None:
+                seq_len = attention_mask[i].sum().item()
+            else:
+                seq_len = input_ids.size(1)
+
+            # Limit sequence length to max_length
+            actual_length = min(seq_len, max_length)
+            if actual_length < 10:  # Skip very short sequences
+                continue
+
+            # Extract the sequence
+            sequence = input_ids[i][:actual_length].unsqueeze(0).to(device)
+            sampled_sequences.append(sequence)
+            sample_count += 1
+
+    return sampled_sequences
+
+
+def _generate(
+    model: torch.nn.Module,
+    tokenizer: Any,
+    original_sequence: torch.Tensor,
+    num_diffusion_steps: int,
+    temperature: float,
+    mask_token_id: int,
+) -> dict:
+    """Generate a single sample using reverse diffusion."""
+    # Get original text for comparison
+    original_text = tokenizer.decode(
+        original_sequence[0].cpu(), skip_special_tokens=True
+    )
+
+    # Apply custom masking with random ratio (10% to 70%)
+    total_tokens = original_sequence.size(1)
+    min_ratio, max_ratio = 0.1, 0.7
+    target_mask_ratio = torch.rand(1).item() * (max_ratio - min_ratio) + min_ratio
+    target_masked_tokens = int(total_tokens * target_mask_ratio)
+
+    # Create random mask indices
+    mask_positions = torch.randperm(total_tokens)[:target_masked_tokens]
+    masked_indices = torch.zeros(
+        1, total_tokens, dtype=torch.bool, device=original_sequence.device
+    )
+    masked_indices[0, mask_positions] = True
+
+    # Create masked sequence
+    masked_sequence = original_sequence.clone()
+    masked_sequence[masked_indices] = mask_token_id
+
+    # Calculate actual mask ratio
+    masked_tokens = masked_indices.sum().item()
+    mask_ratio = masked_tokens / total_tokens
+
+    # Get masked text for comparison
+    masked_text = tokenizer.decode(masked_sequence[0].cpu(), skip_special_tokens=False)
+    # Clean up mask token representation
+    masked_text = _clean_masked_text(masked_text, tokenizer, mask_token_id)
+
+    # Run reverse diffusion process
+    sequence = masked_sequence.clone()
+    for step in range(num_diffusion_steps):
+        sequence = _diffusion_step(
+            model, sequence, step, num_diffusion_steps, temperature, mask_token_id
+        )
+
+    # Get final generated text
+    generated_text = tokenizer.decode(sequence[0].cpu(), skip_special_tokens=True)
+
+    return {
+        "original": original_text,
+        "masked": masked_text,
+        "generated": generated_text,
+        "mask_ratio": mask_ratio,
+        "masked_tokens": masked_tokens,
+        "total_tokens": total_tokens,
+        "formatted": (
+            f"Original: '{original_text}' → Masked: '{masked_text}' "
+            f"({mask_ratio:.1%}) → Generated: '{generated_text}'"
+        ),
+    }
+
+
+def _clean_masked_text(masked_text: str, tokenizer: Any, mask_token_id: int) -> str:
+    """Clean up masked text for display."""
+    # Get the mask token representation from the tokenizer
+    mask_token_repr = tokenizer.decode([mask_token_id], skip_special_tokens=False)
+    cleaned = masked_text.replace(mask_token_repr, "[MASK]")
+
+    # Clean up special tokens and whitespace
+    cleaned = cleaned.replace("<s>", "").replace("</s>", "").strip()
+    cleaned = " ".join(cleaned.split())
+
+    return cleaned
+
+
+def _diffusion_step(
+    model: torch.nn.Module,
+    sequence: torch.Tensor,
+    step: int,
+    num_diffusion_steps: int,
+    temperature: float,
+    mask_token_id: int,
+) -> torch.Tensor:
+    """Perform a single diffusion step with remasking."""
+    # Only process if there are masked tokens remaining
+    current_mask = sequence == mask_token_id
+    if not current_mask.any():
+        return sequence
+
+    # Create bidirectional attention mask for diffusion
+    batch_size, seq_len = sequence.shape
+    attention_mask = torch.ones(
+        batch_size, 1, seq_len, seq_len, dtype=torch.bool, device=sequence.device
+    )
+
+    # Forward pass
+    outputs = model(input_ids=sequence, attention_mask=attention_mask)
+    logits = outputs.logits
+
+    # Only sample at currently masked positions
+    if current_mask.any():
+        masked_logits = logits[current_mask]
+
+        # Apply temperature scaling
+        if temperature > 0:
+            scaled_logits = masked_logits / temperature
+        else:
+            scaled_logits = masked_logits
+
+        # Suppress mask token in outputs
+        scaled_logits[:, mask_token_id] = -float("inf")
+
+        # Sample predictions
+        if temperature > 0:
+            # Add Gumbel noise for sampling
+            gumbel_noise = -torch.log(
+                -torch.log(torch.rand_like(scaled_logits, dtype=torch.float32))
+            )
+            gumbel_logits = scaled_logits + gumbel_noise
+            predicted_tokens = torch.argmax(gumbel_logits, dim=-1)
+        else:
+            # Deterministic sampling when temperature is 0
+            predicted_tokens = torch.argmax(scaled_logits, dim=-1)
+
+        # Calculate probabilities for confidence scoring
+        probs = torch.softmax(scaled_logits, dim=-1)
+        predicted_token_probs = probs[range(len(predicted_tokens)), predicted_tokens]
+
+        # Determine how many tokens to unmask this step
+        remaining_masked = current_mask.sum().item()
+        if step == num_diffusion_steps - 1:
+            num_to_unmask = remaining_masked
+        else:
+            unmask_ratio = 1.0 / (num_diffusion_steps - step)
+            num_to_unmask = max(1, int(remaining_masked * unmask_ratio))
+
+        # Select highest confidence predictions to unmask
+        if num_to_unmask >= remaining_masked:
+            sequence[current_mask] = predicted_tokens
+        else:
+            _, top_indices = predicted_token_probs.topk(num_to_unmask)
+            mask_positions = torch.where(current_mask)[1]
+            positions_to_unmask = mask_positions[top_indices]
+            sequence[0, positions_to_unmask] = predicted_tokens[top_indices]
+
+    return sequence

--- a/src/axolotl/integrations/diffusion/plugin.py
+++ b/src/axolotl/integrations/diffusion/plugin.py
@@ -1,0 +1,40 @@
+"""Diffusion LM training plugin for Axolotl."""
+
+from transformers import PreTrainedModel, Trainer
+
+from axolotl.integrations.base import BasePlugin
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+
+from .trainer import DiffusionTrainer
+
+LOG = get_logger(__name__)
+
+
+class DiffusionPlugin(BasePlugin):
+    """
+    Plugin for diffusion language model training.
+
+    This plugin enables diffusion-based training using the LLaDA approach, which uses
+    random masking and bidirectional attention to train language models.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.cfg = None
+
+    def get_input_args(self) -> str:
+        """Returns the pydantic model for LLaDA plugin arguments."""
+        return "axolotl.integrations.diffusion.DiffusionArgs"
+
+    def post_model_load(self, cfg: DictDefault, model: PreTrainedModel):
+        """Perform actions after model is loaded."""
+        self.cfg = cfg
+
+    def get_trainer_cls(self, cfg: DictDefault) -> Trainer | None:
+        """Return custom trainer class for diffusion training."""
+        return DiffusionTrainer
+
+    def post_trainer_create(self, cfg: DictDefault, trainer: Trainer):
+        """Configure trainer after creation."""
+        trainer.set_config(cfg)

--- a/src/axolotl/integrations/diffusion/plugin.py
+++ b/src/axolotl/integrations/diffusion/plugin.py
@@ -1,6 +1,7 @@
 """Diffusion LM training plugin for Axolotl."""
 
-from transformers import PreTrainedModel, Trainer
+from peft import PeftModel
+from transformers import PreTrainedModel
 
 from axolotl.integrations.base import BasePlugin
 from axolotl.utils.dict import DictDefault
@@ -27,14 +28,14 @@ class DiffusionPlugin(BasePlugin):
         """Returns the pydantic model for LLaDA plugin arguments."""
         return "axolotl.integrations.diffusion.DiffusionArgs"
 
-    def post_model_load(self, cfg: DictDefault, model: PreTrainedModel):
+    def post_model_load(self, cfg: DictDefault, model: PreTrainedModel | PeftModel):
         """Perform actions after model is loaded."""
         self.cfg = cfg
 
-    def get_trainer_cls(self, cfg: DictDefault) -> Trainer | None:
+    def get_trainer_cls(self, cfg: DictDefault) -> type[DiffusionTrainer] | None:
         """Return custom trainer class for diffusion training."""
         return DiffusionTrainer
 
-    def post_trainer_create(self, cfg: DictDefault, trainer: Trainer):
+    def post_trainer_create(self, cfg: DictDefault, trainer: DiffusionTrainer):
         """Configure trainer after creation."""
         trainer.set_config(cfg)

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -281,15 +281,17 @@ class DiffusionTrainer(AxolotlTrainer):
             "avg_p_mask": avg_p_mask,
             "ce_loss": ce_loss.item(),
         }
-        # When SFT labels are provided, also log answer-specific metrics
-        if labels is not None:
+
+        # If doing SFT training, log answer-specific metrics
+        if self.cfg.datasets is not None:
             with torch.no_grad():
                 answer_mask = labels != -100
-                answer_lengths = answer_mask.sum(dim=1).float()  # [batch_size]
-                total_answer_tokens = answer_mask.sum().item()
-                total_tokens = labels.numel()
+                answer_lengths = answer_mask.sum(dim=1).float()  # type: ignore
+                total_answer_tokens = answer_mask.sum().item()  # type: ignore
+                total_tokens = labels.numel()  # type: ignore
                 metrics["answer_ratio"] = total_answer_tokens / max(total_tokens, 1)
                 metrics["avg_answer_length"] = answer_lengths.mean().item()
+
         if self.cfg.diffusion.importance_weighting:
             metrics["importance_weight_avg"] = (1.0 / masked_p_mask).mean().item()
 

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -270,13 +270,6 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
             "avg_p_mask": p_mask[masked_indices].mean().item(),
             "ce_loss": ce_loss.item(),
         }
-
-        # Add SFT-specific metrics
-        if labels is not None:
-            answer_mask = labels != -100
-            metrics["answer_ratio"] = answer_mask.float().mean().item()
-            metrics["avg_answer_length"] = answer_mask.sum(dim=1).float().mean().item()
-
         if self.config.importance_weighting:
             metrics["importance_weight_avg"] = (1.0 / masked_p_mask).mean().item()
 

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -1,0 +1,245 @@
+"""Custom trainer for diffusion LM training."""
+
+from typing import Dict, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from transformers import PreTrainedModel
+
+from axolotl.core.trainers.base import AxolotlTrainer
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
+    """Custom trainer for diffusion LM training that overrides loss computation."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.config = None
+
+    def set_config(self, config: DictDefault):
+        """Set config for diffusion training."""
+        self.config = config
+
+    def forward_process(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        eps: float = 1e-3,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Forward noising process. A timestep is sampled along the process, and tokens are
+        masked with probability determined by the configured noise schedule.
+
+        Args:
+            input_ids: Input token ids [batch_size, seq_len].
+            attention_mask: Attention mask [batch_size, seq_len].
+            eps: Small epsilon value for minimum masking probability.
+
+        Returns:
+            noisy_batch: Input with some tokens masked.
+            masked_indices: Boolean mask indicating which tokens were masked.
+            p_mask: Masking probabilities for each token [batch_size, seq_len].
+        """
+        batch_size, seq_len = input_ids.shape
+        device = input_ids.device
+
+        # Sample random timesteps for each sample in batch
+        t = torch.rand(batch_size, device=device)
+
+        # Calculate masking probability with epsilon
+        p_mask = (1 - eps) * t + eps  # [batch_size]
+        p_mask = p_mask[:, None].repeat(1, seq_len)  # [batch_size, seq_len]
+
+        # Don't mask padding tokens if attention_mask is provided
+        if attention_mask is not None:
+            valid_mask = attention_mask.bool()
+            p_mask = p_mask * valid_mask.float()
+
+        # Create random mask based on probability
+        masked_indices = torch.rand((batch_size, seq_len), device=device) < p_mask
+        if attention_mask is not None:
+            masked_indices = masked_indices & attention_mask.bool()
+
+        # Get tokenizer
+        tokenizer = self.processing_class
+        assert tokenizer is not None, "Tokenizer not available on Trainer object."
+
+        # Get mask token ID
+        mask_token_id = getattr(tokenizer, "mask_token_id", None)
+        if mask_token_id is None:
+            mask_token_id = getattr(tokenizer, "unk_token_id", None)
+
+        # Create masked input using configured mask token
+        noisy_batch = torch.where(masked_indices, mask_token_id, input_ids)
+
+        return noisy_batch, masked_indices, p_mask
+
+    def create_bidirectional_attention_mask(
+        self, input_ids: torch.Tensor, attention_mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """
+        Create bidirectional attention mask to override default causal masking.
+
+        Args:
+            input_ids: Input token ids [batch_size, seq_len].
+            attention_mask: Attention mask [batch_size, seq_len].
+
+        Returns:
+            bidirectional_mask: 4D attention mask [batch_size, 1, seq_len, seq_len].
+        """
+        batch_size, seq_len = input_ids.shape
+
+        # Create bidirectional attention mask to override default causal masking
+        # Shape: [batch_size, 1, seq_len, seq_len]
+        bidirectional_mask = torch.ones(
+            seq_len, seq_len, dtype=torch.bool, device=input_ids.device
+        )
+        bidirectional_mask = (
+            bidirectional_mask.unsqueeze(0)
+            .unsqueeze(0)
+            .expand(batch_size, 1, seq_len, seq_len)
+        )
+
+        # Apply padding mask if provided
+        if attention_mask is not None:
+            # Convert attention_mask to 4D and apply
+            expanded_mask = attention_mask.bool().unsqueeze(1).unsqueeze(2)
+            expanded_mask = expanded_mask.expand(batch_size, 1, seq_len, seq_len)
+
+            bidirectional_mask = (
+                bidirectional_mask & expanded_mask & expanded_mask.transpose(-1, -2)
+            )
+
+        return bidirectional_mask
+
+    def compute_diffusion_loss(
+        self,
+        model: PreTrainedModel,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        """
+        Compute diffusion loss.
+
+        Args:
+            model: The model to compute loss for.
+            input_ids: Ground truth token ids [batch_size, seq_len].
+            attention_mask: Attention mask [batch_size, seq_len].
+
+        Returns:
+            loss: Cross-entropy loss.
+            metrics: Dictionary of metrics.
+        """
+        # Apply forward process
+        noisy_batch, masked_indices, p_mask = self.forward_process(
+            input_ids, attention_mask, self.config.eps
+        )
+
+        # Create bidirectional attention mask (always required for diffusion training)
+        bidirectional_mask = self.create_bidirectional_attention_mask(
+            input_ids, attention_mask
+        )
+
+        # Forward pass
+        outputs = model(
+            input_ids=noisy_batch,
+            attention_mask=bidirectional_mask,
+        )
+        logits = outputs.logits
+
+        # Apply attention mask to masked_indices if provided
+        if attention_mask is not None:
+            loss_mask = masked_indices & attention_mask.bool()
+        else:
+            loss_mask = masked_indices
+
+        if loss_mask.sum() > 0:
+            valid_indices = torch.where(loss_mask)
+            batch_indices, seq_indices = valid_indices
+
+            # Extract the relevant data
+            masked_logits = logits[
+                batch_indices, seq_indices
+            ]  # [num_masked_tokens, vocab_size]
+            masked_targets = input_ids[
+                batch_indices, seq_indices
+            ]  # [num_masked_tokens]
+            masked_p_mask = p_mask[batch_indices, seq_indices]  # [num_masked_tokens]
+
+            # Compute cross-entropy loss without reduction (cast to fp32 for stability)
+            token_loss = F.cross_entropy(
+                masked_logits.float(), masked_targets, reduction="none"
+            )
+
+            # Apply importance weighting if enabled
+            if self.config.importance_weighting:
+                masked_p_mask = masked_p_mask.float()
+                weighted_loss = token_loss / masked_p_mask
+            else:
+                weighted_loss = token_loss
+
+            # Final loss: sum weighted losses, normalize by total tokens
+            loss = weighted_loss.sum() / (input_ids.shape[0] * input_ids.shape[1])
+            ce_loss = token_loss.mean()
+
+            # Compute accuracy on masked tokens
+            with torch.no_grad():
+                pred_tokens = masked_logits.argmax(dim=-1)
+                accuracy = (pred_tokens == masked_targets).float().mean()
+        else:
+            loss = torch.tensor(0.0, device=input_ids.device, requires_grad=True)
+            accuracy = torch.tensor(0.0, device=input_ids.device)
+            ce_loss = torch.tensor(0.0, device=input_ids.device)
+            masked_p_mask = torch.tensor(1.0, device=input_ids.device)
+
+        metrics = {
+            "loss": loss.item(),
+            "accuracy": accuracy.item(),
+            "mask_ratio": masked_indices.float().mean().item(),
+            "num_masked_tokens": loss_mask.sum().item(),
+            "avg_p_mask": (
+                p_mask[masked_indices].mean().item()
+                if masked_indices.sum() > 0
+                else 0.0
+            ),
+            "ce_loss": ce_loss.item() if loss_mask.sum() > 0 else 0.0,
+        }
+
+        if self.config.importance_weighting:
+            metrics["importance_weight_avg"] = (
+                (1.0 / masked_p_mask).mean().item() if loss_mask.sum() > 0 else 0.0
+            )
+
+        return loss, metrics
+
+    def compute_loss(
+        self,
+        model: PreTrainedModel,
+        inputs: Dict[str, torch.Tensor],
+        return_outputs: bool = False,
+        num_items_in_batch: Optional[int] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        """Override compute_loss to use diffusion loss."""
+        input_ids = inputs.get("input_ids")
+        attention_mask = inputs.get("attention_mask")
+
+        if input_ids is None:
+            raise ValueError("input_ids is required for diffusion training")
+
+        loss, metrics = self.compute_diffusion_loss(model, input_ids, attention_mask)
+
+        # Log metrics
+        if self.state.is_local_process_zero:
+            for key, value in metrics.items():
+                self.log({f"train/diffusion_{key}": value})
+
+        if return_outputs:
+            # TODO: compute outputs (?)
+            outputs = [loss]
+            return (loss, outputs)
+
+        return loss

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -277,7 +277,6 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
             else:
                 weighted_loss = token_loss
 
-            # Final loss: sum weighted losses, normalize
             if labels is not None:
                 # For SFT data: normalize by answer length per sample
                 answer_mask = labels != -100

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -65,6 +65,7 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
 
         self._special_token_ids = special_tokens
 
+    @torch.compile
     def _forward_process(
         self,
         input_ids: torch.Tensor,
@@ -120,6 +121,7 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
 
         return noisy_batch, masked_indices, p_mask
 
+    @torch.compile
     def _create_bidirectional_attention_mask(
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor | None = None
     ) -> torch.Tensor:

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -152,8 +152,6 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
 
         # Sample random timesteps for each sample in batch
         t = torch.rand(batch_size, device=device)
-
-        # Calculate masking probability with epsilon
         p_mask = (1 - eps) * t + eps  # [batch_size]
         p_mask = p_mask[:, None].repeat(1, seq_len)  # [batch_size, seq_len]
 

--- a/src/axolotl/integrations/diffusion/trainer.py
+++ b/src/axolotl/integrations/diffusion/trainer.py
@@ -23,7 +23,7 @@ def _maybe_torch_compile(fn):
         return fn
 
 
-class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
+class DiffusionTrainer(AxolotlTrainer):
     """Custom trainer for diffusion LM training that overrides loss computation."""
 
     def __init__(self, *args, **kwargs):
@@ -36,29 +36,9 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
         self.cfg = config
         self._cache_special_token_ids()
         self._resolve_mask_token_id()
-        # Log resolved mask token id
-        try:
-            tok = getattr(self, "processing_class", None)
-            tid = int(self.cfg.diffusion_mask_token_id)
-            token_repr = None
-            if tok is not None:
-                if hasattr(tok, "convert_ids_to_tokens"):
-                    try:
-                        token_repr = tok.convert_ids_to_tokens(tid)
-                    except Exception:  # pragma: no cover
-                        token_repr = None
-                if not token_repr and hasattr(tok, "decode"):
-                    try:
-                        token_repr = tok.decode([tid], skip_special_tokens=False)
-                    except Exception:  # pragma: no cover
-                        token_repr = None
-            LOG.info(
-                "Diffusion: using mask_token_id=%s%s",
-                tid,
-                f" (token={token_repr})" if token_repr else "",
-            )
-        except Exception:  # pragma: no cover
-            pass
+
+        token_id = int(self.cfg.diffusion_mask_token_id)
+        LOG.info(f"Diffusion: using mask_token_id={token_id}")
 
         if config.diffusion_generate_samples:
             generation_callback = DiffusionGenerationCallback(self)
@@ -80,7 +60,7 @@ class DiffusionTrainer(AxolotlTrainer):  # pylint: disable=too-many-ancestors
         )
         try:
             self.cfg.diffusion_mask_token_id = int(mid)
-        except Exception:  # pragma: no cover
+        except Exception:
             pass
 
     def compute_loss(

--- a/src/axolotl/integrations/diffusion/utils.py
+++ b/src/axolotl/integrations/diffusion/utils.py
@@ -31,7 +31,11 @@ def resolve_mask_token_id(
                 vocab_size = None
 
     # Use explicit id from config if valid
-    cfg_id = getattr(cfg, "mask_token_id", None) if hasattr(cfg, "mask_token_id") else cfg.get("mask_token_id")
+    cfg_id = (
+        getattr(cfg, "mask_token_id", None)
+        if hasattr(cfg, "mask_token_id")
+        else cfg.get("mask_token_id")
+    )
     if isinstance(cfg_id, int) and cfg_id >= 0:
         if vocab_size is None or cfg_id < vocab_size:
             return int(cfg_id)
@@ -59,7 +63,11 @@ def resolve_mask_token_id(
         return tid
 
     # Try mask_token_str from config, else the default training token
-    token_str = getattr(cfg, "mask_token_str", None) if hasattr(cfg, "mask_token_str") else cfg.get("mask_token_str")
+    token_str = (
+        getattr(cfg, "mask_token_str", None)
+        if hasattr(cfg, "mask_token_str")
+        else cfg.get("mask_token_str")
+    )
     for candidate in (token_str, default_token):
         tid = _existing_special_token_id(candidate)
         if isinstance(tid, int):
@@ -72,8 +80,10 @@ def resolve_mask_token_id(
         try:
             tokenizer.add_special_tokens({"additional_special_tokens": [token_to_add]})
             # Resize embeddings if possible
-            if model is not None and hasattr(tokenizer, "__len__") and hasattr(
-                model, "resize_token_embeddings"
+            if (
+                model is not None
+                and hasattr(tokenizer, "__len__")
+                and hasattr(model, "resize_token_embeddings")
             ):
                 try:
                     model.resize_token_embeddings(len(tokenizer))
@@ -89,5 +99,3 @@ def resolve_mask_token_id(
     # Fallback to unk or 0 (do not update cfg)
     fallback = getattr(tokenizer, "unk_token_id", 0) or 0
     return int(fallback)
-
-    

--- a/src/axolotl/integrations/diffusion/utils.py
+++ b/src/axolotl/integrations/diffusion/utils.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
+
+import torch
 
 from axolotl.utils.dict import DictDefault
 
@@ -118,3 +120,40 @@ def resolve_mask_token_id(
     # Fallback to unk or 0 (do not update cfg)
     fallback = getattr(tokenizer, "unk_token_id", 0) or 0
     return int(fallback)
+
+
+def create_bidirectional_attention_mask(
+    input_ids: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    sample_packing: bool = False,
+) -> torch.Tensor:
+    """
+    Create bidirectional attention mask to override default causal masking.
+    Handles sample-packed sequences where different samples are identified
+    by different attention mask values.
+
+    Args:
+        input_ids: Input token ids [batch_size, seq_len]
+        attention_mask: Attention mask [batch_size, seq_len]
+        sample_packing: Whether sample packing is enabled
+
+    Returns:
+        bidirectional_mask: 4D attention mask [batch_size, 1, seq_len, seq_len]
+    """
+    batch_size, seq_len = input_ids.shape
+    device = input_ids.device
+
+    if attention_mask is None or not sample_packing:
+        return torch.ones(
+            batch_size, 1, seq_len, seq_len, dtype=torch.bool, device=device
+        )
+
+    # Handle sample packing: tokens can only attend within their sample
+    mask_i = attention_mask.unsqueeze(2)  # [batch_size, seq_len, 1]
+    mask_j = attention_mask.unsqueeze(1)  # [batch_size, 1, seq_len]
+
+    # Tokens can attend to each other if they have the same non-zero sample ID
+    bidirectional_mask = (mask_i == mask_j) & (mask_i > 0)
+
+    # Add head dimension: [batch_size, 1, seq_len, seq_len]
+    return bidirectional_mask.unsqueeze(1)

--- a/src/axolotl/integrations/diffusion/utils.py
+++ b/src/axolotl/integrations/diffusion/utils.py
@@ -1,0 +1,93 @@
+"""Shared utilities for diffusion integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from axolotl.utils.dict import DictDefault
+
+
+def resolve_mask_token_id(
+    tokenizer: Any,
+    cfg: DictDefault,
+    *,
+    allow_add: bool,
+    model: Any | None = None,
+    default_token: str = "<|diffusion_mask|>",
+) -> int:
+    """Resolve mask token id. Training may add a new special token; inference won't."""
+    # Determine vocab size if available
+    vocab_size = None
+    if tokenizer is not None:
+        if hasattr(tokenizer, "vocab_size") and tokenizer.vocab_size is not None:
+            try:
+                vocab_size = int(tokenizer.vocab_size)  # type: ignore[arg-type]
+            except Exception:  # pragma: no cover
+                vocab_size = None
+        elif hasattr(tokenizer, "__len__"):
+            try:
+                vocab_size = int(len(tokenizer))
+            except Exception:  # pragma: no cover
+                vocab_size = None
+
+    # Use explicit id from config if valid
+    cfg_id = getattr(cfg, "mask_token_id", None) if hasattr(cfg, "mask_token_id") else cfg.get("mask_token_id")
+    if isinstance(cfg_id, int) and cfg_id >= 0:
+        if vocab_size is None or cfg_id < vocab_size:
+            return int(cfg_id)
+
+    def _existing_special_token_id(token_str: str | None) -> int | None:
+        """Attempt to resolve an existing special token string to a real ID."""
+        if not token_str or not hasattr(tokenizer, "convert_tokens_to_ids"):
+            return None
+        try:
+            tid = tokenizer.convert_tokens_to_ids(token_str)
+        except Exception:  # pragma: no cover
+            return None
+
+        if not isinstance(tid, int) or tid < 0:
+            return None
+
+        # Ensure it's registered as special and not UNK, and within vocab
+        unk_id = getattr(tokenizer, "unk_token_id", None)
+        specials = set(getattr(tokenizer, "all_special_tokens", []) or [])
+        addl = set(getattr(tokenizer, "additional_special_tokens", []) or [])
+        is_special = token_str in specials or token_str in addl
+        in_vocab = vocab_size is None or tid < vocab_size
+        if (unk_id is not None and tid == unk_id) or not is_special or not in_vocab:
+            return None
+        return tid
+
+    # Try mask_token_str from config, else the default training token
+    token_str = getattr(cfg, "mask_token_str", None) if hasattr(cfg, "mask_token_str") else cfg.get("mask_token_str")
+    for candidate in (token_str, default_token):
+        tid = _existing_special_token_id(candidate)
+        if isinstance(tid, int):
+            cfg.mask_token_id = int(tid)
+            return int(tid)
+
+    # Optionally add and return a dedicated special token during training
+    if allow_add and hasattr(tokenizer, "add_special_tokens"):
+        token_to_add = token_str or default_token
+        try:
+            tokenizer.add_special_tokens({"additional_special_tokens": [token_to_add]})
+            # Resize embeddings if possible
+            if model is not None and hasattr(tokenizer, "__len__") and hasattr(
+                model, "resize_token_embeddings"
+            ):
+                try:
+                    model.resize_token_embeddings(len(tokenizer))
+                except Exception:  # pragma: no cover
+                    pass
+            new_id = tokenizer.convert_tokens_to_ids(token_to_add)
+            if isinstance(new_id, int) and new_id >= 0:
+                cfg.mask_token_id = int(new_id)
+                return int(new_id)
+        except Exception:  # pragma: no cover
+            pass
+
+    # Fallback to unk or 0 (do not update cfg)
+    fallback = getattr(tokenizer, "unk_token_id", 0) or 0
+    return int(fallback)
+
+    

--- a/src/axolotl/integrations/diffusion/utils.py
+++ b/src/axolotl/integrations/diffusion/utils.py
@@ -22,22 +22,16 @@ def resolve_mask_token_id(
         if hasattr(tokenizer, "vocab_size") and tokenizer.vocab_size is not None:
             try:
                 vocab_size = int(tokenizer.vocab_size)  # type: ignore[arg-type]
-            except Exception:  # pragma: no cover
+            except Exception:
                 vocab_size = None
         elif hasattr(tokenizer, "__len__"):
             try:
                 vocab_size = int(len(tokenizer))
-            except Exception:  # pragma: no cover
+            except Exception:
                 vocab_size = None
 
-    # Use explicit id from config if valid (prefixed or legacy)
-    cfg_id = None
-    if hasattr(cfg, "diffusion_mask_token_id"):
-        cfg_id = getattr(cfg, "diffusion_mask_token_id")
-    elif hasattr(cfg, "mask_token_id"):
-        cfg_id = getattr(cfg, "mask_token_id")
-    elif hasattr(cfg, "get"):
-        cfg_id = cfg.get("diffusion_mask_token_id") or cfg.get("mask_token_id")
+    # Use explicit id from config if provided
+    cfg_id = cfg.diffusion_mask_token_id
     if isinstance(cfg_id, int) and cfg_id >= 0:
         if vocab_size is None or cfg_id < vocab_size:
             return int(cfg_id)
@@ -47,11 +41,11 @@ def resolve_mask_token_id(
         if not token_str or not hasattr(tokenizer, "convert_tokens_to_ids"):
             return None
         try:
-            tid = tokenizer.convert_tokens_to_ids(token_str)
-        except Exception:  # pragma: no cover
+            token_id = tokenizer.convert_tokens_to_ids(token_str)
+        except Exception:
             return None
 
-        if not isinstance(tid, int) or tid < 0:
+        if not isinstance(token_id, int) or token_id < 0:
             return None
 
         # Ensure it's registered as special and not UNK, and within vocab
@@ -59,37 +53,32 @@ def resolve_mask_token_id(
         specials = set(getattr(tokenizer, "all_special_tokens", []) or [])
         addl = set(getattr(tokenizer, "additional_special_tokens", []) or [])
         is_special = token_str in specials or token_str in addl
-        in_vocab = vocab_size is None or tid < vocab_size
-        if (unk_id is not None and tid == unk_id) or not is_special or not in_vocab:
+        in_vocab = vocab_size is None or token_id < vocab_size
+        if (
+            (unk_id is not None and token_id == unk_id)
+            or not is_special
+            or not in_vocab
+        ):
             return None
-        return tid
+        return token_id
 
-    # Try mask token string from config (prefixed or legacy), else default
-    token_str = None
-    if hasattr(cfg, "diffusion_mask_token_str"):
-        token_str = getattr(cfg, "diffusion_mask_token_str")
-    elif hasattr(cfg, "mask_token_str"):
-        token_str = getattr(cfg, "mask_token_str")
-    elif hasattr(cfg, "get"):
-        token_str = cfg.get("diffusion_mask_token_str") or cfg.get("mask_token_str")
+    # Try mask token string if provided
+    token_str = cfg.diffusion_mask_token_str
     for candidate in (token_str, default_token):
-        tid = _existing_special_token_id(candidate)
-        if isinstance(tid, int):
+        token_id = _existing_special_token_id(candidate)
+        if isinstance(token_id, int):
             try:
-                cfg.diffusion_mask_token_id = int(tid)
+                cfg.diffusion_mask_token_id = int(token_id)
             except Exception:
                 pass
-            try:
-                cfg.mask_token_id = int(tid)
-            except Exception:
-                pass
-            return int(tid)
+            return int(token_id)
 
     # Optionally add and return a dedicated special token during training
     if allow_add and hasattr(tokenizer, "add_special_tokens"):
         token_to_add = token_str or default_token
         try:
             tokenizer.add_special_tokens({"additional_special_tokens": [token_to_add]})
+
             # Resize embeddings if possible
             if (
                 model is not None
@@ -98,7 +87,7 @@ def resolve_mask_token_id(
             ):
                 try:
                     model.resize_token_embeddings(len(tokenizer))
-                except Exception:  # pragma: no cover
+                except Exception:
                     pass
             new_id = tokenizer.convert_tokens_to_ids(token_to_add)
             if isinstance(new_id, int) and new_id >= 0:
@@ -106,12 +95,8 @@ def resolve_mask_token_id(
                     cfg.diffusion_mask_token_id = int(new_id)
                 except Exception:
                     pass
-                try:
-                    cfg.mask_token_id = int(new_id)
-                except Exception:
-                    pass
                 return int(new_id)
-        except Exception:  # pragma: no cover
+        except Exception:
             pass
 
     # Fallback to unk or 0 (do not update cfg)

--- a/src/axolotl/loaders/adapter.py
+++ b/src/axolotl/loaders/adapter.py
@@ -14,6 +14,7 @@ from peft import (
     PeftConfig,
     PeftMixedModel,
     PeftModel,
+    TaskType,
     get_peft_model,
 )
 from transformers import PreTrainedModel
@@ -101,6 +102,15 @@ def load_lora(
     if cfg.peft_trainable_token_indices:
         lora_config_kwargs["trainable_token_indices"] = cfg.peft_trainable_token_indices
 
+    # Determine the correct PEFT task type
+    model_cls = type(model).__name__
+    if "SequenceClassification" in model_cls:
+        task_type = TaskType.SEQ_CLS
+    elif "TokenClassification" in model_cls:
+        task_type = TaskType.TOKEN_CLS
+    else:
+        task_type = TaskType.CAUSAL_LM
+
     lora_config = LoraConfig(
         r=cfg.lora_r,
         lora_alpha=cfg.lora_alpha,
@@ -112,7 +122,7 @@ def load_lora(
         fan_in_fan_out=cfg.lora_fan_in_fan_out,
         modules_to_save=cfg.lora_modules_to_save if cfg.lora_modules_to_save else None,
         bias="none",
-        task_type="CAUSAL_LM",
+        task_type=task_type,
         **lora_config_kwargs,
     )
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -694,7 +694,6 @@ class ModelLoader:
         """Load model from pretrained weights."""
         loader = model_loader_class or self.auto_model_loader
         kwargs = {
-            **self.model_kwargs,
             "config": self.model_config,
             "trust_remote_code": self.cfg.trust_remote_code or False,
             **self.model_kwargs,

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -674,10 +674,10 @@ class ModelLoader:
         return hf_ds_cfg
 
     def _load_model_from_config(self, model_loader_class=None) -> PreTrainedModel:
-        """Load model with random initialization using from_config.
+        """
+        Load model with random initialization using from_config.
 
         Uses the selected loader when provided; otherwise falls back to the auto loader.
-        For auto loaders, forward trust_remote_code. Cast to cfg.torch_dtype when set.
         """
         loader = model_loader_class or self.auto_model_loader
         if loader in [AutoModelForCausalLM, AutoModelForVision2Seq]:

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -673,6 +673,23 @@ class ModelLoader:
 
         return hf_ds_cfg
 
+    def _load_model_from_config(self) -> PreTrainedModel:
+        """Load model with random initialization using from_config."""
+        if self.auto_model_loader in [AutoModelForCausalLM, AutoModelForVision2Seq]:
+            return self.auto_model_loader.from_config(config=self.model_config)
+        return self.auto_model_loader(config=self.model_config)
+
+    def _load_model_from_pretrained(self, model_loader_class=None) -> PreTrainedModel:
+        """Load model from pretrained weights."""
+        loader = model_loader_class or self.auto_model_loader
+        kwargs = {
+            **self.model_kwargs,
+            "config": self.model_config,
+            "trust_remote_code": self.cfg.trust_remote_code or False,
+            **self.model_kwargs,
+        }
+        return loader.from_pretrained(self.base_model, **kwargs)
+
     def _build_model(self) -> bool:
         """Load model, with load strategy depending on config."""
         skip_move_to_device = False
@@ -687,7 +704,8 @@ class ModelLoader:
         if self.is_fsdp_enabled:
             if self.cfg.fsdp_config.cpu_ram_efficient_loading:
                 skip_move_to_device = True
-                # Don't delete device_map for QLoRA + FSDP - it was set correctly in _set_device_map
+                # Don't delete device_map for QLoRA + FSDP - it was set correctly in
+                # _set_device_map
                 if (
                     "device_map" in self.model_kwargs
                     and not self.is_qlora_and_fsdp_enabled
@@ -716,6 +734,11 @@ class ModelLoader:
                 or self.cfg.qlora_sharded_model_loading
             )
         ):
+            if self.cfg.reinit_weights:
+                LOG.warning(
+                    "reinit_weights is not supported with sharded quantized loading. "
+                    "Loading from pretrained weights instead."
+                )
             quant_storage = self.cfg.torch_dtype
             quantization_config = getattr(
                 self.model_config, "quantization_config", None
@@ -731,33 +754,12 @@ class ModelLoader:
                 quantization_config=quantization_config,
             )
             skip_move_to_device = True
-        elif (
-            self.model_config.model_type in ["llama", "llama4"]
-            and not self.cfg.trust_remote_code
-            and not self.cfg.gptq
-        ):
-            # Please don't remove underscore binding without reading the fn docstring.
-            _ = self._configure_zero3_memory_efficient_loading()
-
-            # Load model with random initialization if specified
-            if self.cfg.random_init_weights:
-                # AutoModel classes support the from_config method
-                if self.auto_model_loader in [
-                    AutoModelForCausalLM,
-                    AutoModelForVision2Seq,
-                ]:
-                    self.model = self.auto_model_loader.from_config(
-                        config=self.model_config,
-                    )
-                else:
-                    self.model = self.auto_model_loader(config=self.model_config)
-            else:
-                self.model = self.auto_model_loader.from_pretrained(
-                    self.base_model,
-                    config=self.model_config,
-                    **self.model_kwargs,
-                )
         elif self.model_type == "MambaLMHeadModel":
+            if self.cfg.reinit_weights:
+                LOG.warning(
+                    "reinit_weights is not supported with MambaLMHeadModel. "
+                    "Loading from pretrained weights instead."
+                )
             # FIXME this is janky at best and hacked together to make it work
             MambaLMHeadModel = fix_mamba_attn_for_loss()
 
@@ -770,41 +772,27 @@ class ModelLoader:
                 self.base_model,
                 **self.model_kwargs,
             )
-        elif (
-            self.model_type
-            and self.model_type != "AutoModelForCausalLM"
-            and not self.cfg.trust_remote_code
-        ):
-            if self.cfg.gptq:
-                self.model = self.auto_model_loader.from_pretrained(
-                    self.base_model,
-                    config=self.model_config,
-                    trust_remote_code=self.cfg.trust_remote_code or False,
-                    **self.model_kwargs,
-                )
-            else:
-                self.model = getattr(transformers, self.model_type).from_pretrained(
-                    self.base_model,
-                    config=self.model_config,
-                    trust_remote_code=self.cfg.trust_remote_code or False,
-                    **self.model_kwargs,
-                )
-        elif self.cfg.gptq:
-            self.model = self.auto_model_loader.from_pretrained(
-                self.base_model,
-                config=self.model_config,
-                trust_remote_code=self.cfg.trust_remote_code or False,
-                **self.model_kwargs,
-            )
         else:
-            # Please don't remove underscore binding without reading the fn docstring.
+            # Please don't remove underscore binding without reading the fn docstring
             _ = self._configure_zero3_memory_efficient_loading()
-            self.model = self.auto_model_loader.from_pretrained(
-                self.base_model,
-                config=self.model_config,
-                trust_remote_code=self.cfg.trust_remote_code or False,
-                **self.model_kwargs,
-            )
+
+            if (
+                self.model_type
+                and self.model_type != "AutoModelForCausalLM"
+                and not self.cfg.trust_remote_code
+                and not self.cfg.gptq
+            ):
+                # Use model type from transformers
+                model_loader_class = getattr(transformers, self.model_type)
+            else:
+                # Use auto model loader (handles gptq and default cases)
+                model_loader_class = self.auto_model_loader
+
+            if self.cfg.reinit_weights:
+                self.model = self._load_model_from_config()
+            else:
+                self.model = self._load_model_from_pretrained(model_loader_class)
+
         if is_deepspeed_zero3_enabled():
             skip_move_to_device = True
 

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -3,8 +3,8 @@
 Applies pre- and post-model load patches for various fixes and optimizations.
 """
 
-import os
 import importlib.util
+import os
 from functools import cached_property
 
 import addict
@@ -468,8 +468,9 @@ class PatchManager:
 
     def _apply_patch_deepspeed_zero3(self):
         try:
-            from axolotl.monkeypatch.deepspeed_utils import apply_deepspeed_patches
             from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
+
+            from axolotl.monkeypatch.deepspeed_utils import apply_deepspeed_patches
 
             if self.cfg.activation_offloading is True and (
                 is_deepspeed_zero3_enabled()

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -160,9 +160,11 @@ def get_state_dict(self, model, unwrap=True):
                 state_dict[param_name] = param.cpu()
             torch.distributed.barrier()
     elif self.distributed_type == DistributedType.FSDP:
-        from torch.distributed.fsdp import FullStateDictConfig
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        from torch.distributed.fsdp import StateDictType
+        from torch.distributed.fsdp import (
+            FullStateDictConfig,
+            FullyShardedDataParallel as FSDP,
+            StateDictType,
+        )
 
         full_state_dict_config = FullStateDictConfig(
             offload_to_cpu=True, rank0_only=True

--- a/src/axolotl/monkeypatch/attention/flex_attn.py
+++ b/src/axolotl/monkeypatch/attention/flex_attn.py
@@ -1,11 +1,12 @@
 """Flex attention monkey patch"""
 
 import sys
-from packaging import version
 
 import torch
 import transformers
+from packaging import version
 from transformers.utils.import_utils import _torch_version, is_torch_less_or_equal
+
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)

--- a/src/axolotl/monkeypatch/deepspeed_utils.py
+++ b/src/axolotl/monkeypatch/deepspeed_utils.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.util
+
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)

--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -17,8 +17,8 @@ from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
 from axolotl.utils.schemas.config import (
     AxolotlConfigWCapabilities as AxolotlConfigWCapabilitiesBase,
+    AxolotlInputConfig as AxolotlInputConfigBase,
 )
-from axolotl.utils.schemas.config import AxolotlInputConfig as AxolotlInputConfigBase
 from axolotl.utils.schemas.datasets import DPODataset, KTODataset, SFTDataset
 
 LOG = get_logger(__name__)

--- a/src/axolotl/utils/data/__init__.py
+++ b/src/axolotl/utils/data/__init__.py
@@ -1,13 +1,13 @@
 """Init for `axolotl.utils.data` module."""
 
-from axolotl.utils.data.streaming import (
-    encode_streaming,
-    wrap_streaming_dataset,
-)
 from axolotl.utils.data.rl import prepare_preference_datasets
 from axolotl.utils.data.sft import (
     get_dataset_wrapper,
     prepare_datasets,
+)
+from axolotl.utils.data.streaming import (
+    encode_streaming,
+    wrap_streaming_dataset,
 )
 from axolotl.utils.data.utils import md5
 

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -16,7 +16,6 @@ from transformers import PreTrainedTokenizer, ProcessorMixin
 
 from axolotl.prompters import Prompter
 from axolotl.utils.data.lock import FileLockLoader
-from axolotl.utils.data.streaming import wrap_streaming_dataset
 from axolotl.utils.data.shared import (
     create_train_validation_split,
     datasets_with_name_generator,
@@ -27,6 +26,7 @@ from axolotl.utils.data.shared import (
     save_preprocessed_dataset,
     try_load_from_hub,
 )
+from axolotl.utils.data.streaming import wrap_streaming_dataset
 from axolotl.utils.data.utils import (
     deduplicate_and_log_datasets,
     handle_long_seq_in_dataset,

--- a/src/axolotl/utils/environment.py
+++ b/src/axolotl/utils/environment.py
@@ -6,8 +6,6 @@ from importlib.metadata import version
 
 from accelerate.utils.environment import (
     check_cuda_p2p_ib_support as accelerate_check_cuda_p2p_ib_support,
-)
-from accelerate.utils.environment import (
     get_gpu_info,
 )
 from packaging.version import Version, parse

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -106,6 +106,12 @@ class AxolotlInputConfig(
             "description": "Don't upcast the embeddings to float32 when using PEFT. Useful for low-VRAM GPUs"
         },
     )
+    reinit_weights: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Reinitialize model weights randomly instead of loading pretrained weights"
+        },
+    )
 
     trainer_cls: str | None = Field(
         default=None,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -14,7 +14,6 @@ from transformers.utils.import_utils import is_torch_npu_available
 from axolotl.utils.logging import get_logger
 from axolotl.utils.schemas.enums import ChatTemplate, RingAttnFunc, RLType
 
-
 LOG = get_logger(__name__)
 
 SUPPORTED_METRICS = {"sacrebleu", "comet", "ter", "chrf", "perplexity"}

--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -45,18 +45,21 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 3,
-                # Diffusion sample generation
-                "diffusion_generate_samples": True,
-                "diffusion_generation_interval": 1,
-                "diffusion_num_generation_samples": 1,
-                "diffusion_generation_steps": 2,
-                "diffusion_generation_max_length": 32,
-                "diffusion_generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "diffusion_mask_token_id": 16,
-                "diffusion_eps": 1e-3,
-                "diffusion_importance_weighting": False,
+                "diffusion": {
+                    # sample generation
+                    "generate_samples": True,
+                    "generation_interval": 1,
+                    "num_generation_samples": 1,
+                    "generation_steps": 2,
+                    "generation_max_length": 32,
+                    "generation_temperature": 0.0,
+                    # training-specific
+                    "mask_token_id": 16,
+                    "eps": 1e-3,
+                    "importance_weighting": False,
+                },
             }
         )
 
@@ -98,18 +101,21 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 2,
-                # Diffusion sample generation
-                "diffusion_generate_samples": True,
-                "diffusion_generation_interval": 1,
-                "diffusion_num_generation_samples": 1,
-                "diffusion_generation_steps": 2,
-                "diffusion_generation_max_length": 32,
-                "diffusion_generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "diffusion_mask_token_id": 16,
-                "diffusion_eps": 1e-3,
-                "diffusion_importance_weighting": True,
+                "diffusion": {
+                    # sample generation
+                    "generate_samples": True,
+                    "generation_interval": 1,
+                    "num_generation_samples": 1,
+                    "generation_steps": 2,
+                    "generation_max_length": 32,
+                    "generation_temperature": 0.0,
+                    # training-specific
+                    "mask_token_id": 16,
+                    "eps": 1e-3,
+                    "importance_weighting": True,
+                },
                 # Ensure we have proper SFT labels
                 "train_on_inputs": False,
             }

--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -45,18 +45,18 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 3,
-                # Enable lightweight sample generation via callback
-                "generate_samples": True,
-                "generation_interval": 1,
-                "num_generation_samples": 1,
-                "generation_steps": 2,
-                "generation_max_length": 32,
-                "generation_temperature": 0.0,
+                # Diffusion sample generation
+                "diffusion_generate_samples": True,
+                "diffusion_generation_interval": 1,
+                "diffusion_num_generation_samples": 1,
+                "diffusion_generation_steps": 2,
+                "diffusion_generation_max_length": 32,
+                "diffusion_generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "mask_token_id": 16,
-                "eps": 1e-3,
-                "importance_weighting": False,
+                "diffusion_mask_token_id": 16,
+                "diffusion_eps": 1e-3,
+                "diffusion_importance_weighting": False,
             }
         )
 
@@ -98,18 +98,18 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 2,
-                # Enable lightweight sample generation via callback
-                "generate_samples": True,
-                "generation_interval": 1,
-                "num_generation_samples": 1,
-                "generation_steps": 2,
-                "generation_max_length": 32,
-                "generation_temperature": 0.0,
+                # Diffusion sample generation
+                "diffusion_generate_samples": True,
+                "diffusion_generation_interval": 1,
+                "diffusion_num_generation_samples": 1,
+                "diffusion_generation_steps": 2,
+                "diffusion_generation_max_length": 32,
+                "diffusion_generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "mask_token_id": 16,
-                "eps": 1e-3,
-                "importance_weighting": True,
+                "diffusion_mask_token_id": 16,
+                "diffusion_eps": 1e-3,
+                "diffusion_importance_weighting": True,
                 # Ensure we have proper SFT labels
                 "train_on_inputs": False,
             }

--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -45,11 +45,18 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 3,
+                # Enable lightweight sample generation via callback
+                "generate_samples": True,
+                "generation_interval": 1,
+                "num_generation_samples": 1,
+                "generation_steps": 2,
+                "generation_max_length": 32,
+                "generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "diffusion_mask_token_id": 16,
-                "diffusion_eps": 1e-3,
-                "diffusion_importance_weighting": False,
+                "mask_token_id": 16,
+                "eps": 1e-3,
+                "importance_weighting": False,
             }
         )
 
@@ -91,11 +98,18 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 2,
+                # Enable lightweight sample generation via callback
+                "generate_samples": True,
+                "generation_interval": 1,
+                "num_generation_samples": 1,
+                "generation_steps": 2,
+                "generation_max_length": 32,
+                "generation_temperature": 0.0,
                 # Diffusion-specific config
                 "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
-                "diffusion_mask_token_id": 16,
-                "diffusion_eps": 1e-3,
-                "diffusion_importance_weighting": True,
+                "mask_token_id": 16,
+                "eps": 1e-3,
+                "importance_weighting": True,
                 # Ensure we have proper SFT labels
                 "train_on_inputs": False,
             }

--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -1,0 +1,138 @@
+"""
+E2E smoke test for diffusion training plugin
+"""
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config
+from axolotl.utils.dict import DictDefault
+
+from tests.e2e.utils import check_model_output_exists
+
+
+class TestDiffusion:
+    """
+    Test case for diffusion training plugin
+    """
+
+    def test_diffusion_smoke_test(self, temp_dir):
+        """
+        Smoke test for diffusion training to ensure the plugin loads and trains without error.
+        """
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "tokenizer_type": "AutoTokenizer",
+                "trust_remote_code": True,
+                "sequence_len": 256,
+                "val_set_size": 0.1,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "max_steps": 3,  # Very short for smoke test
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.0001,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "bf16": True,
+                "save_safetensors": True,
+                "save_first_step": False,
+                "logging_steps": 1,
+                "eval_steps": 3,
+                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
+                # Diffusion-specific config
+                "diffusion_mask_token_id": 32000,
+                "diffusion_eps": 1e-3,
+                "diffusion_importance_weighting": False,
+            }
+        )
+
+        # Normalize and validate config
+        cfg = normalize_config(cfg)
+        cfg = validate_config(cfg)
+
+        # Load datasets to ensure they work with diffusion training
+        datasets_meta = load_datasets(cfg=cfg, cli_args=DictDefault({}))
+        assert datasets_meta.train_dataset is not None
+        assert len(datasets_meta.train_dataset) > 0
+
+        # Run training
+        train(cfg=cfg, cli_args=DictDefault({}), dataset_meta=datasets_meta)
+
+        # Check that model was saved
+        check_model_output_exists(cfg)
+
+    def test_diffusion_sft_labels(self, temp_dir):
+        """
+        Test that diffusion training properly handles SFT data with labels.
+        """
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "tokenizer_type": "AutoTokenizer",
+                "trust_remote_code": True,
+                "sequence_len": 256,
+                "val_set_size": 0.1,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "max_steps": 2,  # Very short for smoke test
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.0001,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "bf16": True,
+                "save_safetensors": True,
+                "save_first_step": False,
+                "logging_steps": 1,
+                "eval_steps": 2,
+                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
+                # Diffusion-specific config
+                "diffusion_mask_token_id": 32000,
+                "diffusion_eps": 1e-3,
+                "diffusion_importance_weighting": True,  # Test importance weighting
+                # Ensure we have proper SFT labels
+                "train_on_inputs": False,  # This ensures prompt tokens get -100 labels
+            }
+        )
+
+        # Normalize and validate config
+        cfg = normalize_config(cfg)
+        cfg = validate_config(cfg)
+
+        # Load datasets
+        datasets_meta = load_datasets(cfg=cfg, cli_args=DictDefault({}))
+        
+        # Verify that the dataset has labels
+        sample = datasets_meta.train_dataset[0]
+        assert "labels" in sample, "SFT dataset should have labels"
+        
+        # Check that some labels are -100 (prompt tokens)
+        labels = sample["labels"]
+        if hasattr(labels, "tolist"):
+            labels = labels.tolist()
+        assert -100 in labels, "SFT dataset should have -100 labels for prompt tokens"
+
+        # Run training
+        train(cfg=cfg, cli_args=DictDefault({}), dataset_meta=datasets_meta)
+
+        # Check that model was saved
+        check_model_output_exists(cfg)

--- a/tests/e2e/test_diffusion.py
+++ b/tests/e2e/test_diffusion.py
@@ -1,6 +1,4 @@
-"""
-E2E smoke test for diffusion training plugin
-"""
+"""E2E smoke test for diffusion training plugin."""
 
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
@@ -11,13 +9,12 @@ from tests.e2e.utils import check_model_output_exists
 
 
 class TestDiffusion:
-    """
-    Test case for diffusion training plugin
-    """
+    """Test case for diffusion training plugin."""
 
     def test_diffusion_smoke_test(self, temp_dir):
         """
-        Smoke test for diffusion training to ensure the plugin loads and trains without error.
+        Smoke test for diffusion training to ensure the plugin loads and trains without
+        error.
         """
         cfg = DictDefault(
             {
@@ -36,7 +33,7 @@ class TestDiffusion:
                     },
                 ],
                 "num_epochs": 1,
-                "max_steps": 3,  # Very short for smoke test
+                "max_steps": 3,
                 "micro_batch_size": 1,
                 "gradient_accumulation_steps": 1,
                 "output_dir": temp_dir,
@@ -48,33 +45,23 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 3,
-                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
                 # Diffusion-specific config
-                "diffusion_mask_token_id": 32000,
+                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
+                "diffusion_mask_token_id": 16,
                 "diffusion_eps": 1e-3,
                 "diffusion_importance_weighting": False,
             }
         )
 
-        # Normalize and validate config
-        cfg = normalize_config(cfg)
         cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
 
-        # Load datasets to ensure they work with diffusion training
-        datasets_meta = load_datasets(cfg=cfg, cli_args=DictDefault({}))
-        assert datasets_meta.train_dataset is not None
-        assert len(datasets_meta.train_dataset) > 0
-
-        # Run training
-        train(cfg=cfg, cli_args=DictDefault({}), dataset_meta=datasets_meta)
-
-        # Check that model was saved
-        check_model_output_exists(cfg)
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
 
     def test_diffusion_sft_labels(self, temp_dir):
-        """
-        Test that diffusion training properly handles SFT data with labels.
-        """
+        """Test that diffusion training properly handles SFT data with labels."""
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",
@@ -92,7 +79,7 @@ class TestDiffusion:
                     },
                 ],
                 "num_epochs": 1,
-                "max_steps": 2,  # Very short for smoke test
+                "max_steps": 3,
                 "micro_batch_size": 1,
                 "gradient_accumulation_steps": 1,
                 "output_dir": temp_dir,
@@ -104,35 +91,29 @@ class TestDiffusion:
                 "save_first_step": False,
                 "logging_steps": 1,
                 "eval_steps": 2,
-                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
                 # Diffusion-specific config
-                "diffusion_mask_token_id": 32000,
+                "plugins": ["axolotl.integrations.diffusion.DiffusionPlugin"],
+                "diffusion_mask_token_id": 16,
                 "diffusion_eps": 1e-3,
-                "diffusion_importance_weighting": True,  # Test importance weighting
+                "diffusion_importance_weighting": True,
                 # Ensure we have proper SFT labels
-                "train_on_inputs": False,  # This ensures prompt tokens get -100 labels
+                "train_on_inputs": False,
             }
         )
 
-        # Normalize and validate config
-        cfg = normalize_config(cfg)
         cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
 
-        # Load datasets
-        datasets_meta = load_datasets(cfg=cfg, cli_args=DictDefault({}))
-        
         # Verify that the dataset has labels
-        sample = datasets_meta.train_dataset[0]
+        sample = dataset_meta.train_dataset[0]
         assert "labels" in sample, "SFT dataset should have labels"
-        
+
         # Check that some labels are -100 (prompt tokens)
         labels = sample["labels"]
         if hasattr(labels, "tolist"):
             labels = labels.tolist()
         assert -100 in labels, "SFT dataset should have -100 labels for prompt tokens"
 
-        # Run training
-        train(cfg=cfg, cli_args=DictDefault({}), dataset_meta=datasets_meta)
-
-        # Check that model was saved
-        check_model_output_exists(cfg)
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -222,15 +222,16 @@ class TestDiffusionTrainer:
         assert loss.item() == 0.0
         assert loss.requires_grad
 
-    def test_cache_special_token_ids(self, diffusion_trainer_instance):
+    def test_cache_special_token_ids(self, mock_tokenizer):
         """Test caching of special token IDs."""
-        # Should cache BOS, EOS, PAD tokens
-        expected_tokens = {0, 1, 2}  # pad, bos, eos
-        assert diffusion_trainer_instance._special_token_ids == expected_tokens
+        trainer = object.__new__(DiffusionTrainer)
+        trainer.processing_class = mock_tokenizer
+        trainer._cache_special_token_ids()
+        assert trainer._special_token_ids == {0, 1, 2}
 
     def test_cache_special_token_ids_no_tokenizer(self):
         """Test caching when no tokenizer is available."""
-        trainer = object.__new__(DiffusionTrainer)  # Bypass __init__
+        trainer = object.__new__(DiffusionTrainer)
         trainer.processing_class = None
         trainer._cache_special_token_ids()
 

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -67,7 +67,7 @@ class TestDiffusionTrainer:
         assert not masked_indices[special_token_positions].any()
 
         # Check that mask token is applied
-        mask_token_id = diffusion_trainer_instance._config.mask_token_id
+        mask_token_id = diffusion_trainer_instance.config.mask_token_id
         masked_positions = masked_indices
         if masked_positions.any():
             assert (noisy_batch[masked_positions] == mask_token_id).all()
@@ -131,7 +131,7 @@ class TestDiffusionTrainer:
         self, diffusion_trainer_instance
     ):
         """Test bidirectional attention mask with sample packing."""
-        diffusion_trainer_instance._config.sample_packing = True
+        diffusion_trainer_instance.config.sample_packing = True
         input_ids = torch.tensor([[1, 10, 20, 30, 40, 2]], dtype=torch.long)
         # Sample IDs: first sample (1), second sample (2)
         attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -67,7 +67,7 @@ class TestDiffusionTrainer:
         assert not masked_indices[special_token_positions].any()
 
         # Check that mask token is applied
-        mask_token_id = diffusion_trainer_instance.config.diffusion_mask_token_id
+        mask_token_id = diffusion_trainer_instance.cfg.diffusion_mask_token_id
         masked_positions = masked_indices
         if masked_positions.any():
             assert (noisy_batch[masked_positions] == mask_token_id).all()
@@ -131,7 +131,7 @@ class TestDiffusionTrainer:
         self, diffusion_trainer_instance
     ):
         """Test bidirectional attention mask with sample packing."""
-        diffusion_trainer_instance.config.sample_packing = True
+        diffusion_trainer_instance.cfg.sample_packing = True
         input_ids = torch.tensor([[1, 10, 20, 30, 40, 2]], dtype=torch.long)
         # Sample IDs: first sample (1), second sample (2)
         attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -1,0 +1,273 @@
+"""Tests for diffusion trainer integration."""
+
+import pytest
+import torch
+from unittest.mock import Mock
+
+from axolotl.integrations.diffusion.trainer import DiffusionTrainer
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.fixture
+def mock_tokenizer():
+    """Create a mock tokenizer."""
+    tokenizer = Mock()
+    tokenizer.bos_token_id = 1
+    tokenizer.eos_token_id = 2
+    tokenizer.pad_token_id = 0
+    return tokenizer
+
+
+@pytest.fixture
+def diffusion_config():
+    """Create a diffusion config."""
+    return DictDefault({
+        "mask_token_id": 32000,
+        "eps": 1e-3,
+        "importance_weighting": False,
+        "sample_packing": False,
+    })
+
+
+@pytest.fixture
+def diffusion_trainer(mock_tokenizer, diffusion_config):
+    """Create a diffusion trainer instance."""
+    # Create a mock model to satisfy Trainer's requirements
+    mock_model = Mock()
+    mock_model.training = True
+    
+    trainer = DiffusionTrainer(model=mock_model)
+    trainer.processing_class = mock_tokenizer
+    trainer.set_config(diffusion_config)
+    return trainer
+
+
+class TestDiffusionTrainer:
+    """Test the DiffusionTrainer class."""
+
+    def test_forward_process_basic(self, diffusion_trainer):
+        """Test basic forward process without labels."""
+        input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
+        
+        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
+            input_ids, eps=0.1
+        )
+        
+        # Check shapes
+        assert noisy_batch.shape == input_ids.shape
+        assert masked_indices.shape == input_ids.shape
+        assert p_mask.shape == input_ids.shape
+        
+        # Check that special tokens are not masked
+        special_token_positions = (input_ids == 1) | (input_ids == 2) | (input_ids == 0)
+        assert not masked_indices[special_token_positions].any()
+        
+        # Check that mask token is applied
+        mask_token_id = diffusion_trainer._config.mask_token_id
+        masked_positions = masked_indices
+        if masked_positions.any():
+            assert (noisy_batch[masked_positions] == mask_token_id).all()
+
+    def test_forward_process_with_labels(self, diffusion_trainer):
+        """Test forward process with SFT labels."""
+        input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
+        labels = torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long)
+        
+        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
+            input_ids, labels=labels, eps=0.1
+        )
+        
+        # Check shapes
+        assert noisy_batch.shape == input_ids.shape
+        assert masked_indices.shape == input_ids.shape
+        assert p_mask.shape == input_ids.shape
+        
+        # Check that only answer tokens can be masked (where labels != -100)
+        answer_mask = labels != -100
+        non_answer_mask = labels == -100
+        
+        # No masking should occur on non-answer tokens
+        assert not masked_indices[non_answer_mask].any()
+        
+        # Check that probabilities are zero for non-answer tokens
+        assert (p_mask[non_answer_mask] == 0).all()
+
+    def test_forward_process_with_attention_mask(self, diffusion_trainer):
+        """Test forward process with attention mask."""
+        input_ids = torch.tensor([[1, 10, 20, 0]], dtype=torch.long)
+        attention_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
+        
+        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
+            input_ids, attention_mask=attention_mask, eps=0.1
+        )
+        
+        # Check that padding tokens are not masked
+        padding_positions = attention_mask == 0
+        assert not masked_indices[padding_positions].any()
+        assert (p_mask[padding_positions] == 0).all()
+
+    def test_bidirectional_attention_mask_no_packing(self, diffusion_trainer):
+        """Test bidirectional attention mask without sample packing."""
+        input_ids = torch.tensor([[1, 10, 20, 2]], dtype=torch.long)
+        
+        mask = diffusion_trainer._create_bidirectional_attention_mask(input_ids)
+        
+        # Should be all-to-all attention
+        expected_shape = (1, 1, 4, 4)
+        assert mask.shape == expected_shape
+        assert mask.all()
+
+    def test_bidirectional_attention_mask_with_packing(self, diffusion_trainer):
+        """Test bidirectional attention mask with sample packing."""
+        diffusion_trainer._config.sample_packing = True
+        input_ids = torch.tensor([[1, 10, 20, 30, 40, 2]], dtype=torch.long)
+        # Sample IDs: first sample (1), second sample (2)
+        attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)
+        
+        mask = diffusion_trainer._create_bidirectional_attention_mask(
+            input_ids, attention_mask
+        )
+        
+        # Check that tokens within same sample can attend to each other
+        # but not across samples
+        assert mask[0, 0, 0, 1].item()  # First sample tokens can attend to each other
+        assert mask[0, 0, 1, 2].item()
+        assert not mask[0, 0, 0, 3].item()  # Can't attend across samples
+        assert not mask[0, 0, 2, 4].item()
+        assert mask[0, 0, 3, 4].item()  # Second sample tokens can attend to each other
+
+    def test_compute_loss_basic(self, diffusion_trainer):
+        """Test basic loss computation."""
+        # Mock model that returns logits
+        mock_model = Mock()
+        mock_outputs = Mock()
+        vocab_size = 1000
+        seq_len = 5
+        mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
+        mock_model.return_value = mock_outputs
+        mock_model.training = True
+        
+        input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
+        
+        # Mock the store_metrics method
+        diffusion_trainer.store_metrics = Mock()
+        
+        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+            mock_model, input_ids
+        )
+        
+        # Check that loss is computed
+        assert isinstance(loss, torch.Tensor)
+        assert loss.requires_grad
+        assert outputs == mock_outputs
+        
+        # Check that metrics were stored
+        diffusion_trainer.store_metrics.assert_called_once()
+
+    def test_compute_loss_with_labels(self, diffusion_trainer):
+        """Test loss computation with SFT labels."""
+        # Mock model
+        mock_model = Mock()
+        mock_outputs = Mock()
+        vocab_size = 1000
+        seq_len = 5
+        mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
+        mock_model.return_value = mock_outputs
+        mock_model.training = True
+        
+        input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
+        labels = torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long)
+        
+        # Mock the store_metrics method
+        diffusion_trainer.store_metrics = Mock()
+        
+        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+            mock_model, input_ids, labels=labels
+        )
+        
+        # Check that loss is computed
+        assert isinstance(loss, torch.Tensor)
+        assert loss.requires_grad
+        
+        # Check that SFT metrics were added
+        call_args = diffusion_trainer.store_metrics.call_args[0][0]
+        assert "answer_ratio" in call_args
+        assert "avg_answer_length" in call_args
+
+    def test_compute_loss_no_masked_tokens(self, diffusion_trainer):
+        """Test loss computation when no tokens are masked."""
+        # Mock model
+        mock_model = Mock()
+        mock_outputs = Mock()
+        vocab_size = 1000
+        seq_len = 3
+        mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
+        mock_model.return_value = mock_outputs
+        mock_model.training = True
+        
+        # Only special tokens (which won't be masked)
+        input_ids = torch.tensor([[1, 0, 2]], dtype=torch.long)
+        
+        # Mock the store_metrics method
+        diffusion_trainer.store_metrics = Mock()
+        
+        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+            mock_model, input_ids
+        )
+        
+        # Loss should be zero when no tokens are masked
+        assert loss.item() == 0.0
+        assert loss.requires_grad
+
+    def test_cache_special_token_ids(self, diffusion_trainer, mock_tokenizer):
+        """Test caching of special token IDs."""
+        # Should cache BOS, EOS, PAD tokens
+        expected_tokens = {0, 1, 2}  # pad, bos, eos
+        assert diffusion_trainer._special_token_ids == expected_tokens
+
+    def test_cache_special_token_ids_no_tokenizer(self):
+        """Test caching when no tokenizer is available."""
+        # Create a mock model to satisfy Trainer's requirements
+        mock_model = Mock()
+        trainer = DiffusionTrainer(model=mock_model)
+        trainer.processing_class = None
+        trainer._cache_special_token_ids()
+        
+        assert trainer._special_token_ids == set()
+
+    def test_main_compute_loss_interface(self, diffusion_trainer):
+        """Test the main compute_loss interface."""
+        # Mock model
+        mock_model = Mock()
+        mock_outputs = Mock()
+        mock_outputs.logits = torch.randn(1, 5, 1000)
+        mock_model.return_value = mock_outputs
+        mock_model.training = True
+        
+        # Mock the store_metrics method
+        diffusion_trainer.store_metrics = Mock()
+        
+        inputs = {
+            "input_ids": torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.long),
+            "labels": torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long),
+        }
+        
+        # Test without return_outputs
+        loss = diffusion_trainer.compute_loss(mock_model, inputs)
+        assert isinstance(loss, torch.Tensor)
+        
+        # Test with return_outputs
+        loss, outputs = diffusion_trainer.compute_loss(
+            mock_model, inputs, return_outputs=True
+        )
+        assert isinstance(loss, torch.Tensor)
+        assert outputs == mock_outputs
+
+    def test_missing_input_ids_raises_error(self, diffusion_trainer):
+        """Test that missing input_ids raises ValueError."""
+        mock_model = Mock()
+        inputs = {"attention_mask": torch.tensor([[1, 1, 1]])}
+        
+        with pytest.raises(ValueError, match="input_ids is required"):
+            diffusion_trainer.compute_loss(mock_model, inputs)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -26,9 +26,9 @@ def diffusion_config():
     """Create a diffusion config."""
     return DictDefault(
         {
-            "mask_token_id": 32000,
-            "eps": 1e-3,
-            "importance_weighting": False,
+            "diffusion_mask_token_id": 32000,
+            "diffusion_eps": 1e-3,
+            "diffusion_importance_weighting": False,
             "sample_packing": False,
         }
     )
@@ -67,7 +67,7 @@ class TestDiffusionTrainer:
         assert not masked_indices[special_token_positions].any()
 
         # Check that mask token is applied
-        mask_token_id = diffusion_trainer_instance.config.mask_token_id
+        mask_token_id = diffusion_trainer_instance.config.diffusion_mask_token_id
         masked_positions = masked_indices
         if masked_positions.any():
             assert (noisy_batch[masked_positions] == mask_token_id).all()

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -26,9 +26,11 @@ def diffusion_config():
     """Create a diffusion config."""
     return DictDefault(
         {
-            "diffusion_mask_token_id": 32000,
-            "diffusion_eps": 1e-3,
-            "diffusion_importance_weighting": False,
+            "diffusion": {
+                "mask_token_id": 32000,
+                "eps": 1e-3,
+                "importance_weighting": False,
+            },
             "sample_packing": False,
         }
     )
@@ -67,7 +69,7 @@ class TestDiffusionTrainer:
         assert not masked_indices[special_token_positions].any()
 
         # Check that mask token is applied
-        mask_token_id = diffusion_trainer_instance.cfg.diffusion_mask_token_id
+        mask_token_id = diffusion_trainer_instance.cfg.diffusion.mask_token_id
         masked_positions = masked_indices
         if masked_positions.any():
             assert (noisy_batch[masked_positions] == mask_token_id).all()

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from axolotl.integrations.diffusion.trainer import DiffusionTrainer
+from axolotl.integrations.diffusion import DiffusionTrainer
 from axolotl.utils.dict import DictDefault
 
 

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -137,7 +137,9 @@ class TestDiffusionTrainer:
         # Sample IDs: first sample (1), second sample (2)
         attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)
 
-        mask = create_bidirectional_attention_mask(input_ids, attention_mask)
+        mask = create_bidirectional_attention_mask(
+            input_ids, attention_mask, sample_packing=True
+        )
 
         # Check that tokens within same sample can attend to each other
         # but not across samples

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from axolotl.integrations.diffusion import DiffusionTrainer
+from axolotl.integrations.diffusion.utils import create_bidirectional_attention_mask
 from axolotl.utils.dict import DictDefault
 
 
@@ -120,9 +121,7 @@ class TestDiffusionTrainer:
         """Test bidirectional attention mask without sample packing."""
         input_ids = torch.tensor([[1, 10, 20, 2]], dtype=torch.long)
 
-        mask = diffusion_trainer_instance._create_bidirectional_attention_mask(
-            input_ids
-        )
+        mask = create_bidirectional_attention_mask(input_ids)
 
         # Should be all-to-all attention
         expected_shape = (1, 1, 4, 4)
@@ -138,9 +137,7 @@ class TestDiffusionTrainer:
         # Sample IDs: first sample (1), second sample (2)
         attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)
 
-        mask = diffusion_trainer_instance._create_bidirectional_attention_mask(
-            input_ids, attention_mask
-        )
+        mask = create_bidirectional_attention_mask(input_ids, attention_mask)
 
         # Check that tokens within same sample can attend to each other
         # but not across samples

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -174,7 +174,7 @@ class TestDiffusionTrainer:
         # Check that metrics were stored
         diffusion_trainer_instance.store_metrics.assert_called_once()
 
-    def test_compute_loss_with_labels(self, diffusion_trainer_instance):
+    def test_compute_loss_sft(self, diffusion_trainer_instance):
         """Test loss computation with SFT labels."""
         # Mock model
         mock_model = Mock()
@@ -184,6 +184,7 @@ class TestDiffusionTrainer:
         mock_outputs.logits = torch.randn(1, seq_len, vocab_size, requires_grad=True)
         mock_model.return_value = mock_outputs
         mock_model.training = True
+        diffusion_trainer_instance.cfg.datasets = Mock()
 
         input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
         labels = torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -1,8 +1,11 @@
 """Tests for diffusion trainer integration."""
 
+# pylint: disable=redefined-outer-name,protected-access
+
+from unittest.mock import Mock
+
 import pytest
 import torch
-from unittest.mock import Mock
 
 from axolotl.integrations.diffusion.trainer import DiffusionTrainer
 from axolotl.utils.dict import DictDefault
@@ -21,113 +24,122 @@ def mock_tokenizer():
 @pytest.fixture
 def diffusion_config():
     """Create a diffusion config."""
-    return DictDefault({
-        "mask_token_id": 32000,
-        "eps": 1e-3,
-        "importance_weighting": False,
-        "sample_packing": False,
-    })
+    return DictDefault(
+        {
+            "mask_token_id": 32000,
+            "eps": 1e-3,
+            "importance_weighting": False,
+            "sample_packing": False,
+        }
+    )
 
 
 @pytest.fixture
-def diffusion_trainer(mock_tokenizer, diffusion_config):
-    """Create a diffusion trainer instance."""
-    # Create a mock model to satisfy Trainer's requirements
-    mock_model = Mock()
-    mock_model.training = True
-    
-    trainer = DiffusionTrainer(model=mock_model)
+def diffusion_trainer_instance(mock_tokenizer, diffusion_config):
+    """Create a diffusion trainer instance for testing methods directly."""
+    # Create a minimal trainer instance just for testing methods
+    trainer = object.__new__(DiffusionTrainer)  # Bypass __init__
+    trainer.config = diffusion_config
+    trainer._special_token_ids = {0, 1, 2}  # pad, bos, eos
     trainer.processing_class = mock_tokenizer
-    trainer.set_config(diffusion_config)
+    trainer.store_metrics = Mock()  # Mock metrics storage
     return trainer
 
 
 class TestDiffusionTrainer:
     """Test the DiffusionTrainer class."""
 
-    def test_forward_process_basic(self, diffusion_trainer):
+    def test_forward_process_basic(self, diffusion_trainer_instance):
         """Test basic forward process without labels."""
         input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
-        
-        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
-            input_ids, eps=0.1
+
+        noisy_batch, masked_indices, p_mask = (
+            diffusion_trainer_instance._forward_process(input_ids, eps=0.1)
         )
-        
+
         # Check shapes
         assert noisy_batch.shape == input_ids.shape
         assert masked_indices.shape == input_ids.shape
         assert p_mask.shape == input_ids.shape
-        
+
         # Check that special tokens are not masked
         special_token_positions = (input_ids == 1) | (input_ids == 2) | (input_ids == 0)
         assert not masked_indices[special_token_positions].any()
-        
+
         # Check that mask token is applied
-        mask_token_id = diffusion_trainer._config.mask_token_id
+        mask_token_id = diffusion_trainer_instance._config.mask_token_id
         masked_positions = masked_indices
         if masked_positions.any():
             assert (noisy_batch[masked_positions] == mask_token_id).all()
 
-    def test_forward_process_with_labels(self, diffusion_trainer):
+    def test_forward_process_with_labels(self, diffusion_trainer_instance):
         """Test forward process with SFT labels."""
         input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
         labels = torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long)
-        
-        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
-            input_ids, labels=labels, eps=0.1
+
+        noisy_batch, masked_indices, p_mask = (
+            diffusion_trainer_instance._forward_process(
+                input_ids, labels=labels, eps=0.1
+            )
         )
-        
+
         # Check shapes
         assert noisy_batch.shape == input_ids.shape
         assert masked_indices.shape == input_ids.shape
         assert p_mask.shape == input_ids.shape
-        
+
         # Check that only answer tokens can be masked (where labels != -100)
-        answer_mask = labels != -100
         non_answer_mask = labels == -100
-        
+
         # No masking should occur on non-answer tokens
         assert not masked_indices[non_answer_mask].any()
-        
-        # Check that probabilities are zero for non-answer tokens
-        assert (p_mask[non_answer_mask] == 0).all()
 
-    def test_forward_process_with_attention_mask(self, diffusion_trainer):
+        # p_mask should be the same for all positions (sampled timestep),
+        # but masking is only applied to answer tokens
+        assert p_mask.shape == input_ids.shape
+        # Verify that masked_indices respects the answer mask
+        assert not masked_indices[non_answer_mask].any()
+
+    def test_forward_process_with_attention_mask(self, diffusion_trainer_instance):
         """Test forward process with attention mask."""
         input_ids = torch.tensor([[1, 10, 20, 0]], dtype=torch.long)
         attention_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
-        
-        noisy_batch, masked_indices, p_mask = diffusion_trainer._forward_process(
+
+        _, masked_indices, p_mask = diffusion_trainer_instance._forward_process(
             input_ids, attention_mask=attention_mask, eps=0.1
         )
-        
+
         # Check that padding tokens are not masked
         padding_positions = attention_mask == 0
         assert not masked_indices[padding_positions].any()
         assert (p_mask[padding_positions] == 0).all()
 
-    def test_bidirectional_attention_mask_no_packing(self, diffusion_trainer):
+    def test_bidirectional_attention_mask_no_packing(self, diffusion_trainer_instance):
         """Test bidirectional attention mask without sample packing."""
         input_ids = torch.tensor([[1, 10, 20, 2]], dtype=torch.long)
-        
-        mask = diffusion_trainer._create_bidirectional_attention_mask(input_ids)
-        
+
+        mask = diffusion_trainer_instance._create_bidirectional_attention_mask(
+            input_ids
+        )
+
         # Should be all-to-all attention
         expected_shape = (1, 1, 4, 4)
         assert mask.shape == expected_shape
         assert mask.all()
 
-    def test_bidirectional_attention_mask_with_packing(self, diffusion_trainer):
+    def test_bidirectional_attention_mask_with_packing(
+        self, diffusion_trainer_instance
+    ):
         """Test bidirectional attention mask with sample packing."""
-        diffusion_trainer._config.sample_packing = True
+        diffusion_trainer_instance._config.sample_packing = True
         input_ids = torch.tensor([[1, 10, 20, 30, 40, 2]], dtype=torch.long)
         # Sample IDs: first sample (1), second sample (2)
         attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.long)
-        
-        mask = diffusion_trainer._create_bidirectional_attention_mask(
+
+        mask = diffusion_trainer_instance._create_bidirectional_attention_mask(
             input_ids, attention_mask
         )
-        
+
         # Check that tokens within same sample can attend to each other
         # but not across samples
         assert mask[0, 0, 0, 1].item()  # First sample tokens can attend to each other
@@ -136,65 +148,59 @@ class TestDiffusionTrainer:
         assert not mask[0, 0, 2, 4].item()
         assert mask[0, 0, 3, 4].item()  # Second sample tokens can attend to each other
 
-    def test_compute_loss_basic(self, diffusion_trainer):
+    def test_compute_loss_basic(self, diffusion_trainer_instance):
         """Test basic loss computation."""
         # Mock model that returns logits
         mock_model = Mock()
         mock_outputs = Mock()
         vocab_size = 1000
         seq_len = 5
-        mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
+        mock_outputs.logits = torch.randn(1, seq_len, vocab_size, requires_grad=True)
         mock_model.return_value = mock_outputs
         mock_model.training = True
-        
+
         input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
-        
-        # Mock the store_metrics method
-        diffusion_trainer.store_metrics = Mock()
-        
-        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+
+        loss, outputs = diffusion_trainer_instance._compute_diffusion_loss(
             mock_model, input_ids
         )
-        
+
         # Check that loss is computed
         assert isinstance(loss, torch.Tensor)
         assert loss.requires_grad
         assert outputs == mock_outputs
-        
-        # Check that metrics were stored
-        diffusion_trainer.store_metrics.assert_called_once()
 
-    def test_compute_loss_with_labels(self, diffusion_trainer):
+        # Check that metrics were stored
+        diffusion_trainer_instance.store_metrics.assert_called_once()
+
+    def test_compute_loss_with_labels(self, diffusion_trainer_instance):
         """Test loss computation with SFT labels."""
         # Mock model
         mock_model = Mock()
         mock_outputs = Mock()
         vocab_size = 1000
         seq_len = 5
-        mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
+        mock_outputs.logits = torch.randn(1, seq_len, vocab_size, requires_grad=True)
         mock_model.return_value = mock_outputs
         mock_model.training = True
-        
+
         input_ids = torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long)
         labels = torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long)
-        
-        # Mock the store_metrics method
-        diffusion_trainer.store_metrics = Mock()
-        
-        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+
+        loss, _ = diffusion_trainer_instance._compute_diffusion_loss(
             mock_model, input_ids, labels=labels
         )
-        
+
         # Check that loss is computed
         assert isinstance(loss, torch.Tensor)
         assert loss.requires_grad
-        
+
         # Check that SFT metrics were added
-        call_args = diffusion_trainer.store_metrics.call_args[0][0]
+        call_args = diffusion_trainer_instance.store_metrics.call_args[0][0]
         assert "answer_ratio" in call_args
         assert "avg_answer_length" in call_args
 
-    def test_compute_loss_no_masked_tokens(self, diffusion_trainer):
+    def test_compute_loss_no_masked_tokens(self, diffusion_trainer_instance):
         """Test loss computation when no tokens are masked."""
         # Mock model
         mock_model = Mock()
@@ -204,38 +210,33 @@ class TestDiffusionTrainer:
         mock_outputs.logits = torch.randn(1, seq_len, vocab_size)
         mock_model.return_value = mock_outputs
         mock_model.training = True
-        
+
         # Only special tokens (which won't be masked)
         input_ids = torch.tensor([[1, 0, 2]], dtype=torch.long)
-        
-        # Mock the store_metrics method
-        diffusion_trainer.store_metrics = Mock()
-        
-        loss, outputs = diffusion_trainer._compute_diffusion_loss(
+
+        loss, _ = diffusion_trainer_instance._compute_diffusion_loss(
             mock_model, input_ids
         )
-        
+
         # Loss should be zero when no tokens are masked
         assert loss.item() == 0.0
         assert loss.requires_grad
 
-    def test_cache_special_token_ids(self, diffusion_trainer, mock_tokenizer):
+    def test_cache_special_token_ids(self, diffusion_trainer_instance):
         """Test caching of special token IDs."""
         # Should cache BOS, EOS, PAD tokens
         expected_tokens = {0, 1, 2}  # pad, bos, eos
-        assert diffusion_trainer._special_token_ids == expected_tokens
+        assert diffusion_trainer_instance._special_token_ids == expected_tokens
 
     def test_cache_special_token_ids_no_tokenizer(self):
         """Test caching when no tokenizer is available."""
-        # Create a mock model to satisfy Trainer's requirements
-        mock_model = Mock()
-        trainer = DiffusionTrainer(model=mock_model)
+        trainer = object.__new__(DiffusionTrainer)  # Bypass __init__
         trainer.processing_class = None
         trainer._cache_special_token_ids()
-        
+
         assert trainer._special_token_ids == set()
 
-    def test_main_compute_loss_interface(self, diffusion_trainer):
+    def test_main_compute_loss_interface(self, diffusion_trainer_instance):
         """Test the main compute_loss interface."""
         # Mock model
         mock_model = Mock()
@@ -243,31 +244,28 @@ class TestDiffusionTrainer:
         mock_outputs.logits = torch.randn(1, 5, 1000)
         mock_model.return_value = mock_outputs
         mock_model.training = True
-        
-        # Mock the store_metrics method
-        diffusion_trainer.store_metrics = Mock()
-        
+
         inputs = {
             "input_ids": torch.tensor([[1, 10, 20, 30, 2]], dtype=torch.long),
             "attention_mask": torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.long),
             "labels": torch.tensor([[-100, -100, 20, 30, 2]], dtype=torch.long),
         }
-        
+
         # Test without return_outputs
-        loss = diffusion_trainer.compute_loss(mock_model, inputs)
+        loss = diffusion_trainer_instance.compute_loss(mock_model, inputs)
         assert isinstance(loss, torch.Tensor)
-        
+
         # Test with return_outputs
-        loss, outputs = diffusion_trainer.compute_loss(
+        loss, outputs = diffusion_trainer_instance.compute_loss(
             mock_model, inputs, return_outputs=True
         )
         assert isinstance(loss, torch.Tensor)
         assert outputs == mock_outputs
 
-    def test_missing_input_ids_raises_error(self, diffusion_trainer):
+    def test_missing_input_ids_raises_error(self, diffusion_trainer_instance):
         """Test that missing input_ids raises ValueError."""
         mock_model = Mock()
         inputs = {"attention_mask": torch.tensor([[1, 1, 1]])}
-        
+
         with pytest.raises(ValueError, match="input_ids is required"):
-            diffusion_trainer.compute_loss(mock_model, inputs)
+            diffusion_trainer_instance.compute_loss(mock_model, inputs)

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -39,7 +39,7 @@ def diffusion_trainer_instance(mock_tokenizer, diffusion_config):
     """Create a diffusion trainer instance for testing methods directly."""
     # Create a minimal trainer instance just for testing methods
     trainer = object.__new__(DiffusionTrainer)  # Bypass __init__
-    trainer.config = diffusion_config
+    trainer.cfg = diffusion_config
     trainer._special_token_ids = {0, 1, 2}  # pad, bos, eos
     trainer.processing_class = mock_tokenizer
     trainer.store_metrics = Mock()  # Mock metrics storage

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -14,12 +14,14 @@ class DummyTrainer:
     def __init__(self, use_eval: bool):
         # Config used by callback
         self.cfg = SimpleNamespace(
-            diffusion_generation_interval=1,
-            diffusion_num_generation_samples=1,
-            diffusion_generation_max_length=32,
-            diffusion_generation_steps=4,
-            diffusion_generation_temperature=0.0,
-            diffusion_mask_token_id=16,
+            diffusion=SimpleNamespace(
+                generation_interval=1,
+                num_generation_samples=1,
+                generation_max_length=32,
+                generation_steps=4,
+                generation_temperature=0.0,
+                mask_token_id=16,
+            ),
             use_wandb=False,
         )
 

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -14,12 +14,12 @@ class DummyTrainer:
     def __init__(self, use_eval: bool):
         # Config used by callback
         self.config = SimpleNamespace(
-            generation_interval=1,
-            num_generation_samples=1,
-            generation_max_length=32,
-            generation_steps=4,
-            generation_temperature=0.0,
-            mask_token_id=16,
+            diffusion_generation_interval=1,
+            diffusion_num_generation_samples=1,
+            diffusion_generation_max_length=32,
+            diffusion_generation_steps=4,
+            diffusion_generation_temperature=0.0,
+            diffusion_mask_token_id=16,
             use_wandb=False,
         )
 

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -13,7 +13,7 @@ class DummyTrainer:
 
     def __init__(self, use_eval: bool):
         # Config used by callback
-        self.config = SimpleNamespace(
+        self.cfg = SimpleNamespace(
             diffusion_generation_interval=1,
             diffusion_num_generation_samples=1,
             diffusion_generation_max_length=32,
@@ -25,9 +25,7 @@ class DummyTrainer:
 
         # Model/tokenizer are passed through to generate_samples; not used here
         self.model = Mock()
-        self.tokenizer = Mock()
-        # HF Trainer deprecates .tokenizer in favor of .processing_class
-        self.processing_class = self.tokenizer
+        self.processing_class = Mock()
 
         # Datasets and loaders
         self.eval_dataset = object() if use_eval else None

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from axolotl.integrations.diffusion.callbacks import DiffusionGenerationCallback
+from axolotl.integrations.diffusion import DiffusionGenerationCallback
 
 
 class DummyTrainer:

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -26,6 +26,8 @@ class DummyTrainer:
         # Model/tokenizer are passed through to generate_samples; not used here
         self.model = Mock()
         self.tokenizer = Mock()
+        # HF Trainer deprecates .tokenizer in favor of .processing_class
+        self.processing_class = self.tokenizer
 
         # Datasets and loaders
         self.eval_dataset = object() if use_eval else None

--- a/tests/integrations/test_diffusion_callback.py
+++ b/tests/integrations/test_diffusion_callback.py
@@ -1,0 +1,90 @@
+"""Tests for diffusion generation callback dataloader selection and triggering."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from axolotl.integrations.diffusion.callbacks import DiffusionGenerationCallback
+
+
+class DummyTrainer:
+    """Minimal trainer double with required attributes/methods for the callback."""
+
+    def __init__(self, use_eval: bool):
+        # Config used by callback
+        self.config = SimpleNamespace(
+            generation_interval=1,
+            num_generation_samples=1,
+            generation_max_length=32,
+            generation_steps=4,
+            generation_temperature=0.0,
+            mask_token_id=16,
+            use_wandb=False,
+        )
+
+        # Model/tokenizer are passed through to generate_samples; not used here
+        self.model = Mock()
+        self.tokenizer = Mock()
+
+        # Datasets and loaders
+        self.eval_dataset = object() if use_eval else None
+        self._train_loader = object()
+        self._eval_loader = object()
+
+        # State for world process check
+        self.state = SimpleNamespace(is_world_process_zero=True)
+
+        # Track which loader was requested
+        self.requested: list[str] = []
+
+    def get_train_dataloader(self):
+        self.requested.append("train")
+        return self._train_loader
+
+    def get_eval_dataloader(self):
+        self.requested.append("eval")
+        return self._eval_loader
+
+
+@pytest.mark.parametrize("use_eval", [False, True])
+def test_callback_uses_correct_dataloader(monkeypatch, use_eval):
+    trainer = DummyTrainer(use_eval=use_eval)
+    callback = DiffusionGenerationCallback(trainer)
+
+    captured = {}
+
+    # Patch generate_samples in the callback module's namespace
+    def fake_generate_samples(**kwargs):
+        captured["dataloader"] = kwargs.get("dataloader")
+        # Return one dummy sample to exercise logging path
+        return [
+            {
+                "original": "o",
+                "masked": "m",
+                "generated": "g",
+                "mask_ratio": 0.5,
+                "masked_tokens": 1,
+                "total_tokens": 2,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "axolotl.integrations.diffusion.callbacks.generate_samples",
+        fake_generate_samples,
+    )
+
+    # Trigger at step 1 (interval=1)
+    args = SimpleNamespace()
+    state = SimpleNamespace(global_step=1)
+    control = SimpleNamespace()
+
+    callback.on_step_end(args=args, state=state, control=control)
+
+    # Assert the expected dataloader path was used
+    if use_eval:
+        assert trainer.requested[0] == "eval"
+        assert captured["dataloader"] is trainer._eval_loader
+    else:
+        assert trainer.requested[0] == "train"
+        assert captured["dataloader"] is trainer._train_loader

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,12 +5,12 @@ from unittest.mock import Mock, patch
 
 from datasets import IterableDataset
 
-from axolotl.utils.dict import DictDefault
+from axolotl.utils.config import validate_config
 from axolotl.utils.data.sft import (
     _prepare_streaming_dataset,
     prepare_datasets,
 )
-from axolotl.utils.config import validate_config
+from axolotl.utils.dict import DictDefault
 
 
 class TestStreamingConfig(unittest.TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Diffusion LM training plugin.

Features:
- Trainer subclass for diffusion loss calculation + metrics logging
- Pretrain + SFT support
- Inference CLI support (with and without gradio)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Diffusion LM training plugin with training, masked-token generation, and interactive inference commands (:complete, :mask) with colorized outputs.
  - Per-metric reduction support in training logs (mean/min/max/sum).
  - Option to reinitialize model weights instead of loading pretrained weights.
  - Improved compatibility with HF Trainer subclasses for processing.
- Examples
  - New Llama-3.2-1B diffusion pretrain and SFT config examples.
- Documentation
  - New Diffusion plugin README with setup and usage.
- Tests
  - Added end-to-end and integration tests for diffusion.
- Chores
  - Updated linting config; import/order cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->