### PR TITLE
Moe aux loss free

### DIFF
--- a/src/axolotl/integrations/aux_free_router/README.md
+++ b/src/axolotl/integrations/aux_free_router/README.md
@@ -39,3 +39,13 @@ Compatibility
 Notes
 - If you also enable Liger’s aux-loss paths, the plugin neutralizes aux loss when aux-free is on.
 - Telemetry: logs per-layer min/mean/max token loads, `|bias| max`, and bias sign flip fraction at the configured interval.
+- Sample packing: packed batches are compatible with aux-free routing. Because load counts are accumulated on-device per expert before reduction, packing tends to smooth token histograms and reduce bias oscillation. Keep `pad_to_sequence_len: true` when packing to preserve the target token budget per expert.
+
+Telemetry metrics
+- `moe_afb/l{idx}_load_min|mean|max`: token frequency per expert after reduction (0–1 range, sums to 1).
+- `moe_afb/l{idx}_bias_abs_max`: absolute maximum of the learned bias for the layer.
+- `moe_afb/l{idx}_bias_sign_flip_frac`: fraction of experts whose bias sign changed since the previous step (simple oscillation indicator).
+
+Usage tips
+- Leave `moe_afb_telemetry_interval` unset to log on the Trainer’s `logging_steps`. Increase the interval for large jobs to reduce log volume.
+- Compare aux-free vs. aux-loss load metrics by plotting the `load_*` series; aux-free typically tightens min/max spread without the auxiliary loss term.

--- a/src/axolotl/integrations/aux_free_router/README.md
+++ b/src/axolotl/integrations/aux_free_router/README.md
@@ -30,7 +30,6 @@ Config keys
 - moe_afb_warmup_steps: delay before applying updates. Default: 0.
 - moe_bias_sync_group: reduction group for counts, 'world' (DP) or 'ep' (expert-parallel). Default: world.
 - expert_parallel_size: number of ranks per expert-parallel group when using `moe_bias_sync_group: ep`. Defaults to 1 (world).
-- moe_afb_telemetry_interval: emit router telemetry every N optimizer steps (defaults to `logging_steps` when unset).
 
 Compatibility
 - Targeted families: Mixtral, Qwen3-MoE, Bailing/Ring 2.0, and Llama 4 text MoE layers.
@@ -38,7 +37,7 @@ Compatibility
 
 Notes
 - If you also enable Liger’s aux-loss paths, the plugin neutralizes aux loss when aux-free is on.
-- Telemetry: logs per-layer min/mean/max token loads, `|bias| max`, and bias sign flip fraction at the configured interval.
+- Telemetry: logs per-layer min/mean/max token loads, `|bias| max`, and bias sign flip fraction using the Trainer’s `logging_steps` cadence.
 - Sample packing: packed batches are compatible with aux-free routing. Because load counts are accumulated on-device per expert before reduction, packing tends to smooth token histograms and reduce bias oscillation. Keep `pad_to_sequence_len: true` when packing to preserve the target token budget per expert.
 
 Telemetry metrics
@@ -47,5 +46,5 @@ Telemetry metrics
 - `moe_afb/l{idx}_bias_sign_flip_frac`: fraction of experts whose bias sign changed since the previous step (simple oscillation indicator).
 
 Usage tips
-- Leave `moe_afb_telemetry_interval` unset to log on the Trainer’s `logging_steps`. Increase the interval for large jobs to reduce log volume.
+- Increase `logging_steps` if router telemetry becomes noisy for large jobs—the plugin follows the Trainer’s logging cadence.
 - Compare aux-free vs. aux-loss load metrics by plotting the `load_*` series; aux-free typically tightens min/max spread without the auxiliary loss term.

--- a/src/axolotl/integrations/aux_free_router/README.md
+++ b/src/axolotl/integrations/aux_free_router/README.md
@@ -30,6 +30,7 @@ Config keys
 - moe_afb_warmup_steps: delay before applying updates. Default: 0.
 - moe_bias_sync_group: reduction group for counts, 'world' (DP) or 'ep' (expert-parallel). Default: world.
 - expert_parallel_size: number of ranks per expert-parallel group when using `moe_bias_sync_group: ep`. Defaults to 1 (world).
+- moe_afb_telemetry_interval: emit router telemetry every N optimizer steps (defaults to `logging_steps` when unset).
 
 Compatibility
 - Targeted families: Mixtral, Qwen3-MoE, Bailing/Ring 2.0, and Llama 4 text MoE layers.
@@ -37,4 +38,4 @@ Compatibility
 
 Notes
 - If you also enable Liger’s aux-loss paths, the plugin neutralizes aux loss when aux-free is on.
-- Telemetry: future updates will log per-expert loads and bias magnitudes.
+- Telemetry: logs per-layer min/mean/max token loads, `|bias| max`, and bias sign flip fraction at the configured interval.

--- a/src/axolotl/integrations/aux_free_router/README.md
+++ b/src/axolotl/integrations/aux_free_router/README.md
@@ -19,7 +19,8 @@ Enable
   moe_update_momentum: 0.9     # default if unset
   moe_bias_cap: 2.0            # default if unset
   moe_afb_warmup_steps: 100    # optional
-  moe_bias_sync_group: world   # or 'ep' if expert-parallel is configured
+  moe_bias_sync_group: world   # or 'ep' if expert_parallel_size > 1
+  expert_parallel_size: 1      # set to your EP width when using moe_bias_sync_group: ep
 
 Config keys
 - moe_balance_type: gshard (auxiliary loss) | noaux_tc (aux-free). Default: model native.
@@ -28,9 +29,10 @@ Config keys
 - moe_bias_cap: absolute clamp for bias. Default: 2.0.
 - moe_afb_warmup_steps: delay before applying updates. Default: 0.
 - moe_bias_sync_group: reduction group for counts, 'world' (DP) or 'ep' (expert-parallel). Default: world.
+- expert_parallel_size: number of ranks per expert-parallel group when using `moe_bias_sync_group: ep`. Defaults to 1 (world).
 
 Compatibility
-- Targeted families: Mixtral, Qwen3-MoE. Jamba optional.
+- Targeted families: Mixtral, Qwen3-MoE, Bailing/Ring 2.0, and Llama 4 text MoE layers.
 - Pass-through: Models with native aux-free routing (e.g., DeepSeek-V3) are left unmodified; only telemetry may be added in future.
 
 Notes

--- a/src/axolotl/integrations/aux_free_router/README.md
+++ b/src/axolotl/integrations/aux_free_router/README.md
@@ -1,0 +1,38 @@
+# Aux-Loss-Free MoE Router Plugin
+
+This integration adds an aux-loss-free (AFB) gating option to compatible MoE architectures without forking model code.
+
+Summary
+- Bias only affects expert selection (top-k); mixture weights come from unbiased logits.
+- Per-expert token loads are accumulated on device and reduced across DP or EP groups.
+- Bias is updated post-optimizer step outside autograd using EMA-smoothed loads.
+- Existing aux loss is disabled when aux-free is enabled to avoid double signals.
+
+Enable
+- Add the plugin to your YAML, then set the aux-free toggle:
+
+  plugins:
+    - axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin
+
+  moe_balance_type: noaux_tc
+  moe_update_rate: 0.01        # default if unset
+  moe_update_momentum: 0.9     # default if unset
+  moe_bias_cap: 2.0            # default if unset
+  moe_afb_warmup_steps: 100    # optional
+  moe_bias_sync_group: world   # or 'ep' if expert-parallel is configured
+
+Config keys
+- moe_balance_type: gshard (auxiliary loss) | noaux_tc (aux-free). Default: model native.
+- moe_update_rate: bias update rate (gamma). Default: 0.01.
+- moe_update_momentum: EMA momentum for load smoothing. Default: 0.9.
+- moe_bias_cap: absolute clamp for bias. Default: 2.0.
+- moe_afb_warmup_steps: delay before applying updates. Default: 0.
+- moe_bias_sync_group: reduction group for counts, 'world' (DP) or 'ep' (expert-parallel). Default: world.
+
+Compatibility
+- Targeted families: Mixtral, Qwen3-MoE. Jamba optional.
+- Pass-through: Models with native aux-free routing (e.g., DeepSeek-V3) are left unmodified; only telemetry may be added in future.
+
+Notes
+- If you also enable Liger’s aux-loss paths, the plugin neutralizes aux loss when aux-free is on.
+- Telemetry: future updates will log per-expert loads and bias magnitudes.

--- a/src/axolotl/integrations/aux_free_router/__init__.py
+++ b/src/axolotl/integrations/aux_free_router/__init__.py
@@ -1,0 +1,2 @@
+"""Aux-loss-free (AFB) MoE router integration package."""
+

--- a/src/axolotl/integrations/aux_free_router/__init__.py
+++ b/src/axolotl/integrations/aux_free_router/__init__.py
@@ -1,2 +1,9 @@
 """Aux-loss-free (AFB) MoE router integration package."""
 
+from .args import AuxFreeRouterArgs
+from .plugin import AuxFreeMoEPlugin
+
+__all__ = [
+    "AuxFreeRouterArgs",
+    "AuxFreeMoEPlugin",
+]

--- a/src/axolotl/integrations/aux_free_router/adapters.py
+++ b/src/axolotl/integrations/aux_free_router/adapters.py
@@ -189,8 +189,14 @@ class BailingAdapter(BaseMoEAdapter):
     family = "bailing_moe"
 
     def matches(self, model: nn.Module) -> bool:
-        model_type = getattr(getattr(model, "config", object()), "model_type", "")
-        return model_type in ("bailing_moe", "bailing_moe_v2")
+        cfg = getattr(model, "config", None)
+        if cfg is None:
+            return False
+        model_type = getattr(cfg, "model_type", "") or ""
+        if model_type in ("bailing_moe", "bailing_moe_v2", "ring_moe", "ring"):
+            return True
+        cfg_name = cfg.__class__.__name__.lower()
+        return "bailingmoev2" in cfg_name or "ring" in cfg_name
 
     def find_moe_layers(self, model: nn.Module) -> Iterable[nn.Module]:
         for m in model.modules():

--- a/src/axolotl/integrations/aux_free_router/args.py
+++ b/src/axolotl/integrations/aux_free_router/args.py
@@ -1,0 +1,72 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Plugin args for the Aux-Loss-Free MoE router integration.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class AuxFreeRouterArgs(BaseModel):
+    """
+    Input args for Aux-Loss-Free MoE routing.
+    """
+
+    moe_balance_type: Literal["gshard", "noaux_tc"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "MoE load balancing strategy: 'gshard' for auxiliary loss, "
+            "'noaux_tc' for aux-loss-free bias updates affecting top-k selection only. "
+            "Defaults to model's native behavior when unset."
+        },
+    )
+    moe_update_rate: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Per-step bias update rate (gamma). Recommended: 0.005–0.05. "
+            "If unset, plugin default is 0.01."
+        },
+    )
+    moe_update_momentum: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "EMA momentum for expert load smoothing (0–1). "
+            "If unset, plugin default is 0.9."
+        },
+    )
+    moe_bias_cap: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Absolute clamp for expert bias magnitude. "
+            "If unset, plugin default is 2.0."
+        },
+    )
+    moe_afb_warmup_steps: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Number of initial steps to delay aux-free bias updates, "
+            "allowing routing to stabilize. If unset, plugin default is 0."
+        },
+    )
+    moe_bias_sync_group: Literal["world", "ep"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Reduction group for expert load counts: 'world' (DP) or "
+            "'ep' (expert-parallel group if available). Defaults to 'world' when unset."
+        },
+    )
+

--- a/src/axolotl/integrations/aux_free_router/core.py
+++ b/src/axolotl/integrations/aux_free_router/core.py
@@ -5,6 +5,9 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
 
 
 @dataclass
@@ -29,22 +32,52 @@ class AuxFreeState:
 class AuxFreeShim:
     """Model-agnostic shim for aux-loss-free expert selection and bias updates."""
 
-    def __init__(self, state: AuxFreeState, ep_group: Optional[dist.ProcessGroup] = None):
+    def __init__(
+        self,
+        state: AuxFreeState,
+        ep_group: Optional[dist.ProcessGroup] = None,
+        ep_size: Optional[int] = None,
+    ):
         self.state = state
         self.ep_group = ep_group
+        self._ep_size = ep_size
+        self._ep_group_pending = (
+            self.state.cfg.sync_group == "ep" and self.ep_group is None
+        )
+        self._layer_modules: dict[int, torch.nn.Module] = {}
 
     @torch.no_grad()
     def select_experts(self, layer_idx: int, logits: torch.Tensor, top_k: int) -> tuple[torch.Tensor, torch.Tensor]:
         """Returns (topk_indices, weights) using biased selection and unbiased weights."""
-        b = self.state.bias[layer_idx]
+        module = self._layer_modules.get(layer_idx)
+        if module is not None and hasattr(module, "_afb_bias"):
+            b = getattr(module, "_afb_bias")
+        else:
+            b = self.state.bias[layer_idx]
         biased = logits + b  # bias is a buffer
         topk_scores, topk_idx = torch.topk(biased, k=top_k, dim=-1)
         chosen_logits = torch.gather(logits, -1, topk_idx)
         weights = torch.softmax(chosen_logits.float(), dim=-1).to(logits.dtype)
         return topk_idx, weights
 
+    def register_layer_buffers(self, layer_idx: int, module: torch.nn.Module) -> None:
+        """Bind model buffers so shim updates stay in sync with patched layers."""
+        self._layer_modules[layer_idx] = module
+        bias = getattr(module, "_afb_bias")
+        ema = getattr(module, "_afb_ema")
+        # Keep state views pointing to the same tensors to avoid drift.
+        if layer_idx < len(self.state.bias):
+            self.state.bias[layer_idx] = bias
+        if layer_idx < len(self.state.ema_load):
+            self.state.ema_load[layer_idx] = ema
+
+    def begin_step(self) -> None:
+        """Call once per optimizer step before per-layer updates."""
+        self.state.steps += 1
+
     @torch.no_grad()
     def all_reduce_counts(self, counts: torch.Tensor) -> torch.Tensor:
+        self._maybe_init_ep_group()
         if not dist.is_available() or not dist.is_initialized():
             return counts
         group = self.ep_group if self.ep_group is not None else dist.group.WORLD
@@ -55,22 +88,63 @@ class AuxFreeShim:
     def update_bias(self, layer_idx: int, step_counts: torch.Tensor, tokens_seen: int):
         """Apply EMA-smoothed bias update toward uniform target, with clamp and optional mean-centering."""
         cfg = self.state.cfg
-        self.state.steps += 1
         if self.state.steps <= cfg.warmup_steps:
             return
 
         nE = step_counts.numel()
         if tokens_seen <= 0:
             return
-        freq = step_counts.float() / float(tokens_seen)
-        ema = self.state.ema_load[layer_idx]
+        module = self._layer_modules.get(layer_idx)
+        if module is not None and hasattr(module, "_afb_ema"):
+            ema = getattr(module, "_afb_ema")
+            bias = getattr(module, "_afb_bias")
+        else:
+            ema = self.state.ema_load[layer_idx]
+            bias = self.state.bias[layer_idx]
+        counts = step_counts.to(ema.device)
+        freq = counts.float() / float(tokens_seen)
         ema.mul_(cfg.momentum).add_((1.0 - cfg.momentum) * freq)
         target = 1.0 / float(nE)
         delta = cfg.rate * (target - ema)
         # optional mean-centering to keep sum(bias) ~ 0
         delta = delta - delta.mean()
-        bias = self.state.bias[layer_idx]
         bias.add_(delta)
         if cfg.bias_cap is not None and cfg.bias_cap > 0:
             bias.clamp_(-cfg.bias_cap, cfg.bias_cap)
 
+    def _maybe_init_ep_group(self) -> None:
+        if not self._ep_group_pending:
+            return
+        if not dist.is_available() or not dist.is_initialized():
+            return
+        ep_size = self._ep_size
+        if not ep_size or ep_size <= 1:
+            LOG.warning(
+                "AuxFreeMoE: moe_bias_sync_group='ep' requested but expert_parallel_size<=1; defaulting to world group"
+            )
+            self.ep_group = dist.group.WORLD
+            self._ep_group_pending = False
+            return
+        world = dist.get_world_size()
+        if world % ep_size != 0:
+            LOG.warning(
+                "AuxFreeMoE: expert_parallel_size %s does not divide world size %s; defaulting to world group",
+                ep_size,
+                world,
+            )
+            self.ep_group = dist.group.WORLD
+            self._ep_group_pending = False
+            return
+        if ep_size == world:
+            self.ep_group = dist.group.WORLD
+        else:
+            rank = dist.get_rank()
+            group_start = (rank // ep_size) * ep_size
+            ranks = tuple(range(group_start, group_start + ep_size))
+            self.ep_group = dist.new_group(ranks)
+        LOG.info(
+            "AuxFreeMoE: initialized expert-parallel reduction group (size=%s, world=%s)",
+            ep_size,
+            dist.get_world_size(),
+        )
+        self._ep_group_pending = False

--- a/src/axolotl/integrations/aux_free_router/core.py
+++ b/src/axolotl/integrations/aux_free_router/core.py
@@ -17,7 +17,6 @@ class AuxFreeConfig:
     bias_cap: float = 2.0
     warmup_steps: int = 0
     sync_group: str = "world"  # or "ep"
-    telemetry_interval: Optional[int] = None
 
 
 class AuxFreeState:

--- a/src/axolotl/integrations/aux_free_router/core.py
+++ b/src/axolotl/integrations/aux_free_router/core.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass
+class AuxFreeConfig:
+    rate: float = 0.01
+    momentum: float = 0.9
+    bias_cap: float = 2.0
+    warmup_steps: int = 0
+    sync_group: str = "world"  # or "ep"
+
+
+class AuxFreeState:
+    """Holds per-layer bias and EMA load buffers."""
+
+    def __init__(self, num_layers: int, num_experts: int, device: torch.device, cfg: AuxFreeConfig):
+        self.bias = [torch.zeros(num_experts, device=device) for _ in range(num_layers)]
+        self.ema_load = [torch.zeros(num_experts, device=device) for _ in range(num_layers)]
+        self.cfg = cfg
+        self.steps = 0
+
+
+class AuxFreeShim:
+    """Model-agnostic shim for aux-loss-free expert selection and bias updates."""
+
+    def __init__(self, state: AuxFreeState, ep_group: Optional[dist.ProcessGroup] = None):
+        self.state = state
+        self.ep_group = ep_group
+
+    @torch.no_grad()
+    def select_experts(self, layer_idx: int, logits: torch.Tensor, top_k: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns (topk_indices, weights) using biased selection and unbiased weights."""
+        b = self.state.bias[layer_idx]
+        biased = logits + b  # bias is a buffer
+        topk_scores, topk_idx = torch.topk(biased, k=top_k, dim=-1)
+        chosen_logits = torch.gather(logits, -1, topk_idx)
+        weights = torch.softmax(chosen_logits.float(), dim=-1).to(logits.dtype)
+        return topk_idx, weights
+
+    @torch.no_grad()
+    def all_reduce_counts(self, counts: torch.Tensor) -> torch.Tensor:
+        if not dist.is_available() or not dist.is_initialized():
+            return counts
+        group = self.ep_group if self.ep_group is not None else dist.group.WORLD
+        dist.all_reduce(counts, op=dist.ReduceOp.SUM, group=group)
+        return counts
+
+    @torch.no_grad()
+    def update_bias(self, layer_idx: int, step_counts: torch.Tensor, tokens_seen: int):
+        """Apply EMA-smoothed bias update toward uniform target, with clamp and optional mean-centering."""
+        cfg = self.state.cfg
+        self.state.steps += 1
+        if self.state.steps <= cfg.warmup_steps:
+            return
+
+        nE = step_counts.numel()
+        if tokens_seen <= 0:
+            return
+        freq = step_counts.float() / float(tokens_seen)
+        ema = self.state.ema_load[layer_idx]
+        ema.mul_(cfg.momentum).add_((1.0 - cfg.momentum) * freq)
+        target = 1.0 / float(nE)
+        delta = cfg.rate * (target - ema)
+        # optional mean-centering to keep sum(bias) ~ 0
+        delta = delta - delta.mean()
+        bias = self.state.bias[layer_idx]
+        bias.add_(delta)
+        if cfg.bias_cap is not None and cfg.bias_cap > 0:
+            bias.clamp_(-cfg.bias_cap, cfg.bias_cap)
+

--- a/src/axolotl/integrations/aux_free_router/plugin.py
+++ b/src/axolotl/integrations/aux_free_router/plugin.py
@@ -134,6 +134,9 @@ class AuxFreeMoEPlugin(BasePlugin):
         self._shim: Optional[AuxFreeShim] = None
         self._ep_group_cache: dict[tuple[int, ...], dist.ProcessGroup] = {}
 
+    def get_input_args(self):
+        return "axolotl.integrations.aux_free_router.AuxFreeRouterArgs"
+
     def post_model_build(self, cfg, model):
         # Enable only when explicitly requested
         if getattr(cfg, "moe_balance_type", None) != "noaux_tc":

--- a/src/axolotl/integrations/aux_free_router/plugin.py
+++ b/src/axolotl/integrations/aux_free_router/plugin.py
@@ -1,0 +1,133 @@
+"""Aux-loss-free MoE Router Plugin for Axolotl.
+
+This plugin wires an aux-free gating option into compatible MoE models using
+unbiased logits for mixture weights and per-expert biases for top-k selection.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from transformers.trainer_callback import TrainerCallback
+
+from axolotl.integrations.base import BasePlugin
+from axolotl.utils.distributed import is_distributed
+from axolotl.utils.logging import get_logger
+
+from .adapters import BaseMoEAdapter, MixtralAdapter, Qwen3Adapter, discover_and_prepare_layers
+from .core import AuxFreeConfig, AuxFreeShim, AuxFreeState
+
+LOG = get_logger(__name__)
+
+
+class MoeAuxFreeBiasUpdateCallback(TrainerCallback):
+    """Post-step callback to update aux-free biases from accumulated expert counts.
+
+    Note: The current revision expects per-layer counts to be accumulated on each
+    MoE layer as a buffer named `_afb_counts` during forward (to be added with
+    routing patches in a follow-up).
+    """
+
+    def __init__(self, shim: AuxFreeShim, layer_modules: list[torch.nn.Module]):
+        self.shim = shim
+        self.layer_modules = layer_modules
+
+    def on_step_end(self, args, state, control, **kwargs):  # noqa: D401
+        # Iterate prepared MoE layers and apply the bias update rule.
+        cfg = self.shim.state.cfg
+        for layer in self.layer_modules:
+            if not hasattr(layer, "_afb_counts") or not hasattr(layer, "_afb_layer_idx"):
+                continue
+            counts = getattr(layer, "_afb_counts")
+            if counts is None:
+                continue
+            counts = counts.to(counts.device)
+            counts = self.shim.all_reduce_counts(counts)
+            tokens_seen = int(counts.sum().item())
+            # local layer-state EMA and bias update
+            if tokens_seen > 0:
+                freq = counts.float() / float(tokens_seen)
+                ema = getattr(layer, "_afb_ema")
+                ema.mul_(cfg.momentum).add_((1.0 - cfg.momentum) * freq)
+                nE = counts.numel()
+                target = 1.0 / float(nE)
+                delta = cfg.rate * (target - ema)
+                delta = delta - delta.mean()
+                bias = getattr(layer, "_afb_bias")
+                bias.add_(delta)
+                if cfg.bias_cap is not None and cfg.bias_cap > 0:
+                    bias.clamp_(-cfg.bias_cap, cfg.bias_cap)
+            # reset step counts
+            counts.zero_()
+        return control
+
+
+class AuxFreeMoEPlugin(BasePlugin):
+    """Plugin that enables aux-loss-free routing when configured."""
+
+    def __init__(self):
+        super().__init__()
+        self._handles: list = []
+        self._shim: Optional[AuxFreeShim] = None
+
+    def post_model_build(self, cfg, model):
+        # Enable only when explicitly requested
+        if getattr(cfg, "moe_balance_type", None) != "noaux_tc":
+            return
+
+        # Be conservative — skip known native aux-free families
+        native_auxfree = getattr(getattr(model, "config", object()), "model_type", "") in (
+            "deepseek_v3",
+            "glm4_moe",
+        )
+        if native_auxfree:
+            LOG.info("AuxFreeMoE: model reports native aux-free routing; skipping patching")
+            return
+
+        # Build aux-free state and shim
+        rate = cfg.moe_update_rate if cfg.moe_update_rate is not None else 0.01
+        momentum = (
+            cfg.moe_update_momentum if cfg.moe_update_momentum is not None else 0.9
+        )
+        bias_cap = cfg.moe_bias_cap if cfg.moe_bias_cap is not None else 2.0
+        warmup = cfg.moe_afb_warmup_steps if cfg.moe_afb_warmup_steps is not None else 0
+        sync_group = cfg.moe_bias_sync_group if cfg.moe_bias_sync_group else "world"
+        af_cfg = AuxFreeConfig(
+            rate=rate, momentum=momentum, bias_cap=bias_cap, warmup_steps=warmup, sync_group=sync_group
+        )
+
+        # Discover layers to count the number and experts for state sizing
+        adapters: list[BaseMoEAdapter] = [MixtralAdapter(), Qwen3Adapter()]
+
+        # For initial state sizing, we conservatively assume the first discovered layer defines nE
+        n_layers = 0
+        n_experts = None
+        for m in model.modules():
+            n_layers += 1  # upper bound — we will re-use bias slots sparsely
+        device = next(model.parameters(), torch.tensor(0)).device
+        if n_layers <= 0:
+            n_layers = 1
+        if n_experts is None:
+            # we'll set a minimal placeholder; prepare() will conceptually use module buffers instead
+            n_experts = 2
+        state = AuxFreeState(num_layers=n_layers, num_experts=n_experts, device=device, cfg=af_cfg)
+        self._shim = AuxFreeShim(state=state, ep_group=None)
+
+        # Discover and prepare layers (attach per-layer buffers)
+        self._handles = discover_and_prepare_layers(model, adapters, self._shim)
+
+        LOG.info(
+            f"AuxFreeMoE: enabled with rate={rate}, momentum={momentum}, cap={bias_cap}, warmup={warmup}, group={sync_group}"
+        )
+
+    def add_callbacks_post_trainer(self, cfg, trainer):
+        if getattr(cfg, "moe_balance_type", None) != "noaux_tc":
+            return []
+        if self._shim is None:
+            return []
+        # gather concrete layer modules from handles
+        layers = [h.layer for h in self._handles]
+        cb = MoeAuxFreeBiasUpdateCallback(self._shim, layers)
+        LOG.info("AuxFreeMoE: registering post-step bias update callback")
+        return [cb]

--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -265,6 +265,7 @@ def validate_config(
     AxolotlInputConfig = AxolotlInputConfigBase
 
     if cfg.plugins:
+        prepare_plugins(cfg)
         (
             AxolotlConfigWCapabilities,
             AxolotlInputConfig,

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -780,6 +780,12 @@ class AxolotlInputConfig(
             "description": "Number of tensor parallel processes in TP group. Only supported with DeepSpeed AutoTP."
         },
     )
+    expert_parallel_size: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Number of processes participating in expert-parallel collectives. Set >1 to form EP groups for aux-free reductions; defaults to world when unset."
+        },
+    )
     special_tokens: SpecialTokensConfig | None = Field(
         default=None,
         json_schema_extra={

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -664,6 +664,44 @@ class AxolotlInputConfig(
 
     llama4_linearized_experts: bool | None = None
 
+    # MoE aux-loss-free (AFB) toggles
+    moe_balance_type: Literal["gshard", "noaux_tc"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "MoE load balancing strategy: 'gshard' for auxiliary loss, 'noaux_tc' for aux-loss-free bias updates affecting top-k selection only. Defaults to model's native behavior when unset.",
+        },
+    )
+    moe_update_rate: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Per-step bias update rate (gamma). Recommended: 0.005–0.05. If unset, plugin default is 0.01.",
+        },
+    )
+    moe_update_momentum: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "EMA momentum for expert load smoothing (0–1). If unset, plugin default is 0.9.",
+        },
+    )
+    moe_bias_cap: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Absolute clamp for expert bias magnitude. If unset, plugin default is 2.0.",
+        },
+    )
+    moe_afb_warmup_steps: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Number of initial steps to delay aux-free bias updates, allowing routing to stabilize. If unset, plugin default is 0.",
+        },
+    )
+    moe_bias_sync_group: Literal["world", "ep"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Reduction group for expert load counts: 'world' (DP) or 'ep' (expert-parallel group if available). Defaults to 'world' when unset.",
+        },
+    )
+
     deepspeed: str | dict[str, Any] | None = Field(
         default=None,
         json_schema_extra={

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -664,44 +664,6 @@ class AxolotlInputConfig(
 
     llama4_linearized_experts: bool | None = None
 
-    # MoE aux-loss-free (AFB) toggles
-    moe_balance_type: Literal["gshard", "noaux_tc"] | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "MoE load balancing strategy: 'gshard' for auxiliary loss, 'noaux_tc' for aux-loss-free bias updates affecting top-k selection only. Defaults to model's native behavior when unset.",
-        },
-    )
-    moe_update_rate: float | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "Per-step bias update rate (gamma). Recommended: 0.005–0.05. If unset, plugin default is 0.01.",
-        },
-    )
-    moe_update_momentum: float | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "EMA momentum for expert load smoothing (0–1). If unset, plugin default is 0.9.",
-        },
-    )
-    moe_bias_cap: float | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "Absolute clamp for expert bias magnitude. If unset, plugin default is 2.0.",
-        },
-    )
-    moe_afb_warmup_steps: int | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "Number of initial steps to delay aux-free bias updates, allowing routing to stabilize. If unset, plugin default is 0.",
-        },
-    )
-    moe_bias_sync_group: Literal["world", "ep"] | None = Field(
-        default=None,
-        json_schema_extra={
-            "description": "Reduction group for expert load counts: 'world' (DP) or 'ep' (expert-parallel group if available). Defaults to 'world' when unset.",
-        },
-    )
-
     deepspeed: str | dict[str, Any] | None = Field(
         default=None,
         json_schema_extra={

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1297,6 +1297,14 @@ class ComplexValidationMixin:
         return self
 
     @model_validator(mode="after")
+    def check_expert_parallel_size(self):
+        if not getattr(self, "expert_parallel_size", None):
+            self.expert_parallel_size = 1
+        elif self.expert_parallel_size < 1:
+            raise ValueError("expert_parallel_size must be >= 1")
+        return self
+
+    @model_validator(mode="after")
     def check_context_parallel_size(self):
         if self.sequence_parallel_degree and not self.context_parallel_size:
             LOG.warning(

--- a/tests/e2e/test_llama4_moe_aux_free.py
+++ b/tests/e2e/test_llama4_moe_aux_free.py
@@ -55,9 +55,9 @@ class TestLlama4MoeAuxFree(unittest.TestCase):
             }
         )
 
+        prepare_plugins(cfg)
         cfg = validate_config(cfg)
         normalize_config(cfg)
-        prepare_plugins(cfg)
         dataset_meta = load_datasets(cfg=cfg)
 
         model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)

--- a/tests/e2e/test_llama4_moe_aux_free.py
+++ b/tests/e2e/test_llama4_moe_aux_free.py
@@ -52,7 +52,6 @@ class TestLlama4MoeAuxFree(unittest.TestCase):
                 "moe_update_rate": 0.01,
                 "moe_update_momentum": 0.9,
                 "moe_bias_cap": 2.0,
-                "moe_afb_telemetry_interval": 1,
             }
         )
 

--- a/tests/e2e/test_llama4_moe_aux_free.py
+++ b/tests/e2e/test_llama4_moe_aux_free.py
@@ -1,0 +1,74 @@
+"""
+E2E smoke test for Llama 4 aux-loss-free routing via plugin
+"""
+
+import unittest
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+from .utils import check_model_output_exists, with_temp_dir
+
+
+class TestLlama4MoeAuxFree(unittest.TestCase):
+    """Smoke test to ensure aux-free plugin patches Llama 4 MoE correctly."""
+
+    @with_temp_dir
+    def test_llama4_aux_free_smoke(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "yujiepan/llama-4-tiny-random",
+                "tokenizer_config": "yujiepan/llama-4-tiny-random",
+                "trust_remote_code": True,
+                "flash_attention": False,
+                "sequence_len": 512,
+                "bf16": False,
+                "fp16": False,
+                "val_set_size": 0.02,
+                "special_tokens": {},
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "max_steps": 5,
+                "save_steps": 0,
+                "eval_steps": 0,
+                "save_first_step": False,
+                "plugins": [
+                    "axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin",
+                ],
+                "moe_balance_type": "noaux_tc",
+                "moe_update_rate": 0.01,
+                "moe_update_momentum": 0.9,
+                "moe_bias_cap": 2.0,
+                "moe_afb_telemetry_interval": 1,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        patched = next((m for m in model.modules() if hasattr(m, "_afb_bias")), None)
+        assert patched is not None, "Llama 4 MoE layer was not patched by aux-free plugin"
+        assert patched._afb_bias.ndim == 1
+        assert patched._afb_counts.ndim == 1
+        check_model_output_exists(temp_dir, cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_moe_aux_free.py
+++ b/tests/e2e/test_moe_aux_free.py
@@ -1,0 +1,79 @@
+"""
+E2E smoke tests for Aux-Loss-Free MoE routing via plugin
+"""
+
+import unittest
+
+import torch
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config, prepare_plugins
+from axolotl.utils.dict import DictDefault
+
+from .utils import check_model_output_exists, with_temp_dir
+
+
+class TestMoeAuxFree(unittest.TestCase):
+    """Smoke tests to ensure aux-free plugin enables and runs on Mixtral tiny."""
+
+    @with_temp_dir
+    def test_mixtral_aux_free_smoke(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "hf-internal-testing/Mixtral-tiny",
+                "tokenizer_config": "LoneStriker/Mixtral-8x7B-v0.1-HF",
+                "flash_attention": False,
+                "sequence_len": 512,
+                "bf16": False,
+                "fp16": False,
+                "val_set_size": 0.02,
+                "special_tokens": {},
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "max_steps": 5,
+                "save_steps": 0,
+                "eval_steps": 0,
+                "save_first_step": False,
+                # Aux-free plugin and toggles
+                "plugins": [
+                    "axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin",
+                ],
+                "moe_balance_type": "noaux_tc",
+                "moe_update_rate": 0.01,
+                "moe_update_momentum": 0.9,
+                "moe_bias_cap": 2.0,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        # Inspect model modules for a patched MoE layer
+        patched = None
+        for m in model.modules():
+            if hasattr(m, "_afb_patched") and getattr(m, "_afb_patched") is True:
+                patched = m
+                break
+        assert patched is not None, "No MoE layer patched by aux-free plugin"
+        assert hasattr(patched, "_afb_bias") and patched._afb_bias.ndim == 1
+        assert hasattr(patched, "_afb_counts") and patched._afb_counts.ndim == 1
+        # ensure counts buffer got reset by callback (best effort)
+        assert torch.all(patched._afb_counts == 0)
+
+        check_model_output_exists(temp_dir, cfg)

--- a/tests/e2e/test_moe_aux_free.py
+++ b/tests/e2e/test_moe_aux_free.py
@@ -57,9 +57,9 @@ class TestMoeAuxFree(unittest.TestCase):
             }
         )
 
+        prepare_plugins(cfg)
         cfg = validate_config(cfg)
         normalize_config(cfg)
-        prepare_plugins(cfg)
         dataset_meta = load_datasets(cfg=cfg)
 
         model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)

--- a/tests/e2e/test_moe_aux_parity.py
+++ b/tests/e2e/test_moe_aux_parity.py
@@ -1,0 +1,83 @@
+"""
+Parity test comparing aux-loss (gshard) vs aux-loss-free (noaux_tc) on Mixtral-tiny.
+Checks that aux-free training loss does not degrade beyond a small tolerance.
+"""
+
+import unittest
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config, prepare_plugins
+from axolotl.utils.dict import DictDefault
+
+from .utils import with_temp_dir
+
+
+def _last_logged_loss(trainer) -> float | None:
+    # Scan log_history for the most recent entry with a 'loss' key
+    for entry in reversed(trainer.state.log_history):
+        if isinstance(entry, dict) and "loss" in entry:
+            return float(entry["loss"])
+    return None
+
+
+class TestMoeAuxParity(unittest.TestCase):
+    @with_temp_dir
+    def test_mixtral_auxfree_vs_auxloss_loss_parity(self, temp_dir):
+        base_cfg = {
+            "base_model": "hf-internal-testing/Mixtral-tiny",
+            "tokenizer_config": "LoneStriker/Mixtral-8x7B-v0.1-HF",
+            "flash_attention": False,
+            "sequence_len": 512,
+            "bf16": False,
+            "fp16": False,
+            "val_set_size": 0.02,
+            "special_tokens": {},
+            "datasets": [
+                {"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"},
+            ],
+            "num_epochs": 1,
+            "micro_batch_size": 2,
+            "gradient_accumulation_steps": 1,
+            "learning_rate": 1e-5,
+            "optimizer": "adamw_torch",
+            "lr_scheduler": "cosine",
+            "max_steps": 8,
+            "save_steps": 0,
+            "eval_steps": 0,
+            "save_first_step": False,
+            "seed": 42,
+            "logging_steps": 1,
+        }
+
+        # Baseline: aux-loss (gshard)
+        cfg0 = DictDefault(dict(base_cfg))
+        cfg0.output_dir = f"{temp_dir}/baseline"
+        cfg0 = validate_config(cfg0)
+        normalize_config(cfg0)
+        # baseline uses default aux-loss routing; no plugin registration
+        dataset_meta0 = load_datasets(cfg=cfg0)
+        model0, _, trainer0 = train(cfg=cfg0, dataset_meta=dataset_meta0)
+        loss0 = _last_logged_loss(trainer0)
+        assert loss0 is not None
+
+        # Aux-free: plugin + noaux_tc
+        cfg1 = DictDefault(dict(base_cfg))
+        cfg1.output_dir = f"{temp_dir}/auxfree"
+        cfg1.plugins = [
+            "axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin",
+        ]
+        cfg1.moe_balance_type = "noaux_tc"
+        cfg1.moe_update_rate = 0.01
+        cfg1.moe_update_momentum = 0.9
+        cfg1.moe_bias_cap = 2.0
+        cfg1 = validate_config(cfg1)
+        normalize_config(cfg1)
+        prepare_plugins(cfg1)
+        dataset_meta1 = load_datasets(cfg=cfg1)
+        model1, _, trainer1 = train(cfg=cfg1, dataset_meta=dataset_meta1)
+        loss1 = _last_logged_loss(trainer1)
+        assert loss1 is not None
+
+        # Assert aux-free loss is within 10% of aux-loss baseline
+        assert loss1 <= 1.1 * loss0, f"aux-free loss {loss1} > 1.1 * baseline {loss0}"

--- a/tests/e2e/test_moe_aux_parity.py
+++ b/tests/e2e/test_moe_aux_parity.py
@@ -71,9 +71,9 @@ class TestMoeAuxParity(unittest.TestCase):
         cfg1.moe_update_rate = 0.01
         cfg1.moe_update_momentum = 0.9
         cfg1.moe_bias_cap = 2.0
+        prepare_plugins(cfg1)
         cfg1 = validate_config(cfg1)
         normalize_config(cfg1)
-        prepare_plugins(cfg1)
         dataset_meta1 = load_datasets(cfg=cfg1)
         model1, _, trainer1 = train(cfg=cfg1, dataset_meta=dataset_meta1)
         loss1 = _last_logged_loss(trainer1)

--- a/tests/e2e/test_qwen3_moe_aux_free.py
+++ b/tests/e2e/test_qwen3_moe_aux_free.py
@@ -1,0 +1,76 @@
+"""
+E2E smoke test for Aux-Loss-Free MoE routing on Qwen3-MoE tiny
+"""
+
+import unittest
+
+import torch
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config, prepare_plugins
+from axolotl.utils.dict import DictDefault
+
+from .utils import check_model_output_exists, with_temp_dir
+
+
+class TestQwen3MoeAuxFree(unittest.TestCase):
+    @with_temp_dir
+    def test_qwen3_moe_aux_free_smoke(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                "tokenizer_config": "trl-internal-testing/tiny-Qwen3MoeForCausalLM",
+                "flash_attention": False,
+                "sequence_len": 512,
+                "bf16": False,
+                "fp16": False,
+                "val_set_size": 0.02,
+                "special_tokens": {},
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "max_steps": 5,
+                "save_steps": 0,
+                "eval_steps": 0,
+                "save_first_step": False,
+                # Aux-free plugin and toggles
+                "plugins": [
+                    "axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin",
+                ],
+                "moe_balance_type": "noaux_tc",
+                "moe_update_rate": 0.01,
+                "moe_update_momentum": 0.9,
+                "moe_bias_cap": 2.0,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        # check that at least one sparse MoE block has been patched
+        found = False
+        for m in model.modules():
+            if m.__class__.__name__.endswith("SparseMoeBlock") and hasattr(m, "_afb_patched"):
+                assert m._afb_patched is True
+                assert hasattr(m, "_afb_bias") and m._afb_bias.ndim == 1
+                assert hasattr(m, "_afb_counts") and m._afb_counts.ndim == 1
+                found = True
+                break
+        assert found, "No Qwen3-MoE sparse block patched by aux-free plugin"
+
+        check_model_output_exists(temp_dir, cfg)

--- a/tests/e2e/test_qwen3_moe_aux_free.py
+++ b/tests/e2e/test_qwen3_moe_aux_free.py
@@ -55,9 +55,9 @@ class TestQwen3MoeAuxFree(unittest.TestCase):
             }
         )
 
+        prepare_plugins(cfg)
         cfg = validate_config(cfg)
         normalize_config(cfg)
-        prepare_plugins(cfg)
         dataset_meta = load_datasets(cfg=cfg)
 
         model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)

--- a/tests/e2e/test_ring_moe_aux_free.py
+++ b/tests/e2e/test_ring_moe_aux_free.py
@@ -53,7 +53,6 @@ class TestRingMoeAuxFree(unittest.TestCase):
                 "moe_update_rate": 0.01,
                 "moe_update_momentum": 0.9,
                 "moe_bias_cap": 2.0,
-                "moe_afb_telemetry_interval": 1,
             }
         )
 

--- a/tests/e2e/test_ring_moe_aux_free.py
+++ b/tests/e2e/test_ring_moe_aux_free.py
@@ -1,0 +1,75 @@
+"""
+E2E smoke test for Ring 2.0 aux-loss-free routing via plugin
+"""
+
+import unittest
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+from .utils import check_model_output_exists, with_temp_dir
+
+
+class TestRingMoeAuxFree(unittest.TestCase):
+    """Smoke test to ensure aux-free plugin patches Ring Mini 2.0 correctly."""
+
+    @with_temp_dir
+    def test_ring_aux_free_smoke(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "yujiepan/ring-tiny-random",
+                "tokenizer_config": "yujiepan/ring-tiny-random",
+                "trust_remote_code": True,
+                "flash_attention": False,
+                "sequence_len": 512,
+                "bf16": False,
+                "fp16": False,
+                "val_set_size": 0.02,
+                "special_tokens": {},
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "max_steps": 5,
+                "save_steps": 0,
+                "eval_steps": 0,
+                "save_first_step": False,
+                # Aux-free plugin config
+                "plugins": [
+                    "axolotl.integrations.aux_free_router.plugin.AuxFreeMoEPlugin",
+                ],
+                "moe_balance_type": "noaux_tc",
+                "moe_update_rate": 0.01,
+                "moe_update_momentum": 0.9,
+                "moe_bias_cap": 2.0,
+                "moe_afb_telemetry_interval": 1,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        patched = next((m for m in model.modules() if hasattr(m, "_afb_bias")), None)
+        assert patched is not None, "Ring MoE layer was not patched by aux-free plugin"
+        assert patched._afb_bias.ndim == 1
+        assert patched._afb_counts.ndim == 1
+        check_model_output_exists(temp_dir, cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_ring_moe_aux_free.py
+++ b/tests/e2e/test_ring_moe_aux_free.py
@@ -56,9 +56,9 @@ class TestRingMoeAuxFree(unittest.TestCase):
             }
         )
 
+        prepare_plugins(cfg)
         cfg = validate_config(cfg)
         normalize_config(cfg)
-        prepare_plugins(cfg)
         dataset_meta = load_datasets(cfg=cfg)
 
         model, _, _ = train(cfg=cfg, dataset_meta=dataset_meta)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import torch
 from packaging import version
-from tbparse import SummaryReader
+try:
+    from tbparse import SummaryReader
+except ImportError:  # pragma: no cover - optional dependency
+    SummaryReader = None
 
 from axolotl.utils.dict import DictDefault
 
@@ -177,6 +180,8 @@ def check_tensorboard(
     """
     helper function to parse and check tensorboard logs
     """
+    if SummaryReader is None:
+        raise unittest.SkipTest("tbparse is not installed; skipping tensorboard assertions")
     tb_log_path = most_recent_subdir(temp_run_dir)
     event_file = os.path.join(tb_log_path, sorted(os.listdir(tb_log_path))[0])
     reader = SummaryReader(event_file)

--- a/tests/unit/test_aux_free_adapters.py
+++ b/tests/unit/test_aux_free_adapters.py
@@ -1,0 +1,162 @@
+import sys
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from importlib import util as importlib_util
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+from axolotl.integrations.aux_free_router.plugin import AuxFreeMoEPlugin
+
+
+def _cfg(**overrides):
+    defaults = dict(
+        moe_balance_type="noaux_tc",
+        moe_update_rate=0.1,
+        moe_update_momentum=0.9,
+        moe_bias_cap=2.0,
+        moe_afb_warmup_steps=0,
+        moe_bias_sync_group="world",
+        expert_parallel_size=1,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _load_bailing_modules():
+    repo_dir = snapshot_download(
+        repo_id="inclusionAI/Ring-mini-2.0",
+        allow_patterns=[
+            "configuration_bailing_moe_v2.py",
+            "modeling_bailing_moe_v2.py",
+            "__init__.py",
+        ],
+    )
+    repo = Path(repo_dir)
+    config_path = repo / "configuration_bailing_moe_v2.py"
+    modeling_path = repo / "modeling_bailing_moe_v2.py"
+
+    config_name = "bailing_moe_v2.configuration_bailing_moe_v2"
+    if config_name not in sys.modules:
+        spec = importlib_util.spec_from_file_location(config_name, config_path)
+        module = importlib_util.module_from_spec(spec)
+        sys.modules[config_name] = module
+        sys.modules["configuration_bailing_moe_v2"] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+    config_module = sys.modules[config_name]
+
+    modeling_name = "bailing_moe_v2.modeling_bailing_moe_v2"
+    if modeling_name not in sys.modules:
+        spec = importlib_util.spec_from_file_location(modeling_name, modeling_path)
+        module = importlib_util.module_from_spec(spec)
+        sys.modules[modeling_name] = module
+        sys.modules["modeling_bailing_moe_v2"] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+    modeling_module = sys.modules[modeling_name]
+
+    BailingMoeV2Config = config_module.BailingMoeV2Config
+    BailingMoeV2SparseMoeBlock = modeling_module.BailingMoeV2SparseMoeBlock
+
+    return BailingMoeV2Config, BailingMoeV2SparseMoeBlock
+
+
+def _build_bailing_model():
+    BailingConfig, BailingBlock = _load_bailing_modules()
+    config = BailingConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=32,
+        num_experts=4,
+        num_shared_experts=None,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+    )
+    block = BailingBlock(config)
+
+    class DummyModel(nn.Module):
+        def __init__(self, layer):
+            super().__init__()
+            self.block = layer
+            self.config = SimpleNamespace(model_type="bailing_moe")
+
+        def forward(self, hidden_states):
+            return self.block(hidden_states)
+
+    return DummyModel(block), block
+
+
+def _build_llama4_model():
+    from transformers import Llama4TextConfig
+    from transformers.models.llama4.modeling_llama4 import Llama4TextMoe
+
+    config = Llama4TextConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_local_experts=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_experts_per_tok=2,
+    )
+    layer = Llama4TextMoe(config)
+
+    class DummyModel(nn.Module):
+        def __init__(self, moe_layer):
+            super().__init__()
+            self.moe = moe_layer
+            self.config = SimpleNamespace(model_type="llama4")
+
+        def forward(self, hidden_states):
+            return self.moe(hidden_states)
+
+    return DummyModel(layer), layer
+
+
+def _run_callback(plugin, cfg):
+    callbacks = plugin.add_callbacks_post_trainer(cfg, trainer=SimpleNamespace())
+    assert callbacks, "expected aux-free callback to be registered"
+    callback = callbacks[0]
+    dummy = SimpleNamespace()
+    callback.on_step_end(args=dummy, state=dummy, control=dummy)
+
+
+class TestAuxFreeAdapters(unittest.TestCase):
+    def test_bailing_adapter_updates_counts_and_bias(self):
+        model, block = _build_bailing_model()
+        cfg = _cfg()
+        plugin = AuxFreeMoEPlugin()
+        plugin.post_model_build(cfg, model)
+
+        self.assertTrue(hasattr(block, "_afb_bias"))
+        hidden = torch.randn(2, 3, block.config.hidden_size)
+        block(hidden)
+        self.assertGreater(torch.count_nonzero(block._afb_counts), 0)
+
+        _run_callback(plugin, cfg)
+        self.assertEqual(torch.count_nonzero(block._afb_counts), 0)
+        self.assertFalse(torch.allclose(block._afb_ema, torch.zeros_like(block._afb_ema)))
+
+    def test_llama4_adapter_biases_router_selection(self):
+        model, layer = _build_llama4_model()
+        cfg = _cfg()
+        plugin = AuxFreeMoEPlugin()
+        plugin.post_model_build(cfg, model)
+
+        self.assertTrue(hasattr(layer, "_afb_bias"))
+        hidden = torch.randn(2, 4, layer.hidden_dim)
+        layer(hidden)
+        self.assertGreater(torch.count_nonzero(layer._afb_counts), 0)
+
+        _run_callback(plugin, cfg)
+        self.assertEqual(torch.count_nonzero(layer._afb_counts), 0)
+        self.assertFalse(torch.allclose(layer._afb_ema, torch.zeros_like(layer._afb_ema)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a new plugin that adds aux-loss-free balancing as a gating option to compatible MoE architectures without forking model code.

This is basically an plugin/monkeypatching version of DeepSeek's [Auxiliary-Loss-Free Load Balancing Strategy for Mixture-of-Experts](https://arxiv.org/pdf/2408.15664).

This code has been tested and the plugin itself should be pretty well documented.

Some more background about my ALFB approach: 
- https://chatgpt.com/share/69136736-9a1c-8012-b051-77f6cc157464

Compatibility:
- mixtral
- qwen3moe
- bailingv2
- llama4 (text layers)
- passhthrough for deepspeedv3

Btw I know @NanoCode012 had some comments on changing the telemetry/logging vars/configs?

Take a look at the README/config stuff, happy to make some updates to bring it inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Aux-Loss-Free MoE Router plugin enabling auxiliary-loss-free routing for supported Mixture-of-Experts models (Mixtral, Qwen3, Llama4, Bailing, Ring).

* **Documentation**
  * Added comprehensive documentation for configuring and using the Aux-Free MoE Router.

* **Configuration**
  * Added new MoE routing parameters: `moe_balance_type`, `moe_update_rate`, `moe_update_momentum`, `moe_bias_cap`, `moe_afb_warmup_steps`, `moe_bias_sync_group`, and `expert_parallel_size`.

* **Tests**
  * Added end-to-end and unit tests validating aux-free routing functionality and parity with traditional auxiliary-loss routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->