### PR TITLE
MoE Grouped MM support (5X+ MoE training perf gains)

### DIFF
--- a/docs/amd_hpc.qmd
+++ b/docs/amd_hpc.qmd
@@ -106,3 +106,15 @@ CUDA_VISIBLE_DEVICES="" python -m axolotl.cli.preprocess /path/to/your/config.ya
 ### 12. Train
 
 You are now ready to submit your previously prepared job script. 🚂
+
+## MegaBlocks Grouped MoE on MI300X
+
+Axolotl ships a MegaBlocks HIP backend that replaces the per-expert Python loop in Ring/Bailing MoE blocks. To enable it on ROCm:
+
+- In your training config set `mlp_impl: megablocks` (or legacy `use_grouped_moe_kernels: true`). The patch manager will automatically stack expert weights and route all MoE layers through the grouped kernels.
+- Run the bundled parity tests before scaling up:  
+  `RUN_SLOW_MEGABLOCKS_PARITY=1 MEGABLOCKS_CAPTURE_GATING=1 python -m pytest axolotl.shisa/tests/e2e/test_ring_moe_grouped.py -k megablocks -s`  
+  This verifies grouped torch vs MegaBlocks loss and gradient parity on MI300X.
+- **Do not** export `MEGABLOCKS_GG_USE_HIPBLASLT=1` yet. The hipBLASLt path currently triggers MI300X GPU page faults (`gfxhub0 retry page fault` in dmesg). Leave the flag unset to keep using the proven fallback HIP kernel.
+
+For ad-hoc validation we also provide `better-moe-training/tools/run_ring_moe_parity.py`, which records loss traces and routing histograms for grouped vs MegaBlocks runs and saves them as JSON.

--- a/src/axolotl/common/architectures.py
+++ b/src/axolotl/common/architectures.py
@@ -13,6 +13,7 @@ MOE_ARCH_BLOCK = {
     "qwen2_moe": "Qwen2MoeSparseMoeBlock",
     "qwen3_moe": "Qwen3MoeSparseMoeBlock",
     "qwen3_vl_moe": "Qwen3VLMoeTextSparseMoeBlock",
+    "glm4_moe": "Glm4MoeMoE",
     "deepseek_v2": "DeepseekV2MoE",
     "deepseek_v3": "DeepseekV3MoE",
     "gpt_oss": "GptOssDecoderLayer",

--- a/src/axolotl/common/architectures.py
+++ b/src/axolotl/common/architectures.py
@@ -17,4 +17,6 @@ MOE_ARCH_BLOCK = {
     "deepseek_v3": "DeepseekV3MoE",
     "gpt_oss": "GptOssDecoderLayer",
     "lfm2_moe": "Lfm2MoeSparseMoeBlock",
+    "bailing_moe": "BailingMoeV2SparseMoeBlock",
+    "bailing_moe_v2": "BailingMoeV2SparseMoeBlock",
 }

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -98,6 +98,7 @@ class PatchManager:
         self._apply_lora_kernel_patch(model)
         self._apply_bailing_moe_grouped_patch(model)
         self._apply_qwen3_moe_grouped_patch(model)
+        self._apply_glm4_moe_grouped_patch(model)
 
     def _apply_flash_attention_patches(self):
         """Apply patches related to Flash Attention."""
@@ -598,6 +599,51 @@ class PatchManager:
         else:
             LOG.warning(
                 "Requested grouped MoE kernels but no Qwen3 MoE blocks were patched."
+            )
+
+    def _apply_glm4_moe_grouped_patch(self, model: PreTrainedModel):
+        """Enable grouped MoE kernels for GLM4 MoE architectures when requested."""
+        model_type = getattr(self.model_config, "model_type", None)
+        if model_type is None and isinstance(self.model_config, dict):
+            model_type = self.model_config.get("model_type")
+
+        supported_types = {"glm4_moe"}
+        config_class_name = ""
+        if hasattr(self.model_config, "__class__"):
+            config_class_name = self.model_config.__class__.__name__.lower()
+
+        if (
+            model_type not in supported_types
+            and self.cfg.model_config_type not in supported_types
+            and "glm4moe" not in config_class_name
+        ):
+            return
+
+        mlp_impl = self.cfg.mlp_impl
+        if mlp_impl is None and self.cfg.use_grouped_moe_kernels:
+            mlp_impl = "grouped"
+
+        if mlp_impl is None:
+            return
+
+        if mlp_impl not in {"grouped", "megablocks"}:
+            LOG.warning("Unsupported mlp_impl=%s for GLM4 MoE grouped patch.", mlp_impl)
+            return
+
+        try:
+            from axolotl.monkeypatch.models.glm4_moe.modeling import (
+                patch_glm4_moe_grouped_experts,
+            )
+        except ImportError as exc:
+            LOG.warning("Unable to import grouped MoE patch for GLM4 MoE: %s", exc)
+            return
+
+        patched = patch_glm4_moe_grouped_experts(model, mlp_impl=mlp_impl)
+        if patched:
+            LOG.info("Applied grouped MoE kernels to %d GLM4 MoE blocks.", patched)
+        else:
+            LOG.warning(
+                "Requested grouped MoE kernels but no GLM4 MoE blocks were patched."
             )
 
     def _apply_patch_deepspeed_zero3(self):

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -96,6 +96,7 @@ class PatchManager:
         self._apply_llama_flash_attn_patches(model)
         self._apply_unsloth_patches(model)
         self._apply_lora_kernel_patch(model)
+        self._apply_bailing_moe_grouped_patch(model)
 
     def _apply_flash_attention_patches(self):
         """Apply patches related to Flash Attention."""
@@ -494,6 +495,59 @@ class PatchManager:
             from axolotl.monkeypatch.lora_kernels import apply_lora_kernel_patches
 
             apply_lora_kernel_patches(model=model, cfg=self.cfg)
+
+    def _apply_bailing_moe_grouped_patch(self, model: PreTrainedModel):
+        """Enable grouped MoE kernels for Bailing/Ring architectures when requested."""
+        model_type = getattr(self.model_config, "model_type", None)
+        if model_type is None and isinstance(self.model_config, dict):
+            model_type = self.model_config.get("model_type")
+
+        supported_types = {"bailing_moe", "bailing_moe_v2"}
+        config_class_name = ""
+        if hasattr(self.model_config, "__class__"):
+            config_class_name = self.model_config.__class__.__name__.lower()
+
+        def _looks_like_bailing_config() -> bool:
+            cfg_obj = self.model_config
+            if cfg_obj is None:
+                return False
+            attrs = ("n_group", "topk_group", "num_shared_experts", "routed_scaling_factor")
+            return any(hasattr(cfg_obj, attr) for attr in attrs)
+
+        if (
+            model_type not in supported_types
+            and self.cfg.model_config_type not in supported_types
+            and "bailingmoe" not in config_class_name
+            and not _looks_like_bailing_config()
+        ):
+            return
+
+        mlp_impl = self.cfg.mlp_impl
+        if mlp_impl is None and self.cfg.use_grouped_moe_kernels:
+            mlp_impl = "grouped"
+
+        if mlp_impl is None:
+            return
+
+        if mlp_impl not in {"grouped", "megablocks"}:
+            LOG.warning("Unsupported mlp_impl=%s for Bailing MoE grouped patch.", mlp_impl)
+            return
+
+        try:
+            from axolotl.monkeypatch.models.bailing_moe_v2.modeling import (
+                patch_model_with_grouped_experts,
+            )
+        except ImportError as exc:
+            LOG.warning("Unable to import grouped MoE patch for Bailing MoE: %s", exc)
+            return
+
+        patched = patch_model_with_grouped_experts(model, mlp_impl=mlp_impl)
+        if patched:
+            LOG.info("Applied grouped MoE kernels to %d Bailing MoE blocks.", patched)
+        else:
+            LOG.warning(
+                "Requested grouped MoE kernels but no Bailing MoE blocks were patched."
+            )
 
     def _apply_patch_deepspeed_zero3(self):
         try:

--- a/src/axolotl/monkeypatch/models/bailing_moe_v2/__init__.py
+++ b/src/axolotl/monkeypatch/models/bailing_moe_v2/__init__.py
@@ -1,0 +1,6 @@
+"""Grouped MoE patches for Ring/Bailing (BailingMoeV2) architectures."""
+
+from .modeling import patch_model_with_grouped_experts
+
+__all__ = ["patch_model_with_grouped_experts"]
+

--- a/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
+++ b/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
@@ -224,7 +224,12 @@ class BailingMoeV2GroupedExperts(nn.Module):
             outputs_list: list[torch.Tensor] = []
             start_idx = 0
             bias_iter = bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
-            for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+            for count, weight, bias in zip(
+                repeat_sizes.tolist(),
+                weight_bank,
+                bias_iter,
+                strict=True,
+            ):
                 if count == 0:
                     continue
                 end_idx = start_idx + count

--- a/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
+++ b/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
@@ -1,0 +1,368 @@
+"""Grouped MoE kernels for Bailing/Ring (BailingMoeV2) architectures."""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Iterable, Optional
+import os
+import sys
+from pathlib import Path
+import torch
+import torch.nn as nn
+from transformers.activations import ACT2FN
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+_MEGABLOCKS_BACKEND = None
+_MEGABLOCKS_IMPORT_ERROR: Optional[Exception] = None
+
+
+def _load_megablocks_backend() -> Optional[object]:
+    global _MEGABLOCKS_BACKEND, _MEGABLOCKS_IMPORT_ERROR
+    if _MEGABLOCKS_BACKEND is not None or _MEGABLOCKS_IMPORT_ERROR is not None:
+        return _MEGABLOCKS_BACKEND
+
+    try:
+        from megablocks.grouped_gemm import backend as mb_backend  # type: ignore
+
+        _MEGABLOCKS_BACKEND = mb_backend
+        backend_path = getattr(mb_backend, "__file__", None)
+        if backend_path:
+            LOG.info("Loaded MegaBlocks grouped GEMM backend from %s", backend_path)
+        return _MEGABLOCKS_BACKEND
+    except ImportError:
+        pass
+
+    root = Path(__file__).resolve().parents[6]
+    candidate_repo = root / "better-moe-training" / "megablocks-hip"
+    search_roots: list[Path] = []
+
+    env_path = os.environ.get("MEGABLOCKS_HIP_PATH")
+    if env_path:
+        search_roots.append(Path(env_path))
+    if candidate_repo.exists():
+        try:
+            from kernels.utils import build_variant  # type: ignore
+
+            variant = build_variant()
+        except Exception:
+            variant = None
+
+        if variant:
+            search_roots.append(candidate_repo / "build" / variant)
+        search_roots.append(candidate_repo / "torch-ext")
+
+    for path in search_roots:
+        if path.exists():
+            if str(path) not in sys.path:
+                sys.path.append(str(path))
+
+    try:
+        from megablocks.grouped_gemm import backend as mb_backend  # type: ignore
+
+        _MEGABLOCKS_BACKEND = mb_backend
+        backend_path = getattr(mb_backend, "__file__", None)
+        if backend_path:
+            LOG.info("Loaded MegaBlocks grouped GEMM backend from %s", backend_path)
+        return _MEGABLOCKS_BACKEND
+    except Exception as exc:  # pragma: no cover - we record and fallback
+        _MEGABLOCKS_IMPORT_ERROR = exc
+        LOG.warning("Failed to load MegaBlocks grouped GEMM backend: %s", exc)
+        return None
+
+
+class BailingMoeV2GroupedExperts(nn.Module):
+    """Grouped expert MLP that replaces per-expert Python loops."""
+
+    def __init__(self, config, experts: Iterable[nn.Module], backend_impl: str):
+        super().__init__()
+        experts = list(experts)
+        if not experts:
+            raise ValueError("Expected at least one expert module to convert.")
+
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.moe_intermediate_size
+        self.num_experts = config.num_experts
+        self.act_fn = ACT2FN[config.hidden_act]
+        self.backend_impl = backend_impl
+        self._warned_grouped_mm_fallback = False
+        self._warned_megablocks_missing = False
+
+        device = experts[0].gate_proj.weight.device
+        dtype = experts[0].gate_proj.weight.dtype
+
+        gate_weights = []
+        up_weights = []
+        down_weights = []
+        gate_bias = experts[0].gate_proj.bias
+        up_bias = experts[0].up_proj.bias
+        down_bias = experts[0].down_proj.bias
+
+        if len(experts) != self.num_experts:
+            raise ValueError(
+                f"Config expects {self.num_experts} experts, but received {len(experts)}."
+            )
+
+        for expert in experts:
+            gate_weights.append(expert.gate_proj.weight.detach().clone())
+            up_weights.append(expert.up_proj.weight.detach().clone())
+            down_weights.append(expert.down_proj.weight.detach().clone())
+
+        self.gate_weight = nn.Parameter(torch.stack(gate_weights, dim=0).to(device=device, dtype=dtype))
+        self.up_weight = nn.Parameter(torch.stack(up_weights, dim=0).to(device=device, dtype=dtype))
+        self.down_weight = nn.Parameter(torch.stack(down_weights, dim=0).to(device=device, dtype=dtype))
+
+        if gate_bias is not None:
+            stacked = torch.stack(
+                [expert.gate_proj.bias.detach().clone() for expert in experts], dim=0
+            ).to(device=device, dtype=gate_bias.dtype)
+            self.gate_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("gate_bias", None)
+
+        if up_bias is not None:
+            stacked = torch.stack(
+                [expert.up_proj.bias.detach().clone() for expert in experts], dim=0
+            ).to(device=device, dtype=up_bias.dtype)
+            self.up_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("up_bias", None)
+
+        if down_bias is not None:
+            stacked = torch.stack(
+                [expert.down_proj.bias.detach().clone() for expert in experts], dim=0
+            ).to(device=device, dtype=down_bias.dtype)
+            self.down_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("down_bias", None)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute grouped expert outputs.
+
+        Args:
+            hidden_states: (batch, seq, hidden)
+            topk_idx: (batch*seq, top_k)
+            topk_weight: (batch*seq, top_k)
+        """
+        bsz, seq_len, hidden = hidden_states.shape
+        hidden_flat = hidden_states.reshape(-1, hidden)
+        num_tokens = hidden_flat.size(0)
+        if num_tokens == 0:
+            return hidden_states
+
+        topk = topk_idx.shape[-1]
+        dispatch_indices = torch.arange(num_tokens, device=hidden_flat.device, dtype=torch.long)
+        dispatch_indices = dispatch_indices.repeat_interleave(topk)
+
+        flat_expert = topk_idx.reshape(-1)
+        flat_weight = topk_weight.reshape(-1).to(hidden_states.dtype)
+
+        active_counts = torch.bincount(flat_expert, minlength=self.num_experts)
+        active_expert_indices = torch.nonzero(active_counts, as_tuple=False).flatten()
+        if active_expert_indices.numel() == 0:
+            return hidden_states.new_zeros((bsz, seq_len, hidden))
+
+        active_counts = active_counts.index_select(0, active_expert_indices)
+        offsets = torch.cumsum(
+            active_counts.to(dtype=torch.int32), dim=0, dtype=torch.int32
+        ).contiguous()
+
+        _, sort_perm = torch.sort(flat_expert)
+        sorted_tokens = dispatch_indices.index_select(0, sort_perm)
+        expert_inputs = hidden_flat.index_select(0, sorted_tokens).to(self.gate_weight.dtype)
+
+        repeat_sizes = active_counts.to(torch.long)
+
+        gate_active = self.gate_weight.index_select(0, active_expert_indices)
+        up_active = self.up_weight.index_select(0, active_expert_indices)
+        down_active = self.down_weight.index_select(0, active_expert_indices)
+
+        gate_bias_active = (
+            self.gate_bias.index_select(0, active_expert_indices) if self.gate_bias is not None else None
+        )
+        up_bias_active = (
+            self.up_bias.index_select(0, active_expert_indices) if self.up_bias is not None else None
+        )
+        down_bias_active = (
+            self.down_bias.index_select(0, active_expert_indices) if self.down_bias is not None else None
+        )
+
+        def _run_linear(inputs: torch.Tensor, weight_bank: torch.Tensor, bias_bank: torch.Tensor | None) -> torch.Tensor:
+            weight_t = weight_bank.transpose(-2, -1).contiguous()
+            batch_sizes_cpu = repeat_sizes.to(device="cpu", dtype=torch.long)
+
+            use_megablocks = self.backend_impl == "megablocks"
+            if use_megablocks:
+                mb_backend = _load_megablocks_backend()
+                if mb_backend is None:
+                    if not self._warned_megablocks_missing:
+                        LOG.warning(
+                            "Requested mlp_impl=megablocks but MegaBlocks backend not found; "
+                            "falling back to torch grouped_mm / Python loops."
+                        )
+                        self._warned_megablocks_missing = True
+                    use_megablocks = False
+                elif not inputs.is_cuda or inputs.dtype != torch.bfloat16 or weight_t.dtype != torch.bfloat16:
+                    if not self._warned_megablocks_missing:
+                        LOG.warning(
+                            "MegaBlocks backend requires CUDA tensors in bf16; "
+                            "falling back to torch grouped_mm / Python loops."
+                        )
+                        self._warned_megablocks_missing = True
+                    use_megablocks = False
+                else:
+                    outputs = mb_backend.gmm(
+                        inputs,
+                        weight_t,
+                        batch_sizes_cpu,
+                        trans_b=False,
+                    )
+                    if bias_bank is not None:
+                        outputs = outputs + torch.repeat_interleave(
+                            bias_bank, repeat_sizes, dim=0
+                        ).to(outputs.dtype)
+                    return outputs
+
+            try:
+                outputs = torch._grouped_mm(inputs, weight_t, offs=offsets)
+                if bias_bank is not None:
+                    expanded_bias = torch.repeat_interleave(bias_bank, repeat_sizes, dim=0).to(outputs.dtype)
+                    outputs = outputs + expanded_bias
+                return outputs
+            except RuntimeError as exc:
+                if "grouped gemm is not supported" in str(exc).lower():
+                    mb_backend = _load_megablocks_backend()
+                    if mb_backend is not None and inputs.is_cuda and inputs.dtype == torch.bfloat16 and weight_t.dtype == torch.bfloat16:
+                        outputs = mb_backend.gmm(
+                            inputs,
+                            weight_t,
+                            batch_sizes_cpu,
+                            trans_b=False,
+                        )
+                        if bias_bank is not None:
+                            outputs = outputs + torch.repeat_interleave(
+                                bias_bank, repeat_sizes, dim=0
+                            ).to(outputs.dtype)
+                        return outputs
+                    if not self._warned_grouped_mm_fallback:
+                        LOG.warning(
+                            "torch._grouped_mm unavailable on this backend (%s); falling back to per-expert matmuls.",
+                            exc,
+                        )
+                        self._warned_grouped_mm_fallback = True
+                else:
+                    raise
+
+                outputs_list: list[torch.Tensor] = []
+                start_idx = 0
+                bias_iter = (
+                    bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
+                )
+                for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+                    if count == 0:
+                        continue
+                    end_idx = start_idx + count
+                    chunk = inputs[start_idx:end_idx]
+                    result = torch.matmul(chunk, weight.transpose(0, 1))
+                    if bias is not None:
+                        result = result + bias
+                    outputs_list.append(result)
+                    start_idx = end_idx
+                if outputs_list:
+                    return torch.cat(outputs_list, dim=0)
+                return inputs.new_empty((0, weight_bank.size(1)))
+
+        gate_out = _run_linear(expert_inputs, gate_active, gate_bias_active)
+        up_out = _run_linear(expert_inputs, up_active, up_bias_active)
+
+        activated = self.act_fn(gate_out).to(up_out.dtype)
+        activated = activated * up_out
+
+        combined = _run_linear(activated, down_active, down_bias_active)
+
+        inverse_perm = torch.empty_like(sort_perm)
+        inverse_perm.index_copy_(
+            0,
+            sort_perm,
+            torch.arange(sort_perm.size(0), device=sort_perm.device, dtype=sort_perm.dtype),
+        )
+        unsorted_outputs = combined.index_select(0, inverse_perm)
+        weighted = unsorted_outputs.to(hidden_states.dtype) * flat_weight.unsqueeze(-1)
+
+        output_flat = hidden_states.new_zeros((num_tokens, hidden))
+        scatter_index = dispatch_indices.unsqueeze(-1).expand_as(weighted)
+        output_flat.scatter_add_(0, scatter_index, weighted)
+
+        return output_flat.view(bsz, seq_len, hidden)
+
+
+def _grouped_forward(self, hidden_states: torch.Tensor):
+    identity = hidden_states
+    bsz, seq_len, _ = hidden_states.shape
+    topk_idx, topk_weight, router_logits = self.gate(hidden_states)
+    expert_out = self.experts(hidden_states, topk_idx, topk_weight)
+    if getattr(self, "shared_experts", None) is not None:
+        expert_out = expert_out + self.shared_experts(identity)
+
+    return expert_out, (
+        router_logits.view(bsz, seq_len, -1),
+        topk_idx.view(bsz, seq_len, -1),
+    )
+
+
+def _grouped_moe_infer(self, hidden_states: torch.Tensor, topk_idx: torch.Tensor, topk_weight: torch.Tensor):
+    seq_len, hidden = hidden_states.shape
+    expert_out = self.experts(
+        hidden_states.view(1, seq_len, hidden),
+        topk_idx,
+        topk_weight,
+    )
+    return expert_out.view(seq_len, hidden)
+
+
+def patch_model_with_grouped_experts(model: nn.Module, mlp_impl: str = "grouped") -> int:
+    """Convert BailingMoeV2SparseMoeBlock modules to grouped expert implementations.
+
+    Returns:
+        Number of blocks patched.
+    """
+
+    if mlp_impl not in {"grouped", "megablocks"}:
+        raise ValueError(f"Unsupported mlp_impl={mlp_impl} for grouped experts patch.")
+
+    if not hasattr(torch, "_grouped_mm"):
+        raise RuntimeError(
+            "torch._grouped_mm is required for grouped MoE kernels but is unavailable in this torch build."
+        )
+
+    patched = 0
+    for module in model.modules():
+        if module.__class__.__name__ != "BailingMoeV2SparseMoeBlock":
+            continue
+        if getattr(module, "_axolotl_grouped_moe", False):
+            patched += 1
+            continue
+
+        old_experts = module.experts
+        try:
+            grouped = BailingMoeV2GroupedExperts(module.config, old_experts, backend_impl=mlp_impl)
+        except Exception as exc:  # pragma: no cover - safety net for unexpected configs
+            LOG.warning("Failed to convert Bailing MoE block to grouped experts: %s", exc)
+            continue
+
+        module.experts = grouped
+        module.forward = MethodType(_grouped_forward, module)
+        module.moe_infer = MethodType(_grouped_moe_infer, module)
+        module._axolotl_grouped_moe = True
+        module._axolotl_mlp_impl = mlp_impl
+        patched += 1
+    return patched

--- a/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
+++ b/src/axolotl/monkeypatch/models/bailing_moe_v2/modeling.py
@@ -36,37 +36,18 @@ def _load_megablocks_backend() -> Optional[object]:
     except ImportError:
         pass
 
-    search_roots: list[Path] = []
-
     env_path = os.environ.get("MEGABLOCKS_HIP_PATH")
     if env_path:
-        search_roots.append(Path(env_path))
-
-    root = Path(__file__).resolve().parents[6]
-    workspace_repo = root / "better-moe-training" / "megablocks-hip"
-    home_repo = Path.home() / "axolotl" / "megablocks-hip"
-
-    def _append_repo_paths(repo_root: Path) -> None:
-        if not repo_root.exists():
-            return
-        try:
-            from kernels.utils import build_variant  # type: ignore
-
-            variant = build_variant()
-        except Exception:
-            variant = None
-
-        if variant:
-            search_roots.append(repo_root / "build" / variant)
-        search_roots.append(repo_root / "torch-ext")
-
-    _append_repo_paths(workspace_repo)
-    _append_repo_paths(home_repo)
-
-    for path in search_roots:
-        if path.exists():
-            if str(path) not in sys.path:
-                sys.path.append(str(path))
+        build_root = Path(env_path)
+        if build_root.exists():
+            if str(build_root) not in sys.path:
+                sys.path.append(str(build_root))
+    else:
+        LOG.warning(
+            "MEGABLOCKS_HIP_PATH is not set. MegaBlocks HIP kernels will not be available. "
+            "Clone https://huggingface.co/shisa-ai/megablocks-hip, run `python build.py`, "
+            "and export MEGABLOCKS_HIP_PATH to the resulting build directory."
+        )
 
     try:
         from megablocks.grouped_gemm import backend as mb_backend  # type: ignore

--- a/src/axolotl/monkeypatch/models/glm4_moe/__init__.py
+++ b/src/axolotl/monkeypatch/models/glm4_moe/__init__.py
@@ -1,0 +1,7 @@
+"""
+Grouped MoE patches for GLM4 MoE architectures.
+"""
+
+from .modeling import patch_glm4_moe_grouped_experts
+
+__all__ = ["patch_glm4_moe_grouped_experts"]

--- a/src/axolotl/monkeypatch/models/glm4_moe/modeling.py
+++ b/src/axolotl/monkeypatch/models/glm4_moe/modeling.py
@@ -212,7 +212,12 @@ class Glm4MoeGroupedExperts(nn.Module):
             outputs: list[torch.Tensor] = []
             start_idx = 0
             bias_iter = bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
-            for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+            for count, weight, bias in zip(
+                repeat_sizes.tolist(),
+                weight_bank,
+                bias_iter,
+                strict=True,
+            ):
                 if count == 0:
                     continue
                 end_idx = start_idx + count

--- a/src/axolotl/monkeypatch/models/glm4_moe/modeling.py
+++ b/src/axolotl/monkeypatch/models/glm4_moe/modeling.py
@@ -1,0 +1,396 @@
+"""Grouped MoE kernels for GLM4 MoE architectures."""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+from transformers.activations import ACT2FN
+
+from axolotl.monkeypatch.models.utils import clone_expert_parameter
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+try:
+    # Reuse the shared MegaBlocks loader so both adapters hit the same cache.
+    from axolotl.monkeypatch.models.bailing_moe_v2.modeling import (  # noqa: WPS433
+        _load_megablocks_backend,
+    )
+except ImportError:  # pragma: no cover - MegaBlocks optional dependency
+
+    def _load_megablocks_backend() -> Optional[object]:
+        return None
+
+
+class Glm4MoeGroupedExperts(nn.Module):
+    """Vectorised grouped expert MLP for GLM4 MoE blocks."""
+
+    def __init__(self, config, experts: Iterable[nn.Module], backend_impl: str):
+        super().__init__()
+        experts = list(experts)
+        if not experts:
+            raise ValueError("Expected at least one expert module to convert.")
+
+        self.config = config
+        self.hidden_size = getattr(config, "hidden_size", None)
+        if self.hidden_size is None:
+            raise ValueError("GLM4 config missing hidden_size.")
+        self.intermediate_size = getattr(config, "moe_intermediate_size", None)
+        if self.intermediate_size is None:
+            raise ValueError("GLM4 config missing moe_intermediate_size.")
+        self.num_experts = getattr(config, "n_routed_experts", len(experts))
+        self.act_fn = ACT2FN[getattr(config, "hidden_act", "silu")]
+        self.backend_impl = backend_impl
+        self._warned_grouped_mm_fallback = False
+        self._warned_megablocks_missing = False
+
+        device = experts[0].gate_proj.weight.device
+        dtype = experts[0].gate_proj.weight.dtype
+
+        gate_dims = tuple(
+            getattr(experts[0].gate_proj.weight, "ds_shape", experts[0].gate_proj.weight.shape)
+        )
+        up_dims = tuple(
+            getattr(experts[0].up_proj.weight, "ds_shape", experts[0].up_proj.weight.shape)
+        )
+        down_dims = tuple(
+            getattr(experts[0].down_proj.weight, "ds_shape", experts[0].down_proj.weight.shape)
+        )
+
+        gate_weights: list[torch.Tensor] = []
+        up_weights: list[torch.Tensor] = []
+        down_weights: list[torch.Tensor] = []
+        gate_bias = experts[0].gate_proj.bias
+        up_bias = experts[0].up_proj.bias
+        down_bias = experts[0].down_proj.bias
+
+        if len(experts) != self.num_experts:
+            raise ValueError(
+                f"Config expects {self.num_experts} experts, but received {len(experts)}."
+            )
+
+        for idx, expert in enumerate(experts):
+            if (
+                expert.gate_proj.weight.numel() == 0
+                or expert.up_proj.weight.numel() == 0
+                or expert.down_proj.weight.numel() == 0
+            ):
+                LOG.warning(
+                    "Encountered expert %s with empty weights during GLM4 grouped conversion; "
+                    "gate=%s up=%s down=%s (dtype=%s device=%s)",
+                    idx,
+                    tuple(expert.gate_proj.weight.shape),
+                    tuple(expert.up_proj.weight.shape),
+                    tuple(expert.down_proj.weight.shape),
+                    expert.gate_proj.weight.dtype,
+                    expert.gate_proj.weight.device,
+                )
+            gate_weights.append(clone_expert_parameter(expert.gate_proj.weight))
+            up_weights.append(clone_expert_parameter(expert.up_proj.weight))
+            down_weights.append(clone_expert_parameter(expert.down_proj.weight))
+
+        gate_stack = torch.stack(gate_weights, dim=0).to(device=device, dtype=dtype)
+        up_stack = torch.stack(up_weights, dim=0).to(device=device, dtype=dtype)
+        down_stack = torch.stack(down_weights, dim=0).to(device=device, dtype=dtype)
+
+        if gate_stack.numel() == 0 and all(dim > 0 for dim in gate_dims):
+            gate_stack = torch.zeros(
+                (self.num_experts,) + gate_dims,
+                device=device,
+                dtype=dtype,
+            )
+        if up_stack.numel() == 0 and all(dim > 0 for dim in up_dims):
+            up_stack = torch.zeros(
+                (self.num_experts,) + up_dims,
+                device=device,
+                dtype=dtype,
+            )
+        if down_stack.numel() == 0 and all(dim > 0 for dim in down_dims):
+            down_stack = torch.zeros(
+                (self.num_experts,) + down_dims,
+                device=device,
+                dtype=dtype,
+            )
+
+        self.gate_weight = nn.Parameter(gate_stack)
+        self.up_weight = nn.Parameter(up_stack)
+        self.down_weight = nn.Parameter(down_stack)
+
+        if gate_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.gate_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=gate_bias.dtype)
+            self.gate_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("gate_bias", None)
+
+        if up_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.up_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=up_bias.dtype)
+            self.up_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("up_bias", None)
+
+        if down_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.down_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=down_bias.dtype)
+            self.down_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("down_bias", None)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        if hidden_states.dim() != 3:
+            raise ValueError(
+                f"Expected (batch, seq, hidden) hidden_states but received shape {tuple(hidden_states.shape)}."
+            )
+
+        bsz, seq_len, hidden = hidden_states.shape
+        hidden_flat = hidden_states.reshape(-1, hidden)
+        num_tokens = hidden_flat.size(0)
+        if num_tokens == 0:
+            return hidden_states
+
+        topk = topk_idx.shape[-1]
+        dispatch_indices = torch.arange(
+            num_tokens,
+            device=hidden_flat.device,
+            dtype=torch.long,
+        ).repeat_interleave(topk)
+
+        flat_expert = topk_idx.reshape(-1)
+        flat_weight = topk_weight.reshape(-1).to(hidden_states.dtype)
+
+        active_counts = torch.bincount(flat_expert, minlength=self.num_experts)
+        active_expert_indices = torch.nonzero(active_counts, as_tuple=False).flatten()
+        if active_expert_indices.numel() == 0:
+            return hidden_states.new_zeros((bsz, seq_len, hidden))
+
+        counts = active_counts.index_select(0, active_expert_indices)
+        repeat_sizes = counts.to(torch.long)
+        offsets = torch.cumsum(
+            counts.to(dtype=torch.int32),
+            dim=0,
+            dtype=torch.int32,
+        ).contiguous()
+
+        _, sort_perm = torch.sort(flat_expert)
+        sorted_tokens = dispatch_indices.index_select(0, sort_perm)
+        expert_inputs = hidden_flat.index_select(0, sorted_tokens).to(self.gate_weight.dtype)
+
+        gate_active = self.gate_weight.index_select(0, active_expert_indices)
+        up_active = self.up_weight.index_select(0, active_expert_indices)
+        down_active = self.down_weight.index_select(0, active_expert_indices)
+
+        gate_bias_active = (
+            self.gate_bias.index_select(0, active_expert_indices) if self.gate_bias is not None else None
+        )
+        up_bias_active = (
+            self.up_bias.index_select(0, active_expert_indices) if self.up_bias is not None else None
+        )
+        down_bias_active = (
+            self.down_bias.index_select(0, active_expert_indices) if self.down_bias is not None else None
+        )
+
+        def _fallback_linear(
+            inputs: torch.Tensor,
+            weight_bank: torch.Tensor,
+            bias_bank: torch.Tensor | None,
+        ) -> torch.Tensor:
+            outputs: list[torch.Tensor] = []
+            start_idx = 0
+            bias_iter = bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
+            for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+                if count == 0:
+                    continue
+                end_idx = start_idx + count
+                chunk = inputs[start_idx:end_idx]
+                result = chunk @ weight.transpose(0, 1)
+                if bias is not None:
+                    result = result + bias
+                outputs.append(result)
+                start_idx = end_idx
+            if outputs:
+                return torch.cat(outputs, dim=0)
+            return inputs.new_empty((0, weight_bank.size(1)))
+
+        def _run_linear(
+            inputs: torch.Tensor,
+            weight_bank: torch.Tensor,
+            bias_bank: torch.Tensor | None,
+        ) -> torch.Tensor:
+            weight_t = weight_bank.transpose(-2, -1).contiguous()
+            batch_sizes_cpu = repeat_sizes.to(device="cpu", dtype=torch.long)
+
+            use_megablocks = self.backend_impl == "megablocks"
+            if use_megablocks:
+                mb_backend = _load_megablocks_backend()
+                if mb_backend is None:
+                    if not self._warned_megablocks_missing:
+                        LOG.warning(
+                            "Requested mlp_impl=megablocks but MegaBlocks backend not found; "
+                            "falling back to torch grouped_mm / Python loops."
+                        )
+                        self._warned_megablocks_missing = True
+                    use_megablocks = False
+                elif (
+                    not inputs.is_cuda
+                    or inputs.dtype != torch.bfloat16
+                    or weight_t.dtype != torch.bfloat16
+                ):
+                    if not self._warned_megablocks_missing:
+                        LOG.warning(
+                            "MegaBlocks backend requires CUDA tensors in bf16; "
+                            "falling back to torch grouped_mm / Python loops."
+                        )
+                        self._warned_megablocks_missing = True
+                    use_megablocks = False
+                else:
+                    outputs = mb_backend.gmm(
+                        inputs,
+                        weight_t,
+                        batch_sizes_cpu,
+                        trans_b=False,
+                    )
+                    if bias_bank is not None:
+                        outputs = outputs + torch.repeat_interleave(
+                            bias_bank,
+                            repeat_sizes,
+                            dim=0,
+                        ).to(outputs.dtype)
+                    return outputs
+
+            if inputs.is_cuda and hasattr(torch, "_grouped_mm"):
+                try:
+                    outputs = torch._grouped_mm(inputs, weight_t, offs=offsets)
+                    if bias_bank is not None:
+                        expanded = torch.repeat_interleave(
+                            bias_bank,
+                            repeat_sizes,
+                            dim=0,
+                        ).to(outputs.dtype)
+                        outputs = outputs + expanded
+                    return outputs
+                except (RuntimeError, NotImplementedError) as exc:
+                    if isinstance(exc, RuntimeError) and "grouped gemm is not supported" not in str(exc).lower():
+                        raise
+                    mb_backend = _load_megablocks_backend()
+                    if (
+                        mb_backend is not None
+                        and inputs.is_cuda
+                        and inputs.dtype == torch.bfloat16
+                        and weight_t.dtype == torch.bfloat16
+                    ):
+                        outputs = mb_backend.gmm(
+                            inputs,
+                            weight_t,
+                            batch_sizes_cpu,
+                            trans_b=False,
+                        )
+                        if bias_bank is not None:
+                            outputs = outputs + torch.repeat_interleave(
+                                bias_bank,
+                                repeat_sizes,
+                                dim=0,
+                            ).to(outputs.dtype)
+                        return outputs
+                    if not self._warned_grouped_mm_fallback:
+                        LOG.warning(
+                            "torch._grouped_mm unavailable on this backend (%s); falling back to per-expert matmuls.",
+                            exc,
+                        )
+                        self._warned_grouped_mm_fallback = True
+
+            return _fallback_linear(inputs, weight_bank, bias_bank)
+
+        gate_out = _run_linear(expert_inputs, gate_active, gate_bias_active)
+        up_out = _run_linear(expert_inputs, up_active, up_bias_active)
+
+        activated = self.act_fn(gate_out).to(up_out.dtype)
+        activated = activated * up_out
+
+        combined = _run_linear(activated, down_active, down_bias_active)
+
+        inverse_perm = torch.empty_like(sort_perm)
+        inverse_perm.index_copy_(
+            0,
+            sort_perm,
+            torch.arange(
+                sort_perm.size(0),
+                device=sort_perm.device,
+                dtype=sort_perm.dtype,
+            ),
+        )
+        unsorted_outputs = combined.index_select(0, inverse_perm)
+        weighted = unsorted_outputs.to(hidden_states.dtype) * flat_weight.unsqueeze(-1)
+
+        output_flat = hidden_states.new_zeros((num_tokens, hidden))
+        scatter_index = dispatch_indices.unsqueeze(-1).expand_as(weighted)
+        output_flat.scatter_add_(0, scatter_index, weighted)
+
+        return output_flat.view(bsz, seq_len, hidden)
+
+
+def _grouped_moe(self, hidden_states: torch.Tensor, topk_idx: torch.Tensor, topk_weight: torch.Tensor):
+    hidden_rank = hidden_states.dim()
+    if hidden_rank == 2:
+        reshaped = hidden_states.view(1, hidden_states.size(0), hidden_states.size(1))
+    elif hidden_rank == 3:
+        reshaped = hidden_states
+    else:
+        raise ValueError(f"Unexpected hidden_states rank {hidden_rank} for GLM4 MoE grouped kernel.")
+
+    expert_out = self.experts(reshaped, topk_idx, topk_weight)
+    return expert_out.view(-1, expert_out.size(-1))
+
+
+def patch_glm4_moe_grouped_experts(model: nn.Module, mlp_impl: str = "grouped") -> int:
+    """Convert Glm4MoeMoE modules to grouped expert implementations."""
+    if mlp_impl not in {"grouped", "megablocks"}:
+        raise ValueError(f"Unsupported mlp_impl={mlp_impl} for GLM4 grouped experts.")
+
+    if mlp_impl == "grouped" and not hasattr(torch, "_grouped_mm"):
+        raise RuntimeError(
+            "torch._grouped_mm is required for grouped MoE kernels but is unavailable in this torch build."
+        )
+
+    try:
+        from transformers.models.glm4_moe.modeling_glm4_moe import Glm4MoeMoE
+    except ImportError:
+        LOG.warning("transformers.models.glm4_moe not available; skipping grouped patch.")
+        return 0
+
+    patched = 0
+    for module in model.modules():
+        if not isinstance(module, Glm4MoeMoE):
+            continue
+        if getattr(module, "_axolotl_grouped_moe", False):
+            patched += 1
+            continue
+
+        old_experts = module.experts
+        try:
+            grouped = Glm4MoeGroupedExperts(module.config, old_experts, backend_impl=mlp_impl)
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            LOG.warning("Failed to convert GLM4 MoE block to grouped experts: %s", exc)
+            continue
+
+        module.experts = grouped
+        module.moe = MethodType(_grouped_moe, module)
+        module._axolotl_grouped_moe = True
+        module._axolotl_mlp_impl = mlp_impl
+        patched += 1
+
+    return patched

--- a/src/axolotl/monkeypatch/models/qwen3_moe/__init__.py
+++ b/src/axolotl/monkeypatch/models/qwen3_moe/__init__.py
@@ -1,0 +1,5 @@
+"""Grouped MoE monkeypatches for Qwen3 MoE architectures."""
+
+from .modeling import patch_qwen3_moe_grouped_experts
+
+__all__ = ["patch_qwen3_moe_grouped_experts"]

--- a/src/axolotl/monkeypatch/models/qwen3_moe/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_moe/modeling.py
@@ -169,7 +169,12 @@ class Qwen3MoeGroupedExperts(nn.Module):
             outputs: list[torch.Tensor] = []
             start_idx = 0
             bias_iter = bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
-            for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+            for count, weight, bias in zip(
+                repeat_sizes.tolist(),
+                weight_bank,
+                bias_iter,
+                strict=True,
+            ):
                 if count == 0:
                     continue
                 end_idx = start_idx + count

--- a/src/axolotl/monkeypatch/models/qwen3_moe/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_moe/modeling.py
@@ -1,0 +1,253 @@
+"""Grouped MoE kernels for Qwen3 MoE architectures."""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from axolotl.monkeypatch.models.utils import clone_expert_parameter
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+class Qwen3MoeGroupedExperts(nn.Module):
+    """Vectorised grouped expert MLP for Qwen3 MoE blocks."""
+
+    def __init__(self, block: nn.Module, experts: Iterable[nn.Module]):
+        super().__init__()
+        experts = list(experts)
+        if not experts:
+            raise ValueError("Expected at least one expert module to convert.")
+
+        self.num_experts = getattr(block, "num_experts", len(experts))
+        top_k = getattr(block, "top_k", None)
+        if top_k is None:
+            top_k = getattr(block, "num_experts_per_tok", None)
+        self.top_k = top_k
+        hidden_size = getattr(block.gate, "in_features", None)
+        if hidden_size is None:
+            hidden_size = getattr(experts[0].gate_proj, "in_features", None)
+        self.hidden_size = hidden_size
+        self.intermediate_size = getattr(experts[0].gate_proj, "out_features", None)
+
+        if len(experts) != self.num_experts:
+            raise ValueError(
+                f"Config expects {self.num_experts} experts, but received {len(experts)}."
+            )
+
+        device = experts[0].gate_proj.weight.device
+        dtype = experts[0].gate_proj.weight.dtype
+
+        gate_dims = tuple(getattr(experts[0].gate_proj.weight, "ds_shape", experts[0].gate_proj.weight.shape))
+        up_dims = tuple(getattr(experts[0].up_proj.weight, "ds_shape", experts[0].up_proj.weight.shape))
+        down_dims = tuple(getattr(experts[0].down_proj.weight, "ds_shape", experts[0].down_proj.weight.shape))
+
+        gate_weights: list[torch.Tensor] = []
+        up_weights: list[torch.Tensor] = []
+        down_weights: list[torch.Tensor] = []
+
+        gate_bias = experts[0].gate_proj.bias
+        up_bias = experts[0].up_proj.bias
+        down_bias = experts[0].down_proj.bias
+
+        for idx, expert in enumerate(experts):
+            if expert.gate_proj.weight.numel() == 0:
+                LOG.warning(
+                    "Encountered expert %s with empty gate weight during Qwen3 grouped conversion; shape: %s, dtype: %s",
+                    idx,
+                    tuple(expert.gate_proj.weight.shape),
+                    expert.gate_proj.weight.dtype,
+                )
+            gate_weights.append(clone_expert_parameter(expert.gate_proj.weight))
+            up_weights.append(clone_expert_parameter(expert.up_proj.weight))
+            down_weights.append(clone_expert_parameter(expert.down_proj.weight))
+
+        gate_stack = torch.stack(gate_weights, dim=0).to(device=device, dtype=dtype)
+        up_stack = torch.stack(up_weights, dim=0).to(device=device, dtype=dtype)
+        down_stack = torch.stack(down_weights, dim=0).to(device=device, dtype=dtype)
+
+        if gate_stack.numel() == 0 and all(dim > 0 for dim in gate_dims):
+            gate_stack = torch.zeros((self.num_experts,) + gate_dims, device=device, dtype=dtype)
+        if up_stack.numel() == 0 and all(dim > 0 for dim in up_dims):
+            up_stack = torch.zeros((self.num_experts,) + up_dims, device=device, dtype=dtype)
+        if down_stack.numel() == 0 and all(dim > 0 for dim in down_dims):
+            down_stack = torch.zeros((self.num_experts,) + down_dims, device=device, dtype=dtype)
+
+        self.gate_weight = nn.Parameter(gate_stack)
+        self.up_weight = nn.Parameter(up_stack)
+        self.down_weight = nn.Parameter(down_stack)
+
+        if gate_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.gate_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=gate_bias.dtype)
+            self.gate_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("gate_bias", None)
+
+        if up_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.up_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=up_bias.dtype)
+            self.up_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("up_bias", None)
+
+        if down_bias is not None:
+            stacked = torch.stack(
+                [clone_expert_parameter(expert.down_proj.bias) for expert in experts],
+                dim=0,
+            ).to(device=device, dtype=down_bias.dtype)
+            self.down_bias = nn.Parameter(stacked)
+        else:
+            self.register_parameter("down_bias", None)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        routing_weights: torch.Tensor,
+        selected_experts: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz, seq_len, hidden = hidden_states.shape
+        hidden_flat = hidden_states.view(-1, hidden)
+        topk = selected_experts.shape[-1]
+
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        token_indices = torch.arange(hidden_flat.size(0), device=hidden_flat.device, dtype=torch.long)
+        token_indices = token_indices.repeat_interleave(topk)
+        expert_ids = selected_experts.reshape(-1)
+        routing_flat = routing_weights.reshape(-1)
+
+        active_counts = torch.bincount(expert_ids, minlength=self.num_experts)
+        active_expert_ids = torch.nonzero(active_counts, as_tuple=False).flatten()
+        if active_expert_ids.numel() == 0:
+            return hidden_states.new_zeros((bsz, seq_len, hidden))
+
+        counts = active_counts.index_select(0, active_expert_ids)
+        offsets = torch.cumsum(counts.to(dtype=torch.int32), dim=0, dtype=torch.int32).contiguous()
+
+        _, sort_perm = torch.sort(expert_ids)
+        sorted_tokens = token_indices.index_select(0, sort_perm)
+        expert_inputs = hidden_flat.index_select(0, sorted_tokens).to(self.gate_weight.dtype)
+        repeat_sizes = counts.to(torch.long)
+
+        gate_active = self.gate_weight.index_select(0, active_expert_ids)
+        up_active = self.up_weight.index_select(0, active_expert_ids)
+        down_active = self.down_weight.index_select(0, active_expert_ids)
+
+        gate_bias_active = (
+            self.gate_bias.index_select(0, active_expert_ids) if self.gate_bias is not None else None
+        )
+        up_bias_active = (
+            self.up_bias.index_select(0, active_expert_ids) if self.up_bias is not None else None
+        )
+        down_bias_active = (
+            self.down_bias.index_select(0, active_expert_ids) if self.down_bias is not None else None
+        )
+
+        def _run_linear(inputs: torch.Tensor, weight_bank: torch.Tensor, bias_bank: torch.Tensor | None) -> torch.Tensor:
+            weight_t = weight_bank.transpose(-2, -1).contiguous()
+            if inputs.is_cuda and hasattr(torch, "_grouped_mm"):
+                try:
+                    out = torch._grouped_mm(inputs, weight_t, offs=offsets)
+                    if bias_bank is not None:
+                        bias_active = bias_bank
+                        out = out + torch.repeat_interleave(bias_active, repeat_sizes, dim=0).to(out.dtype)
+                    return out
+                except (RuntimeError, NotImplementedError) as exc:
+                    if isinstance(exc, RuntimeError) and "grouped gemm is not supported" not in str(exc).lower():
+                        raise
+
+            outputs: list[torch.Tensor] = []
+            start_idx = 0
+            bias_iter = bias_bank if bias_bank is not None else [None] * weight_bank.size(0)
+            for count, weight, bias in zip(repeat_sizes.tolist(), weight_bank, bias_iter):
+                if count == 0:
+                    continue
+                end_idx = start_idx + count
+                chunk = inputs[start_idx:end_idx]
+                result = torch.matmul(chunk, weight.transpose(0, 1))
+                if bias is not None:
+                    result = result + bias
+                outputs.append(result)
+                start_idx = end_idx
+            if outputs:
+                return torch.cat(outputs, dim=0)
+            return inputs.new_empty((0, weight_bank.size(1)))
+
+        gate_out = _run_linear(expert_inputs, gate_active, gate_bias_active)
+        up_out = _run_linear(expert_inputs, up_active, up_bias_active)
+
+        activated = F.silu(gate_out).to(up_out.dtype) * up_out
+        down_out = _run_linear(activated, down_active, down_bias_active)
+
+        inverse_perm = torch.empty_like(sort_perm)
+        inverse_perm.index_copy_(
+            0,
+            sort_perm,
+            torch.arange(sort_perm.numel(), device=sort_perm.device, dtype=sort_perm.dtype),
+        )
+        unsorted = down_out.index_select(0, inverse_perm)
+        weighted = unsorted.to(hidden_states.dtype) * routing_flat.unsqueeze(-1)
+
+        output = hidden_states.new_zeros((hidden_flat.size(0), hidden))
+        scatter_index = token_indices.unsqueeze(-1).expand_as(weighted)
+        output.scatter_add_(0, scatter_index, weighted)
+
+        return output.view(bsz, seq_len, hidden)
+
+
+def _grouped_forward(self, hidden_states: torch.Tensor):
+    batch_size, seq_len, hidden = hidden_states.shape
+    hidden_flat = hidden_states.view(-1, hidden)
+    router_logits = self.gate(hidden_flat)
+
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+    if getattr(self, "norm_topk_prob", False):
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(hidden_states.dtype)
+
+    expert_out = self.experts(hidden_states, routing_weights, selected_experts)
+    return expert_out, router_logits
+
+
+def patch_qwen3_moe_grouped_experts(model: nn.Module, mlp_impl: str = "grouped") -> int:
+    """Convert Qwen3MoeSparseMoeBlock modules to grouped expert implementations."""
+    if mlp_impl != "grouped":
+        raise ValueError(f"Unsupported mlp_impl={mlp_impl} for Qwen3 grouped experts.")
+
+    try:
+        from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeSparseMoeBlock
+    except ImportError:
+        LOG.warning("transformers.models.qwen3_moe not available; skipping grouped patch.")
+        return 0
+
+    patched = 0
+    for module in model.modules():
+        if not isinstance(module, Qwen3MoeSparseMoeBlock):
+            continue
+        if getattr(module, "_axolotl_grouped_moe", False):
+            patched += 1
+            continue
+
+        try:
+            grouped = Qwen3MoeGroupedExperts(module, module.experts)
+        except Exception as exc:
+            LOG.warning("Failed to convert Qwen3 MoE block to grouped experts: %s", exc)
+            continue
+
+        module.experts = grouped
+        module.forward = MethodType(_grouped_forward, module)
+        module._axolotl_grouped_moe = True
+        module._axolotl_mlp_impl = mlp_impl
+        patched += 1
+    return patched

--- a/src/axolotl/monkeypatch/models/utils/__init__.py
+++ b/src/axolotl/monkeypatch/models/utils/__init__.py
@@ -1,0 +1,41 @@
+"""Utilities shared across grouped MoE monkeypatches."""
+
+from __future__ import annotations
+
+import torch
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def clone_expert_parameter(param: torch.Tensor) -> torch.Tensor:
+    """
+    Clone a potentially ZeRO-partitioned expert parameter.
+
+    Under ZeRO-3 the original tensor may reside on a meta device with ``numel == 0``
+    on non-owner ranks. When this happens we gather the full parameter before
+    cloning so downstream ``torch.stack`` calls see concrete storage. If gathering
+    fails for any reason we fall back to cloning the local view; later code is
+    expected to fill in zeros when needed.
+    """
+    ds_shape = getattr(param, "ds_shape", None)
+
+    if param.numel() == 0 and ds_shape is not None and isinstance(param, torch.nn.Parameter):
+        try:
+            from deepspeed import zero  # Lazy import to avoid hard dependency
+
+            with zero.GatheredParameters([param], modifier_rank=None):
+                return param.data.detach().clone()
+        except Exception:  # pragma: no cover - defensive path
+            summary = None
+            if hasattr(param, "ds_summary"):
+                try:
+                    summary = param.ds_summary()
+                except Exception:
+                    summary = None
+            LOG.debug("Failed to gather ZeRO-partitioned parameter %s", summary or "<unnamed>", exc_info=True)
+            return param.detach().clone()
+
+    return param.detach().clone()
+

--- a/src/axolotl/monkeypatch/multipack.py
+++ b/src/axolotl/monkeypatch/multipack.py
@@ -37,6 +37,7 @@ SUPPORTED_MULTIPACK_MODEL_TYPES = [
     "deepseek_v3",
     "glm",
     "glm4",
+    "glm4_moe",
     "smollm3",
     "granite",
     "granitemoe",

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -742,6 +742,18 @@ class AxolotlInputConfig(
             "description": "Number of tensor parallel processes in TP group. Only supported with DeepSpeed AutoTP."
         },
     )
+    mlp_impl: Literal["vanilla", "grouped", "megablocks"] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Select expert MLP backend for MoE blocks. `grouped` enables torch._grouped_mm kernels, `megablocks` reserved for future dropless integration."
+        },
+    )
+    use_grouped_moe_kernels: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Backwards-compatible toggle for enabling grouped MoE kernels on supported architectures."
+        },
+    )
     special_tokens: SpecialTokensConfig | None = Field(
         default=None,
         json_schema_extra={

--- a/tests/e2e/test_glm4_moe_grouped.py
+++ b/tests/e2e/test_glm4_moe_grouped.py
@@ -1,0 +1,240 @@
+"""
+E2E comparison test for GLM4 MoE grouped kernels.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import random
+import shutil
+import tempfile
+import unittest
+from contextlib import nullcontext
+from functools import wraps
+
+import numpy as np
+import torch
+from datasets import Dataset
+
+from axolotl.common.datasets import TrainDatasetMeta
+from axolotl.train import train
+from axolotl.loaders import load_tokenizer
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+
+def with_temp_dir(test_func):
+    @wraps(test_func)
+    def wrapper(*args, **kwargs):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test_func(*args, temp_dir=temp_dir, **kwargs)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    return wrapper
+
+
+class TestGlm4MoeGrouped(unittest.TestCase):
+    """Ensure grouped kernels behave identically to vanilla GLM4 MoE."""
+
+    _BASE_CFG = {
+        "base_model": "tiny-random/glm-4-moe",
+        "tokenizer_config": "tiny-random/glm-4-moe",
+        "trust_remote_code": True,
+        "flash_attention": False,
+        "sequence_len": 256,
+        "bf16": False,
+        "fp16": False,
+        "val_set_size": 0.0,
+        "special_tokens": {},
+        "datasets": [
+            {
+                "path": "axolotl/tests/fixtures/alpaca/alpaca.json",
+                "type": "alpaca",
+            },
+        ],
+        "num_epochs": 1,
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "learning_rate": 1e-4,
+        "optimizer": "adamw_torch",
+        "lr_scheduler": "cosine",
+        "max_steps": 2,
+        "save_steps": 0,
+        "eval_steps": 0,
+        "save_first_step": False,
+        "logging_steps": 1,
+        "report_to": [],
+        "gradient_checkpointing": False,
+        "train_on_inputs": False,
+        "seed": 1234,
+        "skip_prepare_dataset": False,
+        "remove_unused_columns": False,
+        "dataset_num_proc": 1,
+    }
+
+    @staticmethod
+    def _set_seed(seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+
+    def _run_training(
+        self,
+        temp_dir: str,
+        mlp_impl: str,
+        *,
+        max_steps: int | None = None,
+        seed: int | None = None,
+    ) -> tuple[int, list[tuple[int, float]]]:
+        cfg_dict = copy.deepcopy(self._BASE_CFG)
+        cfg_dict["output_dir"] = os.path.join(temp_dir, mlp_impl)
+        cfg_dict["bf16"] = False
+        cfg_dict["fp16"] = False
+
+        if mlp_impl == "grouped":
+            cfg_dict["mlp_impl"] = "grouped"
+            cfg_dict["use_grouped_moe_kernels"] = True
+        elif mlp_impl == "megablocks":
+            cfg_dict["mlp_impl"] = "megablocks"
+            cfg_dict["use_grouped_moe_kernels"] = True
+            cfg_dict["bf16"] = True
+        else:
+            cfg_dict["use_grouped_moe_kernels"] = False
+            cfg_dict.pop("mlp_impl", None)
+
+        if max_steps is not None:
+            cfg_dict["max_steps"] = max_steps
+        if seed is not None:
+            cfg_dict["seed"] = seed
+
+        cache_dir = os.path.join(temp_dir, "hf-cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        prev_cache = os.environ.get("HF_DATASETS_CACHE")
+        os.environ["HF_DATASETS_CACHE"] = cache_dir
+
+        from datasets import config as datasets_config  # type: ignore
+
+        prev_cache_cfg = datasets_config.HF_DATASETS_CACHE
+        datasets_config.HF_DATASETS_CACHE = cache_dir
+
+        try:
+            cfg = DictDefault(cfg_dict)
+            cfg = validate_config(cfg)
+            normalize_config(cfg)
+            prepare_plugins(cfg)
+
+            tokenizer = load_tokenizer(cfg)
+            prompts = [
+                "Reverse the token order: Hello world",
+                "Summarize input: Axolotl enables fast fine-tuning.",
+            ]
+            encoded = tokenizer(
+                prompts,
+                padding=False,
+                return_attention_mask=True,
+                add_special_tokens=True,
+            )
+            dataset_dict = {
+                "input_ids": encoded["input_ids"],
+                "attention_mask": encoded["attention_mask"],
+                "labels": [ids[:] for ids in encoded["input_ids"]],
+            }
+            train_dataset = Dataset.from_dict(dataset_dict)
+            dataset_meta = TrainDatasetMeta(train_dataset=train_dataset)
+
+            self._set_seed(int(cfg.seed or 0))
+
+            with nullcontext():
+                model, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        finally:
+            if prev_cache is None:
+                os.environ.pop("HF_DATASETS_CACHE", None)
+            else:
+                os.environ["HF_DATASETS_CACHE"] = prev_cache
+            datasets_config.HF_DATASETS_CACHE = prev_cache_cfg
+
+        patched_count = sum(
+            1 for module in model.modules() if getattr(module, "_axolotl_grouped_moe", False)
+        )
+        loss_entries: list[tuple[int, float]] = []
+        for entry in trainer.state.log_history:
+            if not isinstance(entry, dict) or "loss" not in entry:
+                continue
+            step = int(entry.get("step", len(loss_entries) + 1))
+            loss_entries.append((step, float(entry["loss"])))
+
+        self.assertGreater(len(loss_entries), 0, "Expected training loss history to be populated.")
+
+        if hasattr(trainer, "accelerator") and hasattr(trainer.accelerator, "free_memory"):
+            trainer.accelerator.free_memory()
+
+        del model, trainer
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        return patched_count, loss_entries
+
+    @with_temp_dir
+    def test_grouped_matches_vanilla_training(self, temp_dir: str):
+        vanilla_patched, vanilla_trace = self._run_training(temp_dir, mlp_impl="vanilla")
+        grouped_patched, grouped_trace = self._run_training(temp_dir, mlp_impl="grouped")
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(grouped_patched, 0, "Grouped run did not patch any MoE blocks.")
+        self.assertEqual(
+            len(vanilla_trace),
+            len(grouped_trace),
+            "Loss histories should have identical lengths.",
+        )
+
+        for (step_v, vanilla), (step_g, grouped) in zip(vanilla_trace, grouped_trace):
+            self.assertEqual(step_v, step_g, "Logged training steps should align between runs.")
+            self.assertAlmostEqual(
+                vanilla,
+                grouped,
+                delta=1e-4,
+                msg=f"Loss diverged at step {step_v}: vanilla={vanilla}, grouped={grouped}",
+            )
+
+    @with_temp_dir
+    def test_megablocks_matches_vanilla(self, temp_dir: str):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm device required for MegaBlocks parity test.")
+
+        try:
+            from axolotl.monkeypatch.models.bailing_moe_v2.modeling import (
+                _load_megablocks_backend,
+            )
+        except ImportError:
+            self.skipTest("MegaBlocks backend loader unavailable; skipping.")
+
+        if _load_megablocks_backend() is None:
+            self.skipTest("MegaBlocks backend not available; skipping parity test.")
+
+        vanilla_patched, vanilla_trace = self._run_training(temp_dir, mlp_impl="vanilla")
+        megablocks_patched, megablocks_trace = self._run_training(
+            temp_dir,
+            mlp_impl="megablocks",
+        )
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(megablocks_patched, 0, "MegaBlocks run did not patch any MoE blocks.")
+        self.assertEqual(
+            len(vanilla_trace),
+            len(megablocks_trace),
+            "Loss histories should have identical lengths.",
+        )
+
+        for (step_v, vanilla), (step_m, megablocks) in zip(vanilla_trace, megablocks_trace):
+            self.assertEqual(step_v, step_m, "Logged training steps should align between runs.")
+            self.assertAlmostEqual(
+                vanilla,
+                megablocks,
+                delta=1e-4,
+                msg=f"Loss diverged at step {step_v}: vanilla={vanilla}, megablocks={megablocks}",
+            )

--- a/tests/e2e/test_qwen3_moe_grouped.py
+++ b/tests/e2e/test_qwen3_moe_grouped.py
@@ -1,0 +1,177 @@
+"""
+E2E comparison test for Qwen3 MoE grouped kernels.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import random
+import shutil
+import tempfile
+import unittest
+from contextlib import nullcontext
+from functools import wraps
+
+import numpy as np
+import torch
+from datasets import Dataset
+
+from axolotl.common.datasets import TrainDatasetMeta
+from axolotl.loaders import load_tokenizer
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+
+def with_temp_dir(test_func):
+    @wraps(test_func)
+    def wrapper(*args, **kwargs):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test_func(*args, temp_dir=temp_dir, **kwargs)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    return wrapper
+
+
+class TestQwen3MoeGrouped(unittest.TestCase):
+    """Ensure grouped kernels behave identically to vanilla Qwen3 MoE."""
+
+    _BASE_CFG = {
+        "base_model": "tiny-random/qwen3-moe",
+        "tokenizer_config": "tiny-random/qwen3-moe",
+        "trust_remote_code": True,
+        "flash_attention": False,
+        "sequence_len": 256,
+        "bf16": False,
+        "fp16": False,
+        "val_set_size": 0.0,
+        "special_tokens": {},
+        "datasets": [
+            {
+                "path": "synthetic/qwen3-e2e",
+                "type": "alpaca",
+            },
+        ],
+        "num_epochs": 1,
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "learning_rate": 1e-4,
+        "optimizer": "adamw_torch",
+        "lr_scheduler": "cosine",
+        "max_steps": 2,
+        "save_steps": 0,
+        "eval_steps": 0,
+        "save_first_step": False,
+        "logging_steps": 1,
+        "report_to": [],
+        "gradient_checkpointing": False,
+        "train_on_inputs": False,
+        "seed": 9876,
+        "remove_unused_columns": False,
+        "dataset_num_proc": 1,
+    }
+
+    @staticmethod
+    def _set_seed(seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+
+    def _run_training(
+        self,
+        temp_dir: str,
+        mlp_impl: str,
+        *,
+        max_steps: int | None = None,
+        seed: int | None = None,
+    ) -> tuple[int, list[tuple[int, float]]]:
+        cfg_dict = copy.deepcopy(self._BASE_CFG)
+        cfg_dict["output_dir"] = os.path.join(temp_dir, mlp_impl)
+
+        if mlp_impl == "grouped":
+            cfg_dict["mlp_impl"] = "grouped"
+            cfg_dict["use_grouped_moe_kernels"] = True
+        else:
+            cfg_dict["use_grouped_moe_kernels"] = False
+            cfg_dict.pop("mlp_impl", None)
+
+        if max_steps is not None:
+            cfg_dict["max_steps"] = max_steps
+        if seed is not None:
+            cfg_dict["seed"] = seed
+
+        cfg = DictDefault(cfg_dict)
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+
+        tokenizer = load_tokenizer(cfg)
+        prompts = [
+            "Write a friendly greeting in one sentence.",
+            "Summarize the benefits of grouped MoE kernels in one sentence.",
+        ]
+        encoded = tokenizer(
+            prompts,
+            padding=False,
+            return_attention_mask=True,
+            add_special_tokens=True,
+        )
+        dataset_dict = {
+            "input_ids": encoded["input_ids"],
+            "attention_mask": encoded["attention_mask"],
+            "labels": [ids[:] for ids in encoded["input_ids"]],
+        }
+        dataset_meta = TrainDatasetMeta(train_dataset=Dataset.from_dict(dataset_dict))
+
+        self._set_seed(int(cfg.seed or 0))
+
+        with nullcontext():
+            model, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        patched_count = sum(
+            1 for module in model.modules() if getattr(module, "_axolotl_grouped_moe", False)
+        )
+        loss_entries: list[tuple[int, float]] = []
+        for entry in trainer.state.log_history:
+            if not isinstance(entry, dict) or "loss" not in entry:
+                continue
+            step = int(entry.get("step", len(loss_entries) + 1))
+            loss_entries.append((step, float(entry["loss"])))
+
+        self.assertGreater(len(loss_entries), 0, "Expected training loss history to be populated.")
+
+        if hasattr(trainer, "accelerator") and hasattr(trainer.accelerator, "free_memory"):
+            trainer.accelerator.free_memory()
+
+        del model, trainer
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        return patched_count, loss_entries
+
+    @with_temp_dir
+    def test_grouped_matches_vanilla_training(self, temp_dir: str):
+        vanilla_patched, vanilla_trace = self._run_training(temp_dir, mlp_impl="vanilla")
+        grouped_patched, grouped_trace = self._run_training(temp_dir, mlp_impl="grouped")
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(grouped_patched, 0, "Grouped run did not patch any MoE blocks.")
+        self.assertEqual(
+            len(vanilla_trace),
+            len(grouped_trace),
+            "Loss histories should have identical lengths.",
+        )
+
+        for (step_v, vanilla), (step_g, grouped) in zip(vanilla_trace, grouped_trace):
+            self.assertEqual(step_v, step_g, "Logged training steps should align between runs.")
+            self.assertAlmostEqual(
+                vanilla,
+                grouped,
+                delta=1e-4,
+                msg=f"Loss diverged at step {step_v}: vanilla={vanilla}, grouped={grouped}",
+            )

--- a/tests/e2e/test_ring_moe_grouped.py
+++ b/tests/e2e/test_ring_moe_grouped.py
@@ -1,0 +1,469 @@
+"""
+E2E comparison test for Ring 2.0 grouped MoE kernels.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import random
+import shutil
+import tempfile
+import unittest
+from contextlib import nullcontext
+from functools import wraps
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+
+def with_temp_dir(test_func):
+    @wraps(test_func)
+    def wrapper(*args, **kwargs):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test_func(*args, temp_dir=temp_dir, **kwargs)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    return wrapper
+
+
+class GatingStatsCollector:
+    """Monkeypatch grouped experts to record per-expert token counts each forward."""
+
+    def __init__(self) -> None:
+        self._orig_forward = None
+        self._per_step: list[torch.Tensor] = []
+
+    def __enter__(self) -> "GatingStatsCollector":
+        from axolotl.monkeypatch.models.bailing_moe_v2.modeling import BailingMoeV2GroupedExperts
+
+        orig_forward = BailingMoeV2GroupedExperts.forward
+
+        @wraps(orig_forward)  # type: ignore[arg-type]
+        def wrapped(
+            module: Any,
+            hidden_states: torch.Tensor,
+            topk_idx: torch.Tensor,
+            topk_weight: torch.Tensor,
+        ):
+            outputs = orig_forward(module, hidden_states, topk_idx, topk_weight)
+            with torch.no_grad():
+                counts = torch.bincount(
+                    topk_idx.reshape(-1).detach().to("cpu"),
+                    minlength=module.num_experts,
+                )
+                self._per_step.append(counts)
+            return outputs
+
+        self._orig_forward = orig_forward
+        BailingMoeV2GroupedExperts.forward = wrapped  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        from axolotl.monkeypatch.models.bailing_moe_v2.modeling import BailingMoeV2GroupedExperts
+
+        if self._orig_forward is not None:
+            BailingMoeV2GroupedExperts.forward = self._orig_forward  # type: ignore[assignment]
+
+    def summary(self) -> Optional[dict[str, Any]]:
+        if not self._per_step:
+            return None
+
+        stacked = torch.stack(self._per_step, dim=0).to(torch.float32)
+        total = stacked.sum(dim=0)
+        return {
+            "steps": stacked.size(0),
+            "per_step": [counts.tolist() for counts in self._per_step],
+            "total_per_expert": total.tolist(),
+            "mean_per_expert": stacked.mean(dim=0).tolist(),
+            "max_tokens": float(total.max().item()),
+            "min_tokens": float(total.min().item()),
+        }
+
+
+class TestRingMoeGrouped(unittest.TestCase):
+    """Ensure grouped torch._grouped_mm backend trains identically to vanilla loops."""
+
+    _BASE_CFG = {
+        "base_model": "yujiepan/ring-tiny-random",
+        "tokenizer_config": "yujiepan/ring-tiny-random",
+        "trust_remote_code": True,
+        "flash_attention": False,
+        "sequence_len": 512,
+        "bf16": True,
+        "fp16": False,
+        "val_set_size": 0.0,
+        "special_tokens": {},
+        "datasets": [
+            {
+                "path": "mhenrichsen/alpaca_2k_test",
+                "type": "alpaca",
+            },
+        ],
+        "num_epochs": 1,
+        "micro_batch_size": 2,
+        "gradient_accumulation_steps": 1,
+        "learning_rate": 1e-4,
+        "optimizer": "adamw_torch",
+        "lr_scheduler": "cosine",
+        "max_steps": 3,
+        "save_steps": 0,
+        "eval_steps": 0,
+        "save_first_step": False,
+        "logging_steps": 1,
+        "report_to": [],
+        "gradient_checkpointing": False,
+        "train_on_inputs": False,
+        "seed": 1234,
+    }
+
+    @staticmethod
+    def _set_seed(seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+
+    def _run_training(
+        self,
+        temp_dir: str,
+        mlp_impl: str,
+        *,
+        max_steps: int | None = None,
+        seed: int | None = None,
+        record_gating: bool = False,
+    ) -> tuple[int, list[tuple[int, float]], Optional[dict[str, Any]]]:
+        cfg_dict = copy.deepcopy(self._BASE_CFG)
+        cfg_dict["output_dir"] = os.path.join(temp_dir, mlp_impl)
+
+        cfg_dict["bf16"] = torch.cuda.is_available()
+        cfg_dict["fp16"] = False
+
+        if mlp_impl == "grouped":
+            cfg_dict["mlp_impl"] = "grouped"
+            cfg_dict["use_grouped_moe_kernels"] = True
+        elif mlp_impl == "megablocks":
+            cfg_dict["mlp_impl"] = "megablocks"
+            cfg_dict["use_grouped_moe_kernels"] = True
+            cfg_dict["bf16"] = True
+        else:
+            cfg_dict["use_grouped_moe_kernels"] = False
+            cfg_dict.pop("mlp_impl", None)
+
+        if max_steps is not None:
+            cfg_dict["max_steps"] = max_steps
+        if seed is not None:
+            cfg_dict["seed"] = seed
+
+        cfg = DictDefault(cfg_dict)
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        prepare_plugins(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        self._set_seed(int(cfg.seed or 0))
+
+        capture_gating = record_gating or os.environ.get("MEGABLOCKS_CAPTURE_GATING") == "1"
+        gating_collector: Optional[GatingStatsCollector] = GatingStatsCollector() if capture_gating else None
+
+        context_manager = gating_collector if gating_collector is not None else nullcontext()
+        with context_manager:
+            model, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+
+        patched_count = sum(
+            1 for module in model.modules() if getattr(module, "_axolotl_grouped_moe", False)
+        )
+        loss_entries: list[tuple[int, float]] = []
+        for entry in trainer.state.log_history:
+            if not isinstance(entry, dict) or "loss" not in entry:
+                continue
+            step = int(entry.get("step", len(loss_entries) + 1))
+            loss_entries.append((step, float(entry["loss"])))
+
+        self.assertGreater(len(loss_entries), 0, "Expected training loss history to be populated.")
+
+        if hasattr(trainer, "accelerator") and hasattr(trainer.accelerator, "free_memory"):
+            trainer.accelerator.free_memory()
+
+        del model, trainer
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        gating_summary = gating_collector.summary() if gating_collector is not None else None
+        return patched_count, loss_entries, gating_summary
+
+    @with_temp_dir
+    def test_grouped_matches_vanilla_training(self, temp_dir: str):
+        vanilla_patched, vanilla_trace, _ = self._run_training(temp_dir, mlp_impl="vanilla")
+        grouped_patched, grouped_trace, _ = self._run_training(temp_dir, mlp_impl="grouped")
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(grouped_patched, 0, "Grouped run did not patch any MoE blocks.")
+        self.assertEqual(
+            len(vanilla_trace),
+            len(grouped_trace),
+            "Loss histories should have identical lengths.",
+        )
+
+        for (step_v, vanilla), (step_g, grouped) in zip(vanilla_trace, grouped_trace):
+            self.assertEqual(step_v, step_g, "Logged training steps should align between runs.")
+            self.assertAlmostEqual(
+                vanilla,
+                grouped,
+                delta=1e-4,
+                msg=f"Loss diverged at step {step_v}: vanilla={vanilla}, grouped={grouped}",
+            )
+
+    @with_temp_dir
+    def test_megablocks_matches_vanilla(self, temp_dir: str):
+        from axolotl.monkeypatch.models.bailing_moe_v2.modeling import _load_megablocks_backend
+
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm device required for MegaBlocks parity test.")
+
+        if _load_megablocks_backend() is None:
+            self.skipTest("MegaBlocks backend not available; skipping parity test.")
+
+        vanilla_patched, vanilla_trace, _ = self._run_training(temp_dir, mlp_impl="vanilla")
+        megablocks_patched, megablocks_trace, _ = self._run_training(temp_dir, mlp_impl="megablocks")
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(megablocks_patched, 0, "MegaBlocks run did not patch any MoE blocks.")
+        self.assertEqual(
+            len(vanilla_trace),
+            len(megablocks_trace),
+            "Loss histories should have identical lengths.",
+        )
+
+        for (step_v, vanilla), (step_m, megablocks) in zip(vanilla_trace, megablocks_trace):
+            self.assertEqual(step_v, step_m, "Logged training steps should align between runs.")
+            self.assertAlmostEqual(
+                vanilla,
+                megablocks,
+                delta=1e-4,
+                msg=f"MegaBlocks loss diverged at step {step_v}: vanilla={vanilla}, megablocks={megablocks}",
+            )
+
+    @with_temp_dir
+    def test_megablocks_longer_run(self, temp_dir: str):
+        if os.environ.get("RUN_SLOW_MEGABLOCKS_PARITY") != "1":
+            self.skipTest("Set RUN_SLOW_MEGABLOCKS_PARITY=1 to enable slower parity test.")
+
+        from axolotl.monkeypatch.models.bailing_moe_v2.modeling import _load_megablocks_backend
+
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm device required for MegaBlocks parity test.")
+
+        backend = _load_megablocks_backend()
+        if backend is None:
+            self.skipTest("MegaBlocks backend not available; skipping parity test.")
+
+        steps = int(os.environ.get("MEGABLOCKS_PARITY_STEPS", "50"))
+        seed = int(os.environ.get("MEGABLOCKS_PARITY_SEED", "1337"))
+
+        capture_gating = os.environ.get("MEGABLOCKS_CAPTURE_GATING") == "1"
+
+        vanilla_patched, vanilla_trace, vanilla_gating = self._run_training(
+            temp_dir,
+            mlp_impl="vanilla",
+            max_steps=steps,
+            seed=seed,
+            record_gating=capture_gating,
+        )
+        megablocks_patched, megablocks_trace, megablocks_gating = self._run_training(
+            temp_dir,
+            mlp_impl="megablocks",
+            max_steps=steps,
+            seed=seed,
+            record_gating=capture_gating,
+        )
+
+        self.assertEqual(vanilla_patched, 0, "Vanilla run should not apply grouped kernels.")
+        self.assertGreater(megablocks_patched, 0, "MegaBlocks run did not patch any MoE blocks.")
+
+        self.assertEqual(len(vanilla_trace), len(megablocks_trace))
+
+        trace_out = Path(temp_dir) / "megablocks_parity_trace.json"
+        trace_data = []
+        for (step_v, vanilla), (step_m, megablocks) in zip(vanilla_trace, megablocks_trace):
+            self.assertEqual(step_v, step_m, "Logged training steps should align between runs.")
+            trace_data.append(
+                {
+                    "step": step_v,
+                    "vanilla_loss": vanilla,
+                    "megablocks_loss": megablocks,
+                    "delta": abs(vanilla - megablocks),
+                }
+            )
+
+        payload: dict[str, Any] = {"loss_trace": trace_data}
+        if capture_gating:
+            payload["gating"] = {
+                "vanilla": vanilla_gating,
+                "megablocks": megablocks_gating,
+            }
+        trace_out.write_text(json.dumps(payload, indent=2))
+
+        final_vanilla = vanilla_trace[-1][1]
+        final_megablocks = megablocks_trace[-1][1]
+        delta = abs(final_vanilla - final_megablocks)
+        self.assertLess(
+            delta,
+            0.05,
+            f"MegaBlocks final loss deviates too much (vanilla={final_vanilla:.4f}, megablocks={final_megablocks:.4f})",
+        )
+
+    def test_megablocks_gradient_parity(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm device required for MegaBlocks gradient parity test.")
+
+        from axolotl.monkeypatch.models.bailing_moe_v2.modeling import (
+            BailingMoeV2GroupedExperts,
+            _load_megablocks_backend,
+        )
+
+        backend = _load_megablocks_backend()
+        if backend is None:
+            self.skipTest("MegaBlocks backend not available; skipping gradient parity test.")
+
+        device = torch.device("cuda")
+        torch.manual_seed(1337)
+
+        hidden_size = 32
+        intermediate_size = 48
+        num_experts = 16
+        top_k = 2
+        batch = 2
+        seq = 8
+
+        config = SimpleNamespace(
+            hidden_size=hidden_size,
+            moe_intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            hidden_act="silu",
+        )
+
+        class _TinyExpert(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=True)
+                self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=True)
+                self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=True)
+
+        base_experts: list[nn.Module] = []
+        for _ in range(num_experts):
+            expert = _TinyExpert()
+            expert.to(device=device, dtype=torch.bfloat16)
+            base_experts.append(expert)
+
+        loop_mod = BailingMoeV2GroupedExperts(config, base_experts, backend_impl="grouped").to(device)
+        megablocks_mod = BailingMoeV2GroupedExperts(config, base_experts, backend_impl="megablocks").to(device)
+
+        hidden_seed = torch.randn(batch, seq, hidden_size, device=device, dtype=torch.bfloat16)
+
+        token_slots = batch * seq * top_k
+        idx_values = torch.arange(token_slots, device=device, dtype=torch.long) % num_experts
+        topk_idx = idx_values.view(batch * seq, top_k)
+        topk_weight = torch.full((batch * seq, top_k), 1.0 / top_k, device=device, dtype=torch.bfloat16)
+
+        def python_loop_forward(
+            module: BailingMoeV2GroupedExperts,
+            hidden_states: torch.Tensor,
+            expert_idx: torch.Tensor,
+            expert_weight: torch.Tensor,
+        ) -> torch.Tensor:
+            bsz, seq_len, hidden = hidden_states.shape
+            hidden_flat = hidden_states.view(-1, hidden)
+            num_tokens = hidden_flat.size(0)
+            topk = expert_idx.shape[-1]
+            dispatch_indices = torch.arange(num_tokens, device=hidden_states.device, dtype=torch.long)
+            dispatch_indices = dispatch_indices.repeat_interleave(topk)
+            flat_expert = expert_idx.reshape(-1)
+            flat_weight = expert_weight.reshape(-1).to(hidden_states.dtype)
+
+            output_flat = hidden_states.new_zeros((num_tokens, hidden))
+            for expert_id in range(module.num_experts):
+                mask = flat_expert == expert_id
+                if not torch.any(mask):
+                    continue
+                token_idx = dispatch_indices[mask]
+                tokens = hidden_flat.index_select(0, token_idx).float()
+
+                gate = torch.nn.functional.linear(
+                    tokens,
+                    module.gate_weight[expert_id].float(),
+                    module.gate_bias[expert_id].float() if module.gate_bias is not None else None,
+                )
+                up = torch.nn.functional.linear(
+                    tokens,
+                    module.up_weight[expert_id].float(),
+                    module.up_bias[expert_id].float() if module.up_bias is not None else None,
+                )
+                activated = module.act_fn(gate).to(up.dtype)
+                activated = activated * up
+                down = torch.nn.functional.linear(
+                    activated,
+                    module.down_weight[expert_id].float(),
+                    module.down_bias[expert_id].float() if module.down_bias is not None else None,
+                )
+                weighted = down.to(hidden_states.dtype) * flat_weight[mask].unsqueeze(-1)
+                output_flat.index_add_(0, token_idx, weighted)
+
+            return output_flat.view(bsz, seq_len, hidden)
+
+        hidden_loop = hidden_seed.clone().detach().to(torch.float32).requires_grad_(True)
+        hidden_megablocks = hidden_seed.clone().detach().requires_grad_(True)
+
+        loop_out = python_loop_forward(loop_mod, hidden_loop, topk_idx, topk_weight.to(torch.float32))
+        loss_loop = loop_out.float().pow(2).mean()
+        loss_loop.backward()
+
+        out_megablocks = megablocks_mod(hidden_megablocks, topk_idx, topk_weight)
+        loss_megablocks = out_megablocks.float().pow(2).mean()
+        loss_megablocks.backward()
+
+        self.assertIsNotNone(hidden_loop.grad)
+        self.assertIsNotNone(hidden_megablocks.grad)
+
+        input_grad_diff = torch.max(
+            torch.abs(hidden_loop.grad.float() - hidden_megablocks.grad.float())
+        ).item()
+        self.assertLess(
+            input_grad_diff,
+            5e-3,
+            f"Input gradients diverged: max_abs_diff={input_grad_diff:.4e}",
+        )
+
+        loop_params = dict(loop_mod.named_parameters())
+        mega_params = dict(megablocks_mod.named_parameters())
+        self.assertEqual(loop_params.keys(), mega_params.keys())
+
+        for name, loop_param in loop_params.items():
+            mega_param = mega_params[name]
+            self.assertIsNotNone(loop_param.grad)
+            self.assertIsNotNone(mega_param.grad)
+            grad_loop = loop_param.grad.float()
+            grad_mega = mega_param.grad.float()
+            max_diff = torch.max(torch.abs(grad_loop - grad_mega)).item()
+            self.assertLess(
+                max_diff,
+                5e-3,
+                f"Gradient mismatch for {name}: max_abs_diff={max_diff:.4e}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_ring_moe_grouped.py
+++ b/tests/e2e/test_ring_moe_grouped.py
@@ -16,7 +16,7 @@ from contextlib import nullcontext
 from functools import wraps
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 import torch
@@ -40,11 +40,22 @@ def with_temp_dir(test_func):
     return wrapper
 
 
+ForwardFn = Callable[
+    [
+        Any,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    torch.Tensor,
+]
+
+
 class GatingStatsCollector:
     """Monkeypatch grouped experts to record per-expert token counts each forward."""
 
     def __init__(self) -> None:
-        self._orig_forward = None
+        self._orig_forward: Optional[ForwardFn] = None
         self._per_step: list[torch.Tensor] = []
 
     def __enter__(self) -> "GatingStatsCollector":

--- a/tests/e2e/test_ring_moe_grouped.py
+++ b/tests/e2e/test_ring_moe_grouped.py
@@ -9,7 +9,6 @@ import json
 import os
 import random
 import shutil
-os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
 import tempfile
 import unittest
 import importlib

--- a/tests/e2e/test_ring_moe_grouped.py
+++ b/tests/e2e/test_ring_moe_grouped.py
@@ -9,6 +9,7 @@ import json
 import os
 import random
 import shutil
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
 import tempfile
 import unittest
 import importlib
@@ -170,7 +171,7 @@ class TestRingMoeGrouped(unittest.TestCase):
             },
         ],
         "num_epochs": 1,
-        "micro_batch_size": 2,
+        "micro_batch_size": 1,
         "gradient_accumulation_steps": 1,
         "learning_rate": 1e-4,
         "optimizer": "adamw_torch",
@@ -209,7 +210,7 @@ class TestRingMoeGrouped(unittest.TestCase):
         cfg_dict = copy.deepcopy(self._BASE_CFG)
         cfg_dict["output_dir"] = os.path.join(temp_dir, mlp_impl)
 
-        cfg_dict["bf16"] = torch.cuda.is_available()
+        cfg_dict["bf16"] = False
         cfg_dict["fp16"] = False
 
         if mlp_impl == "grouped":

--- a/tests/unit/test_bailing_moe_grouped.py
+++ b/tests/unit/test_bailing_moe_grouped.py
@@ -1,0 +1,74 @@
+import torch
+import torch.nn as nn
+from types import SimpleNamespace
+
+from axolotl.monkeypatch.models.bailing_moe_v2.modeling import (
+    BailingMoeV2GroupedExperts,
+)
+
+
+class DummyExpert(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.moe_intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.moe_intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.moe_intermediate_size, config.hidden_size, bias=False
+        )
+        self.act_fn = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
+        return self.down_proj(hidden)
+
+
+def test_grouped_experts_matches_python_loop():
+    torch.manual_seed(0)
+
+    config = SimpleNamespace(
+        hidden_size=16,
+        moe_intermediate_size=32,
+        hidden_act="silu",
+        num_experts=4,
+        num_experts_per_tok=2,
+    )
+
+    experts = nn.ModuleList([DummyExpert(config) for _ in range(config.num_experts)])
+    grouped = BailingMoeV2GroupedExperts(config, experts, backend_impl="grouped")
+
+    batch, seq = 2, 3
+    hidden_states = torch.randn(batch, seq, config.hidden_size)
+
+    topk_idx = torch.stack(
+        [
+            torch.randperm(config.num_experts)[: config.num_experts_per_tok]
+            for _ in range(batch * seq)
+        ],
+        dim=0,
+    )
+    topk_weight = torch.rand(batch * seq, config.num_experts_per_tok)
+    topk_weight = topk_weight / topk_weight.sum(dim=-1, keepdim=True)
+    topk_weight = topk_weight.to(hidden_states.dtype)
+
+    # Baseline Python loop (mirrors original forward implementation)
+    hidden_flat = hidden_states.view(-1, config.hidden_size)
+    repeated_hidden = hidden_flat.repeat_interleave(config.num_experts_per_tok, dim=0)
+    flat_idx = topk_idx.view(-1)
+
+    loop_outputs = torch.zeros_like(repeated_hidden)
+    for expert_id, expert in enumerate(experts):
+        mask = flat_idx == expert_id
+        if mask.any():
+            loop_outputs[mask] = expert(repeated_hidden[mask])
+
+    loop_outputs = loop_outputs.view(-1, config.num_experts_per_tok, config.hidden_size)
+    weighted = loop_outputs * topk_weight.unsqueeze(-1)
+    loop_result = weighted.sum(dim=1).view(batch, seq, config.hidden_size)
+
+    grouped_result = grouped(hidden_states, topk_idx, topk_weight)
+
+    torch.testing.assert_close(grouped_result, loop_result, atol=1e-5, rtol=1e-5)

--- a/tests/unit/test_glm4_moe_grouped.py
+++ b/tests/unit/test_glm4_moe_grouped.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import copy
+import torch
+
+from axolotl.monkeypatch.models.glm4_moe.modeling import (
+    patch_glm4_moe_grouped_experts,
+)
+
+
+def _load_model():
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "tiny-random/glm-4-moe",
+        trust_remote_code=True,
+    )
+    model.eval()
+    return model
+
+
+def test_glm4_grouped_parity():
+    torch.manual_seed(123)
+    base_model = _load_model()
+    grouped_model = copy.deepcopy(base_model)
+
+    patched = patch_glm4_moe_grouped_experts(grouped_model, mlp_impl="grouped")
+    assert patched > 0
+
+    input_ids = torch.randint(
+        0,
+        base_model.config.vocab_size,
+        (2, 8),
+        dtype=torch.long,
+    )
+
+    with torch.no_grad():
+        vanilla_logits = base_model(input_ids=input_ids).logits
+        grouped_logits = grouped_model(input_ids=input_ids).logits
+
+    assert torch.allclose(
+        vanilla_logits,
+        grouped_logits,
+        atol=1e-5,
+        rtol=1e-5,
+    ), "Grouped MoE output deviates from vanilla GLM4 MoE"

--- a/tests/unit/test_qwen3_moe_grouped.py
+++ b/tests/unit/test_qwen3_moe_grouped.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import copy
+import torch
+
+from axolotl.monkeypatch.models.qwen3_moe.modeling import (
+    patch_qwen3_moe_grouped_experts,
+)
+
+
+def _load_model():
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "tiny-random/qwen3-moe", trust_remote_code=True
+    )
+    model.eval()
+    return model
+
+
+def test_qwen3_grouped_parity():
+    torch.manual_seed(42)
+    base_model = _load_model()
+    grouped_model = copy.deepcopy(base_model)
+
+    patched = patch_qwen3_moe_grouped_experts(grouped_model, mlp_impl="grouped")
+    assert patched > 0
+
+    input_ids = torch.randint(
+        0, base_model.config.vocab_size, (2, 4), dtype=torch.long
+    )
+
+    with torch.no_grad():
+        vanilla_logits = base_model(input_ids=input_ids).logits
+        grouped_logits = grouped_model(input_ids=input_ids).logits
+
+    assert torch.allclose(
+        vanilla_logits, grouped_logits, atol=1e-5, rtol=1e-5
+    ), "Grouped MoE output deviates from vanilla Qwen3 MoE"


### PR DESCRIPTION
Adds support for grouped MoE kernels that replaces HF Transformers mega slow expert loop using either Torch's grouped_mm or the TRL [kernels-community/megablocks](https://huggingface.co/kernels-community/megablocks) or my [shisa-ai/megablocks/hip](https://huggingface.co/shisa-ai/megablocks-hip) port.


Support for:
- Qwen3 MoE
- Bailing V2 (Ling/Ring 2.0)
- GLM4 

Can be easily extended. I only tested the first two but they work.

  - Adds monkeypatch modules that stack expert weights, run routing with torch._grouped_mm, and fall back to MegaBlocks HIP kernels or per-expert matmuls when the grouped op isn’t available
  - Multi-GPU/DeepSpeed friendly - shared helper (clone_expert_parameter) understands ZeRO-partitioned tensors so expert weights can be stacked even under ZeRO-3
  - This should work on NVIDIA or AMD (all tests on MI300X node)
  - Config schema grows mlp_impl/use_grouped_moe_kernels toggles; docs/AMD guide describe how to build/run the MegaBlocks HIP backend on MI300X.
  - Test coverage: unit tests for Bailing grouped MLP parity and Qwen3 grouped parity; a comprehensive Ring grouped-vs-vanilla parity suite (plus optional MegaBlocks long/grad runs) to ensure loss traces stay aligned; smoke tests for Qwen3/Ring training with grouped kernels.

  Testing

  - PYTHONPATH=src pytest tests/unit/test_bailing_moe_grouped.py
  - PYTHONPATH=src pytest tests/unit/test_qwen3_moe_grouped.py
  - PYTHONPATH=src pytest tests/e2e/test_ring_moe_grouped.py -k grouped_matches_vanilla
  - Full-model validation already done with Qwen3_MoE configs (grouped vs vanilla numerics match).

Numerics on runs on my tests match exactly, just faster:

<img width="3160" height="1660" alt="W B Chart 11_12_2025, 11_41_21 AM" src="https://github.com/user-attachments/assets/cbfcaf96-3b1d-4e2f-b0e5-2a634d51b132" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grouped MoE kernel support for faster training and inference on supported MoE architectures
  * New configuration options to select MoE backend implementations and enable grouped MoE kernels
  * MI300X optimization support with MegaBlocks grouped MoE

* **Documentation**
  * Added MI300X MegaBlocks grouped MoE configuration guide with validation examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->