### PR TITLE
Fix: `warmup_steps: 0` & `warmup_ratio: 0` not disabling warmup

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -196,9 +196,9 @@ class TrainerBuilderBase(abc.ABC):
     ):
         warmup_steps = 0
         warmup_ratio = 0.0
-        if self.cfg.warmup_steps:
+        if self.cfg.warmup_steps is not None:
             warmup_steps = self.cfg.warmup_steps
-        elif self.cfg.warmup_ratio:
+        elif self.cfg.warmup_ratio is not None:
             if total_num_steps:
                 warmup_steps = max(int(self.cfg.warmup_ratio * total_num_steps), 0)
             else:

--- a/tests/e2e/integrations/test_liger.py
+++ b/tests/e2e/integrations/test_liger.py
@@ -3,6 +3,7 @@ Simple end-to-end test for Liger integration
 """
 
 import pytest
+
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, prepare_plugins, validate_config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

When using `warmup_steps: 0` or `warmup_ratio: 0` the code within [`_configure_warmup_and_logging`](https://github.com/axolotl-ai-cloud/axolotl/blob/11eb36585a210786ece0f94315662525b9f375f5/src/axolotl/core/builders/base.py#L194) interprets it as `False`, skipping over to `elif total_num_steps:` causing it to set `warmup_steps = min(int(0.03 * total_num_steps), 100)`.

The checks should include `is not None`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced warmup configuration handling to correctly recognize zero values for warmup steps and warmup ratio settings. Previously, setting these parameters to zero was incorrectly treated as if they were unset, potentially causing unintended warmup behavior during model training. This fix ensures explicit zero values are properly respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->