### PR TITLE
removed: deprecated state_dict_type() set_state_dict_type()

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -281,7 +281,6 @@ def save_trained_model(
                 state_dict_type = cfg.fsdp_config.final_state_dict_type
             else:
                 state_dict_type = cfg.fsdp_config.state_dict_type
-            trainer.accelerator.state.fsdp_plugin.set_state_dict_type(state_dict_type)
         trainer.save_model(cfg.output_dir)
         if state_dict_type == "SHARDED_STATE_DICT":
             LOG.info(


### PR DESCRIPTION

# Description
removed: deprecated state_dict_type() set_state_dict_type()

## Motivation and Context

#2402 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved model state collection onto PyTorch’s centralized distributed checkpoint API for FSDP workflows, standardizing save behavior.
* **Bug Fixes**
  * More reliable model saves in distributed/FSDP setups; honors full-state-dict options (CPU offload, rank0-only) and reduces save-time failures.
* **Chores**
  * Simplified internal state-dict handling and removed redundant configuration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->