### PR TITLE
Log before eval step

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -362,6 +362,11 @@ class AxolotlTrainer(
             num_items_in_batch=num_items_in_batch,
         )
 
+    @override
+    def evaluate(self, *args, **kwargs):
+        LOG.info("Running evaluation step...")
+        return super().evaluate(*args, **kwargs)
+
     @staticmethod
     def orpo_concatenate_inputs(inputs, label_pad_token=-100, pad_token=0, device=None):
         concatenated_batch = {}


### PR DESCRIPTION
It's not clear during training that an eval step is happening. This adds the following logging:

```diff
[2025-09-10 10:58:06,507] [INFO] [axolotl.train.save_initial_configs:414] [PID:65109] [RANK:0] Pre-saving adapter config to ./outputs/lora-out...
[2025-09-10 10:58:06,507] [INFO] [axolotl.train.save_initial_configs:418] [PID:65109] [RANK:0] Pre-saving tokenizer to ./outputs/lora-out...
[2025-09-10 10:58:06,580] [INFO] [axolotl.train.save_initial_configs:423] [PID:65109] [RANK:0] Pre-saving model config to ./outputs/lora-out...
[2025-09-10 10:58:06,585] [INFO] [axolotl.train.execute_training:203] [PID:65109] [RANK:0] Starting trainer...
+[2025-09-10 10:58:06,758] [INFO] [axolotl.core.trainers.base.evaluate:367] [PID:65109] [RANK:0] Running evaluation step...                                                                                                                                                                                  
| 0/950 [00:00<?, ?it/s]
{'eval_loss': 1.3642939329147339, 'eval_runtime': 16.2872, 'eval_samples_per_second': 6.14, 'eval_steps_per_second': 3.07, 'memory/max_active (GiB)': 1.92, 'memory/max_allocated (GiB)': 10.97, 'memory/device_reserved (GiB)': 0, 'epoch': 0}
  0%|                                                                                                                                                                                                     | 0/950 [00:16<?, ?it/s[2025-09-10 10:58:25,030] 
{'loss': 1.5977, 'grad_norm': 1.0696640014648438, 'learning_rate': 0.0, 'memory/max_active (GiB)': 2.05, 'memory/max_allocated (GiB)': 11.43, 'memory/device_reserved (GiB)': 0, 'tokens_per_second_per_gpu': 24093.14, 'epoch': 0.0}
{'loss': 0.9325, 'grad_norm': 0.9180364012718201, 'learning_rate': 2e-05, 'memory/max_active (GiB)': 2.05, 'memory/max_allocated (GiB)': 11.44, 'memory/device_reserved (GiB)': 0, 'tokens_per_second_per_gpu': 490.41, 'epoch': 0.0}
{'loss': 1.3314, 'grad_norm': 1.497214674949646, 'learning_rate': 4e-05, 'memory/max_active (GiB)': 2.05, 'memory/max_allocated (GiB)': 11.83, 'memory/device_reserved (GiB)': 0, 'tokens_per_second_per_gpu': 389.11, 'epoch': 0.0}
{'loss': 1.8012, 'grad_norm': 3.244070529937744, 'learning_rate': 6e-05, 'memory/max_active (GiB)': 2.05, 'memory/max_allocated (GiB)': 11.83, 'memory/device_reserved (GiB)': 0, 'tokens_per_second_per_gpu': 163.48, 'epoch': 0.0}
...
{'loss': 1.1119, 'grad_norm': 0.5066446661949158, 'learning_rate': 0.00019608512076038962, 'memory/max_active (GiB)': 2.05, 'memory/max_allocated (GiB)': 24.49, 'memory/device_reserved (GiB)': 0, 'tokens_per_second_per_gpu': 1107.42, 'epoch': 0.1}
+[2025-09-10 10:59:22,847] [INFO] [axolotl.core.trainers.base.evaluate:367] [PID:65109] [RANK:0] Running evaluation step...
 10%|██████████████████▊                                                                                                                                                                         | 95/950 [01:16<11:19,  1.26it/s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear log message at the start of model evaluation to improve runtime visibility.
  * Preserves existing evaluation behavior and metrics; only adds user-facing logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->