### PR TITLE
fix(rl): pass max_prompt_len to training args as max_prompt_length

### DIFF
--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -151,6 +151,9 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()
+            
+            if self.cfg.max_prompt_len:
+                training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         elif self.cfg.rl in [RLType.DPO, RLType.IPO]:
             training_args_cls = AxolotlDPOConfig

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -134,6 +134,14 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             if self.cfg.cpo_alpha is not None:
                 training_args_kwargs["cpo_alpha"] = self.cfg.cpo_alpha
 
+            # Handle when max_prompt_length == max_length from defaults
+            # CPOTrainer requires strictly less than
+            if (
+                training_args_kwargs["max_prompt_length"]
+                == training_args_kwargs["max_length"]
+            ):
+                training_args_kwargs["max_prompt_length"] -= 1
+
         elif self.cfg.rl is RLType.ORPO:
             training_args_cls = AxolotlORPOConfig
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -151,7 +151,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()
-            
+
             if self.cfg.max_prompt_len:
                 training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -119,7 +119,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.use_wandb:
             training_args_kwargs["run_name"] = self.cfg.wandb_name
-        
+
         if self.cfg.max_prompt_len:
             training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -119,6 +119,9 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.use_wandb:
             training_args_kwargs["run_name"] = self.cfg.wandb_name
+        
+        if self.cfg.max_prompt_len:
+            training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         training_args_cls = None
         blocklist_args_kwargs = []
@@ -131,8 +134,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
 
         elif self.cfg.rl is RLType.ORPO:
             training_args_cls = AxolotlORPOConfig
-            if self.cfg.max_prompt_len:
-                training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         elif self.cfg.rl is RLType.KTO:
             training_args_cls = AxolotlKTOConfig
@@ -144,16 +145,10 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
                 self.cfg.kto_undesirable_weight or 1.0
             )
 
-            if self.cfg.max_prompt_len:
-                training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
-
         elif self.cfg.rl is RLType.GRPO:
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()
-
-            if self.cfg.max_prompt_len:
-                training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
 
         elif self.cfg.rl in [RLType.DPO, RLType.IPO]:
             training_args_cls = AxolotlDPOConfig

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -122,6 +122,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
 
         if self.cfg.max_prompt_len:
             training_args_kwargs["max_prompt_length"] = self.cfg.max_prompt_len
+        else:
+            training_args_kwargs["max_prompt_length"] = self.cfg.sequence_len
 
         training_args_cls = None
         blocklist_args_kwargs = []

--- a/src/axolotl/core/trainers/dpo/__init__.py
+++ b/src/axolotl/core/trainers/dpo/__init__.py
@@ -27,7 +27,6 @@ class DPOStrategy:
             training_args_kwargs["label_smoothing"] = cfg.dpo_label_smoothing
         training_args_kwargs["max_completion_length"] = None
         training_args_kwargs["max_length"] = cfg.sequence_len
-        training_args_kwargs["max_prompt_length"] = cfg.sequence_len
         training_args_kwargs["generate_during_eval"] = cfg.dpo_generate_during_eval
         if cfg.dpo_use_weighting is not None:
             training_args_kwargs["use_weighting"] = cfg.dpo_use_weighting

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -424,8 +424,8 @@ class AxolotlInputConfig(
         },
     )
     min_sample_len: int | None = None
-    max_prompt_len: int = Field(
-        default=512,
+    max_prompt_len: int | None = Field(
+        default=None,
         json_schema_extra={"description": "maximum prompt length for RL training"},
     )
     sample_packing: bool | None = Field(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR fixes a bug where `max_prompt_len` in GRPO config was not being passed into the training arguments.  
Now, if `self.cfg.max_prompt_len` is set, it will correctly be mapped to `training_args_kwargs["max_prompt_length"]`.

## Motivation and Context

- Previously, setting `max_prompt_len` in the config had no effect.  
- This fix ensures that the config parameter is properly respected by the training loop.  
- Helps prevent unexpected behavior when users rely on `max_prompt_len` to control context size.

## How has this been tested?

- Modified GRPO code to include `max_prompt_length` when `self.cfg.max_prompt_len` is provided.  
- Verified via logging that the value is correctly propagated into `training_args_kwargs`.  
- Ran a training job with `max_prompt_len=1024` and confirmed that the effective prompt length was limited.  

Environment:
- Python 3.12  
- PyTorch 2.7.1
- Axolotl 0.13.0.dev0

## Screenshots (if appropriate)

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GRPO training now respects the max_prompt_len setting by passing it into training as max_prompt_length, making prompt length handling consistent across RL strategies.
  * Improves control over prompt truncation, memory usage, and training stability for GRPO workflows.
  * No other training behavior or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->