### PR TITLE
only calculate packed ds length once if using a large world size

### DIFF
--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -5,6 +5,7 @@ into fixed-capacity batches to optimize memory usage and training throughput.
 
 import gc
 import math
+import os
 import time
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import cpu_count, get_context
@@ -291,7 +292,10 @@ class MultipackBatchSampler(BatchSampler):
         self.total_token_slots = 0
 
         # The number of times to calculate batches to determine minimum packed dataset length
-        self.num_count_samples = num_count_samples
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        self.num_count_samples = (
+            1 if world_size >= num_count_samples else num_count_samples
+        )
 
         if self.sequential and not isinstance(sampler, SequentialSampler):
             LOG.warning(


### PR DESCRIPTION
# Description

reduces the number of times we calculate the packed dataset length to get the min length to account for randomness when using large world sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved batch count estimation in distributed training, ensuring stable batching across different cluster sizes and reducing misconfigured sample counts.
- Chores
  - Automatic adaptation to distributed environments, minimizing manual configuration for sampling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->