### PR TITLE
Refactor Loraconfig and model constructor 

### DIFF
--- a/src/axolotl/loaders/adapter.py
+++ b/src/axolotl/loaders/adapter.py
@@ -182,6 +182,9 @@ def load_adapter(
         if config_only:
             return None, config
 
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+
         model = builder.build_model(model, config)
         return model, config
 

--- a/src/axolotl/loaders/adapter.py
+++ b/src/axolotl/loaders/adapter.py
@@ -19,10 +19,10 @@ from peft import (
 )
 from transformers import PreTrainedModel
 
+from axolotl.loaders.adapters.builders.factory import AdapterBuilderFactory
 from axolotl.loaders.utils import get_linear_embedding_layers
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
-from axolotl.loaders.adapters.builders.factory import AdapterBuilderFactory
 
 LOG = get_logger(__name__)
 

--- a/src/axolotl/loaders/adapter.py
+++ b/src/axolotl/loaders/adapter.py
@@ -167,15 +167,11 @@ def load_adapter(
     adapter: str | None,
     inference: bool = False,
     config_only: bool = False,
-) -> tuple[PreTrainedModel | PeftModel | PeftMixedModel, PeftConfig | None]:
+) -> tuple[PreTrainedModel | PeftModel | PeftMixedModel | None, PeftConfig | None]:
     try:
         if adapter is None:
             return model, None
         builder = AdapterBuilderFactory.create_builder(adapter, cfg)
-
-        if not builder:
-            LOG.warning(f"No builder found for adapter type '{adapter}'")
-            return model, None
 
         config = builder.build_config(model)
 
@@ -185,10 +181,10 @@ def load_adapter(
         if hasattr(model, "enable_input_require_grads"):
             model.enable_input_require_grads()
 
-        model = builder.build_model(model, config)
+        model = builder.build_model(model, config, inference=inference)
         return model, config
 
-    except Exception as e:
+    except ValueError as e:
         LOG.debug(
             f"Builder pattern failed, falling back to legacy adapter loading: {e}"
         )

--- a/src/axolotl/loaders/adapters/__init__.py
+++ b/src/axolotl/loaders/adapters/__init__.py
@@ -1,0 +1,13 @@
+"""Adapters package."""
+
+from .builders import (
+    AdapterBuilderFactory,
+    BaseAdapterBuilder,
+    LoraAdapterBuilder,
+)
+
+__all__ = [
+    "AdapterBuilderFactory",
+    "BaseAdapterBuilder",
+    "LoraAdapterBuilder",
+]

--- a/src/axolotl/loaders/adapters/builders/__init__.py
+++ b/src/axolotl/loaders/adapters/builders/__init__.py
@@ -1,0 +1,11 @@
+"""Adapter builders package."""
+
+from .base import BaseAdapterBuilder
+from .factory import AdapterBuilderFactory
+from .lora import LoraAdapterBuilder
+
+__all__ = [
+    "BaseAdapterBuilder",
+    "AdapterBuilderFactory",
+    "LoraAdapterBuilder",
+]

--- a/src/axolotl/loaders/adapters/builders/base.py
+++ b/src/axolotl/loaders/adapters/builders/base.py
@@ -36,12 +36,14 @@ class BaseAdapterBuilder(ABC):
         return lora_config
 
     @abstractmethod
-    def build_model(self, model: PreTrainedModel, config: PeftConfig) -> PeftModel:
+    def build_model(
+        self, model: PreTrainedModel, config: PeftConfig, *, inference: bool = False
+    ) -> PeftModel:
         """Build the PEFT model"""
         self.setup_quantization_for_training(model)
 
         if self.cfg.lora_model_dir:
-            model = self.load_pretrained_adapter(model)
+            model = self.load_pretrained_adapter(model, inference)
         else:
             model = self.create_peft_model(model, config)
 

--- a/src/axolotl/loaders/adapters/builders/base.py
+++ b/src/axolotl/loaders/adapters/builders/base.py
@@ -1,0 +1,225 @@
+import os
+from abc import abstractmethod, ABC
+from typing import Optional, Union, List, Any, Dict
+from transformers import PreTrainedModel
+from peft import PeftConfig, PeftModel, get_peft_model
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+from axolotl.loaders.adapter import find_all_linear_names
+
+LOG = get_logger(__name__)
+
+
+class BaseAdapterBuilder(ABC):
+    """Base class for adapter builders"""
+
+    def __init__(self, cfg: DictDefault):
+        self.cfg = cfg
+        self.rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    @abstractmethod
+    def build_config(self, model: PreTrainedModel, **kwargs) -> PeftConfig:
+        """Build the PEFT configuration"""
+        pass
+
+    @abstractmethod
+    def build_model(self, model: PreTrainedModel, config: PeftConfig) -> PeftModel:
+        """Build the PEFT model"""
+        pass
+
+    def prepare_target_modules(
+        self,
+        model: PreTrainedModel,
+        target_modules: Optional[Union[str, List[str]]] = None,
+    ) -> List[str]:
+        """
+        Prepare and validate target modules for the adapter.
+
+        Args:
+            model: The base model
+            target_modules: User-specified target modules
+
+        Returns:
+            List[str]: Processed list of target modules
+        """
+
+        lora_target_modules: Union[str, List[str]] = (
+            target_modules or self.cfg.lora_target_modules or []
+        )
+
+        if self.cfg.lora_target_linear:
+            linear_names = find_all_linear_names(model)
+            LOG.info(f"found linear modules: {repr(sorted(linear_names))}")
+            lora_target_modules_as_list = (
+                lora_target_modules
+                if isinstance(lora_target_modules, list)
+                else [lora_target_modules]
+                if lora_target_modules
+                else []
+            )
+            lora_target_modules = list(set(lora_target_modules_as_list + linear_names))
+        elif isinstance(lora_target_modules, str):
+            lora_target_modules = [lora_target_modules]
+        elif lora_target_modules is None:
+            lora_target_modules = []
+
+        return lora_target_modules
+
+    def prepare_target_parameters(
+        self, target_parameters: Optional[Union[str, List[str]]] = None
+    ) -> List[str]:
+        """
+        Prepare target parameters for the adapter.
+
+        Args:
+            target_parameters: User-specified target parameters
+
+        Returns:
+            List[str]: Processed list of target parameters
+        """
+        result = target_parameters or self.cfg.lora_target_parameters or []
+        if isinstance(result, str):
+            return [result]
+        elif isinstance(result, list):
+            return result
+        else:
+            return []
+
+    def build_common_config_kwargs(self) -> Dict[str, Any]:
+        """
+        Build common configuration kwargs shared across adapter types.
+
+        Returns:
+            Dict[str, Any]: Common configuration parameters
+        """
+        config_kwargs = {}
+
+        # LoftQ configuration
+        loftq_bits = (
+            self.cfg.peft
+            and self.cfg.peft.loftq_config
+            and self.cfg.peft.loftq_config.loftq_bits
+        )
+        if loftq_bits:
+            from peft import LoftQConfig
+
+            config_kwargs["loftq_config"] = LoftQConfig(loftq_bits=loftq_bits)
+            config_kwargs["init_lora_weights"] = "loftq"
+
+        # LoRA weight initialization
+        if self.cfg.peft_init_lora_weights:
+            config_kwargs["init_lora_weights"] = self.cfg.peft_init_lora_weights
+
+        # DoRA configuration
+        if self.cfg.peft_use_dora:
+            config_kwargs["use_dora"] = self.cfg.peft_use_dora
+            LOG.info("Initializing LoRA weights using DoRA. This might take longer.")
+
+        # RSLoRA configuration
+        if self.cfg.peft_use_rslora:
+            config_kwargs["use_rslora"] = self.cfg.peft_use_rslora
+
+        # Layer replication
+        if self.cfg.peft_layer_replication:
+            config_kwargs["layer_replication"] = self.cfg.peft_layer_replication
+
+        return config_kwargs
+
+    def setup_quantization_for_training(self, model: Union[PreTrainedModel, PeftModel]):
+        """
+        Setup quantization metadata for training.
+
+        Args:
+            model: The model to setup quantization for
+        """
+        from axolotl.loaders.adapter import setup_quantized_meta_for_peft
+
+        if (
+            self.cfg.fsdp_config
+            and self.cfg.adapter
+            and self.cfg.fsdp_config.cpu_ram_efficient_loading
+            and self.rank != 0
+        ):
+            setup_quantized_meta_for_peft(model)
+
+    def setup_quantization_for_training_post_build(
+        self, model: Union[PreTrainedModel, PeftModel]
+    ):
+        """
+        Setup quantization metadata after model building for training.
+
+        Args:
+            model: The model to setup quantization for
+        """
+        from axolotl.loaders.adapter import setup_quantized_peft_meta_for_training
+
+        if (
+            self.cfg.fsdp_config
+            and self.cfg.adapter
+            and self.cfg.fsdp_config.cpu_ram_efficient_loading
+            and self.rank != 0
+        ):
+            setup_quantized_peft_meta_for_training(model)
+
+    def load_pretrained_adapter(
+        self, model: PreTrainedModel, inference: bool = False
+    ) -> Union[PreTrainedModel, PeftModel]:
+        """
+        Load a pretrained adapter from a directory.
+
+        Args:
+            model: Base model to load adapter onto
+            inference: Whether this is for inference mode
+
+        Returns:
+            PeftModel: Model with loaded adapter
+        """
+
+        if not self.cfg.lora_model_dir:
+            return model
+
+        LOG.debug(f"Loading pretrained PEFT - {self.__class__.__name__}")
+        model_kwargs: Dict[str, Any] = {}
+
+        if self.cfg.lora_on_cpu:
+            model_kwargs["max_memory"] = {"cpu": "256GiB"}
+            model_kwargs["device_map"] = {"": "cpu"}
+
+        return PeftModel.from_pretrained(
+            model,
+            self.cfg.lora_model_dir,
+            is_trainable=(not inference),
+            **model_kwargs,
+        )
+
+    def create_peft_model(
+        self, model: PreTrainedModel, config: PeftConfig
+    ) -> PeftModel:
+        """
+        Create a PEFT model from base model and config.
+
+        Args:
+            model: Base model
+            config: PEFT configuration
+
+        Returns:
+            PeftModel: Created PEFT model
+        """
+        return get_peft_model(model, config)
+
+    def print_trainable_parameters(self, model: Union[PreTrainedModel, PeftModel]):
+        """
+        Print the number of trainable parameters in the model.
+
+        Args:
+            model: The model to analyze
+        """
+        if self.rank == 0:
+            try:
+                model.print_trainable_parameters()
+            except AttributeError as exc:
+                LOG.warning(
+                    "Exception caught during model.print_trainable_parameters(): %s",
+                    exc,
+                )

--- a/src/axolotl/loaders/adapters/builders/base.py
+++ b/src/axolotl/loaders/adapters/builders/base.py
@@ -1,8 +1,9 @@
 import os
-from abc import abstractmethod, ABC
-from typing import Optional, Union, List, Any, Dict
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+from peft import LoraConfig, PeftConfig, PeftModel, get_peft_model
 from transformers import PreTrainedModel
-from peft import PeftConfig, PeftModel, get_peft_model, LoraConfig
 
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger

--- a/src/axolotl/loaders/adapters/builders/factory.py
+++ b/src/axolotl/loaders/adapters/builders/factory.py
@@ -1,6 +1,8 @@
 from typing import Dict, Type
+
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
+
 from .base import BaseAdapterBuilder
 from .lora import LoraAdapterBuilder
 

--- a/src/axolotl/loaders/adapters/builders/factory.py
+++ b/src/axolotl/loaders/adapters/builders/factory.py
@@ -1,0 +1,68 @@
+from typing import Dict, Type
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+from .base import BaseAdapterBuilder
+from .lora import LoraAdapterBuilder
+
+LOG = get_logger(__name__)
+
+
+class AdapterBuilderFactory:
+    """Factory for creating adapter builders based on adapter type."""
+
+    _builders: Dict[str, Type[BaseAdapterBuilder]] = {
+        "lora": LoraAdapterBuilder,
+        "qlora": LoraAdapterBuilder,
+    }
+
+    @classmethod
+    def register_builder(
+        cls, adapter_type: str, builder_class: Type[BaseAdapterBuilder]
+    ):
+        """
+        Register a new adapter builder.
+
+        Args:
+            adapter_type: Type of adapter (e.g., 'lora', 'qlora')
+            builder_class: Builder class that extends BaseAdapterBuilder
+        """
+        cls._builders[adapter_type] = builder_class
+        LOG.info(
+            f"Registered adapter builder for '{adapter_type}': {builder_class.__name__}"
+        )
+
+    @classmethod
+    def create_builder(cls, adapter_type: str, cfg: DictDefault) -> BaseAdapterBuilder:
+        """
+        Create an adapter builder for the specified type.
+
+        Args:
+            adapter_type: Type of adapter to create builder for
+            cfg: Configuration object
+
+        Returns:
+            BaseAdapterBuilder: Configured adapter builder
+
+        Raises:
+            ValueError: If adapter type is not supported
+        """
+        if adapter_type not in cls._builders:
+            available_types = list(cls._builders.keys())
+            raise ValueError(
+                f"Unsupported adapter type: {adapter_type}. "
+                f"Available types: {available_types}"
+            )
+
+        builder_class = cls._builders[adapter_type]
+        LOG.info(f"Creating {builder_class.__name__} for adapter type '{adapter_type}'")
+        return builder_class(cfg)
+
+    @classmethod
+    def get_supported_adapters(cls) -> list[str]:
+        """
+        Get list of supported adapter types.
+
+        Returns:
+            list[str]: List of supported adapter type names
+        """
+        return list(cls._builders.keys())

--- a/src/axolotl/loaders/adapters/builders/lora.py
+++ b/src/axolotl/loaders/adapters/builders/lora.py
@@ -1,0 +1,71 @@
+from typing import Any, Dict, List, Optional, Union
+from transformers import PreTrainedModel
+from peft import LoraConfig, PeftModel
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.logging import get_logger
+from .base import BaseAdapterBuilder
+
+LOG = get_logger(__name__)
+
+
+class LoraAdapterBuilder(BaseAdapterBuilder):
+    """Builder for LoRA adapters."""
+
+    def build_config(self, model: PreTrainedModel, **kwargs) -> LoraConfig:
+        """
+        Build LoRA configuration.
+        
+        Args:
+            model: The base model
+            **kwargs: Additional configuration options
+            
+        Returns:
+            LoraConfig: Configured LoRA adapter
+        """
+        target_modules = self.prepare_target_modules(model)
+        target_parameters = self.prepare_target_parameters()
+
+        config_kwargs = self.build_common_config_kwargs()
+
+        config_kwargs.update(kwargs)
+
+        lora_config = LoraConfig(
+            r=self.cfg.lora_r,
+            lora_alpha=self.cfg.lora_alpha,
+            target_modules=target_modules,
+            target_parameters=target_parameters,
+            layers_to_transform=self.cfg.peft_layers_to_transform,
+            layers_pattern=self.cfg.peft_layers_pattern,
+            lora_dropout=self.cfg.lora_dropout,
+            fan_in_fan_out=self.cfg.lora_fan_in_fan_out,
+            modules_to_save=self.cfg.lora_modules_to_save if self.cfg.lora_modules_to_save else None,
+            bias="none",
+            task_type="CAUSAL_LM",
+            **config_kwargs,
+        )
+        return lora_config
+
+    def build_model(self, model: PreTrainedModel, config: LoraConfig) -> PeftModel:
+        """
+        Build LoRA model.
+        
+        Args:
+            model: Base model
+            config: LoRA configuration
+            
+        Returns:
+            PeftModel: Model with LoRA adapter applied
+        """
+        self.setup_quantization_for_training(model)
+        
+        if self.cfg.lora_model_dir:
+            LOG.debug("Loading pretrained PEFT - LoRA")
+            model = self.load_pretrained_adapter(model)
+        else:
+            model = self.create_peft_model(model, config)
+
+        self.print_trainable_parameters(model)
+        self.setup_quantization_for_training_post_build(model)
+        
+        return model

--- a/src/axolotl/loaders/adapters/builders/lora.py
+++ b/src/axolotl/loaders/adapters/builders/lora.py
@@ -1,7 +1,8 @@
-from transformers import PreTrainedModel
 from peft import LoraConfig, PeftModel
+from transformers import PreTrainedModel
 
 from axolotl.utils.logging import get_logger
+
 from .base import BaseAdapterBuilder
 
 LOG = get_logger(__name__)

--- a/src/axolotl/loaders/adapters/builders/lora.py
+++ b/src/axolotl/loaders/adapters/builders/lora.py
@@ -46,7 +46,9 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
         )
         return lora_config
 
-    def build_model(self, model: PreTrainedModel, config: LoraConfig) -> PeftModel:
+    def build_model(
+        self, model: PreTrainedModel, config: LoraConfig, *, inference: bool = False
+    ) -> PeftModel:
         """
         Build LoRA model.
 
@@ -61,7 +63,7 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
 
         if self.cfg.lora_model_dir:
             LOG.debug("Loading pretrained PEFT - LoRA")
-            model = self.load_pretrained_adapter(model)
+            model = self.load_pretrained_adapter(model, inference)
         else:
             model = self.create_peft_model(model, config)
 

--- a/src/axolotl/loaders/adapters/builders/lora.py
+++ b/src/axolotl/loaders/adapters/builders/lora.py
@@ -1,8 +1,6 @@
-from typing import Any, Dict, List, Optional, Union
 from transformers import PreTrainedModel
 from peft import LoraConfig, PeftModel
 
-from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
 from .base import BaseAdapterBuilder
 
@@ -15,11 +13,11 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
     def build_config(self, model: PreTrainedModel, **kwargs) -> LoraConfig:
         """
         Build LoRA configuration.
-        
+
         Args:
             model: The base model
             **kwargs: Additional configuration options
-            
+
         Returns:
             LoraConfig: Configured LoRA adapter
         """
@@ -39,7 +37,9 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
             layers_pattern=self.cfg.peft_layers_pattern,
             lora_dropout=self.cfg.lora_dropout,
             fan_in_fan_out=self.cfg.lora_fan_in_fan_out,
-            modules_to_save=self.cfg.lora_modules_to_save if self.cfg.lora_modules_to_save else None,
+            modules_to_save=self.cfg.lora_modules_to_save
+            if self.cfg.lora_modules_to_save
+            else None,
             bias="none",
             task_type="CAUSAL_LM",
             **config_kwargs,
@@ -49,16 +49,16 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
     def build_model(self, model: PreTrainedModel, config: LoraConfig) -> PeftModel:
         """
         Build LoRA model.
-        
+
         Args:
             model: Base model
             config: LoRA configuration
-            
+
         Returns:
             PeftModel: Model with LoRA adapter applied
         """
         self.setup_quantization_for_training(model)
-        
+
         if self.cfg.lora_model_dir:
             LOG.debug("Loading pretrained PEFT - LoRA")
             model = self.load_pretrained_adapter(model)
@@ -67,5 +67,5 @@ class LoraAdapterBuilder(BaseAdapterBuilder):
 
         self.print_trainable_parameters(model)
         self.setup_quantization_for_training_post_build(model)
-        
+
         return model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactor Loraconfig and model constructor 
<!--- Describe your changes in detail -->

## Description 

Refactor Loraconfig and model constructor
refactor introduces a builder-based adapter loading pattern for lora configurations and model construction : ) 

## Motivation and Context

#3111

## How has this been tested?

as currently repo dosent have lora full coverage of lora specific all the current and tests introduced in [3147](https://github.com/axolotl-ai-cloud/axolotl/pull/3147)  passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added config-only mode to generate adapter configs without building models.
  - Introduced an extensible builder-based adapter loading flow with inference-aware behavior.
- Refactor
  - Unified adapter handling under a builder pattern with automatic fallback to legacy paths.
  - Standardized and exposed a clear public adapter API surface.
- Bug Fixes
  - Ensures input-gradient settings remain enabled across all loading paths.
  - Provides clearer errors for unsupported adapters.
- Documentation
  - Added package docs and explicit public exports for adapter-related modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->