### PR TITLE
fix: TRL enable_sleep_mode bug

### DIFF
--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -52,7 +52,7 @@ class GRPOStrategy:
             if trl.vllm_mode:
                 grpo_args_kwargs["vllm_mode"] = trl.vllm_mode
             if trl.vllm_mode == "colocate":
-                grpo_args_kwargs["enable_sleep_mode"] = trl.vllm_enable_sleep_mode  # type: ignore[attr-defined]
+                grpo_args_kwargs["vllm_enable_sleep_mode"] = trl.vllm_enable_sleep_mode  # type: ignore[attr-defined]
                 grpo_args_kwargs["vllm_gpu_memory_utilization"] = (
                     vllm_cfg.gpu_memory_utilization
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
This bug fix changes `enable_sleep_mode` to `vllm_enable_sleep_mode` to align with TRL's naming convention.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
```
  File "/workspace/.venv/lib/python3.12/site-packages/ray/train/_internal/worker_group.py", line 35, in __execute                 
    raise skipped from exception_cause(skipped)                                                                                   
  File "/workspace/.venv/lib/python3.12/site-packages/ray/train/_internal/utils.py", line 176, in discard_return_wrapper          
    train_func(*args, **kwargs)                                                                                                   
  File "/workspace/axolotl/src/axolotl/cli/train.py", line 117, in ray_train_func                                                 
    do_train(**kwargs)                                                                                                            
  File "/workspace/axolotl/src/axolotl/cli/train.py", line 45, in do_train                                                        
    model, tokenizer, trainer = train(cfg=cfg, dataset_meta=dataset_meta)                                                         
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                         
  File "/workspace/axolotl/src/axolotl/train.py", line 568, in train                                                              
    ) = setup_model_and_trainer(cfg, dataset_meta)                                                                                
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File "/workspace/axolotl/src/axolotl/train.py", line 513, in setup_model_and_trainer                                            
    trainer = setup_trainer(                                                                                                      
              ^^^^^^^^^^^^^^                                                                                                      
  File "/workspace/axolotl/src/axolotl/utils/trainer.py", line 718, in setup_trainer                                              
    return trainer_builder.build(total_num_steps)                                                                                 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                 
  File "/workspace/axolotl/src/axolotl/core/builders/rl.py", line 191, in build                                                   
    training_args, trainer_kwargs = self._build_training_arguments(total_num_steps)                                               
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                               
  File "/workspace/axolotl/src/axolotl/core/builders/rl.py", line 179, in _build_training_arguments                               
    training_args = training_args_cls(                                                                                            
                    ^^^^^^^^^^^^^^^^^^                                                                                            
TypeError: AxolotlGRPOConfig.__init__() got an unexpected keyword argument 'enable_sleep_mode'                                    
```
This bug will prevent GRPO training with axolotl when using colocated vLLM. See [here](https://github.com/huggingface/trl/blob/475c732526268154999bfa05f7acf47a39439d09/trl/trainer/grpo_config.py#L424) for the convention used by TRL that is causing this bug.

## How has this been tested?

After manually changing the naming convention I was able to successfully start a training.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Dictionary key change

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal parameter naming in GRPO training configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->