### PR TITLE
feat(qwen3-next): Adds targeting of shared expert and attention modules

### DIFF
--- a/examples/qwen3-next/README.md
+++ b/examples/qwen3-next/README.md
@@ -38,7 +38,7 @@ pip3 uninstall -y causal-conv1d && pip3 install flash-linear-attention==0.3.2
 axolotl train examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml
 ```
 
-This config uses about 41.7 GiB VRAM.
+This config uses about 45.62 GiB VRAM.
 
 Let us know how it goes. Happy finetuning! 🚀
 

--- a/examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml
+++ b/examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml
@@ -27,6 +27,14 @@ lora_r: 16
 lora_alpha: 8
 lora_dropout: 0.05
 lora_target_modules:
+  - linear_attn.in_proj_ba
+  - linear_attn.in_proj_qkvz
+  - linear_attn.out_proj
+  - shared_expert.up_proj
+  - shared_expert.down_proj
+  - shared_expert.gate_proj
+  - shared_expert_gate
+  - mlp.gate
   - q_proj
   - v_proj
   - k_proj


### PR DESCRIPTION
# Description

Adds targeting of shared experts and attention modules for qwen3-next layers.  Tested on 1XH200 and 8XH200.

## Motivation and Context

## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

## Social Handles (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded QLoRA configuration to target additional components across attention, expert, and MLP layers, enabling more comprehensive fine-tuning coverage and potentially improved training outcomes.

* **Chores**
  * Updated configuration defaults to include the new target components for broader adapter application during fine-tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->