### PR TITLE
fix: use KD _loss_function on base model for PEFT compatibility

### DIFF
--- a/src/axolotl/integrations/kd/kernels/models.py
+++ b/src/axolotl/integrations/kd/kernels/models.py
@@ -72,9 +72,9 @@ def kldiv_forward_llama_like(
 
     # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
     # TODO, we can optimize this further by filtering hidden_states on sequence dimension using labels != -100
-    # self.loss_function should be LigerFusedLinearKLTopKLogprobLoss
+    # self._loss_function should be LigerFusedLinearKLTopKLogprobLoss
 
-    loss = self.loss_function(
+    loss = self._loss_function(
         self.lm_head.weight,
         hidden_states,
         target_token_ids,

--- a/tests/e2e/integrations/test_kd.py
+++ b/tests/e2e/integrations/test_kd.py
@@ -104,7 +104,6 @@ class TestKnowledgeDistillation:
             temp_dir + "/runs", "train/loss", 1.4, "Train Loss (%s) is too high"
         )
 
-    @pytest.mark.skip(reason="Chunked KD loss doesn't support PEFT/LoRA")
     @pytest.mark.parametrize(
         "load_in_8bit",
         [True, False],
@@ -120,6 +119,10 @@ class TestKnowledgeDistillation:
                 "lora_r": 16,
                 "lora_alpha": 32,
                 "lora_dropout": 0.0,
+                "lora_modules_to_save": ["embed_tokens", "lm_head"],
+                "lora_mlp_kernel": False,
+                "lora_qkv_kernel": False,
+                "lora_o_kernel": False,
             }
             | kd_min_cfg
         )


### PR DESCRIPTION
- Fix mismatched attribute name (loss_function vs _loss_function)
- Set _loss_function on unwrapped base model for PEFT
- Enable previously skipped test_llama_lora_kd test

Fixes https://github.com/axolotl-ai-cloud/axolotl/issues/3206

<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes the KD plugin to use the correct loss function and work with PEFT/LoRA adapters. The plugin was broken due to incorrect loss function attribute access.

**Root causes:**
1. Trainer set `model._loss_function` but forward called `self.loss_function` (HF's default CE loss)
2. With PEFT, `_loss_function` was set on wrapper but accessed on base model

## Motivation and Context

Fixes #3206

The test `test_llama_lora_kd` was skipped since the original KD implementation (PR #2700) with reason: "Chunked KD loss doesn't support PEFT/LoRA". This PR fixes the underlying bugs and enables LoRA support.

## How has this been tested?

- [x] All existing KD tests pass (`pytest tests/e2e/integrations/test_kd.py::TestKnowledgeDistillation::test_llama_kd`)
- [x] Previously skipped LoRA test now passes (`test_llama_lora_kd` with both `load_in_8bit=True` and `False`)
- [x] Verified bug reproduction without fix using attached config in [the issue](https://github.com/axolotl-ai-cloud/axolotl/issues/3206)
- [x] Verified fix resolves the issue

Logs from the local run:
```
[2025-10-09 01:52:43,749] [WARNING] [py.warnings] /root/miniconda3/envs/py3.11/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4631: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user.
  warnings.warn(  # warn only once

[2025-10-09 01:52:43,750] [WARNING] [py.warnings] /root/miniconda3/envs/py3.11/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py:4631: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user.
  warnings.warn(  # warn only once

{'loss': 16.5625, 'grad_norm': 2.559605121612549, 'learning_rate': 0.0001, 'memory/max_active (GiB)': 5.53, 'memory/max_allocated (GiB)': 5.53, 'memory/device_reserved (GiB)': 6.48, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.12}
{'loss': 17.0, 'grad_norm': 3.5981805324554443, 'learning_rate': 9.619397662556435e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.25}
{'loss': 15.5625, 'grad_norm': 2.962693691253662, 'learning_rate': 8.535533905932738e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.38}
{'loss': 15.4375, 'grad_norm': 2.6835856437683105, 'learning_rate': 6.91341716182545e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.5}
{'loss': 15.2188, 'grad_norm': 3.4933176040649414, 'learning_rate': 5e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.62}
{'loss': 14.4062, 'grad_norm': 2.718255043029785, 'learning_rate': 3.086582838174551e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.75}
{'loss': 15.375, 'grad_norm': 2.5927999019622803, 'learning_rate': 1.4644660940672627e-05, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 0.88}
{'loss': 14.3125, 'grad_norm': 2.3567073345184326, 'learning_rate': 3.8060233744356633e-06, 'memory/max_active (GiB)': 5.57, 'memory/max_allocated (GiB)': 5.57, 'memory/device_reserved (GiB)': 6.49, 'tokens_per_second_per_gpu': 0.0, 'epoch': 1.0}
100%|███████████████████████████████████████████████████████████| 8/8 [00:27<00:00,  2.04s/it][2025-10-09 01:53:11,079] [INFO] [axolotl.core.trainers.base] Saving model checkpoint to ./outputs/kd-lora-test/checkpoint-8
{'train_runtime': 27.7804, 'train_samples_per_second': 1.152, 'train_steps_per_second': 0.288, 'train_loss': 15.484375, 'memory/max_active (GiB)': 1.34, 'memory/max_allocated (GiB)': 1.34, 'memory/device_reserved (GiB)': 6.49, 'epoch': 1.0}
100%|███████████████████████████████████████████████████████████| 8/8 [00:27<00:00,  3.47s/it]
[2025-10-09 01:53:11,690] [INFO] [axolotl.train] Training completed! Saving trained model to ./outputs/kd-lora-test.
[2025-10-09 01:53:11,931] [INFO] [axolotl.train] Model successfully saved to ./outputs/kd-lora-test
```

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix

## Social Handles (Optional)
Twitter: https://x.com/sagtanih
Discord: sagtanih
