### PR TITLE
use can_device_access_peer for P2P checks

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -641,6 +641,7 @@ def setup_parallelism_envs(cfg):
 def prepare_optim_env(cfg):
     if not check_cuda_p2p_ib_support():
         if os.getenv("NCCL_P2P_DISABLE") is None:
+            LOG.warning("P2P support not detected, setting `NCCL_P2P_DISABLE=1`")
             os.environ["NCCL_P2P_DISABLE"] = "1"
     # TODO @SalmanMohammadi remove the cfg.fsdp check in 0.12
     if cfg.fsdp or cfg.fsdp_config:


### PR DESCRIPTION
## Motivation and Context

Per @alpindale 's post https://x.com/AlpinDale/status/1969489133308690914 we can simplify our P2P checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Overhauled GPU peer‑to‑peer (P2P) capability detection using runtime checks and cluster topology, with simplified fail‑open fallback.
  - Updated internal delegation for P2P checks to a unified path.

- Bug Fixes
  - Improved accuracy of P2P detection across multi‑GPU and multi‑node setups, reducing false positives/negatives that could impact training stability.

- Chores
  - Added clearer warnings before automatically disabling P2P when not detected.
  - Enhanced logging to surface P2P decisions and environment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->