### PR TITLE
Update QAT API + add NVFP4 QAT

### DIFF
--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -5,6 +5,7 @@ from enum import Enum
 import torch
 
 
+# TODO: rename this
 class TorchIntDType(Enum):
     """Torch integer data types - `getattr` guards against torch < 2.6 which does not support int4"""
 
@@ -17,6 +18,8 @@ class TorchIntDType(Enum):
     uint7 = getattr(torch, "uint7", None)
     int4 = getattr(torch, "int4", None)
     int8 = getattr(torch, "int8", None)
+    # There is no torch.dtype for nvfp4, so we just use a string here as a placeholder
+    nvfp4 = "nvfp4"
 
 
 class RLType(str, Enum):

--- a/src/axolotl/utils/schemas/quantization.py
+++ b/src/axolotl/utils/schemas/quantization.py
@@ -16,11 +16,11 @@ class QATConfig(BaseModel):
 
     activation_dtype: TorchIntDType | None = Field(
         default=None,
-        description='Fake quantization layout to use for activation quantization. Valid options are "int4" and "int8"',
+        description='Fake quantization layout to use for activation quantization. Valid options are "int4", "int8", and "nvfp4"',
     )
     weight_dtype: TorchIntDType = Field(
         default=TorchIntDType.int8,
-        description='Fake quantization layout to use for weight quantization. Valid options are "int4" and "int8"',
+        description='Fake quantization layout to use for weight quantization. Valid options are "int4", "int8", and "nvfp4"',
     )
     quantize_embedding: bool | None = Field(
         default=False, description="Quantize embedding"
@@ -40,7 +40,9 @@ class QATConfig(BaseModel):
             return TorchIntDType.int4
         if v == "int8":
             return TorchIntDType.int8
-        raise ValueError(f"Invalid dtype: '{v}'. Must be one of: ['int4', 'int8']")
+        if v == "nvfp4":
+            return TorchIntDType.nvfp4
+        raise ValueError(f"Invalid dtype: '{v}'. Must be one of: ['int4', 'int8', 'nvfp4']")
 
 
 class PTQConfig(BaseModel):
@@ -71,4 +73,6 @@ class PTQConfig(BaseModel):
             return TorchIntDType.int4
         if v == "int8":
             return TorchIntDType.int8
-        raise ValueError(f"Invalid dtype: '{v}'. Must be one of: ['int4', 'int8']")
+        if v == "nvfp4":
+            return TorchIntDType.nvfp4
+        raise ValueError(f"Invalid dtype: '{v}'. Must be one of: ['int4', 'int8', 'nvfp4']")


### PR DESCRIPTION
**Summary:** Update axolotl's QAT APIs to the simpler ones introduced in torchao 0.13.0, since the old APIs are now deprecated. We also add prototype support for NVFP4 QAT, which was introduced in the same release.

**Test Plan:**
Change `examples/llama-3/3b-qat-fsdp2.yaml` to use NVFP4:
```
qat:
  activation_dtype: nvfp4
  weight_dtype: nvfp4
  group_size: 16
```

Run the following:
```
axolotl train examples/llama-3/3b-qat-fsdp2.yaml
axolotl quantize examples/llama-3/3b-qat-fsdp2.yaml
accelerate launch -m lm_eval --model hf --model_args pretrained=outputs/quantized/ --tasks wikitext --batch_size 2
```

(ongoing)