### PR TITLE
add chat_template_jinja to wandb

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -816,15 +816,15 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                             temp_ct_file.write(str(chat_tpl))
                             temp_ct_file.flush()
 
-                    artifact = wandb.Artifact(
-                        f"chat-template-{wandb.run.id}", type="jinja-template"
-                    )
-                    artifact.add_file(temp_ct_file.name)
-                    wandb.log_artifact(artifact)
-                    wandb.save(temp_ct_file.name)
-                    LOG.info(
-                        "The chat_template_jinja has been saved to the WandB run under files."
-                    )
+                        artifact = wandb.Artifact(
+                            f"chat-template-{wandb.run.id}", type="jinja-template"
+                        )
+                        artifact.add_file(temp_ct_file.name)
+                        wandb.log_artifact(artifact)
+                        wandb.save(temp_ct_file.name)
+                        LOG.info(
+                            "The chat_template_jinja has been saved to the WandB run under files."
+                        )
             except (FileNotFoundError, ConnectionError, yaml.YAMLError) as err:
                 LOG.warning(f"Error while saving chat_template_jinja to WandB: {err}")
 

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -804,7 +804,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 chat_tpl = cfg.get("chat_template_jinja")
                 if chat_tpl:
                     with NamedTemporaryFile(
-                        mode="w", delete=False, suffix=".j2", prefix="chat_template_"
+                        mode="w", delete=True, suffix=".j2", prefix="chat_template_"
                     ) as temp_ct_file:
                         if (
                             isinstance(chat_tpl, str)

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -814,6 +814,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                             copyfile(chat_tpl, temp_ct_file.name)
                         else:
                             temp_ct_file.write(str(chat_tpl))
+                            temp_ct_file.flush()
 
                     artifact = wandb.Artifact(
                         f"chat-template-{wandb.run.id}", type="jinja-template"

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -804,7 +804,7 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
                 chat_tpl = cfg.get("chat_template_jinja")
                 if chat_tpl:
                     with NamedTemporaryFile(
-                        mode="w", delete=True, suffix=".j2", prefix="chat_template_"
+                        mode="w", delete=True, suffix=".jinja", prefix="chat_template_"
                     ) as temp_ct_file:
                         if (
                             isinstance(chat_tpl, str)


### PR DESCRIPTION

# Description
add chat_template_jinja to wandb


## Motivation and Context
support for uploading chat_template_jinja to wandb






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically captures the chat template from the training configuration and logs it to Weights & Biases as a template artifact at training start.
  - Supports both inline templates and file-based templates, preserving exact templates with each run.

- Bug Fixes
  - Improved reliability and clearer errors when processing and uploading templates, including missing files, network issues, or invalid YAML.
  - Ensures consistent behavior across training callbacks for template logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->