### PR TITLE
data_parallel_size in in VllmserveCliArgs

### DIFF
--- a/src/axolotl/cli/args.py
+++ b/src/axolotl/cli/args.py
@@ -93,6 +93,12 @@ class VllmServeCliArgs:
     reasoning_parser: Optional[str] = field(
         default=None,
     )
+    data_parallel_size: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Number of data parallel workers to use for vLLM serving. This controls how many model replicas are used for parallel inference."
+        },
+    )
 
 
 @dataclass

--- a/src/axolotl/cli/args.py
+++ b/src/axolotl/cli/args.py
@@ -40,6 +40,12 @@ class VllmServeCliArgs:
         default=None,
         metadata={"help": "Number of tensor parallel workers to use."},
     )
+    data_parallel_size: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Number of data parallel workers to use for vLLM serving. This controls how many model replicas are used for parallel inference."
+        },
+    )
     host: Optional[str] = field(
         default=None,  # nosec B104
         metadata={"help": "Host address to run the server on."},
@@ -92,12 +98,6 @@ class VllmServeCliArgs:
 
     reasoning_parser: Optional[str] = field(
         default=None,
-    )
-    data_parallel_size: Optional[int] = field(
-        default=None,
-        metadata={
-            "help": "Number of data parallel workers to use for vLLM serving. This controls how many model replicas are used for parallel inference."
-        },
     )
 
 


### PR DESCRIPTION


# Description
added data_parallel_size in in VllmserveCliArgs

## Motivation and Context
#2690 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional CLI flag `--data-parallel-size` to configure the number of data-parallel workers for vLLM serving. This enables running multiple model replicas for parallel inference to improve throughput. If not specified, behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->