### PR TITLE
add bsaeten info for gpt-oss recipe

### DIFF
--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -41,6 +41,12 @@ model, and final model output, you may need at least 3TB of free disk space to k
 axolotl train examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
 ```
 
+To simplify fine-tuning with 2x8xH100s, we've partnered with [Baseten](https://baseten.co) to showcase multi-node
+training 120B with Basten's Truss. You can read more aboutthis recipe on
+[Baseten's blog](https://www.baseten.co/blog/how-to-fine-tune-gpt-oss-120b-with-baseten-and-axolotl/). The recipe can
+be found on their
+[GitHub](https://github.com/basetenlabs/ml-cookbook/tree/main/examples/oss-gpt-120b-axolotl/training).
+
 ERRATA: Transformers saves the model Architecture prefixed with `FSDP` which needs to be manually renamed in `config.json`.
 See https://github.com/huggingface/transformers/pull/40207 for the status of this issue.
 

--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -41,8 +41,8 @@ model, and final model output, you may need at least 3TB of free disk space to k
 axolotl train examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
 ```
 
-To simplify fine-tuning with 2x8xH100s, we've partnered with [Baseten](https://baseten.co) to showcase multi-node
-training 120B with Basten's Truss. You can read more aboutthis recipe on
+To simplify fine-tuning across 2 nodes × 8x H100 (80GB) GPUs, we've partnered with [Baseten](https://baseten.co) to showcase multi-node
+training of the 120B model using Baseten Truss. You can read more about this recipe on
 [Baseten's blog](https://www.baseten.co/blog/how-to-fine-tune-gpt-oss-120b-with-baseten-and-axolotl/). The recipe can
 be found on their
 [GitHub](https://github.com/basetenlabs/ml-cookbook/tree/main/examples/oss-gpt-120b-axolotl/training).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with step-by-step guidance for Baseten-backed multi-node fine-tuning of a 120B model on 2x8xH100s.
  * Added links to Baseten’s blog post and GitHub training resources to simplify setup and replication.
  * Clarified existing ERRATA about renaming FSDP-prefixed architectures in configuration.
  * Documentation-only update; no code, public API, or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->