### PR TITLE
feat: save checkpoint after training started 

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -114,6 +114,12 @@ class TrainerBuilderBase(abc.ABC):
         if self.cfg.gc_steps:
             callbacks.append(GCCallback(gc_steps=self.cfg.gc_steps))
 
+        if self.cfg.dynamic_checkpoint and self.cfg.dynamic_checkpoint.enabled:
+            from axolotl.utils.callbacks.dynamic_checkpoint import (
+                DynamicCheckpointCallback,
+            )
+            callbacks.append(DynamicCheckpointCallback(self.cfg))
+
         if self.cfg.use_wandb:
             callbacks.append(
                 SaveAxolotlConfigtoWandBCallback(self.cfg.axolotl_config_path)

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -122,6 +122,7 @@ class TrainerBuilderBase(abc.ABC):
             from axolotl.utils.callbacks.dynamic_checkpoint import (
                 DynamicCheckpointCallback,
             )
+
             callbacks.append(DynamicCheckpointCallback(self.cfg))
 
         if self.cfg.use_wandb:

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -99,7 +99,6 @@ class DynamicCheckpointCallback(TrainerCallback):
                     trigger_detected = True
                     self.should_save_checkpoint = False  # Reset flag
 
-            # In distributed mode, synchronize the trigger decision across all ranks
             if is_distributed():
                 import torch
                 import torch.distributed as dist
@@ -110,18 +109,11 @@ class DynamicCheckpointCallback(TrainerCallback):
                     torch.device("cuda" if torch.cuda.is_available() else "cpu"),
                 )
 
-                if is_main_process():
-                    trigger_tensor = torch.tensor(
-                        1 if trigger_detected else 0,
-                        dtype=torch.long,
-                        device=device,
-                    )
-                else:
-                    trigger_tensor = torch.tensor(
-                        0,
-                        dtype=torch.long,
-                        device=device,
-                    )
+                trigger_tensor = torch.tensor(
+                    1 if trigger_detected else 0,
+                    dtype=torch.long,
+                    device=device,
+                )
 
                 dist.broadcast(trigger_tensor, src=0)
 

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -1,0 +1,139 @@
+import signal
+import os
+from pathlib import Path
+from typing import Optional
+from transformers import (
+    TrainerCallback,
+    TrainerControl,
+    TrainerState,
+    TrainingArguments,
+)
+from axolotl.utils.distributed import (
+    is_main_process,
+    barrier,
+    is_distributed,
+)
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+DEFAULT_TRIGGER_FILENAME = ".axolotl_save_checkpoint"
+
+
+class DynamicCheckpointCallback(TrainerCallback):
+    """
+    Callback to save checkpoints on-demand during training via:
+    1. File-based trigger (works everywhere, rank 0 checks file)
+    2. Signal-based trigger (Unix/Linux only, rank 0 sets flag)
+
+    Thread-safe for multi-GPU distributed training.
+    Addresses issue: https://github.com/axolotl-ai-cloud/axolotl/issues/3169
+
+    Usage:
+        # File-based:
+        touch /path/to/output_dir/.axolotl_save_checkpoint
+        # Signal-based (Unix/Linux):
+        kill -SIGUSR1 <training_pid>
+    """
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.enabled = cfg.dynamic_checkpoint.enabled
+
+        if not self.enabled:
+            return
+
+        self.trigger_filename = (
+            cfg.dynamic_checkpoint.trigger_file_path or DEFAULT_TRIGGER_FILENAME
+        )
+
+        self.check_interval = cfg.dynamic_checkpoint.check_interval
+        self.enable_signal = cfg.dynamic_checkpoint.enable_signal
+
+        self.should_save_checkpoint = False
+
+        if self.enable_signal and hasattr(signal, "SIGUSR1") and is_main_process():
+            signal.signal(signal.SIGUSR1, self._signal_handler)
+            LOG.info(
+                f"Dynamic checkpoint: Signal handler registered on rank 0 (SIGUSR1). "
+                f"Trigger with: kill -SIGUSR1 {os.getpid()}",
+                main_process_only=True,
+            )
+
+        LOG.info(
+            f"Dynamic checkpoint enabled. To trigger checkpoint save:\n"
+            f"  • File: touch {cfg.output_dir}/{self.trigger_filename}\n"
+            f"  • Signal: kill -SIGUSR1 <pid> {'(enabled)' if self.enable_signal else '(disabled)'}\n"
+            f"  • Check interval: every {self.check_interval} steps",
+            main_process_only=True,
+        )
+
+    def _signal_handler(self, signum, frame):
+        """Handle SIGUSR1 signal to trigger checkpoint (rank 0 only)"""
+        self.should_save_checkpoint = True
+        LOG.info(
+            "Dynamic checkpoint triggered via SIGUSR1 signal", main_process_only=True
+        )
+
+    def on_step_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **_kwargs,
+    ) -> TrainerControl:
+        """
+        Check for checkpoint triggers at the end of each step.
+        ONLY rank 0 checks the file, then all ranks synchronize.
+        """
+        if not self.enabled:
+            return control
+
+        trigger_detected = False
+
+        if state.global_step % self.check_interval == 0:
+            if is_main_process():
+                trigger_path = Path(args.output_dir) / self.trigger_filename
+
+                if trigger_path.exists():
+                    trigger_detected = True
+                    try:
+                        trigger_path.unlink()  # Delete the trigger file
+                        LOG.info(
+                            f"Dynamic checkpoint triggered via file '{self.trigger_filename}' "
+                            f"at step {state.global_step}",
+                            main_process_only=True,
+                        )
+                    except Exception as exc:
+                        LOG.warning(
+                            f"Failed to delete trigger file: {exc}",
+                            main_process_only=True,
+                        )
+
+                if self.should_save_checkpoint:
+                    trigger_detected = True
+                    self.should_save_checkpoint = False  # Reset flag
+
+            if is_distributed():
+                import torch
+                import torch.distributed as dist
+
+                trigger_tensor = torch.tensor(
+                    1 if trigger_detected else 0,
+                    dtype=torch.long,
+                    device=f"cuda:{torch.cuda.current_device()}",
+                )
+
+                dist.broadcast(trigger_tensor, src=0)
+
+                trigger_detected = bool(trigger_tensor.item())
+
+                barrier()
+
+        if trigger_detected:
+            control.should_save = True
+            LOG.info(
+                f"Saving dynamic checkpoint at step {state.global_step}",
+                main_process_only=False,  # Log on all ranks for debugging
+            )
+        return control

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -53,11 +53,13 @@ class DynamicCheckpointCallback(TrainerCallback):
         dc_config = cfg.dynamic_checkpoint
 
         trigger_path = self._get_config_value(dc_config, "trigger_file_path")
-        self.trigger_filename = trigger_path if trigger_path else DEFAULT_TRIGGER_FILENAME
-        
+        self.trigger_filename = (
+            trigger_path if trigger_path else DEFAULT_TRIGGER_FILENAME
+        )
+
         check_interval = self._get_config_value(dc_config, "check_interval")
         self.check_interval = check_interval if check_interval is not None else 100
-        
+
         enable_signal = self._get_config_value(dc_config, "enable_signal")
         self.enable_signal = enable_signal if enable_signal is not None else False
         self.should_save_checkpoint = False

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -153,6 +153,6 @@ class DynamicCheckpointCallback(TrainerCallback):
             control.should_save = True
             LOG.info(
                 f"Saving dynamic checkpoint at step {state.global_step}",
-                main_process_only=False,  # Log on all ranks for debugging
+                main_process_only=True,
             )
         return control

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from transformers import (
@@ -60,7 +59,6 @@ class DynamicCheckpointCallback(TrainerCallback):
             f"  • Check interval: every {self.check_interval} steps",
             main_process_only=True,
         )
-
 
     def on_step_end(
         self,

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -9,7 +9,6 @@ from transformers import (
 
 from axolotl.utils.distributed import (
     barrier,
-    is_distributed,
     is_main_process,
 )
 from axolotl.utils.logging import get_logger

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -99,7 +99,7 @@ class DynamicCheckpointCallback(TrainerCallback):
                     trigger_detected = True
                     self.should_save_checkpoint = False  # Reset flag
 
-            if is_distributed():
+            if is_main_process():
                 import torch
                 import torch.distributed as dist
 

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -28,7 +28,6 @@ class DynamicCheckpointCallback(TrainerCallback):
     2. Signal-based trigger (Unix/Linux only, rank 0 sets flag)
 
     Thread-safe for multi-GPU distributed training.
-    Addresses issue: https://github.com/axolotl-ai-cloud/axolotl/issues/3169
 
     Usage:
         # File-based:

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -129,14 +129,12 @@ class DynamicCheckpointCallback(TrainerCallback):
                 import torch
                 import torch.distributed as dist
 
-                if hasattr(args, "device"):
-                    device = args.device
-                else:
-                    device = (
-                        torch.device("cuda", torch.cuda.current_device())
-                        if torch.cuda.is_available()
-                        else torch.device("cpu")
-                    )
+                device = getattr(
+                    args,
+                    "device",
+                    torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+                )
+
                 trigger_tensor = torch.tensor(
                     1 if trigger_detected else 0,
                     dtype=torch.long,

--- a/src/axolotl/utils/callbacks/dynamic_checkpoint.py
+++ b/src/axolotl/utils/callbacks/dynamic_checkpoint.py
@@ -16,7 +16,7 @@ from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
 
-DEFAULT_TRIGGER_FILENAME = ".axolotl_save_checkpoint"
+DEFAULT_TRIGGER_FILENAME = "axolotl_checkpoint.save"
 
 
 class DynamicCheckpointCallback(TrainerCallback):
@@ -28,8 +28,7 @@ class DynamicCheckpointCallback(TrainerCallback):
 
     Usage:
         # File-based:
-        touch /path/to/output_dir/.axolotl_save_checkpoint
-        kill -SIGUSR1 <training_pid>
+        touch /path/to/output_dir/axolotl_checkpoint.save
     """
 
     def _get_config_value(self, config, key, default=None):
@@ -47,7 +46,10 @@ class DynamicCheckpointCallback(TrainerCallback):
         self.enabled = True
         dc_config = cfg.dynamic_checkpoint
 
-        self.trigger_filename = DEFAULT_TRIGGER_FILENAME
+        trigger_file_path = self._get_config_value(dc_config, "trigger_file_path")
+        self.trigger_filename = (
+            trigger_file_path if trigger_file_path else DEFAULT_TRIGGER_FILENAME
+        )
 
         check_interval = self._get_config_value(dc_config, "check_interval")
         self.check_interval = check_interval if check_interval is not None else 100

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -23,6 +23,7 @@ from axolotl.utils.schemas.datasets import (
     StepwiseSupervisedDataset,
 )
 from axolotl.utils.schemas.deprecated import DeprecatedParameters, RemappedParameters
+from axolotl.utils.schemas.dynamic_checkpoint import DynamicCheckpointConfig
 from axolotl.utils.schemas.enums import ChatTemplate, RingAttnFunc, RLType
 from axolotl.utils.schemas.fsdp import FSDPConfig
 from axolotl.utils.schemas.integrations import (
@@ -47,7 +48,6 @@ from axolotl.utils.schemas.training import HyperparametersConfig, JaggedLRConfig
 from axolotl.utils.schemas.trl import TRLConfig
 from axolotl.utils.schemas.validation import ValidationMixin
 from axolotl.utils.schemas.vllm import VllmConfig
-from axolotl.utils.schemas.dynamic_checkpoint import DynamicCheckpointConfig
 
 LOG = get_logger(__name__)
 
@@ -143,9 +143,10 @@ class AxolotlInputConfig(
         json_schema_extra={"description": "Reward modelling: `True` or `False`"},
     )
     dynamic_checkpoint: DynamicCheckpointConfig | None = Field(
-        default_factory=lambda: DynamicCheckpointConfig(),
+        default=None,
         json_schema_extra={
-            "description": "Configuration for dynamic checkpointing (trigger by file or signal)."
+            "description": "Configuration for dynamic checkpointing (trigger by file or signal). "
+            "Set 'enabled: true' to activate this feature."
         },
     )
     process_reward_model: bool | None = Field(

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -46,6 +46,7 @@ from axolotl.utils.schemas.training import HyperparametersConfig, JaggedLRConfig
 from axolotl.utils.schemas.trl import TRLConfig
 from axolotl.utils.schemas.validation import ValidationMixin
 from axolotl.utils.schemas.vllm import VllmConfig
+from axolotl.utils.schemas.dynamic_checkpoint import DynamicCheckpointConfig
 
 LOG = get_logger(__name__)
 
@@ -138,6 +139,12 @@ class AxolotlInputConfig(
     reward_model: bool | None = Field(
         default=None,
         json_schema_extra={"description": "Reward modelling: `True` or `False`"},
+    )
+    dynamic_checkpoint: DynamicCheckpointConfig | None = Field(
+        default_factory=lambda: DynamicCheckpointConfig(),
+        json_schema_extra={
+            "description": "Configuration for dynamic checkpointing (trigger by file or signal)."
+        },
     )
     process_reward_model: bool | None = Field(
         default=None,

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -1,0 +1,36 @@
+"""Schema for dynamic checkpoint configuration."""
+
+from pydantic import BaseModel, Field
+
+
+class DynamicCheckpointConfig(BaseModel):
+    """Configuration for dynamic checkpoint triggering during training."""
+
+    enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": "Enable dynamic checkpoint triggering during training. "
+            "Create a file '.axolotl_save_checkpoint' in output_dir to trigger. "
+            "Addresses: https://github.com/axolotl-ai-cloud/axolotl/issues/3169"
+        },
+    )
+    check_interval: int = Field(
+        default=100,
+        json_schema_extra={
+            "description": "Check for trigger file every N steps (reduces I/O overhead). "
+            "Default: 100"
+        },
+    )
+    enable_signal: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": "Enable SIGUSR1 signal-based checkpoint triggering (Unix/Linux only). "
+            "Useful for automated systems. Default: False"
+        },
+    )
+    trigger_file_path: str = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Path to the trigger file. Default: '.axolotl_save_checkpoint'"
+        },
+    )

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -10,7 +10,7 @@ class DynamicCheckpointConfig(BaseModel):
         default=False,
         json_schema_extra={
             "description": "Enable dynamic checkpoint triggering during training. "
-            "Create a file '.axolotl_save_checkpoint' in the configured `output_dir` to trigger. "
+            "Create a file 'axolotl_checkpoint.save' in the configured `output_dir` to trigger. "
         },
     )
     check_interval: int = Field(
@@ -19,5 +19,13 @@ class DynamicCheckpointConfig(BaseModel):
         json_schema_extra={
             "description": "Check for trigger file every N steps (reduces I/O overhead). "
             "Default: 100"
+        },
+    )
+    trigger_file_path: str = Field(
+        default="",
+        json_schema_extra={
+            "description": "Custom trigger filename (optional). "
+            "If not specified, defaults to 'axolotl_checkpoint.save'. "
+            "Specify a filename (not a full path) to override the default."
         },
     )

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -28,7 +28,7 @@ class DynamicCheckpointConfig(BaseModel):
             "Useful for automated systems. Default: False"
         },
     )
-    trigger_file_path: str = Field(
+    trigger_file_path: str | None = Field(
         default=None,
         json_schema_extra={
             "description": "Path to the trigger file. Default: '.axolotl_save_checkpoint'"

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -11,7 +11,6 @@ class DynamicCheckpointConfig(BaseModel):
         json_schema_extra={
             "description": "Enable dynamic checkpoint triggering during training. "
             "Create a file '.axolotl_save_checkpoint' in output_dir to trigger. "
-            "Addresses: https://github.com/axolotl-ai-cloud/axolotl/issues/3169"
         },
     )
     check_interval: int = Field(

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -21,16 +21,4 @@ class DynamicCheckpointConfig(BaseModel):
             "Default: 100"
         },
     )
-    enable_signal: bool = Field(
-        default=False,
-        json_schema_extra={
-            "description": "Enable SIGUSR1 signal-based checkpoint triggering (Unix/Linux only). "
-            "Useful for automated systems. Default: False"
-        },
-    )
-    trigger_file_path: str | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "Path to the trigger file. Default: '.axolotl_save_checkpoint'"
-        },
-    )
+

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -16,6 +16,7 @@ class DynamicCheckpointConfig(BaseModel):
     )
     check_interval: int = Field(
         default=100,
+        ge=1,
         json_schema_extra={
             "description": "Check for trigger file every N steps (reduces I/O overhead). "
             "Default: 100"

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -10,7 +10,7 @@ class DynamicCheckpointConfig(BaseModel):
         default=False,
         json_schema_extra={
             "description": "Enable dynamic checkpoint triggering during training. "
-            "Create a file '.axolotl_save_checkpoint' in output_dir to trigger. "
+            "Create a file '.axolotl_save_checkpoint' in the configured `output_dir` to trigger. "
         },
     )
     check_interval: int = Field(

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -14,7 +14,7 @@ class DynamicCheckpointConfig(BaseModel):
         },
     )
     check_interval: int = Field(
-        default=100,
+        default=10,
         ge=1,
         json_schema_extra={
             "description": "Check for trigger file every N steps (reduces I/O overhead). "

--- a/src/axolotl/utils/schemas/dynamic_checkpoint.py
+++ b/src/axolotl/utils/schemas/dynamic_checkpoint.py
@@ -21,4 +21,3 @@ class DynamicCheckpointConfig(BaseModel):
             "Default: 100"
         },
     )
-

--- a/tests/e2e/integrations/__init__.py
+++ b/tests/e2e/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for axolotl features."""

--- a/tests/e2e/integrations/__init__.py
+++ b/tests/e2e/integrations/__init__.py
@@ -1,1 +1,0 @@
-"""Integration tests for axolotl features."""

--- a/tests/utils/callbacks/test_dynamic_checkpoint.py
+++ b/tests/utils/callbacks/test_dynamic_checkpoint.py
@@ -1,0 +1,462 @@
+"""Unit tests for dynamic checkpoint callback"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+from axolotl.utils.callbacks.dynamic_checkpoint import (
+    DEFAULT_TRIGGER_FILENAME,
+    DynamicCheckpointCallback,
+)
+from axolotl.utils.dict import DictDefault
+
+
+class TestDynamicCheckpointCallbackInit:
+    """Test callback initialization"""
+
+    def test_callback_disabled_by_default(self):
+        """Test that callback is disabled when config.enabled=False"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {"enabled": False},
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.enabled is False
+
+    def test_callback_disabled_when_none(self):
+        """Test that callback is disabled when dynamic_checkpoint is None"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": None,
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.enabled is False
+
+    def test_callback_enabled_when_configured(self):
+        """Test that callback is enabled when config.enabled=True"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {"enabled": True, "check_interval": 10},
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.enabled is True
+        assert callback.check_interval == 10
+
+    def test_default_trigger_filename(self):
+        """Test that default trigger filename is used"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {"enabled": True, "check_interval": 10},
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.trigger_filename == DEFAULT_TRIGGER_FILENAME
+
+    def test_custom_trigger_filename(self):
+        """Test that custom trigger filename is respected"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {
+                    "enabled": True,
+                    "check_interval": 10,
+                    "trigger_file_path": "SAVE_NOW",
+                },
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.trigger_filename == "SAVE_NOW"
+
+    def test_check_interval_default(self):
+        """Test default check interval"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {"enabled": True},
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.check_interval == 100  # Default from schema
+
+    def test_signal_disabled_by_default(self):
+        """Test that signal support is disabled by default"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {"enabled": True},
+                "output_dir": "/tmp/test",
+            }
+        )
+        callback = DynamicCheckpointCallback(cfg)
+        assert callback.enable_signal is False
+
+
+class TestDynamicCheckpointFileDetection:
+    """Test file-based checkpoint triggering"""
+
+    def test_trigger_file_detected_and_deleted(self):
+        """Test that trigger file is detected and deleted"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 1},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+            assert trigger_file.exists()
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=False,
+                ):
+                    result = callback.on_step_end(args, state, control)
+
+            assert not trigger_file.exists()
+            assert result.should_save is True
+
+    def test_check_interval_honored(self):
+        """Test that file is only checked at check_interval steps"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 10},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            args = Mock(output_dir=tmpdir)
+            control = Mock(should_save=False)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=False,
+                ):
+                    # Step 5 - shouldn't check (not divisible by 10)
+                    state = Mock(global_step=5)
+                    result = callback.on_step_end(args, state, control)
+                    assert trigger_file.exists()  # Still there
+                    assert result.should_save is False
+
+                    # Step 10 - should check
+                    state = Mock(global_step=10)
+                    result = callback.on_step_end(args, state, control)
+                    assert not trigger_file.exists()  # Deleted
+                    assert result.should_save is True
+
+    def test_no_file_no_trigger(self):
+        """Test that no trigger occurs when file doesn't exist"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 1},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=False,
+                ):
+                    result = callback.on_step_end(args, state, control)
+
+            assert result.should_save is False
+
+    def test_file_deletion_error_handling(self):
+        """Test that file deletion errors are handled gracefully"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 1},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=False,
+                ):
+                    with patch.object(
+                        Path, "unlink", side_effect=OSError("Permission denied")
+                    ):
+                        result = callback.on_step_end(args, state, control)
+
+            assert result.should_save is True
+
+
+class TestDynamicCheckpointMultiGPU:
+    """Test multi-GPU synchronization"""
+
+    def test_only_rank_0_checks_file(self):
+        """Test that only rank 0 checks filesystem in multi-GPU setup"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 1},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            # Rank 1 (not main process) - shouldn't check file
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=False,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=True,
+                ):
+                    with patch("torch.distributed.broadcast") as mock_broadcast:
+                        with patch(
+                            "axolotl.utils.callbacks.dynamic_checkpoint.barrier"
+                        ):
+                            mock_tensor = MagicMock()
+                            mock_tensor.item.return_value = 0
+                            with patch("torch.tensor", return_value=mock_tensor):
+                                callback.on_step_end(args, state, control)
+
+            assert trigger_file.exists()
+            # Broadcast should have been called
+            assert mock_broadcast.called
+
+    def test_broadcast_synchronization(self):
+        """Test that trigger decision is broadcasted to all ranks"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": True, "check_interval": 1},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            # Rank 0 detects file
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                    return_value=True,
+                ):
+                    with patch("torch.distributed.broadcast") as mock_broadcast:
+                        with patch(
+                            "axolotl.utils.callbacks.dynamic_checkpoint.barrier"
+                        ) as mock_barrier:
+                            mock_tensor = MagicMock()
+                            mock_tensor.item.return_value = 1
+                            with patch("torch.tensor", return_value=mock_tensor):
+                                with patch("torch.cuda.current_device", return_value=0):
+                                    result = callback.on_step_end(args, state, control)
+
+            assert mock_broadcast.called
+            assert mock_barrier.called
+            # All ranks should trigger
+            assert result.should_save is True
+
+
+class TestDynamicCheckpointSignalHandling:
+    """Test signal-based checkpoint triggering"""
+
+    @patch("signal.signal")
+    @patch("signal.SIGUSR1", 10, create=True)  # Mock signal number
+    def test_signal_handler_registration(self, mock_signal_register):
+        """Test that SIGUSR1 handler is registered when enabled"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {
+                    "enabled": True,
+                    "check_interval": 10,
+                    "enable_signal": True,
+                },
+                "output_dir": "/tmp/test",
+            }
+        )
+
+        with patch(
+            "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+            return_value=True,
+        ):
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.hasattr", return_value=True
+            ):
+                _ = DynamicCheckpointCallback(cfg)  # noqa: F841
+
+        assert mock_signal_register.called
+
+    def test_signal_handler_sets_flag(self):
+        """Test that signal handler sets should_save_checkpoint flag"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {
+                    "enabled": True,
+                    "check_interval": 1,
+                    "enable_signal": True,
+                },
+                "output_dir": "/tmp/test",
+            }
+        )
+
+        with patch("signal.signal"):
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.hasattr",
+                    return_value=True,
+                ):
+                    callback = DynamicCheckpointCallback(cfg)
+
+        callback._signal_handler(None, None)
+
+        assert callback.should_save_checkpoint is True
+
+    def test_signal_trigger_via_callback(self):
+        """Test that signal flag triggers checkpoint save"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {
+                    "enabled": True,
+                    "check_interval": 1,
+                    "enable_signal": True,
+                },
+                "output_dir": "/tmp/test",
+            }
+        )
+
+        with patch("signal.signal"):
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+                return_value=True,
+            ):
+                with patch(
+                    "axolotl.utils.callbacks.dynamic_checkpoint.hasattr",
+                    return_value=True,
+                ):
+                    callback = DynamicCheckpointCallback(cfg)
+
+        callback.should_save_checkpoint = True
+
+        args = Mock(output_dir="/tmp/test")
+        state = Mock(global_step=1)
+        control = Mock(should_save=False)
+
+        with patch(
+            "axolotl.utils.callbacks.dynamic_checkpoint.is_main_process",
+            return_value=True,
+        ):
+            with patch(
+                "axolotl.utils.callbacks.dynamic_checkpoint.is_distributed",
+                return_value=False,
+            ):
+                result = callback.on_step_end(args, state, control)
+
+        assert result.should_save is True
+        assert callback.should_save_checkpoint is False
+
+    def test_signal_not_registered_when_disabled(self):
+        """Test that signal handler is not registered when disabled"""
+        cfg = DictDefault(
+            {
+                "dynamic_checkpoint": {
+                    "enabled": True,
+                    "check_interval": 10,
+                    "enable_signal": False,
+                },
+                "output_dir": "/tmp/test",
+            }
+        )
+
+        with patch("signal.signal") as mock_signal_register:
+            _ = DynamicCheckpointCallback(cfg)  # noqa: F841
+
+        assert not mock_signal_register.called
+
+
+class TestDynamicCheckpointDisabled:
+    """Test behavior when callback is disabled"""
+
+    def test_disabled_callback_does_nothing(self):
+        """Test that disabled callback doesn't check or trigger"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = DictDefault(
+                {
+                    "dynamic_checkpoint": {"enabled": False},
+                    "output_dir": tmpdir,
+                }
+            )
+            callback = DynamicCheckpointCallback(cfg)
+
+            trigger_file = Path(tmpdir) / DEFAULT_TRIGGER_FILENAME
+            trigger_file.touch()
+
+            args = Mock(output_dir=tmpdir)
+            state = Mock(global_step=1)
+            control = Mock(should_save=False)
+
+            result = callback.on_step_end(args, state, control)
+
+            assert trigger_file.exists()
+            assert result.should_save is False


### PR DESCRIPTION
# Description
feat: save checkpoint after training started


## Motivation and Context
#3169

## How has this been tested?
unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic checkpoint triggering: save checkpoints on-demand during training using file-based triggers (marker file) or Unix signals (SIGUSR1).
  * Seamless support for single-process and distributed training environments with configurable check intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->