### PR TITLE
log cumulative total trained tokens

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -350,12 +350,22 @@ class AxolotlTrainer(
         # track number of tokens for tokens per second calculation
         if self.args.include_tkps:
             inputs_key = "labels" if "labels" in inputs else "input_ids"
+            num_tokens = (inputs[inputs_key] != -100).sum()
+            if torch.distributed.is_initialized():
+                torch.distributed.all_reduce(
+                    num_tokens, op=torch.distributed.ReduceOp.SUM
+                )
             if hasattr(self.state, "num_tokens"):
                 self.state.num_tokens = (
                     self.state.num_tokens + (inputs[inputs_key] != -100).sum().cpu()
                 )
             else:
                 self.state.num_tokens = (inputs[inputs_key] != -100).sum().cpu()
+
+            if hasattr(self.state, "total_tokens"):
+                self.state.total_tokens += num_tokens
+            else:
+                self.state.total_tokens = num_tokens
 
         if self.args.orpo_alpha:
             return self.orpo_compute_loss(
@@ -621,6 +631,7 @@ class AxolotlTrainer(
             logs["tokens_per_second_per_gpu"] = round(
                 self.state.last_tokens_per_second.item() / self.args.logging_steps, 2
             )
+            logs["total_tokens"] = int(self.state.total_tokens.item())
 
         del self._stored_metrics[train_eval]
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -43,7 +43,7 @@ from axolotl.core.trainers.utils import (
 from axolotl.utils import get_not_null
 from axolotl.utils.bench import get_gpu_memory_usage
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.distributed import is_main_process
+from axolotl.utils.distributed import is_distributed, is_main_process
 from axolotl.utils.logging import get_logger
 from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 
@@ -351,7 +351,7 @@ class AxolotlTrainer(
         if self.args.include_tkps:
             inputs_key = "labels" if "labels" in inputs else "input_ids"
             num_tokens = (inputs[inputs_key] != -100).sum()
-            if torch.distributed.is_initialized():
+            if is_distributed():
                 torch.distributed.all_reduce(
                     num_tokens, op=torch.distributed.ReduceOp.SUM
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

reduces the total tokens trained over all ranks and logs that to wandb

## Motivation and Context

When doing pretraining/continued pretraining, it's useful to see the loss plotted vs the total number of tokens trained so far, but wandb doesn't cleanly handle that information without # of processes * seconds * tokens/sec.

<img width="574" height="312" alt="Screenshot 2025-11-07 at 12 15 05 PM" src="https://github.com/user-attachments/assets/99384918-3174-43b8-9e10-5f8c007b9c1f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token tracking metrics during training with cumulative counting across distributed processes
  * Added total token reporting in training logs alongside per-GPU statistics when metrics are enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->