### PR TITLE
Clamping the len of dataloader to minimum of 1

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -475,7 +475,9 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 train_dataset.remove_columns(["length"]),
                 batch_sampler=sampler,
             )
-            data_loader_len = max(1, len(data_loader) * cfg.micro_batch_size // cfg.batch_size)
+            data_loader_len = max(
+                1, len(data_loader) * cfg.micro_batch_size // cfg.batch_size
+            )
             LOG.debug(f"data_loader_len: {data_loader_len}")
             # FIXME: is there a bug here somewhere? the total num steps depends
             # on the agreed on value for sample_packing_eff_est

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -475,7 +475,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                 train_dataset.remove_columns(["length"]),
                 batch_sampler=sampler,
             )
-            data_loader_len = len(data_loader) * cfg.micro_batch_size // cfg.batch_size
+            data_loader_len = max(1, len(data_loader) * cfg.micro_batch_size // cfg.batch_size)
             LOG.debug(f"data_loader_len: {data_loader_len}")
             # FIXME: is there a bug here somewhere? the total num steps depends
             # on the agreed on value for sample_packing_eff_est


### PR DESCRIPTION
Clamp the value of data loader to a min of 1.

# Description

There are cases when data loader length is evaluated as 0 (mostly due to small dataset, examples below), which does not make sense. 

## Motivation and Context

When testing locally (e.g. for gemma3 & qwen3 models), with 
1. `sample_packing = true`
2. `eval_sample_packing = true` 
3.  small dataset, for example, 100 - 1000 (didn't know exactly the range) raw examples.

I am running into this [ValueError](https://github.com/axolotl-ai-cloud/axolotl/blob/79ddaebe9a6af7efefebdbb54772d11d09561786/src/axolotl/utils/data/sft.py#L115), and after setting `eval_sample_packing = false`  I am running into this  [ValueError](https://github.com/huggingface/transformers/blob/c81723d31b8a532803feee2bbce66e4f03829759/src/transformers/trainer.py#L5535). Both errors are root caused in `calculate_total_num_steps` that num_steps is evaluated as 0. 

For whatever reasons the initial evaluation is 0, we should at least clamp the value to 1.

## How has this been tested?

Axolotl's instruction. i.e. https://github.com/axolotl-ai-cloud/axolotl/blob/79ddaebe9a6af7efefebdbb54772d11d09561786/README.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented zero-step calculations in certain sample-packing setups by ensuring at least one data-loader step, improving robustness when micro-batch size is smaller than batch size or datasets are small.
  - Made total training step estimates more reliable to avoid premature training termination and issues with schedulers and progress indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->