### PR TITLE
feat(doc): update thinking and chat_template notes

### DIFF
--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -108,7 +108,7 @@ Refer to [our docs](https://docs.axolotl.ai/docs/dataset-formats/conversation.ht
 
 ### Thinking and chat_template masking conflict
 
-OpenAI's Harmony template hides non-last turn's `thinking` content in which conflicts with our chat_template masking.
+OpenAI’s Harmony template hides `thinking` in all non-final turns, which conflicts with Axolotl’s `chat_template` masking.
 
 If your dataset has `thinking` content mid-turn, there are two paths we recommend:
 

--- a/examples/gpt-oss/README.md
+++ b/examples/gpt-oss/README.md
@@ -106,6 +106,16 @@ See [Nanobit/text-tools-2k-test](https://huggingface.co/datasets/Nanobit/text-to
 
 Refer to [our docs](https://docs.axolotl.ai/docs/dataset-formats/conversation.html#using-tool-use) for more info.
 
+### Thinking and chat_template masking conflict
+
+OpenAI's Harmony template hides non-last turn's `thinking` content in which conflicts with our chat_template masking.
+
+If your dataset has `thinking` content mid-turn, there are two paths we recommend:
+
+- Train only on the last turn. This can be accomplished via chat_template's [train on last doc](https://docs.axolotl.ai/docs/dataset-formats/conversation.html#training-on-last-message).
+
+- Adjust your dataset to only have `thinking` content in the last turn.
+
 ### TIPS
 
 - Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Add note about mid-turn thinking.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section, “Thinking and chat_template masking conflict,” describing how Harmony hides non-final-turn thinking and how that may conflict with chat_template masking.
  * Provides guidance for datasets with mid-turn thinking: either train only on the last turn or restructure datasets so thinking appears only in the final turn.
  * Notes that the dataset format follows the OpenAI Messages format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->