### PR TITLE
handle batch size correchtly when using split and dispatch batches

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -424,7 +424,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
     ):
         if training_args.pretraining:
             if (
-                self.cfg.pretraining_sample_concatenation is False
+                not self.cfg.pretraining_sample_concatenation
                 or self.cfg.micro_batch_size > 1
             ):
                 return DataCollatorForSeq2Seq(self.tokenizer, **kwargs)

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -272,6 +272,20 @@ class AxolotlTrainer(
                     num_workers=self.args.dataloader_num_workers,
                     rank=self.args.process_index,
                 )
+
+        if (
+            self.args.accelerator_config is not None
+            and self.args.accelerator_config.split_batches
+            and self.args.accelerator_config.dispatch_batches
+        ):
+            if self.args.sample_packing and self.args.pretraining:
+                if not self.args.eval_sample_packing and not is_training:
+                    dataloader_params["batch_size"] *= self.accelerator.num_processes
+                else:
+                    dataloader_params["batch_size"] = self.accelerator.num_processes
+            elif not self.args.sample_packing and self.args.pretraining:
+                dataloader_params["batch_size"] *= self.accelerator.num_processes
+
         if self.args.sample_packing and (
             (is_training and not self.args.pretraining)
             or (not is_training and self.args.eval_sample_packing is not False)


### PR DESCRIPTION
The batch size handling when using split batches isn't quite right. This sets the correct batch size based on how we handle batches when pretraining and needing to scale it properly for dispatch_batches/split_batches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected batch size computation during pretraining when both split and dispatch batching are enabled, with sensible handling across training and evaluation and with/without sample packing. Improves stability and throughput by avoiding unintended per-process sizing.
  - Made pretraining sample concatenation handling more robust to falsy configuration values, ensuring the appropriate collator is selected during pretraining. Prevents misconfiguration that could impact batching and data processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->