### PR TITLE
Add chat_template.argilla_chat support for DPO datasets

### DIFF
--- a/docs/rlhf.qmd
+++ b/docs/rlhf.qmd
@@ -219,6 +219,21 @@ DPO supports the following types with the following dataset format:
 }
 ```
 
+#### chat_template.argilla_chat
+
+```json
+{
+    "chosen": [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."}
+    ],
+    "rejected": [
+        {"role": "user", "content": "..."},
+        {"role": "assistant", "content": "..."}
+    ]
+}
+```
+
 #### chat_template.default
 
 ```yaml

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -120,3 +120,107 @@ def default(cfg, dataset_idx=0, **kwargs):
         return result
 
     return transform_fn, {"remove_columns": [field_messages]}
+
+
+def argilla_chat(cfg, dataset_idx=0, **kwargs):
+    """
+    For argilla-style datasets where chosen/rejected contain full conversations.
+    Format:
+    {
+        "chosen": [
+            {"role": "user", "content": "..."},
+            {"role": "assistant", "content": "..."}
+        ],
+        "rejected": [
+            {"role": "user", "content": "..."},
+            {"role": "assistant", "content": "..."}
+        ]
+    }
+    """
+    ds_cfg = cfg["datasets"][dataset_idx]
+    ds_cfg = handle_legacy_message_fields_logic(ds_cfg)
+
+    chat_template_choice, chat_template_jinja = extract_chat_template_args(
+        cfg=cfg, ds_cfg=ds_cfg
+    )
+    field_chosen = ds_cfg.get("field_chosen", "chosen")
+    field_rejected = ds_cfg.get("field_rejected", "rejected")
+    message_property_mappings = ds_cfg.get(
+        "message_property_mappings",
+        {
+            "role": "role",
+            "content": "content",
+        },
+    )
+    role_map_inv = ds_cfg.get(
+        "roles",
+        {
+            "user": ["user"],
+            "assistant": ["assistant"],
+            "system": ["system"],
+        },
+    )
+    role_map = {}
+    for target, sources in role_map_inv.items():
+        for source in sources:
+            role_map[source] = target
+
+    def transform_fn(sample, tokenizer=None):
+        chat_template_string = get_chat_template(
+            user_choice=chat_template_choice,
+            jinja_template=chat_template_jinja,
+            tokenizer=tokenizer,
+        )
+
+        chosen_raw = sample[field_chosen]
+        rejected_raw = sample[field_rejected]
+
+        # Extract messages (all but last) and responses (last message)
+        chosen_messages = [
+            {
+                "role": role_map[m[message_property_mappings["role"]]],
+                "content": m[message_property_mappings["content"]],
+            }
+            for m in chosen_raw[:-1]
+        ]
+        chosen_response = {
+            "role": role_map[chosen_raw[-1][message_property_mappings["role"]]],
+            "content": chosen_raw[-1][message_property_mappings["content"]],
+        }
+
+        rejected_response = {
+            "role": role_map[rejected_raw[-1][message_property_mappings["role"]]],
+            "content": rejected_raw[-1][message_property_mappings["content"]],
+        }
+
+        dummy_user_message = {"role": "user", "content": "[[dummy_message]]"}
+
+        result = {}
+        result["prompt"] = tokenizer.apply_chat_template(
+            chosen_messages,
+            add_generation_prompt=True,
+            chat_template=chat_template_string,
+            tokenize=False,
+        )
+
+        result["chosen"] = tokenizer.apply_chat_template(
+            [dummy_user_message, chosen_response],
+            add_generation_prompt=False,
+            chat_template=chat_template_string,
+            tokenize=False,
+        )
+        chosen_strip_index = result["chosen"].find(chosen_response["content"])
+        result["chosen"] = result["chosen"][chosen_strip_index:].rstrip()
+
+        result["rejected"] = tokenizer.apply_chat_template(
+            [dummy_user_message, rejected_response],
+            add_generation_prompt=False,
+            chat_template=chat_template_string,
+            tokenize=False,
+        )
+        rejected_strip_index = result["rejected"].find(rejected_response["content"])
+        result["rejected"] = result["rejected"][rejected_strip_index:].rstrip()
+
+        return result
+
+    return transform_fn

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -124,18 +124,34 @@ def default(cfg, dataset_idx=0, **kwargs):
 
 def argilla_chat(cfg, dataset_idx=0, **kwargs):
     """
-    For argilla-style datasets where chosen/rejected contain full conversations.
-    Format:
-    {
-        "chosen": [
-            {"role": "user", "content": "..."},
-            {"role": "assistant", "content": "..."}
-        ],
-        "rejected": [
-            {"role": "user", "content": "..."},
-            {"role": "assistant", "content": "..."}
-        ]
-    }
+    DPO chat template strategy for argilla-style datasets.
+
+    For argilla-style datasets where chosen/rejected contain full conversations
+    instead of single response messages. Extracts the conversation history from
+    the chosen field and formats both chosen/rejected responses using the
+    configured chat template.
+
+    Args:
+        cfg: Configuration object containing chat_template and dataset settings
+        dataset_idx: Index of the dataset in the config (default: 0)
+        **kwargs: Additional keyword arguments (unused)
+
+    Returns:
+        tuple: (transform_fn, dataset_kwargs) where:
+            - transform_fn: Function to transform dataset samples
+            - dataset_kwargs: Dict with 'remove_columns' specifying columns to drop
+
+    Dataset format:
+        {
+            "chosen": [
+                {"role": "user", "content": "..."},
+                {"role": "assistant", "content": "..."}
+            ],
+            "rejected": [
+                {"role": "user", "content": "..."},
+                {"role": "assistant", "content": "..."}
+            ]
+        }
     """
     ds_cfg = cfg["datasets"][dataset_idx]
     ds_cfg = handle_legacy_message_fields_logic(ds_cfg)
@@ -223,4 +239,4 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
 
         return result
 
-    return transform_fn
+    return transform_fn, {"remove_columns": [field_chosen, field_rejected]}

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -8,7 +8,7 @@ import pytest
 from datasets import Dataset
 from transformers import AutoTokenizer
 
-from axolotl.prompt_strategies.dpo.chat_template import default
+from axolotl.prompt_strategies.dpo.chat_template import argilla_chat, default
 from axolotl.utils.dict import DictDefault
 
 from tests.hf_offline_utils import enable_hf_offline
@@ -73,6 +73,36 @@ def fixture_custom_assistant_dataset():
                     "speaker": "agent",
                     "text": "party on",
                 },
+            }
+        ]
+    )
+
+
+@pytest.fixture(name="argilla_chat_dataset")
+def fixture_argilla_chat_dataset():
+    return Dataset.from_list(
+        [
+            {
+                "chosen": [
+                    {
+                        "role": "user",
+                        "content": "hello",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "goodbye",
+                    },
+                ],
+                "rejected": [
+                    {
+                        "role": "user",
+                        "content": "hello",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "party on",
+                    },
+                ],
             }
         ]
     )
@@ -214,6 +244,54 @@ class TestAssistantDPOChatTemplateGemma:
         )
         assert result["chosen"] == "goodbye<end_of_turn>"
         assert result["rejected"] == "party on<end_of_turn>"
+
+
+class TestArgillaChatDPOChatTemplate:
+    """
+    Test class for argilla_chat style datasets (chosen/rejected contain full conversations).
+    """
+
+    def test_llama3_argilla_chat(self, llama3_tokenizer, argilla_chat_dataset):
+        transform_fn = argilla_chat(
+            DictDefault(
+                {
+                    "chat_template": "llama3",
+                    "datasets": [
+                        {
+                            "type": "chat_template.argilla_chat",
+                        }
+                    ],
+                }
+            )
+        )
+        result = transform_fn(argilla_chat_dataset[0], tokenizer=llama3_tokenizer)
+        assert result["prompt"] == (
+            "<|begin_of_text|>"
+            + "<|start_header_id|>user<|end_header_id|>\n\nhello<|eot_id|>"
+            + "<|start_header_id|>assistant<|end_header_id|>\n\n"
+        )
+        assert result["chosen"] == "goodbye<|eot_id|>"
+        assert result["rejected"] == "party on<|eot_id|>"
+
+    def test_phi3_argilla_chat(self, phi3_tokenizer, argilla_chat_dataset):
+        transform_fn = argilla_chat(
+            DictDefault(
+                {
+                    "chat_template": "tokenizer_default",
+                    "datasets": [
+                        {
+                            "type": "chat_template.argilla_chat",
+                        }
+                    ],
+                }
+            )
+        )
+        result = transform_fn(argilla_chat_dataset[0], tokenizer=phi3_tokenizer)
+        assert result["prompt"] == (
+            "<|user|>\nhello<|end|>\n" + "<|assistant|>\n"
+        )
+        assert result["chosen"] == "goodbye<|end|>"
+        assert result["rejected"] == "party on<|end|>"
 
 
 if __name__ == "__main__":

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -252,7 +252,7 @@ class TestArgillaChatDPOChatTemplate:
     """
 
     def test_llama3_argilla_chat(self, llama3_tokenizer, argilla_chat_dataset):
-        transform_fn = argilla_chat(
+        transform_fn, _ = argilla_chat(
             DictDefault(
                 {
                     "chat_template": "llama3",
@@ -274,7 +274,7 @@ class TestArgillaChatDPOChatTemplate:
         assert result["rejected"] == "party on<|eot_id|>"
 
     def test_phi3_argilla_chat(self, phi3_tokenizer, argilla_chat_dataset):
-        transform_fn = argilla_chat(
+        transform_fn, _ = argilla_chat(
             DictDefault(
                 {
                     "chat_template": "tokenizer_default",

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -287,9 +287,7 @@ class TestArgillaChatDPOChatTemplate:
             )
         )
         result = transform_fn(argilla_chat_dataset[0], tokenizer=phi3_tokenizer)
-        assert result["prompt"] == (
-            "<|user|>\nhello<|end|>\n" + "<|assistant|>\n"
-        )
+        assert result["prompt"] == "<|user|>\nhello<|end|>\n" + "<|assistant|>\n"
         assert result["chosen"] == "goodbye<|end|>"
         assert result["rejected"] == "party on<|end|>"
 


### PR DESCRIPTION
# Description

  Creates a new chat_template.argilla_chat prompt strategy for handling
  DPO datasets where chosen/rejected fields contain full conversations
  (messages + final response), following the pattern of chatml.argilla_chat
  and llama3.argilla_chat.

  - Add argilla_chat() function to chat_template.py
  - Add chat_template.argilla_chat to RLHF documentation
  - Add test coverage for argilla_chat with multiple tokenizers

  Dataset format:
  {
    "chosen": [ {"role": "user", "content": "..."}, {"role": "assistant", "content": "..."} ], "rejected": [ {"role": "user", "content": "..."}, {"role": "assistant", "content": "..."} ] }

## Motivation and Context

If you use a chosen/rejected style DPO dataset, you can't use it with a model's chat_template?

## How has this been tested?
Tests added to tests, all tests pass:
```
❯ pytest tests/prompt_strategies/test_dpo_chat_templates.py -v -s
========================================================== test session starts ==========================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /opt/miniforge/envs/axolotl/bin/python3.12
cachedir: .pytest_cache
rootdir: /home/lhl/axolotl
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 6 items

tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplateLlama3::test_llama3_defaults PASSED
tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplateLlama3::test_llama3_configured PASSED
tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplatePhi3::test_phi3_defaults PASSED
tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplateGemma::test_gemma_defaults PASSED
tests/prompt_strategies/test_dpo_chat_templates.py::TestArgillaChatDPOChatTemplate::test_llama3_argilla_chat PASSED
tests/prompt_strategies/test_dpo_chat_templates.py::TestArgillaChatDPOChatTemplate::test_phi3_argilla_chat PASSED

=========================================================== warnings summary ============================================================
tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplateLlama3::test_llama3_defaults
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

tests/prompt_strategies/test_dpo_chat_templates.py::TestAssistantDPOChatTemplateLlama3::test_llama3_defaults
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 6 passed, 2 warnings in 3.55s =====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Argilla-style chat datasets in DPO workflows, enabling proper handling of chosen/rejected conversation pairs and role mappings across templates.

* **Documentation**
  * Introduced a new example block demonstrating usage with Argilla-style chat data, including JSON samples for chosen and rejected arrays.

* **Tests**
  * Expanded test coverage to include Argilla-style chat datasets across multiple templates, validating prompts and chosen/rejected outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->