### PR TITLE
fix: chat template jinja file not being loaded during inference

### DIFF
--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -14,10 +14,7 @@ from transformers import GenerationConfig, TextIteratorStreamer, TextStreamer
 from axolotl.cli.args import InferenceCliArgs
 from axolotl.cli.config import load_cfg
 from axolotl.cli.utils import load_model_and_tokenizer
-from axolotl.utils.chat_templates import (
-    get_chat_template,
-    get_chat_template_from_config,
-)
+from axolotl.utils.chat_templates import get_chat_template_from_config
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
 
@@ -64,7 +61,9 @@ def do_inference(
             importlib.import_module("axolotl.prompters"), prompter
         )
     elif cfg.chat_template:
-        chat_template_str = get_chat_template(cfg.chat_template, tokenizer=tokenizer)
+        chat_template_str = get_chat_template_from_config(
+            cfg.chat_template, ds_cfg=None, tokenizer=tokenizer
+        )
     elif cfg.datasets[0].type == "chat_template":
         chat_template_str = get_chat_template_from_config(
             cfg=cfg, ds_cfg=cfg.datasets[0], tokenizer=tokenizer
@@ -159,7 +158,9 @@ def do_inference_gradio(
             importlib.import_module("axolotl.prompters"), prompter
         )
     elif cfg.chat_template:
-        chat_template_str = get_chat_template(cfg.chat_template, tokenizer=tokenizer)
+        chat_template_str = get_chat_template_from_config(
+            cfg.chat_template, ds_cfg=None, tokenizer=tokenizer
+        )
 
     model = model.to(cfg.device, dtype=cfg.torch_dtype)
 

--- a/src/axolotl/cli/inference.py
+++ b/src/axolotl/cli/inference.py
@@ -62,7 +62,7 @@ def do_inference(
         )
     elif cfg.chat_template:
         chat_template_str = get_chat_template_from_config(
-            cfg.chat_template, ds_cfg=None, tokenizer=tokenizer
+            cfg, ds_cfg=None, tokenizer=tokenizer
         )
     elif cfg.datasets[0].type == "chat_template":
         chat_template_str = get_chat_template_from_config(
@@ -159,7 +159,11 @@ def do_inference_gradio(
         )
     elif cfg.chat_template:
         chat_template_str = get_chat_template_from_config(
-            cfg.chat_template, ds_cfg=None, tokenizer=tokenizer
+            cfg, ds_cfg=None, tokenizer=tokenizer
+        )
+    elif cfg.datasets[0].type == "chat_template":
+        chat_template_str = get_chat_template_from_config(
+            cfg=cfg, ds_cfg=cfg.datasets[0], tokenizer=tokenizer
         )
 
     model = model.to(cfg.device, dtype=cfg.torch_dtype)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Fix chat template not properly loading jinja files during inference.

Repro:

```
chat_template: jinja
chat_template_jinja: smoltemplate.jinja
```

Error:

```
  File "/workspace/axolotl/src/axolotl/utils/chat_templates/base.py", line 47, in get_chat_template
    raise ValueError(
ValueError: `jinja_template` cannot be None when `chat_template` choice is jinja
```

Reason: We didn't pass the `chat_template_jinja` in the check below.
```python
elif cfg.chat_template:
        chat_template_str = get_chat_template(cfg.chat_template, tokenizer=tokenizer)
```

Reported in discord by `deckard` https://discord.com/channels/1104757954588196865/1111279858136383509/1410298828372049990

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the top-level chat template is applied consistently in both CLI and web UI inference, reducing formatting inconsistencies.
  * Adds support for using dataset-backed chat templates in the web UI.

* **Refactor**
  * Unifies chat template handling to a single retrieval flow for more predictable behavior and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->