### PR TITLE
remove unused dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ extras_require = {
     "ring-flash-attn": [
         "flash-attn==2.8.3",
         "ring-flash-attn>=0.1.7",
-        "yunchang==0.6.0",
     ],
     "deepspeed": [
         "deepspeed==0.17.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Must've snuck in during some ulysses dev a while ago.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the yunchang dependency from the ring-flash-attn optional install. This reduces unnecessary packages during installation and may lower install time and conflicts. Functionality remains unchanged. If your workflow depended on yunchang via this extra, please add it explicitly to your environment. No other dependency or build changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->