### PR TITLE
Feature/pretraining-auto-truncate

### DIFF
--- a/docs/dataset-formats/index.qmd
+++ b/docs/dataset-formats/index.qmd
@@ -84,10 +84,6 @@ datasets:
     type: completion
 ```
 
-::: {.callout-important}
-For `completion` only, Axolotl would split texts if it exceeds the context length into multiple smaller prompts. If you are interested in having this for `pretraining_dataset` too, please let us know or help make a PR!
-:::
-
 ### Pre-training dataset configuration tips
 
 #### Setting max_steps

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -38,6 +38,18 @@ def encode_pretraining(
         for sample in full_inputs["attention_mask"]
     ]
 
+    # Resolve a safe pad token id for chunk padding
+    pad_id = (
+        tokenizer.pad_token_id
+        if tokenizer.pad_token_id is not None
+        else (tokenizer.eos_token_id or 0)
+    )
+
+    if tokenizer.pad_token_id is None:
+        LOG.warning(
+            "tokenizer.pad_token_id is None; falling back to %s for padding", pad_id
+        )
+
     inputs_ids, target_ids, attention_mask = [], [], []
 
     # Concatenate if specified all input_ids and attention masks into one tensor when concatenate is True
@@ -53,9 +65,7 @@ def encode_pretraining(
             0, len(full_inputs["input_ids"][sample_index]), max_tokens
         ):
             # Create partial tensors for inputs, targets, and attention masks with fill values
-            partial_inputs_ids = torch.full(
-                (max_tokens,), tokenizer.pad_token_id, dtype=torch.long
-            )
+            partial_inputs_ids = torch.full((max_tokens,), pad_id, dtype=torch.long)
             partial_target_ids = torch.full((max_tokens,), -100, dtype=torch.long)
             partial_attention_mask = torch.zeros((max_tokens,), dtype=torch.long)
 

--- a/src/axolotl/utils/data/pretraining.py
+++ b/src/axolotl/utils/data/pretraining.py
@@ -24,156 +24,70 @@ def encode_pretraining(
     text_column: str = "text",
     concatenate: bool = True,
 ) -> Dict[str, List]:
-    res = tokenizer(
+    full_inputs = tokenizer(
         examples[text_column],
-        truncation=True,
-        max_length=max_tokens - 2,
         add_special_tokens=True,
     )
-    # Convert to PyTorch tensors
-    input_ids = [torch.tensor(seq) for seq in res["input_ids"]]
-    targets = [torch.tensor(seq) for seq in res["input_ids"]]
-    attention_mask = [torch.tensor(seq) for seq in res["attention_mask"]]
-    if not concatenate:
-        return {
-            "input_ids": [seq.tolist() for seq in input_ids],
-            "labels": [seq.tolist() for seq in targets],
-            "attention_mask": [seq.tolist() for seq in attention_mask],
-        }
 
-    new_input_ids = []
-    new_labels = []
-    new_attention_mask = []
-    # Append EOS and PAD tokens to input_ids, and correct attention_mask
-    for i, _ in enumerate(input_ids):
-        input_ids[i] = torch.cat(
-            (
-                input_ids[i],
-                torch.tensor([tokenizer.eos_token_id, tokenizer.pad_token_id]),
-            ),
-            dim=0,
-        )
-        targets[i] = torch.cat(
-            (
-                targets[i],
-                torch.tensor([tokenizer.eos_token_id, -100]),
-            ),
-            dim=0,
-        )
-        attention_mask[i] = torch.cat((attention_mask[i], torch.tensor([1, 0])), dim=0)
+    # Convert input_ids and attention_mask to tensors
+    full_inputs["input_ids"] = [
+        torch.tensor(sample, dtype=torch.long) for sample in full_inputs["input_ids"]
+    ]
+    full_inputs["attention_mask"] = [
+        torch.tensor(sample, dtype=torch.long)
+        for sample in full_inputs["attention_mask"]
+    ]
 
-    # Concatenate tokens so that their lengths are less than max_tokens
-    buffer_input_ids = torch.tensor([], dtype=torch.long)
-    buffer_labels = torch.tensor([], dtype=torch.long)
-    buffer_attention_mask = torch.tensor([], dtype=torch.long)
+    inputs_ids, target_ids, attention_mask = [], [], []
 
-    for ids, labels, mask in zip(input_ids, targets, attention_mask):
-        if buffer_input_ids.numel() == max_tokens:
-            new_input_ids.append(buffer_input_ids)
-            new_labels.append(buffer_labels)
-            new_attention_mask.append(buffer_attention_mask)
-            buffer_input_ids = torch.tensor([], dtype=torch.long)
-            buffer_labels = torch.tensor([], dtype=torch.long)
-            buffer_attention_mask = torch.tensor([], dtype=torch.long)
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
-        elif buffer_input_ids.numel() + ids.numel() <= max_tokens:
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
-        else:
-            buffer_input_ids = torch.cat(
-                (
-                    buffer_input_ids,
-                    torch.full(
-                        (max_tokens - buffer_input_ids.numel(),),
-                        tokenizer.pad_token_id,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_labels = torch.cat(
-                (
-                    buffer_labels,
-                    torch.full(
-                        (max_tokens - buffer_labels.numel(),),
-                        -100,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_attention_mask = torch.cat(
-                (
-                    buffer_attention_mask,
-                    torch.full(
-                        (max_tokens - buffer_attention_mask.numel(),),
-                        0,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            new_input_ids.append(buffer_input_ids)
-            new_labels.append(buffer_labels)
-            new_attention_mask.append(buffer_attention_mask)
-            buffer_input_ids = torch.tensor([], dtype=torch.long)
-            buffer_labels = torch.tensor([], dtype=torch.long)
-            buffer_attention_mask = torch.tensor([], dtype=torch.long)
+    # Concatenate if specified all input_ids and attention masks into one tensor when concatenate is True
+    if concatenate:
+        full_inputs["input_ids"] = [torch.cat(full_inputs["input_ids"], dim=0)]
+        full_inputs["attention_mask"] = [
+            torch.cat(full_inputs["attention_mask"], dim=0)
+        ]
 
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
+    # Iterate through each sample and split into chunks of max_tokens
+    for sample_index in range(len(full_inputs["input_ids"])):
+        for text_index in range(
+            0, len(full_inputs["input_ids"][sample_index]), max_tokens
+        ):
+            # Create partial tensors for inputs, targets, and attention masks with fill values
+            partial_inputs_ids = torch.full(
+                (max_tokens,), tokenizer.pad_token_id, dtype=torch.long
+            )
+            partial_target_ids = torch.full((max_tokens,), -100, dtype=torch.long)
+            partial_attention_mask = torch.zeros((max_tokens,), dtype=torch.long)
 
-    if buffer_input_ids.numel() > 0:  # for any leftover tokens
-        while buffer_input_ids.numel() < max_tokens:  # make all sequences equal in size
-            buffer_input_ids = torch.cat(
-                (
-                    buffer_input_ids,
-                    torch.full(
-                        (max_tokens - buffer_input_ids.numel(),),
-                        tokenizer.pad_token_id,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
+            # Determine the length of the text to copy
+            text_length = min(
+                max_tokens,
+                len(full_inputs["input_ids"][sample_index]) - text_index,
             )
-            buffer_labels = torch.cat(
-                (
-                    buffer_labels,
-                    torch.full(
-                        (max_tokens - buffer_labels.numel(),),
-                        -100,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_attention_mask = torch.cat(
-                (
-                    buffer_attention_mask,
-                    torch.full(
-                        (max_tokens - buffer_attention_mask.numel(),),
-                        0,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-        new_input_ids.append(buffer_input_ids)
-        new_labels.append(buffer_labels)
-        new_attention_mask.append(buffer_attention_mask)
 
-    ret = {
-        "input_ids": [seq.tolist() for seq in new_input_ids],
-        "labels": [seq.tolist() for seq in new_labels],
-        "attention_mask": [seq.tolist() for seq in new_attention_mask],
+            # Copy the text into the partial tensors
+            partial_inputs_ids[:text_length] = full_inputs["input_ids"][sample_index][
+                text_index : text_index + text_length
+            ]
+            partial_target_ids[:text_length] = full_inputs["input_ids"][sample_index][
+                text_index : text_index + text_length
+            ]
+            partial_attention_mask[:text_length] = full_inputs["attention_mask"][
+                sample_index
+            ][text_index : text_index + text_length]
+
+            # Append the partial tensors to the lists
+            inputs_ids.append(partial_inputs_ids)
+            target_ids.append(partial_target_ids)
+            attention_mask.append(partial_attention_mask)
+
+    LOG.debug("Input IDs length: %s", len(inputs_ids))
+
+    return {
+        "input_ids": [input_id.tolist() for input_id in inputs_ids],
+        "labels": [target_id.tolist() for target_id in target_ids],
+        "attention_mask": [mask.tolist() for mask in attention_mask],
     }
-
-    LOG.debug(len(ret["input_ids"]))
-    return ret
 
 
 def wrap_pretraining_dataset(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Description

This PR adds auto-truncation support for pretraining_datasets.

<!--- Describe your changes in detail -->
## Motivation and Context

While investigating an issue in the [dataloader](#3069), I noticed an opportunity to improve the handling of pretraining_datasets.
Although this PR is not a direct fix for that issue, adding auto-truncation was straightforward.

One important thing to notice is that it will become harder for the user to know the `max_steps` value accordingly to its datasets because it's no longer the number of samples.

<!--- Why is this change required? What problem does it solve? -->
## How has this been tested?

I tested the changes locally on my setup with multiple GPUs.
The modification is scoped only to pretraining_datasets with or without concatenation, and only when sample packing is disabled.
While I did not perform extensive testing, I validated the tokenisation process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Enhancement (non-breaking change that adds functionality)

## Social Handles

[Blyzi](https://github.com/Blyzi)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Pretraining data encoding now produces fixed-size token chunks without truncating inputs or adding EOS/PAD tokens; optional concatenation merges samples before chunking.
  - Padding and attention masks are applied consistently; labels ignore padded positions.

- Documentation
  - Removed callout about automatic splitting of long completion samples and updated related examples in dataset format docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->