### PR TITLE
Fix optimum import BetterTransformer error for transformers version >4.56.2

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -17,7 +17,6 @@ import torch
 import torch.distributed as dist
 import wandb
 from datasets import load_dataset
-from optimum.bettertransformer import BetterTransformer
 from tqdm import tqdm
 from transformers import (
     GenerationConfig,
@@ -66,6 +65,14 @@ class SaveBetterTransformerModelCallback(TrainerCallback):
         control: TrainerControl,
         **kwargs,
     ) -> TrainerControl:
+        # Import error due Transformers removed tensorflow support after version 4.56.2.
+        # Need wait until optimum release a new version.
+        try:
+            from optimum.bettertransformer import BetterTransformer
+        except ImportError as e:
+            raise ImportError(
+                f"Import error due Transformers removed tensorflow support after version 4.56.2. Please install transformers<=4.56.2: {e}"
+            )
         # Save
         if (
             args.save_strategy == IntervalStrategy.STEPS

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -69,10 +69,13 @@ class SaveBetterTransformerModelCallback(TrainerCallback):
         # Need wait until optimum release a new version.
         try:
             from optimum.bettertransformer import BetterTransformer
-        except ImportError as e:
-            raise ImportError(
-                f"Import error due Transformers removed tensorflow support after version 4.56.2. Please install transformers<=4.56.2: {e}"
-            )
+        except ImportError as exc:
+            if "is_tf_available" in str(exc):
+                raise ImportError(
+                    "Transformers removed TensorFlow support after version 4.56.2. "
+                    "Please install transformers<=4.56.2 to use BetterTransformer."
+                ) from exc
+            raise
         # Save
         if (
             args.save_strategy == IntervalStrategy.STEPS


### PR DESCRIPTION
 I met above error when run axolotl with transformers version >4.56.2.

```
    File "/home/manhnv/axolotl/src/axolotl/utils/callbacks/__init__.py", line 20, in <module>
        from optimum.bettertransformer import BetterTransformer
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/__init__.py", line 14, in <module>
        from .models import BetterTransformerManager
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/__init__.py", line 14, in <module>
        from .models import BetterTransformerManager
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/__init__.py", line 17, in <module>
        from .decoder_models import (
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/__init__.py", line 17, in <module>
        from .decoder_models import (
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/decoder_models.py", line 50, in <module>
        from .base import BetterTransformerBaseLayer
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/decoder_models.py", line 50, in <module>
        from .base import BetterTransformerBaseLayer
    File "/home/manhnv/axolotl/src/axolotl/integrations/base.py", line 357, in register
        plugin = load_plugin(plugin_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/base.py", line 22, in <module>
        from ...utils import logging, recurse_getattr, recurse_setattr
    File "/usr/local/lib/python3.11/dist-packages/optimum/bettertransformer/models/base.py", line 22, in <module>
        from ...utils import logging, recurse_getattr, recurse_setattr
    Error: cannot import name 'is_tf_available' from 'transformers.utils' (/usr/local/lib/python3.11/dist-packages/transformers/utils/__init__.py)
```

Transformers removed TensorFlow and Jax support after version >4.56.2 so this function not found.
This PR fix this issue by raise `ImportError` if model set `use_bettertransformer=True`, wait until optimum release a new version.

For MRE: install transformers>4.56.2 and run axolotl training.
# Description

<!--- Describe your changes in detail -->

## Motivation and Context

## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - More informative error when Transformers drops TensorFlow support, guiding users to use transformers<=4.56.2.
  - Improved reliability when saving with BetterTransformer by handling import at runtime.
- Refactor
  - Switched to lazy import of BetterTransformer to prevent startup import failures and reduce side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->