### PR TITLE
Allow muon optimizer with DeepSpeed Zero 1-2

### DIFF
--- a/tests/test_validation_dataset.py
+++ b/tests/test_validation_dataset.py
@@ -342,8 +342,27 @@ class TestOptimizerValidation(BaseValidation):
             }
         )
 
-        with pytest.raises(ValueError, match=r".*is currently incompatible with*"):
+        with pytest.raises(
+            ValueError, match=r".*DeepSpeed ZeRO stages 1-2"
+        ):
             validate_config(cfg)
+
+    def test_muon_deepspeed_stage2(self, minimal_cfg):
+        cfg = DictDefault(
+            minimal_cfg
+            | {
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    }
+                ],
+                "optimizer": "muon",
+                "deepspeed": "deepspeed_configs/zero2.json",
+            }
+        )
+
+        validate_config(cfg)
 
     def test_muon_fsdp(self, minimal_cfg):
         cfg = DictDefault(


### PR DESCRIPTION
DeepSpeed has muon support merged for DSZ1/2: https://github.com/deepspeedai/DeepSpeed/pull/7509

I made a simple modification to support this: https://github.com/axolotl-ai-cloud/axolotl/issues/3184

Has a few guards (I can remove if unneccessary) but the main functionality is simple - if DeepSpeed and ZeRO<3 then allows muon. Trains ok for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Muon optimizer compatibility with DeepSpeed by enabling support for ZeRO stages 1-2.
  * Enhanced validation error messages for DeepSpeed configuration incompatibilities.

* **Tests**
  * Added test coverage for Muon optimizer with DeepSpeed ZeRO stage 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->