### PR TITLE
[GPT-OSS] improve FSDP shard merging and documentation for GPT-OSS

### DIFF
--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -40,6 +40,12 @@ On 8xH100s
 axolotl train examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
 ```
 
+When using SHARDED_STATE_DICT with FSDP, there is an additional post-training step to merge the sharded weights.
+This step will automatically determine the
+```bash
+axolotl merge-sharded-fsdp-weights examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
+```
+
 ### Tool use
 
 GPT-OSS has a comprehensive tool understanding. Axolotl supports tool calling datasets for Supervised Fine-tuning.

--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -40,20 +40,23 @@ On 8xH100s
 axolotl train examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
 ```
 
-When using SHARDED_STATE_DICT with FSDP, there is an additional post-training step to merge the sharded weights.
-This step will automatically determine the last checkpoint directory and merge the sharded weights to
-`{output_dir}/merged`.
-```bash
-axolotl merge-sharded-fsdp-weights examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
-mv ./outputs/gpt-oss-out/merged/* ./outputs/gpt-oss-out/
-```
-
-ERRATA: Transformers saves the model Architecture prefixed with `FSDP` which needs to be manually renamed in `config`.
+ERRATA: Transformers saves the model Architecture prefixed with `FSDP` which needs to be manually renamed in `config.json`.
 See https://github.com/huggingface/transformers/pull/40207 for the status of this issue.
 
 ```bash
 sed -i 's/FSDPGptOssForCausalLM/GptOssForCausalLM/g' ./outputs/gpt-oss-out/config.json
 ```
+
+When using SHARDED_STATE_DICT with FSDP, the final checkpoint should automatically merge the sharded weights to your
+configured `output_dir`. However, if that step fails due to a disk space error, you can take an additional step to
+merge the sharded weights.  This step will automatically determine the last checkpoint directory and merge the sharded
+weights to `{output_dir}/merged`.
+
+```bash
+axolotl merge-sharded-fsdp-weights examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
+mv ./outputs/gpt-oss-out/merged/* ./outputs/gpt-oss-out/
+```
+
 
 ### Inferencing your fine-tuned model
 

--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -33,7 +33,8 @@ Note: Memory usage taken from `device_mem_reserved(gib)` from logs.
 
 ### Training 120B
 
-On 8xH100s
+On 8xH100s, make sure you have ~3TB of free disk space. With each checkpoint clocking in at ~720GB, along with the base
+model, and final model output, you may need at least 3TB of free disk space to keep at least 2 checkpoints.
 
 ```bash
 # FFT SFT with offloading (8x80GB @ ~49GiB/GPU)

--- a/examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
+++ b/examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
@@ -20,6 +20,7 @@ datasets:
 dataset_prepared_path: last_run_prepared
 val_set_size: 0
 output_dir: ./outputs/gpt-oss-out/
+save_total_limit: 2  # the 120B model can use up to 720GB of disk space per checkpoint, so let's only keep the last 2
 
 sequence_len: 4096
 sample_packing: true

--- a/src/axolotl/cli/merge_sharded_fsdp_weights.py
+++ b/src/axolotl/cli/merge_sharded_fsdp_weights.py
@@ -205,10 +205,20 @@ def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs):
                 f"Could not find FSDP checkpoint `pytorch_model_fsdp_0` in {checkpoint_dir}"
             )
 
+    output_path = str(Path(parsed_cfg.output_dir) / "merged")
     merge_fsdp_weights(
         checkpoint_dir=str(fsdp_dir),
-        output_path=str(Path(parsed_cfg.output_dir) / "merged"),
+        output_path=output_path,
         safe_serialization=True,
+    )
+    LOG.info(
+        f"FSDP SHARDED_STATE_DICT weights successfully merged to: {output_path}",
+        main_process_only=True,
+    )
+    LOG.info(
+        "Merged weights are only the safetensors and doesn't include the model configuration "
+        f"or tokenizer which may be found in {parsed_cfg.output_dir}.",
+        main_process_only=True,
     )
 
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -11,7 +11,6 @@ from axolotl.core.trainers import (
 )
 from axolotl.core.trainers.dpo import DPOStrategy
 from axolotl.core.trainers.dpo.args import AxolotlDPOConfig
-from axolotl.core.trainers.grpo import GRPOStrategy
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders.utils import ensure_dtype
 from axolotl.utils.callbacks.qat import QATCallback
@@ -53,6 +52,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
         trainer_cls_args = [self.model]
 
         if self.cfg.rl is RLType.GRPO:
+            from axolotl.core.trainers.grpo import GRPOStrategy
+
             trainer_cls = GRPOStrategy.get_trainer_class(
                 sequence_parallel=self.cfg.context_parallel_size > 1
             )
@@ -148,6 +149,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
                 training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         elif self.cfg.rl is RLType.GRPO:
+            from axolotl.core.trainers.grpo import GRPOStrategy
+
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -11,6 +11,7 @@ from axolotl.core.trainers import (
 )
 from axolotl.core.trainers.dpo import DPOStrategy
 from axolotl.core.trainers.dpo.args import AxolotlDPOConfig
+from axolotl.core.trainers.grpo import GRPOStrategy
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders.utils import ensure_dtype
 from axolotl.utils.callbacks.qat import QATCallback
@@ -52,8 +53,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
         trainer_cls_args = [self.model]
 
         if self.cfg.rl is RLType.GRPO:
-            from axolotl.core.trainers.grpo import GRPOStrategy
-
             trainer_cls = GRPOStrategy.get_trainer_class(
                 sequence_parallel=self.cfg.context_parallel_size > 1
             )
@@ -149,8 +148,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
                 training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         elif self.cfg.rl is RLType.GRPO:
-            from axolotl.core.trainers.grpo import GRPOStrategy
-
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()

--- a/src/axolotl/core/trainers/__init__.py
+++ b/src/axolotl/core/trainers/__init__.py
@@ -5,7 +5,6 @@
 
 from .base import AxolotlTrainer
 from .dpo.trainer import AxolotlDPOTrainer
-from .grpo.trainer import AxolotlGRPOSequenceParallelTrainer, AxolotlGRPOTrainer
 from .mamba import AxolotlMambaTrainer
 from .trl import (
     AxolotlCPOTrainer,

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -297,19 +297,20 @@ def save_trained_model(
             )
         # TODO(wing):see https://github.com/huggingface/transformers/pull/40207
         # cleanup the FSDP prefix in the model config.json
-        with open(
-            os.path.join(cfg.output_dir, "config.json"), "r", encoding="utf-8"
-        ) as f:
-            # read the model config as an OrderedDict
-            config = json.load(f, object_pairs_hook=OrderedDict)
-            config["architectures"] = [
-                name.lstrip("FSDP") for name in config["architectures"]
-            ]
-        # write the updated model config back
-        with open(
-            os.path.join(cfg.output_dir, "config.json"), "w", encoding="utf-8"
-        ) as f:
-            json.dump(config, f, indent=2)
+        if trainer.accelerator.is_main_process:
+            with open(
+                os.path.join(cfg.output_dir, "config.json"), "r", encoding="utf-8"
+            ) as f:
+                # read the model config as an OrderedDict
+                config = json.load(f, object_pairs_hook=OrderedDict)
+                config["architectures"] = [
+                    name.lstrip("FSDP") for name in config["architectures"]
+                ]
+            # write the updated model config back
+            with open(
+                os.path.join(cfg.output_dir, "config.json"), "w", encoding="utf-8"
+            ) as f:
+                json.dump(config, f, indent=2)
     elif cfg.deepspeed and is_deepspeed_zero3_enabled():
         # Copied over from: https://github.com/huggingface/accelerate/blob/5ae611118057232f441055f7ef9ba0b0f2b8d533/docs/source/usage_guides/deepspeed.md#saving-and-loading
         trainer.accelerator.wait_for_everyone()

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -24,7 +24,6 @@ from transformers import PreTrainedModel, PreTrainedTokenizer, ProcessorMixin
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.trainer import Trainer
 
-from axolotl.cli.merge_sharded_fsdp_weights import merge_fsdp_weights
 from axolotl.common.datasets import TrainDatasetMeta
 from axolotl.contribs.lgpl import (  # pylint: disable = no-name-in-module
     fix_untrained_tokens,
@@ -302,6 +301,9 @@ def save_trained_model(
                 and cfg.save_model_only
                 and checkpoint_dir
             ):
+                # import here to prevent circular import
+                from axolotl.cli.merge_sharded_fsdp_weights import merge_fsdp_weights
+
                 fsdp_dir = Path(checkpoint_dir) / "pytorch_model_fsdp_0"
                 output_path = str(Path(cfg.output_dir) / "merged")
                 merge_fsdp_weights(

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -289,7 +289,7 @@ def save_trained_model(
             else:
                 state_dict_type = cfg.fsdp_config.state_dict_type
             trainer.accelerator.state.fsdp_plugin.set_state_dict_type(state_dict_type)
-        trainer.save_model(cfg.output_dir)
+        trainer.save_model(cfg.output_dir)  # only handles FULL_STATE_DICT
         if state_dict_type == "SHARDED_STATE_DICT":
             LOG.info(
                 "The final model was saved with a sharded state dict. Please ensure you merge "
@@ -298,7 +298,7 @@ def save_trained_model(
             checkpoint_dir = determine_last_checkpoint(cfg, update=False)
             if (
                 trainer.accelerator.is_main_process
-                and cfg.save_model_only
+                and not (Path(cfg.output_dir) / "model.safetensors.index.json").exists()
                 and checkpoint_dir
             ):
                 # import here to prevent circular import

--- a/src/axolotl/utils/train.py
+++ b/src/axolotl/utils/train.py
@@ -1,0 +1,39 @@
+"""Training utils for checkpoints"""
+
+from pathlib import Path
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def determine_last_checkpoint(cfg: DictDefault, update: bool = True) -> str | None:
+    """
+    Determine the checkpoint to resume from based on configuration.
+
+    Args:
+        cfg: Dictionary mapping `axolotl` config keys to values.
+        update: Whether to update the config with the determined checkpoint
+
+    Returns:
+        Path to the checkpoint to resume from, or `None` if not resuming.
+    """
+    last_checkpoint = None
+    possible_checkpoints = [str(cp) for cp in Path(cfg.output_dir).glob("checkpoint-*")]
+    if len(possible_checkpoints) > 0:
+        sorted_paths = sorted(
+            possible_checkpoints,
+            key=lambda path: int(path.split("-")[-1]),
+        )
+        if not update:
+            return sorted_paths[-1]
+        last_checkpoint = sorted_paths[-1]
+
+    if cfg.resume_from_checkpoint is None and cfg.auto_resume_from_checkpoints:
+        if last_checkpoint is not None:
+            cfg.resume_from_checkpoint = sorted_paths[-1]
+            LOG.info(
+                f"Using Auto-resume functionality to start with checkpoint at {cfg.resume_from_checkpoint}"
+            )
+    return cfg.resume_from_checkpoint

--- a/tests/utils/test_train.py
+++ b/tests/utils/test_train.py
@@ -1,0 +1,24 @@
+"""test for train checkpoint utils"""
+
+import os
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.train import determine_last_checkpoint
+
+
+def test_determine_last_checkpoint(temp_dir):
+    cfg = DictDefault(
+        output_dir=temp_dir,
+    )
+    for cpt_idx in [1, 9, 10, 20]:
+        os.makedirs(
+            os.path.join(cfg.output_dir, f"checkpoint-{cpt_idx}"), exist_ok=True
+        )
+
+    last_checkpoint = determine_last_checkpoint(cfg, update=False)
+    assert last_checkpoint == os.path.join(cfg.output_dir, "checkpoint-20")
+
+    cfg.resume_from_checkpoint = None
+    cfg.auto_resume_from_checkpoints = True
+    determine_last_checkpoint(cfg, update=True)
+    assert cfg.resume_from_checkpoint == os.path.join(cfg.output_dir, "checkpoint-20")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically merges sharded FSDP weights into the output directory after training, with a fallback merged path when disk space is low.
  - More robust CLI merge workflow that locates latest checkpoints and reports merge results.

- Bug Fixes
  - Removes FSDP prefixes from saved model architecture entries to ensure correct model identification.

- Documentation
  - Expanded GPT-OSS README: disk-space guidance, merge workflow, inference tips (SGLang/vLLM notes), dataset and multi-GPU training tips, and resources.

- Tests
  - Added tests validating checkpoint discovery and auto-resume behavior.

- Chores
  - Example config now keeps only the last two checkpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->