### PR TITLE
yodont keep adpater weights in fp32

### DIFF
--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -371,6 +371,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             model.tie_weights()
 
     is_peft_model = isinstance(model, PeftModel)
+    # TODO - this doesn't actually do anything
     for name, module in model.named_children():
         if name == "experts":
             # torch.distributed.breakpoint()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic dtype alignment for LoRA components during FSDP2 model preparation, minimizing manual adjustments.
* **Bug Fixes**
  * Resolves mixed-precision mismatches between base weights/biases and LoRA adapters that could cause errors or instability.
  * Reduces noisy bias-related warnings by applying inline casting.
* **Refactor**
  * Streamlined LoRA handling during FSDP2 preparation to enforce dtype consistency directly, improving reliability and setup smoothness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->