### PR TITLE
make always skip_move_to_device default as true

### DIFF
--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -65,10 +65,9 @@ class ModelInputConfig(BaseModel):
     )
 
     experimental_skip_move_to_device: bool | None = Field(
-        default=None,
+        default=True,
         json_schema_extra={
-            "description": "Don't move the model to the device before sharding. "
-            "This is an experimental feature that may be included in the future as the default."
+            "description": "Don't move the model to the device before sharding. Set to `false` to revert to legacy behavior."
         },
     )
 


### PR DESCRIPTION
# Description

We should default to never moving the model to device until we're ready to train/shard as doing so prematurely will lead to OOMs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed default behavior to skip moving models to device before sharding. This is now enabled by default; set the flag to false to restore legacy behavior.

* **Documentation**
  * Updated description to clarify the new default and how to revert to legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->