### PR TITLE
fix: transformers deprecate load_in_Xbit in model_kwargs

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -515,9 +515,6 @@ class ModelLoader:
             if self.cfg.model_quantization_config_kwargs:
                 mxfp4_kwargs = self.cfg.model_quantization_config_kwargs
             self.model_kwargs["quantization_config"] = Mxfp4Config(**mxfp4_kwargs)
-        else:
-            self.model_kwargs["load_in_8bit"] = self.cfg.load_in_8bit
-            self.model_kwargs["load_in_4bit"] = self.cfg.load_in_4bit
 
         if self.cfg.gptq:
             if not hasattr(self.model_config, "quantization_config"):
@@ -552,9 +549,7 @@ class ModelLoader:
                 self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                     **self.model_config.quantization_config
                 )
-        elif self.cfg.adapter == "qlora" and self.model_kwargs.get(
-            "load_in_4bit", False
-        ):
+        elif self.cfg.adapter == "qlora" and self.cfg.load_in_4bit:
             bnb_config = {
                 "load_in_4bit": True,
                 "llm_int8_threshold": 6.0,
@@ -580,9 +575,7 @@ class ModelLoader:
             self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                 **bnb_config,
             )
-        elif self.cfg.adapter == "lora" and self.model_kwargs.get(
-            "load_in_8bit", False
-        ):
+        elif self.cfg.adapter == "lora" and self.cfg.load_in_8bit:
             bnb_config = {
                 "load_in_8bit": True,
             }
@@ -595,11 +588,6 @@ class ModelLoader:
             self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                 **bnb_config,
             )
-
-        # no longer needed per https://github.com/huggingface/transformers/pull/26610
-        if "quantization_config" in self.model_kwargs or self.cfg.gptq:
-            self.model_kwargs.pop("load_in_8bit", None)
-            self.model_kwargs.pop("load_in_4bit", None)
 
     def _set_attention_config(self):
         """Sample packing uses custom FA2 patch"""

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -81,9 +81,17 @@ class TestModelsUtils:
                 and hasattr(self.model_loader.model_kwargs, "load_in_4bit")
             )
         elif load_in_8bit and self.cfg.adapter is not None:
-            assert self.model_loader.model_kwargs["load_in_8bit"]
+            assert getattr(
+                self.model_loader.model_kwargs["quantization_config"],
+                "load_in_8bit",
+                False,
+            )
         elif load_in_4bit and self.cfg.adapter is not None:
-            assert self.model_loader.model_kwargs["load_in_4bit"]
+            assert getattr(
+                self.model_loader.model_kwargs["quantization_config"],
+                "load_in_4bit",
+                False,
+            )
 
         if (self.cfg.adapter == "qlora" and load_in_4bit) or (
             self.cfg.adapter == "lora" and load_in_8bit

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -80,25 +80,24 @@ class TestModelsUtils:
                 hasattr(self.model_loader.model_kwargs, "load_in_8bit")
                 and hasattr(self.model_loader.model_kwargs, "load_in_4bit")
             )
-        elif load_in_8bit and self.cfg.adapter is not None:
-            assert getattr(
-                self.model_loader.model_kwargs["quantization_config"],
-                "load_in_8bit",
-                False,
-            )
-        elif load_in_4bit and self.cfg.adapter is not None:
-            assert getattr(
-                self.model_loader.model_kwargs["quantization_config"],
-                "load_in_4bit",
-                False,
-            )
 
         if (self.cfg.adapter == "qlora" and load_in_4bit) or (
             self.cfg.adapter == "lora" and load_in_8bit
         ):
-            assert self.model_loader.model_kwargs.get(
-                "quantization_config", BitsAndBytesConfig
+            assert isinstance(
+                self.model_loader.model_kwargs.get("quantization_config"),
+                BitsAndBytesConfig,
             )
+
+            # Check corresponding flag set
+            if load_in_8bit:
+                assert self.model_loader.model_kwargs["quantization_config"][
+                    "_load_in_8bit"
+                ]
+            else:
+                assert self.model_loader.model_kwargs["quantization_config"][
+                    "_load_in_4bit"
+                ]
 
     def test_message_property_mapping(self):
         """Test message property mapping configuration validation"""

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -81,23 +81,26 @@ class TestModelsUtils:
                 and hasattr(self.model_loader.model_kwargs, "load_in_4bit")
             )
 
-        if (self.cfg.adapter == "qlora" and load_in_4bit) or (
-            self.cfg.adapter == "lora" and load_in_8bit
-        ):
+        if self.cfg.adapter == "qlora" and load_in_4bit:
             assert isinstance(
                 self.model_loader.model_kwargs.get("quantization_config"),
                 BitsAndBytesConfig,
             )
 
-            # Check corresponding flag set
-            if load_in_8bit:
-                assert self.model_loader.model_kwargs[
-                    "quantization_config"
-                ]._load_in_8bit
-            else:
-                assert self.model_loader.model_kwargs[
-                    "quantization_config"
-                ]._load_in_4bit
+            assert (
+                self.model_loader.model_kwargs["quantization_config"]._load_in_4bit
+                is True
+            )
+        if self.cfg.adapter == "lora" and load_in_8bit:
+            assert isinstance(
+                self.model_loader.model_kwargs.get("quantization_config"),
+                BitsAndBytesConfig,
+            )
+
+            assert (
+                self.model_loader.model_kwargs["quantization_config"]._load_in_8bit
+                is True
+            )
 
     def test_message_property_mapping(self):
         """Test message property mapping configuration validation"""

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -91,13 +91,13 @@ class TestModelsUtils:
 
             # Check corresponding flag set
             if load_in_8bit:
-                assert self.model_loader.model_kwargs["quantization_config"][
-                    "_load_in_8bit"
-                ]
+                assert self.model_loader.model_kwargs[
+                    "quantization_config"
+                ]._load_in_8bit
             else:
-                assert self.model_loader.model_kwargs["quantization_config"][
-                    "_load_in_4bit"
-                ]
+                assert self.model_loader.model_kwargs[
+                    "quantization_config"
+                ]._load_in_4bit
 
     def test_message_property_mapping(self):
         """Test message property mapping configuration validation"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Upstream plans to deprecate these configs. We already used their new methods but was also using their legacy setting.

Related, 
https://github.com/huggingface/transformers/pull/41287
https://github.com/huggingface/transformers/pull/41283

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistencies where 4‑bit/8‑bit loading could be unintentionally overridden, ensuring explicit configuration flags are always honored.
  * QLoRA and LoRA paths now reliably follow the user’s selected quantization settings.

* **Refactor**
  * Simplified quantization handling by removing hidden fallbacks and cleanup steps, leading to more predictable and transparent behavior when configuring model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->