### PR TITLE
fix: Sweep runs overwrite each other because output_dir from base config is reused

### DIFF
--- a/src/axolotl/cli/utils/sweeps.py
+++ b/src/axolotl/cli/utils/sweeps.py
@@ -3,11 +3,12 @@
 import random
 from copy import deepcopy
 from itertools import product
+from typing import Any
 
 
 def generate_sweep_configs(
     base_config: dict[str, list], sweeps_config: dict[str, list]
-) -> list[dict[str, list]]:
+) -> list[dict[str, Any]]:
     """
     Recursively generates all possible configurations by applying sweeps to the base config.
 

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -89,9 +89,9 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
     # Generate all possible configurations
     permutations = generate_sweep_configs(base_config, sweep_config)
     is_group = len(permutations) > 1
-    
+    base_output_dir = base_config.get("output_dir",'./model-out') 
     for idx, permutation in enumerate(permutations, start=1):
-        permutation_dir = Path(permutation.get("output_dir"))
+        permutation_dir = Path(permutation.get("output_dir"),base_output_dir)
         permutation_id = f"sweep{idx:04d}"
         permutation["output_dir"] = str(permutation_dir / permutation_id)
         

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -4,8 +4,8 @@ import os
 import subprocess  # nosec
 import sys
 import tempfile
-from typing import Any, Iterator, Literal
 from pathlib import Path
+from typing import Any, Iterator, Literal
 
 import yaml
 
@@ -89,12 +89,12 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
     # Generate all possible configurations
     permutations = generate_sweep_configs(base_config, sweep_config)
     is_group = len(permutations) > 1
-    base_output_dir = base_config.get("output_dir",'./model-out') 
+    base_output_dir = base_config.get("output_dir", "./model-out")
     for idx, permutation in enumerate(permutations, start=1):
-        permutation_dir = Path(permutation.get("output_dir",base_output_dir))
+        permutation_dir = Path(permutation.get("output_dir", base_output_dir))
         permutation_id = f"sweep{idx:04d}"
         permutation["output_dir"] = str(permutation_dir / permutation_id)
-        
+
         # pylint: disable=consider-using-with
         temp_file = tempfile.NamedTemporaryFile(
             mode="w",

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -91,7 +91,7 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
     is_group = len(permutations) > 1
     
     for idx, permutation in enumerate(permutations, start=1):
-        permutation_dir = Path(permutation.get("output_dir")
+        permutation_dir = Path(permutation.get("output_dir"))
         permutation_id = f"sweep{idx:04d}"
         permutation["output_dir"] = str(permutation_dir / permutation_id)
         

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -5,6 +5,7 @@ import subprocess  # nosec
 import sys
 import tempfile
 from typing import Any, Iterator, Literal
+from pathlib import Path
 
 import yaml
 
@@ -88,7 +89,12 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
     # Generate all possible configurations
     permutations = generate_sweep_configs(base_config, sweep_config)
     is_group = len(permutations) > 1
-    for permutation in permutations:
+    
+    for idx, permutation in enumerate(permutations, start=1):
+        permutation_dir = Path(permutation.get("output_dir")
+        permutation_id = f"sweep{idx:04d}"
+        permutation["output_dir"] = str(permutation_dir / permutation_id)
+        
         # pylint: disable=consider-using-with
         temp_file = tempfile.NamedTemporaryFile(
             mode="w",

--- a/src/axolotl/cli/utils/train.py
+++ b/src/axolotl/cli/utils/train.py
@@ -91,7 +91,7 @@ def generate_config_files(config: str, sweep: str | None) -> Iterator[tuple[str,
     is_group = len(permutations) > 1
     base_output_dir = base_config.get("output_dir",'./model-out') 
     for idx, permutation in enumerate(permutations, start=1):
-        permutation_dir = Path(permutation.get("output_dir"),base_output_dir)
+        permutation_dir = Path(permutation.get("output_dir",base_output_dir))
         permutation_id = f"sweep{idx:04d}"
         permutation["output_dir"] = str(permutation_dir / permutation_id)
         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context
When running training with the --sweep option, all generated runs share the same output_dir defined in the base config.yml. As a result, multiple sweep permutations overwrite each other’s checkpoints and logs. As a result, final output file only contains last permutation result.

Each sweep permutation should automatically generate a unique output_dir (for example by appending the sweep parameters or a timestamp), so that results are not overwritten.

#3079
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
1. Create a base config.yml with output_dir, for example:
```yaml
base_model: NousResearch/Llama-3.2-1B

# only use 1% of the training split for quick smoke test
datasets:
  - path: teknium/GPT4-LLM-Cleaned
    type: alpaca
    split: train
    split_percent: 1

output_dir: ./outputs/sweep-test

adapter: lora
lora_model_dir:

sequence_len: 512

lora_r: 8
lora_alpha: 16
lora_target_modules:
  - q_proj
  - v_proj

gradient_accumulation_steps: 1
micro_batch_size: 1
# stop after 20 steps (quick test)
max_steps: 20

special_tokens:
  pad_token: "<|end_of_text|>"
```

2. Define a sweep.yaml with multiple values, for example:
```yaml
_:
  # This section is for dependent variables we need to fix
  - load_in_8bit: false
    load_in_4bit: false
    adapter: lora
  - load_in_8bit: true
    load_in_4bit: false
    adapter: lora

# These are independent variables
learning_rate: [0.0003, 0.0006]
lora_r:
  - 16
  - 32
lora_alpha:
  - 16
  - 32
  - 64
 ```
3.  Run:
```bash
axolotl train config.yml --sweep sweep.yaml
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
> Current State : <img width="611" height="177" alt="image" src="https://github.com/user-attachments/assets/9760eccc-1737-4aeb-b2fa-ce14f973e3f6" />

> Proposed solution : 
<img width="571" height="133" alt="image" src="https://github.com/user-attachments/assets/840010e4-6d96-4c70-8aaf-4b30d008713d" />
<img width="645" height="179" alt="image" src="https://github.com/user-attachments/assets/504a01e8-fa3e-4c0a-ac65-569f416e6131" />



## Types of changes
- Refactored output_dir handling in `generate_config_files`
- Each permutation now gets its own subdirectory
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sweep runs now save each permutation’s outputs in unique, numbered subdirectories (e.g., sweep0001) to prevent collisions and overwrites.
  * Generates a separate temporary YAML per permutation for clearer tracking and easier debugging.
  * Ensures each permutation’s output path includes the base output folder and a sweep-specific subdirectory for consistent, platform-independent organization.

* **Improvements**
  * Sweep configuration handling updated to support heterogeneous value types in sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->