### PR TITLE
Remove check_torch_compile_deepspeed for deepspeed compatible

### DIFF
--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -785,15 +785,6 @@ class OptimizationValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
-    def check_torch_compile_deepspeed(cls, data):
-        if data.get("deepspeed") and data.get("torch_compile"):
-            raise ValueError(
-                "torch_compile should be set within your deepspeed config file"
-            )
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
     def check_xentropy_patch_conflicts(cls, data):
         if data.get("flash_attn_cross_entropy") and data.get(
             "unsloth_cross_entropy_loss"


### PR DESCRIPTION
Enabled `deepcompile` of deepspeed does not compile the model automatically.

See: [7598](https://github.com/deepspeedai/DeepSpeed/pull/7598)

# Description

This PR remove `check_torch_compile_deepspeed` from pre model validator, help able enable both `torch_compile: true` for transformers's Trainer and `deepcompile`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now enable DeepSpeed and torch compile together. The previous restriction that blocked this combination has been removed, allowing more flexible training configurations. If you previously structured settings to avoid this conflict, review your configuration to ensure it aligns with your desired behavior when using both features concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->