### PR TITLE
Fix: Resolve torch_dtype correctly for AMP

### DIFF
--- a/examples/LiquidAI/lfm2-350m-fft.yaml
+++ b/examples/LiquidAI/lfm2-350m-fft.yaml
@@ -33,7 +33,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 5e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 gradient_checkpointing: false

--- a/examples/LiquidAI/lfm2-8b-a1b-lora.yaml
+++ b/examples/LiquidAI/lfm2-8b-a1b-lora.yaml
@@ -42,7 +42,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 5e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/LiquidAI/lfm2-vl-lora.yaml
+++ b/examples/LiquidAI/lfm2-vl-lora.yaml
@@ -44,7 +44,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/alst/llama3-8b-deepspeed-alst.yaml
+++ b/examples/alst/llama3-8b-deepspeed-alst.yaml
@@ -31,7 +31,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/alst/llama3-8b-fsdp2-alst.yaml
+++ b/examples/alst/llama3-8b-fsdp2-alst.yaml
@@ -31,7 +31,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/apertus/apertus-8b-qlora.yaml
+++ b/examples/apertus/apertus-8b-qlora.yaml
@@ -49,7 +49,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/arcee/afm-4.5b-qlora.yaml
+++ b/examples/arcee/afm-4.5b-qlora.yaml
@@ -49,7 +49,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/cerebras/btlm-ft.yml
+++ b/examples/archived/cerebras/btlm-ft.yml
@@ -52,7 +52,7 @@ lr_quadratic_warmup: true
 learning_rate: 0.000085
 train_on_inputs: true
 group_by_length: false
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: false

--- a/examples/archived/cerebras/qlora.yml
+++ b/examples/archived/cerebras/qlora.yml
@@ -34,7 +34,7 @@ optimizer: paged_adamw_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0002
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing: true
 resume_from_checkpoint:

--- a/examples/archived/code-llama/13b/lora.yml
+++ b/examples/archived/code-llama/13b/lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/code-llama/13b/qlora.yml
+++ b/examples/archived/code-llama/13b/qlora.yml
@@ -40,7 +40,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/code-llama/34b/lora.yml
+++ b/examples/archived/code-llama/34b/lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/code-llama/34b/qlora.yml
+++ b/examples/archived/code-llama/34b/qlora.yml
@@ -40,7 +40,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/code-llama/7b/lora.yml
+++ b/examples/archived/code-llama/7b/lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/code-llama/7b/qlora.yml
+++ b/examples/archived/code-llama/7b/qlora.yml
@@ -40,7 +40,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/dbrx/16bit-lora.yaml
+++ b/examples/archived/dbrx/16bit-lora.yaml
@@ -44,7 +44,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: false  # don't use with fsdp_activation_checkpointing

--- a/examples/archived/dbrx/8bit-lora.yaml
+++ b/examples/archived/dbrx/8bit-lora.yaml
@@ -47,7 +47,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: false  # don't use with fsdp_activation_checkpointing

--- a/examples/archived/dbrx/fft-ds-zero3.yaml
+++ b/examples/archived/dbrx/fft-ds-zero3.yaml
@@ -31,7 +31,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/deepcoder/deepcoder-14B-preview-lora.yml
+++ b/examples/archived/deepcoder/deepcoder-14B-preview-lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/archived/falcon/config-7b-lora.yml
+++ b/examples/archived/falcon/config-7b-lora.yml
@@ -38,7 +38,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.00003
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing: true
 resume_from_checkpoint:

--- a/examples/archived/falcon/config-7b-qlora.yml
+++ b/examples/archived/falcon/config-7b-qlora.yml
@@ -64,7 +64,7 @@ lr_scheduler: cosine
 # - 2e-4 for 7b & 13b
 # - 1e-4 for 33b & 64b
 learning_rate: 0.0002
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing: true
 # stop training after this many evaluation losses have increased in a row

--- a/examples/archived/falcon/config-7b.yml
+++ b/examples/archived/falcon/config-7b.yml
@@ -35,7 +35,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.00003
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing: true
 resume_from_checkpoint:

--- a/examples/archived/gemma/qlora.yml
+++ b/examples/archived/gemma/qlora.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/gptj/qlora.yml
+++ b/examples/archived/gptj/qlora.yml
@@ -31,7 +31,7 @@ optimizer: paged_adamw_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0001
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing: true
 resume_from_checkpoint:

--- a/examples/archived/jeopardy-bot/config.yml
+++ b/examples/archived/jeopardy-bot/config.yml
@@ -33,7 +33,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.00003
-bf16: auto
+bfloat16: auto
 tf32: true
 resume_from_checkpoint:
 logging_steps: 5

--- a/examples/archived/mpt-7b/config.yml
+++ b/examples/archived/mpt-7b/config.yml
@@ -35,7 +35,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0000002
-bf16: auto
+bfloat16: auto
 tf32: true
 resume_from_checkpoint:
 logging_steps: 5

--- a/examples/archived/openllama-3b/config.yml
+++ b/examples/archived/openllama-3b/config.yml
@@ -33,7 +33,7 @@ torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.000003
 float16: true
-bf16: false
+bfloat16: false
 fp16: false
 tf32: false
 gradient_checkpointing: true

--- a/examples/archived/openllama-3b/lora.yml
+++ b/examples/archived/openllama-3b/lora.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0002
-bf16: false
+bfloat16: false
 fp16: true
 tf32: false
 gradient_checkpointing: true

--- a/examples/archived/openllama-3b/qlora.yml
+++ b/examples/archived/openllama-3b/qlora.yml
@@ -34,7 +34,7 @@ optimizer: paged_adamw_32bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0002
-bf16: false
+bfloat16: false
 fp16: true
 tf32: false
 gradient_checkpointing: true

--- a/examples/archived/pythia-12b/config.yml
+++ b/examples/archived/pythia-12b/config.yml
@@ -33,7 +33,7 @@ num_epochs: 5
 learning_rate: 0.00003
 optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
-bf16: false
+bfloat16: false
 fp16: false
 float16: true
 tf32: true

--- a/examples/archived/pythia/lora.yml
+++ b/examples/archived/pythia/lora.yml
@@ -28,7 +28,7 @@ gradient_accumulation_steps: 1
 micro_batch_size: 4
 num_epochs: 4
 learning_rate: 0.00001
-bf16: auto
+bfloat16: auto
 tf32: true
 resume_from_checkpoint:
 weight_decay: 0.1

--- a/examples/archived/qwen/lora.yml
+++ b/examples/archived/qwen/lora.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: false

--- a/examples/archived/qwen/qlora.yml
+++ b/examples/archived/qwen/qlora.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: false

--- a/examples/archived/qwen/qwen2-moe-lora.yaml
+++ b/examples/archived/qwen/qwen2-moe-lora.yaml
@@ -35,7 +35,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/archived/qwen/qwen2-moe-qlora.yaml
+++ b/examples/archived/qwen/qwen2-moe-qlora.yaml
@@ -38,7 +38,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/archived/redpajama/config-3b.yml
+++ b/examples/archived/redpajama/config-3b.yml
@@ -36,7 +36,7 @@ optimizer: adamw_bnb_8bit
 torchdistx_path:
 lr_scheduler: cosine
 learning_rate: 0.0000002
-bf16: auto
+bfloat16: auto
 tf32: true
 resume_from_checkpoint:
 logging_steps: 5

--- a/examples/archived/replit-3b/config-lora.yml
+++ b/examples/archived/replit-3b/config-lora.yml
@@ -33,7 +33,7 @@ optimizer:
 torchdistx_path:
 lr_scheduler:
 learning_rate: 0.00001
-bf16: auto
+bfloat16: auto
 tf32: true
 gradient_checkpointing:
 resume_from_checkpoint:

--- a/examples/archived/stablelm-2/1.6b/fft.yml
+++ b/examples/archived/stablelm-2/1.6b/fft.yml
@@ -38,7 +38,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/stablelm-2/1.6b/lora.yml
+++ b/examples/archived/stablelm-2/1.6b/lora.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/starcoder2/qlora.yml
+++ b/examples/archived/starcoder2/qlora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 fp16: false
 tf32: false
 

--- a/examples/archived/tiny-llama/lora-mps.yml
+++ b/examples/archived/tiny-llama/lora-mps.yml
@@ -40,7 +40,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 fp16: false
 tf32: true
 

--- a/examples/archived/tiny-llama/lora.yml
+++ b/examples/archived/tiny-llama/lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/tiny-llama/pretrain.yml
+++ b/examples/archived/tiny-llama/pretrain.yml
@@ -30,7 +30,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/tiny-llama/qlora.yml
+++ b/examples/archived/tiny-llama/qlora.yml
@@ -41,7 +41,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/archived/xgen-7b/xgen-7b-8k-qlora.yml
+++ b/examples/archived/xgen-7b/xgen-7b-8k-qlora.yml
@@ -62,7 +62,7 @@ lr_scheduler: cosine
 # - 2e-4 for 7b & 13b
 # - 1e-4 for 33b & 64b
 learning_rate: 0.00002
-bf16: auto
+bfloat16: auto
 tf32: false
 gradient_checkpointing: true
 # stop training after this many evaluation losses have increased in a row

--- a/examples/archived/yi-34B-chat/qlora.yml
+++ b/examples/archived/yi-34B-chat/qlora.yml
@@ -8,7 +8,7 @@ tokenizer_type: LlamaTokenizer
 load_in_8bit: false
 load_in_4bit: true
 sequence_len: 1024
-bf16: auto
+bfloat16: auto
 tf32: false
 flash_attention: true
 special_tokens:

--- a/examples/cohere/command-r-7b-qlora.yml
+++ b/examples/cohere/command-r-7b-qlora.yml
@@ -42,7 +42,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/deepcogito/cogito-v1-preview-llama-3B-lora.yml
+++ b/examples/deepcogito/cogito-v1-preview-llama-3B-lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/deepcogito/cogito-v1-preview-qwen-14B-lora.yml
+++ b/examples/deepcogito/cogito-v1-preview-qwen-14B-lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/deepseek-v2/fft-fsdp-16b.yaml
+++ b/examples/deepseek-v2/fft-fsdp-16b.yaml
@@ -27,7 +27,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/deepseek-v2/qlora-fsdp-2_5.yaml
+++ b/examples/deepseek-v2/qlora-fsdp-2_5.yaml
@@ -51,7 +51,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/devstral/devstral-small-qlora.yml
+++ b/examples/devstral/devstral-small-qlora.yml
@@ -45,7 +45,7 @@ optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/distributed-parallel/llama-3_1-8b-hsdp-tp.yaml
+++ b/examples/distributed-parallel/llama-3_1-8b-hsdp-tp.yaml
@@ -38,7 +38,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-6
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/distributed-parallel/qwen3-8b-fsdp-tp-cp.yaml
+++ b/examples/distributed-parallel/qwen3-8b-fsdp-tp-cp.yaml
@@ -35,7 +35,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-6
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/falcon-h1/falcon-h1-1b-deep-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-1b-deep-qlora.yaml
@@ -54,7 +54,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/falcon-h1/falcon-h1-1b-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-1b-qlora.yaml
@@ -53,7 +53,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/falcon-h1/falcon-h1-34b-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-34b-qlora.yaml
@@ -54,7 +54,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/falcon-h1/falcon-h1-3b-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-3b-qlora.yaml
@@ -54,7 +54,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/falcon-h1/falcon-h1-500m-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-500m-qlora.yaml
@@ -54,7 +54,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/falcon-h1/falcon-h1-7b-qlora.yaml
+++ b/examples/falcon-h1/falcon-h1-7b-qlora.yaml
@@ -54,7 +54,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/gemma2/qlora.yml
+++ b/examples/gemma2/qlora.yml
@@ -47,7 +47,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/gemma2/reward-model.yaml
+++ b/examples/gemma2/reward-model.yaml
@@ -34,7 +34,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/gemma3/gemma-3-1b-qlora.yml
+++ b/examples/gemma3/gemma-3-1b-qlora.yml
@@ -51,7 +51,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/gemma3/gemma-3-270m-qlora.yml
+++ b/examples/gemma3/gemma-3-270m-qlora.yml
@@ -51,7 +51,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/gemma3/gemma-3-4b-qlora.yml
+++ b/examples/gemma3/gemma-3-4b-qlora.yml
@@ -48,7 +48,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/gemma3/gemma-3-4b-vision-qlora.yml
+++ b/examples/gemma3/gemma-3-4b-vision-qlora.yml
@@ -47,7 +47,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/gemma3n/gemma-3n-e2b-qlora.yml
+++ b/examples/gemma3n/gemma-3n-e2b-qlora.yml
@@ -57,7 +57,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/gemma3n/gemma-3n-e2b-vision-audio-qlora.yml
+++ b/examples/gemma3n/gemma-3n-e2b-vision-audio-qlora.yml
@@ -62,7 +62,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/gemma3n/gemma-3n-e2b-vision-qlora.yml
+++ b/examples/gemma3n/gemma-3n-e2b-vision-qlora.yml
@@ -59,7 +59,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/glm4/qlora-32b.yaml
+++ b/examples/glm4/qlora-32b.yaml
@@ -44,7 +44,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
+++ b/examples/gpt-oss/gpt-oss-120b-fft-fsdp2-offload.yaml
@@ -40,7 +40,7 @@ optimizer: adamw_torch_fused  # 8bit optimizers do not work with FSDP2 offload
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/gpt-oss/gpt-oss-20b-fft-deepspeed-zero3.yaml
+++ b/examples/gpt-oss/gpt-oss-20b-fft-deepspeed-zero3.yaml
@@ -36,7 +36,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/gpt-oss/gpt-oss-20b-fft-fsdp2-offload.yaml
+++ b/examples/gpt-oss/gpt-oss-20b-fft-fsdp2-offload.yaml
@@ -37,7 +37,7 @@ optimizer: adamw_torch_fused  # 8bit optimizers do not work with FSDP2 offload
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/gpt-oss/gpt-oss-20b-fft-fsdp2.yaml
+++ b/examples/gpt-oss/gpt-oss-20b-fft-fsdp2.yaml
@@ -36,7 +36,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml
+++ b/examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml
@@ -49,7 +49,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/gpt-oss/gpt-oss-safeguard-20b-sft-lora-singlegpu.yaml
+++ b/examples/gpt-oss/gpt-oss-safeguard-20b-sft-lora-singlegpu.yaml
@@ -49,7 +49,7 @@ optimizer: adamw_torch_8bit
 lr_scheduler: constant_with_warmup
 learning_rate: 2e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 flash_attention: true

--- a/examples/hunyuan/hunyuan-v1-dense-qlora.yaml
+++ b/examples/hunyuan/hunyuan-v1-dense-qlora.yaml
@@ -49,7 +49,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/jamba/qlora.yaml
+++ b/examples/jamba/qlora.yaml
@@ -39,7 +39,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/jamba/qlora_deepspeed.yaml
+++ b/examples/jamba/qlora_deepspeed.yaml
@@ -38,7 +38,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/jamba/qlora_fsdp_large.yaml
+++ b/examples/jamba/qlora_fsdp_large.yaml
@@ -38,7 +38,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: true
+bfloat16: true
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/llama-2/fft_optimized.yml
+++ b/examples/llama-2/fft_optimized.yml
@@ -36,7 +36,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/gptq-lora.yml
+++ b/examples/llama-2/gptq-lora.yml
@@ -46,7 +46,7 @@ torchdistx_path:
 lr_scheduler: cosine
 lr_quadratic_warmup: true
 learning_rate: 0.000017
-bf16: false
+bfloat16: false
 fp16: false
 float16: true
 tf32: true

--- a/examples/llama-2/lisa.yml
+++ b/examples/llama-2/lisa.yml
@@ -40,7 +40,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 5e-5 # recommendation from lisa paper for 7b
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/loftq.yml
+++ b/examples/llama-2/loftq.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/lora.yml
+++ b/examples/llama-2/lora.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/qlora-fsdp.yml
+++ b/examples/llama-2/qlora-fsdp.yml
@@ -40,7 +40,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/qlora.yml
+++ b/examples/llama-2/qlora.yml
@@ -40,7 +40,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-2/relora.yml
+++ b/examples/llama-2/relora.yml
@@ -45,7 +45,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3-vision/lora-11b.yaml
+++ b/examples/llama-3-vision/lora-11b.yaml
@@ -43,7 +43,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/llama-3/3b-qat-fsdp2.yaml
+++ b/examples/llama-3/3b-qat-fsdp2.yaml
@@ -48,7 +48,7 @@ cosine_constant_lr_ratio: 0
 cosine_min_lr_ratio: 1.0
 learning_rate: 2e-5
 save_only_model: true
-bf16: true
+bfloat16: true
 
 resume_from_checkpoint:
 logging_steps: 1

--- a/examples/llama-3/3b-qat-nvfp4.yaml
+++ b/examples/llama-3/3b-qat-nvfp4.yaml
@@ -47,7 +47,7 @@ cosine_constant_lr_ratio: 0
 cosine_min_lr_ratio: 1.0
 learning_rate: 2e-5
 save_only_model: true
-bf16: true
+bfloat16: true
 
 resume_from_checkpoint:
 logging_steps: 1

--- a/examples/llama-3/diffusion/pretrain-1b.yaml
+++ b/examples/llama-3/diffusion/pretrain-1b.yaml
@@ -37,7 +37,7 @@ lr_scheduler: cosine
 learning_rate: 3e-4
 sdp_attention: true
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-3/diffusion/sft-1b.yaml
+++ b/examples/llama-3/diffusion/sft-1b.yaml
@@ -36,7 +36,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 1e-5
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/llama-3/fft-8b-liger-fsdp.yaml
+++ b/examples/llama-3/fft-8b-liger-fsdp.yaml
@@ -41,7 +41,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/fft-8b.yaml
+++ b/examples/llama-3/fft-8b.yaml
@@ -26,7 +26,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/instruct-dpo-lora-8b.yml
+++ b/examples/llama-3/instruct-dpo-lora-8b.yml
@@ -59,7 +59,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/instruct-lora-8b.yml
+++ b/examples/llama-3/instruct-lora-8b.yml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b-deduplicate-dpo.yml
+++ b/examples/llama-3/lora-1b-deduplicate-dpo.yml
@@ -71,7 +71,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b-deduplicate-sft.yml
+++ b/examples/llama-3/lora-1b-deduplicate-sft.yml
@@ -47,7 +47,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b-kernels.yml
+++ b/examples/llama-3/lora-1b-kernels.yml
@@ -48,7 +48,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b-ray.yml
+++ b/examples/llama-3/lora-1b-ray.yml
@@ -42,7 +42,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b-sample-packing-sequentially.yml
+++ b/examples/llama-3/lora-1b-sample-packing-sequentially.yml
@@ -49,7 +49,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-1b.yml
+++ b/examples/llama-3/lora-1b.yml
@@ -43,7 +43,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/lora-8b.yml
+++ b/examples/llama-3/lora-8b.yml
@@ -43,7 +43,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/opentelemetry-qlora.yml
+++ b/examples/llama-3/opentelemetry-qlora.yml
@@ -34,7 +34,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/qlora-1b-kto.yaml
+++ b/examples/llama-3/qlora-1b-kto.yaml
@@ -45,7 +45,7 @@ optimizer: adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/llama-3/qlora-1b.yml
+++ b/examples/llama-3/qlora-1b.yml
@@ -45,7 +45,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/qlora-fsdp-405b.yaml
+++ b/examples/llama-3/qlora-fsdp-405b.yaml
@@ -32,7 +32,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: true
+bfloat16: true
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/llama-3/qlora-fsdp-70b.yaml
+++ b/examples/llama-3/qlora-fsdp-70b.yaml
@@ -40,7 +40,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.00001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/qlora.yml
+++ b/examples/llama-3/qlora.yml
@@ -40,7 +40,7 @@ optimizer: paged_adamw_32bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/llama-3/sparse-finetuning.yaml
+++ b/examples/llama-3/sparse-finetuning.yaml
@@ -34,7 +34,7 @@ learning_rate: 2e-5
 
 train_on_inputs: false
 group_by_length: false
-bf16: auto
+bfloat16: auto
 fp16:
 tf32: false
 

--- a/examples/llama-4/do-no-use-fa2/maverick-qlora-fsdp1.yaml
+++ b/examples/llama-4/do-no-use-fa2/maverick-qlora-fsdp1.yaml
@@ -56,7 +56,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 1e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-4/do-no-use-fa2/scout-qlora-fsdp1.yaml
+++ b/examples/llama-4/do-no-use-fa2/scout-qlora-fsdp1.yaml
@@ -63,7 +63,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-4/do-no-use-fa2/scout-qlora-single-h100.yaml
+++ b/examples/llama-4/do-no-use-fa2/scout-qlora-single-h100.yaml
@@ -66,7 +66,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 1e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-4/do-no-use-fa2/scout-vision-qlora-fsdp.yaml
+++ b/examples/llama-4/do-no-use-fa2/scout-vision-qlora-fsdp.yaml
@@ -58,7 +58,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-4/scout-qlora-flexattn-fsdp2.yaml
+++ b/examples/llama-4/scout-qlora-flexattn-fsdp2.yaml
@@ -55,7 +55,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 1e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llama-4/scout-qlora-single-h100-flex.yaml
+++ b/examples/llama-4/scout-qlora-single-h100-flex.yaml
@@ -60,7 +60,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 1e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 torch_compile: true

--- a/examples/llama-4/scout-vision-qlora-fsdp2-flex.yaml
+++ b/examples/llama-4/scout-vision-qlora-fsdp2-flex.yaml
@@ -57,7 +57,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 1e-4
 
-bf16: true
+bfloat16: true
 tf32: true
 
 logging_steps: 1

--- a/examples/llava/lora-7b.yaml
+++ b/examples/llava/lora-7b.yaml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/magistral/magistral-small-fsdp-qlora.yaml
+++ b/examples/magistral/magistral-small-fsdp-qlora.yaml
@@ -53,7 +53,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing:

--- a/examples/magistral/magistral-small-qlora.yaml
+++ b/examples/magistral/magistral-small-qlora.yaml
@@ -52,7 +52,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/magistral/think/magistral-small-think-qlora.yaml
+++ b/examples/magistral/think/magistral-small-think-qlora.yaml
@@ -52,7 +52,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/magistral/vision/magistral-small-vision-24B-qlora.yml
+++ b/examples/magistral/vision/magistral-small-vision-24B-qlora.yml
@@ -47,7 +47,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/mamba/config.yml
+++ b/examples/mamba/config.yml
@@ -33,7 +33,7 @@ learning_rate: 5e-5
 train_on_inputs: false
 group_by_length: true
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: false

--- a/examples/mistral/bigstral/bigstral-ds-zero3.yaml
+++ b/examples/mistral/bigstral/bigstral-ds-zero3.yaml
@@ -36,7 +36,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/config.yml
+++ b/examples/mistral/config.yml
@@ -30,7 +30,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.000005
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/dpo/mistral-dpo-qlora.yml
+++ b/examples/mistral/dpo/mistral-dpo-qlora.yml
@@ -65,7 +65,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/lora.yml
+++ b/examples/mistral/lora.yml
@@ -48,7 +48,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/mistral-qlora-fsdp.yml
+++ b/examples/mistral/mistral-qlora-fsdp.yml
@@ -45,7 +45,7 @@ optimizer: paged_adamw_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/mistral-small/mistral-small-3.1-24B-lora.yml
+++ b/examples/mistral/mistral-small/mistral-small-3.1-24B-lora.yml
@@ -45,7 +45,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/mistral/mixtral/mixtral-8x22b-qlora-fsdp.yml
+++ b/examples/mistral/mixtral/mixtral-8x22b-qlora-fsdp.yml
@@ -43,7 +43,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/mistral/mixtral/mixtral-qlora-fsdp.yml
+++ b/examples/mistral/mixtral/mixtral-qlora-fsdp.yml
@@ -45,7 +45,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/mistral/mixtral/mixtral.yml
+++ b/examples/mistral/mixtral/mixtral.yml
@@ -63,7 +63,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/mixtral/mixtral_22.yml
+++ b/examples/mistral/mixtral/mixtral_22.yml
@@ -34,7 +34,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0001
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true
@@ -45,7 +45,7 @@ flash_attention: true
 save_total_limit: 1
 save_steps:
 
-deepspeed: deepspeed_configs/zero3_bf16_cpuoffload_all.json
+deepspeed: deepspeed_configs/zero3_bfloat16_cpuoffload_all.json
 weight_decay: 0.0
 special_tokens:
   eos_token: "<|im_end|>"

--- a/examples/mistral/mps/lora-mps.yml
+++ b/examples/mistral/mps/lora-mps.yml
@@ -46,7 +46,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 fp16: false
 tf32: true
 

--- a/examples/mistral/orpo/mistral-qlora-orpo.yml
+++ b/examples/mistral/orpo/mistral-qlora-orpo.yml
@@ -53,7 +53,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/mistral/qlora.yml
+++ b/examples/mistral/qlora.yml
@@ -48,7 +48,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/orpheus/finetune.yml
+++ b/examples/orpheus/finetune.yml
@@ -33,7 +33,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/phi/lora-3.5.yaml
+++ b/examples/phi/lora-3.5.yaml
@@ -42,7 +42,6 @@ lr_scheduler: cosine
 learning_rate: 0.0002
 
 bfloat16: true
-bf16: true
 fp16:
 tf32: false
 

--- a/examples/phi/phi-ft.yml
+++ b/examples/phi/phi-ft.yml
@@ -40,7 +40,7 @@ max_grad_norm: 1.0
 lr_scheduler: cosine
 learning_rate: 0.000003
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/phi/phi-qlora.yml
+++ b/examples/phi/phi-qlora.yml
@@ -43,7 +43,7 @@ max_grad_norm: 1.0
 lr_scheduler: cosine
 learning_rate: 0.000003
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/phi/phi2-ft.yml
+++ b/examples/phi/phi2-ft.yml
@@ -40,7 +40,7 @@ max_grad_norm: 1.0
 lr_scheduler: cosine
 learning_rate: 0.000003
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/phi/phi3-ft-fsdp.yml
+++ b/examples/phi/phi3-ft-fsdp.yml
@@ -41,7 +41,7 @@ max_grad_norm: 1.0
 lr_scheduler: cosine
 learning_rate: 0.000003
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/phi/phi3-ft.yml
+++ b/examples/phi/phi3-ft.yml
@@ -37,7 +37,7 @@ max_grad_norm: 1.0
 lr_scheduler: cosine
 learning_rate: 5.0e-6
 
-bf16: auto
+bfloat16: auto
 
 gradient_checkpointing: true
 gradient_checkpointing_kwargs:

--- a/examples/pixtral/lora-12b.yml
+++ b/examples/pixtral/lora-12b.yml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/qwen2-vl/lora-7b.yaml
+++ b/examples/qwen2-vl/lora-7b.yaml
@@ -40,7 +40,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/qwen2/dpo.yaml
+++ b/examples/qwen2/dpo.yaml
@@ -42,7 +42,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/qwen2/prm.yaml
+++ b/examples/qwen2/prm.yaml
@@ -39,7 +39,7 @@ optimizer: adamw_torch
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32:
 gradient_checkpointing: true

--- a/examples/qwen2/qlora-fsdp.yaml
+++ b/examples/qwen2/qlora-fsdp.yaml
@@ -39,7 +39,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/qwen2/reward-model.yaml
+++ b/examples/qwen2/reward-model.yaml
@@ -33,7 +33,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/qwen2_5-vl/lora-7b.yaml
+++ b/examples/qwen2_5-vl/lora-7b.yaml
@@ -40,7 +40,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml
+++ b/examples/qwen3-next/qwen3-next-80b-a3b-qlora.yaml
@@ -53,7 +53,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/qwen3/32b-qlora.yaml
+++ b/examples/qwen3/32b-qlora.yaml
@@ -52,7 +52,7 @@ optimizer: adamw_torch_4bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: offload

--- a/examples/qwen3/8b-qat-fsdp2.yml
+++ b/examples/qwen3/8b-qat-fsdp2.yml
@@ -49,7 +49,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 2e-5
 
-bf16: true
+bfloat16: true
 tf32: true
 
 resume_from_checkpoint:

--- a/examples/qwen3/qlora-fsdp.yaml
+++ b/examples/qwen3/qlora-fsdp.yaml
@@ -38,7 +38,7 @@ optimizer: adamw_torch_fused
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/qwen3/reward-model.yaml
+++ b/examples/qwen3/reward-model.yaml
@@ -33,7 +33,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: linear
 learning_rate: 0.00002
 
-bf16: true
+bfloat16: true
 tf32: true
 
 gradient_checkpointing: true

--- a/examples/seed-oss/seed-oss-36b-qlora.yaml
+++ b/examples/seed-oss/seed-oss-36b-qlora.yaml
@@ -41,7 +41,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: false
 
 gradient_checkpointing: true

--- a/examples/smolvlm2/smolvlm2-2B-lora.yaml
+++ b/examples/smolvlm2/smolvlm2-2B-lora.yaml
@@ -39,7 +39,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/streaming/pretrain.yaml
+++ b/examples/streaming/pretrain.yaml
@@ -34,7 +34,7 @@ warmup_ratio: 0.1
 weight_decay: 0.01
 
 # Precision and performance
-bf16: auto
+bfloat16: auto
 tf32: true
 
 # Logging and checkpointing

--- a/examples/streaming/sft.yaml
+++ b/examples/streaming/sft.yaml
@@ -32,7 +32,7 @@ warmup_ratio: 0.1
 weight_decay: 0.0
 
 # Precision and performance
-bf16: auto
+bfloat16: auto
 tf32: true
 
 # Logging and checkpointing

--- a/examples/voxtral/voxtral-mini-audio-qlora.yml
+++ b/examples/voxtral/voxtral-mini-audio-qlora.yml
@@ -62,7 +62,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: true
+bfloat16: true
 fp16:
 tf32: true
 

--- a/examples/voxtral/voxtral-mini-qlora.yml
+++ b/examples/voxtral/voxtral-mini-qlora.yml
@@ -56,7 +56,7 @@ optimizer: adamw_bnb_8bit
 lr_scheduler: cosine
 learning_rate: 0.0002
 
-bf16: auto
+bfloat16: auto
 tf32: true
 
 gradient_checkpointing: true

--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -86,9 +86,12 @@ def resolve_dtype(cfg):
         if cfg.bf16:
             cfg.fp16 = False
 
-    if cfg.bf16 or cfg.bfloat16:
+    # For mixed precision, we want the base model loaded in fp32
+    if cfg.fp16 or cfg.bf16:
+       cfg.torch_dtype = torch.float32
+    elif cfg.bfloat16:
         cfg.torch_dtype = torch.bfloat16
-    elif cfg.load_in_8bit or cfg.fp16 or cfg.float16:
+    elif cfg.load_in_8bit or cfg.float16:
         cfg.torch_dtype = torch.float16
     else:
         cfg.torch_dtype = torch.float32

--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -88,7 +88,7 @@ def resolve_dtype(cfg):
 
     # For mixed precision, we want the base model loaded in fp32
     if cfg.fp16 or cfg.bf16:
-       cfg.torch_dtype = torch.float32
+        cfg.torch_dtype = torch.float32
     elif cfg.bfloat16:
         cfg.torch_dtype = torch.bfloat16
     elif cfg.load_in_8bit or cfg.float16:


### PR DESCRIPTION
# Description

The previous logic in `resolve_dtype` incorrectly configured the model's `torch_dtype` for Automatic Mixed Precision (AMP) training.

When `fp16: true` or `bf16: true` was set for mixed precision, the model was loaded directly into a half-precision format. This conflicts with the standard PyTorch AMP workflow, which expects the model to be loaded in FP32 to establish master weights before being managed by the `autocast` context and `GradScaler`. 

This misconfiguration led to `GradScaler` failures with FP16 (expecting FP32 weights) and an inefficient, non-standard AMP implementation for BF16.

This commit adjusts the logic to prioritize the AMP flags. If `fp16` or `bf16` is enabled, `torch_dtype` is now correctly resolved to `torch.float32`. The logic for pure precision modes (`float16`, `bfloat16`) remains.


## Motivation and Context

My hardware (AMD MI100) has a 2x faster theoretical throughput for FP16 compared with BF16, so I was interested in trying FP16 mixed precision despite the reduction in stability.

I initially observed failures when attempting to use FP16 mixed-precision by toggling `fp16: true`. Doing so on an example config would result in an error like the following:

<details>
<summary>traceback</summary>

```
File "/nvme/training/axolotl/src/axolotl/cli/train.py", line 121, in <module>
    fire.Fire(do_cli)
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/src/axolotl/cli/train.py", line 88, in do_cli
    return do_train(parsed_cfg, parsed_cli_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/src/axolotl/cli/train.py", line 45, in do_train
    model, tokenizer, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/src/axolotl/train.py", line 583, in train
    execute_training(cfg, trainer, resume_from_checkpoint)
  File "/nvme/training/axolotl/src/axolotl/train.py", line 204, in execute_training
    trainer.train(resume_from_checkpoint=resume_from_checkpoint)
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/transformers/trainer.py", line 2328, in train
    return inner_training_loop(
           ^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/transformers/trainer.py", line 2713, in _inner_training_loop
    _grad_norm = self.accelerator.clip_grad_norm_(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 2890, in clip_grad_norm_
    self.unscale_gradients()
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 2828, in unscale_gradients
    self.scaler.unscale_(opt)
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py", line 343, in unscale_
    optimizer_state["found_inf_per_device"] = self._unscale_grads_(
                                              ^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/training/axolotl/venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py", line 261, in _unscale_grads_
    raise ValueError("Attempting to unscale FP16 gradients.")
```

</details>

This error was consistent across a number of different configuration changes (flash attention, xformers, gradient accumulation, sample packing, etc.).

BF16 AMP would run without error, as it avoided the gradient scaling pathway.

A simple torch reproducer with FP16 AMP worked without error.

<details>
<summary>torch reprod</summary>

```
import torch
from accelerate import Accelerator

# 1. Dummy Model and Data
model = torch.nn.Linear(10, 10).cuda()
optimizer = torch.optim.AdamW(model.parameters())
dummy_input = torch.randn(4, 10).cuda()
dummy_labels = torch.randn(4, 10).cuda()

# 2. Setup the failing environment
# This is the key part - we are creating the Accelerator programmatically
accelerator = Accelerator(mixed_precision='fp16')
model, optimizer = accelerator.prepare(model, optimizer)

# 3. Run one training step
with accelerator.autocast():
    outputs = model(dummy_input)
    loss = torch.nn.functional.mse_loss(outputs, dummy_labels)

print(f"Loss: {loss.item()}")

# This is where the crash happens
accelerator.backward(loss)

# The clip_grad_norm_ call that triggers the error in your traceback
# We can add it to be 100% sure
if accelerator.sync_gradients:
    accelerator.clip_grad_norm_(model.parameters(), 1.0)

optimizer.step()
optimizer.zero_grad()

print("Step completed successfully.")
```

</details>

As did a HF Trainer reproducer, so I knew the issue was with axolotl.

<details>
<summary>hf trainer reprod</summary>

```
import torch
from transformers import (
    AutoConfig,
    AutoModelForCausalLM,
    AutoTokenizer,
    Trainer,
    TrainingArguments,
)
from datasets import Dataset
import os

os.environ["TOKENIZERS_PARALLELISM"] = "false"

MODEL_CONFIG_PATH = "../mew_init"
TOKENIZER_NAME = "NousResearch/Llama-2-7b-hf"

print("="*80)
print(f"Loading model config from: {MODEL_CONFIG_PATH}")
print("="*80)

config = AutoConfig.from_pretrained(MODEL_CONFIG_PATH)
model = AutoModelForCausalLM.from_config(config)
tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)

NUM_SAMPLES = 100
SEQ_LENGTH = 512

# Create a list of random token sequences
input_ids_list = [torch.randint(0, config.vocab_size, (SEQ_LENGTH,)) for _ in range(NUM_SAMPLES)]

dummy_data = {
    "input_ids": input_ids_list,
    "labels": input_ids_list,
}

train_dataset = Dataset.from_dict(dummy_data)
print(f"Created a dummy dataset with {len(train_dataset)} samples.")
print("="*80)


training_args = TrainingArguments(
    fp16=True,
    output_dir="./reproducer_out",
    max_steps=3,
    per_device_train_batch_size=4,
    gradient_accumulation_steps=2,
    logging_steps=1,
    optim="adamw_torch",
    report_to="none",
)

print("Instantiating Trainer with the following key arguments:")
print(f"  fp16={training_args.fp16}")
print(f"  per_device_train_batch_size={training_args.per_device_train_batch_size}")
print(f"  gradient_accumulation_steps={training_args.gradient_accumulation_steps}")
print(f"  optim={training_args.optim}")
print("="*80)

trainer = Trainer(
    model=model,
    args=training_args,
    train_dataset=train_dataset,
    tokenizer=tokenizer,
)

try:
    print("Starting trainer.train()...")
    trainer.train()
    print("\n--- TEST SUCCEEDED (NO BUG) ---")

except ValueError as e:
    print("\n--- TEST FAILED (BUG REPRODUCED) ---")
    raise e
```

</details>

## How has this been tested?

This change was validated on an AMD MI100 GPU (ROCm backend), where the original code consistently failed with a `ValueError: Attempting to unscale FP16 gradients`. 

After applying this patch, FP16 AMP training now runs successfully, with a significant performance improvement over both FP32 as measured with a custom nanoGPT-style config. 

Flash attention 2 (only supporting FP16/BF16) can be enabled and provides a performance boost, implying that AMP is active and the attention passes are done in lower precision as expected.

| Configuration              | Throughput (tokens/sec) | Speedup vs. FP32 | VRAM (Max Allocated) |
|----------------------------|-------------------------|------------------|----------------------|
| FP32 (Baseline)            | 24,541                  | 1.00x            | 15.38 GiB            |
| FP16 AMP (main)            | -                       | -                | -                    |
| FP16 AMP (PR)              | 30,218                  | 1.23x            | 12.93 GiB            |
| FP16 AMP + Flash Attn (PR) | 36,109                  | 1.47x            | 9.59 GiB             |

The fix should be backend-agnostic.

<details>
<summary>Example config to reproduce crash:</summary>


```
base_model: NousResearch/Llama-3.2-1B
# Automatically upload checkpoint and final model to HF
# hub_model_id: username/custom_model_name

datasets:
  - path: teknium/GPT4-LLM-Cleaned
    type: alpaca

dataset_prepared_path: last_run_prepared
val_set_size: 0.1
output_dir: ./outputs/out

sequence_len: 512
sample_packing: false

wandb_project:
wandb_entity:
wandb_watch:
wandb_name:
wandb_log_model:

gradient_accumulation_steps: 8
micro_batch_size: 1
num_epochs: 1
optimizer: adamw_torch
lr_scheduler: cosine
learning_rate: 2e-5

fp16: true
bf16: false
tf32: false

gradient_checkpointing: true
gradient_checkpointing_kwargs:
  use_reentrant: false
resume_from_checkpoint:
logging_steps: 1
flash_attention: false

warmup_ratio: 0.1
evals_per_epoch: 2
saves_per_epoch: 1
weight_decay: 0.0
special_tokens:
  pad_token: <|end_of_text|>

max_steps: 30
include_tokens_per_second: true
```

</details>

## Types of changes
Bugfix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved mixed-precision handling: base models now load in float32 by default when using fp16/bf16 for more stable behavior.
- Bug Fixes
  - Reduced precision-related crashes and inconsistencies by refining dtype selection between float16, bfloat16, and float32.
- Refactor
  - Streamlined logic to make dtype resolution more predictable in mixed-precision configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->