### PR TITLE
[feat] truncation support with excess_length_strategy

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -28,7 +28,7 @@ from axolotl.utils.data.shared import (
 )
 from axolotl.utils.data.utils import (
     deduplicate_and_log_datasets,
-    handle_long_seq_in_dataset_long_seq_in_dataset,
+    handle_long_seq_in_dataset,
     retry_on_request_exceptions,
 )
 from axolotl.utils.data.wrappers import get_dataset_wrapper
@@ -339,9 +339,9 @@ def _load_raw_datasets(
 
     if not cfg.skip_prepare_dataset:
         if split == "test" and cfg.eval_sequence_len:
-            dataset = drop_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)
+            dataset = handle_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)
         else:
-            dataset = drop_long_seq_in_dataset(dataset, cfg.sequence_len, cfg)
+            dataset = handle_long_seq_in_dataset(dataset, cfg.sequence_len, cfg)
         if cfg.sample_packing:
             dataset, _ = process_datasets_for_packing(cfg, dataset, None)
 

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -28,7 +28,7 @@ from axolotl.utils.data.shared import (
 )
 from axolotl.utils.data.utils import (
     deduplicate_and_log_datasets,
-    drop_long_seq_in_dataset,
+    handle_long_seq_in_dataset_long_seq_in_dataset,
     retry_on_request_exceptions,
 )
 from axolotl.utils.data.wrappers import get_dataset_wrapper

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -152,8 +152,6 @@ def truncate_long_seq(sample, sequence_len=2048, min_sequence_len=2):
     """
     Truncate samples whose sequence length is too long (> sequence_len)
     or drop those too short (< min_sequence_len).
-
-    Works for both single-example (list[int]) or batched (list[list[int]]).
     """
     min_sequence_len = min_sequence_len or 2
 

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -192,11 +192,11 @@ def drop_long_seq_in_dataset(
     if filter_map_kwargs:
         drop_long_kwargs["desc"] = f"Dropping Long Sequences (>{sequence_len})"
 
-    behave = (cfg.excess_len or "drop").lower()
-    if behave not in {"drop", "truncate"}:
-        behave = "drop"
+    excess_length_strategy = (cfg.excess_length_strategy or "drop").lower()
+    if excess_length_strategy not in {"drop", "truncate"}:
+        excess_length_strategy = "drop"
 
-    if behave == "drop":
+    if excess_length_strategy == "drop":
         dataset = dataset.filter(
             drop_long,
             batched=True,

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -225,9 +225,10 @@ def drop_long_seq_in_dataset(
             ]
         return batch
 
-    map_kwargs = dict(
-        num_proc=cfg.dataset_processes, load_from_cache_file=not cfg.is_preprocess
-    )
+    map_kwargs = {
+        "num_proc": cfg.dataset_processes,
+        "load_from_cache_file": not cfg.is_preprocess,
+    }
     dataset = dataset.map(
         _truncate_batch,
         batched=True,

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -414,6 +414,12 @@ class AxolotlInputConfig(
             "description": "The maximum length of an input to train with, this should typically be less than 2048 as most models have a token/context limit of 2048"
         },
     )
+    excess_len: Literal["drop", "truncate"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "What to do when a tokenized row exceeds sequence_len. 'drop' removes the row; 'truncate' slices tensors to sequence_len. Defaults to 'drop' for backward compatibility."
+        },
+    )
     eval_sequence_len: int | None = Field(
         default=None,
         json_schema_extra={

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -414,7 +414,7 @@ class AxolotlInputConfig(
             "description": "The maximum length of an input to train with, this should typically be less than 2048 as most models have a token/context limit of 2048"
         },
     )
-    excess_len: Literal["drop", "truncate"] | None = Field(
+    excess_length_strategy: Literal["drop", "truncate"] | None = Field(
         default=None,
         json_schema_extra={
             "description": "What to do when a tokenized row exceeds sequence_len. 'drop' removes the row; 'truncate' slices tensors to sequence_len. Defaults to 'drop' for backward compatibility."

--- a/tests/test_packed_batch_sampler.py
+++ b/tests/test_packed_batch_sampler.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer
 from axolotl.datasets import TokenizedPromptDataset
 from axolotl.prompt_strategies.completion import load
 from axolotl.utils.collators import V2BatchSamplerDataCollatorForSeq2Seq
-from axolotl.utils.data.utils import drop_long_seq_in_dataset
+from axolotl.utils.data.utils import handle_long_seq_in_dataset
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 
@@ -70,7 +70,7 @@ class TestBatchedSamplerPacking:
         )
         train_dataset = concatenate_datasets([dataset_wrapper])
 
-        train_dataset = drop_long_seq_in_dataset(train_dataset, cfg.sequence_len, cfg)
+        train_dataset = handle_long_seq_in_dataset(train_dataset, cfg.sequence_len, cfg)
 
         lengths = get_dataset_lengths(train_dataset)
         batch_sampler = MultipackBatchSampler(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
added excess_len with drop = default 

## Motivation and Context
#775

# tested 
following config runs fine  

```

base_model: microsoft/DialoGPT-small  
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer


datasets:
  - path: tatsu-lab/alpaca
    type: alpaca
 
    test_datasets:
      - path: tatsu-lab/alpaca
        type: alpaca
        ds_type: json
        data_files:
          - alpaca_data.json


sequence_len: 512  
excess_length_strategy: truncate  # this 
min_sample_len: 10   # and this 


micro_batch_size: 2
gradient_accumulation_steps: 4
eval_batch_size: 2
num_epochs: 1
max_steps: 50 


optimizer: adamw_torch
lr_scheduler: cosine
learning_rate: 5e-5
train_on_inputs: false
group_by_length: false
bf16: auto
fp16: false
tf32: false


logging_steps: 10
eval_steps: 25
eval_strategy: steps
save_steps: 25
save_strategy: steps
output_dir: ./outputs/test-truncation

sample_packing: false  
pad_to_sequence_len: true
dataset_processes: 4


load_in_8bit: false
load_in_4bit: false
strict: false

special_tokens:
  pad_token: '[PAD]'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config option to choose handling of over-length tokenized sequences: "drop" (default) or "truncate".
  * "Truncate" mode slices long sequences to the configured length, updates batch tensors accordingly, and filters out too-short samples. Logs indicate number of removed/truncated samples.

* **Chores**
  * Public API and data-loading flow updated to use the new long-sequence handler and mode-driven behavior.

* **Tests**
  * Tests updated to reflect the new handler and configuration-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->