### PR TITLE
include tool in default message_property_mappings

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -48,9 +48,9 @@ class ChatTemplatePrompter(Prompter):
     ):
         # check if message_property_mappings is None or empty dict
         if message_property_mappings is None or (not message_property_mappings):
+            default_message_property_mappings_keys = ["role", "content", "tool"]
             message_property_mappings = {
-                "role": "role",
-                "content": "content",
+                prop: prop for prop in default_message_property_mappings_keys
             }
             if template_thinking_key and field_thinking:
                 message_property_mappings[template_thinking_key] = field_thinking


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

adds `tool` to `message_property_mappings` alongside `role` and `content`

<!--- Describe your changes in detail -->

## Motivation and Context

#3217 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat templates now include "tool" as a default message property mapping. Previously, only role and content were included in the default mappings. This enhancement provides first-class support for tool properties, enabling better configuration of message templates for tool and function calling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->