### PR TITLE
New "muonclip" Muon implementation (FSDP/DSZ3 compatible, faster, slow Muon clip support)

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -276,8 +276,15 @@ class TrainerBuilderBase(abc.ABC):
             return self._muon_param_metadata, self._muon_param_summary
 
         muonclip_cfg = getattr(self.cfg, "muonclip", None)
-        if not isinstance(muonclip_cfg, MuonClipConfig):
+        if isinstance(muonclip_cfg, dict):
+            muonclip_cfg = MuonClipConfig.model_validate(muonclip_cfg)
+            setattr(self.cfg, "muonclip", muonclip_cfg)
+        elif muonclip_cfg is None:
             muonclip_cfg = MuonClipConfig()
+            setattr(self.cfg, "muonclip", muonclip_cfg)
+        elif not isinstance(muonclip_cfg, MuonClipConfig):
+            muonclip_cfg = MuonClipConfig.model_validate(muonclip_cfg)
+            setattr(self.cfg, "muonclip", muonclip_cfg)
 
         metadata, summary = tag_parameters_for_muon(self.model, muonclip_cfg)
         self._muon_param_metadata = metadata

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -28,6 +28,14 @@ from transformers import TrainerCallback
 from transformers.trainer_pt_utils import AcceleratorConfig
 
 from axolotl.integrations.base import PluginManager
+from axolotl.muonclip import (
+    MuonClipController,
+    MuonStateStore,
+    auto_register_llama_attention,
+    ensure_llama_attention_instrumentation,
+    ensure_qwen_attention_instrumentation,
+    tag_parameters_for_muon,
+)
 from axolotl.monkeypatch.trainer.lr import patch_trainer_get_lr
 from axolotl.utils import (
     is_comet_available,
@@ -39,9 +47,11 @@ from axolotl.utils.callbacks import (
     SaveAxolotlConfigtoWandBCallback,
     SaveModelOnFirstStepCallback,
 )
+from axolotl.utils.callbacks.muonclip import MuonClipCallback
 from axolotl.utils.callbacks.profiler import PytorchProfilerCallback
 from axolotl.utils.distributed import build_parallelism_config
 from axolotl.utils.schemas.enums import CustomSupportedOptimizers
+from axolotl.utils.schemas.muon import MuonClipConfig
 
 LOG = logging.getLogger(__name__)
 
@@ -62,6 +72,10 @@ class TrainerBuilderBase(abc.ABC):
         self._eval_dataset = None
         self._model_ref = None
         self._peft_config = None
+        self._muon_param_metadata = None
+        self._muon_param_summary = None
+        self._muon_state_store: MuonStateStore | None = None
+        self._muon_controller: MuonClipController | None = None
 
         # If the model supports tagging, add the axolotl tag.
         # This makes sure the tag is correctly pushed even if a user calls
@@ -155,6 +169,14 @@ class TrainerBuilderBase(abc.ABC):
                 )
             )
 
+        if (
+            self.cfg.optimizer == "muon"
+            and getattr(self.cfg, "muonclip", None)
+            and self.cfg.muonclip.enabled
+        ):
+            controller = self._get_muon_controller()
+            callbacks.append(MuonClipCallback(controller))
+
         return callbacks
 
     def get_post_trainer_create_callbacks(self, trainer):
@@ -245,6 +267,69 @@ class TrainerBuilderBase(abc.ABC):
             self.cfg.lr_scheduler_kwargs if self.cfg.lr_scheduler_kwargs else {}
         )
 
+    def _ensure_muon_param_tags(self):
+        """
+        Lazily tag model parameters with `use_muon` metadata so DeepSpeed/FSDP can split paths.
+        """
+
+        if self._muon_param_metadata is not None:
+            return self._muon_param_metadata, self._muon_param_summary
+
+        muonclip_cfg = getattr(self.cfg, "muonclip", None)
+        if not isinstance(muonclip_cfg, MuonClipConfig):
+            muonclip_cfg = MuonClipConfig()
+
+        metadata, summary = tag_parameters_for_muon(self.model, muonclip_cfg)
+        self._muon_param_metadata = metadata
+        self._muon_param_summary = summary
+        LOG.info(
+            "MuonClip tagging initialized: %s total params (%s muon / %s fallback)",
+            summary.total,
+            summary.muon,
+            summary.non_muon,
+        )
+        return metadata, summary
+
+    def _get_muon_state_store(self) -> MuonStateStore:
+        if self._muon_state_store is not None:
+            return self._muon_state_store
+
+        try:
+            example_param = next(self.model.parameters())
+        except StopIteration as exc:  # pragma: no cover - safety guard
+            raise RuntimeError("Model has no parameters to initialize Muon state") from exc
+
+        self._muon_state_store = MuonStateStore(
+            device=example_param.device,
+            dtype=example_param.dtype,
+        )
+        return self._muon_state_store
+
+    def _get_muon_controller(self) -> MuonClipController:
+        if self._muon_controller is not None:
+            return self._muon_controller
+
+        self._ensure_muon_param_tags()
+        controller = MuonClipController(
+            self.model,
+            self.cfg.muonclip,
+            state_store=self._get_muon_state_store(),
+            learning_rate=self.cfg.learning_rate or 1e-4,
+        )
+        if getattr(self.cfg.muonclip, "qk_clip", False):
+            ensure_llama_attention_instrumentation()
+            ensure_qwen_attention_instrumentation()
+            count = auto_register_llama_attention(self.model, controller)
+            if count == 0:
+                LOG.warning(
+                    "MuonClip QK-Clip enabled but no supported attention modules were found; "
+                    "logit clipping will be skipped."
+                )
+            else:
+                LOG.info("MuonClip registered %s attention modules for QK-Clip", count)
+        self._muon_controller = controller
+        return controller
+
     def _configure_optimizer(self, training_args_kwargs: dict, trainer_kwargs: dict):
         def _configure_custom_optimizer(
             training_args_kwargs: dict, trainer_kwargs: dict
@@ -268,11 +353,23 @@ class TrainerBuilderBase(abc.ABC):
                 adam_kwargs["eps"] = training_args_kwargs.get("adam_epsilon")
 
             if self.cfg.optimizer == "muon":
-                from axolotl.contribs.mit.muon import (
-                    MuonOptimizerFactory,
-                )
+                muonclip_cfg = getattr(self.cfg, "muonclip", None)
+                if isinstance(muonclip_cfg, dict):
+                    muonclip_cfg = MuonClipConfig(**muonclip_cfg)
+                    setattr(self.cfg, "muonclip", muonclip_cfg)
+                elif not isinstance(muonclip_cfg, MuonClipConfig):
+                    muonclip_cfg = MuonClipConfig()
+                    setattr(self.cfg, "muonclip", muonclip_cfg)
 
-                optimizer_cls = MuonOptimizerFactory
+                if not muonclip_cfg.enabled:
+                    raise ValueError(
+                        "optimizer: muon now always runs via MuonClip; set `muonclip.enabled: true` "
+                        "or remove the block to accept the default."
+                    )
+
+                self._ensure_muon_param_tags()
+                self._get_muon_controller()
+                optimizer_cls = torch.optim.AdamW
                 optimizer_kwargs.update(adam_kwargs)
             elif self.cfg.optimizer == "dion":
                 from axolotl.contribs.mit.dion import (

--- a/src/axolotl/muonclip/__init__.py
+++ b/src/axolotl/muonclip/__init__.py
@@ -1,0 +1,35 @@
+"""Helpers for MuonClip integration."""
+
+from .attention import (
+    auto_register_llama_attention,
+    register_attention_module,
+    record_attention_logits,
+)
+from .controller import MuonClipController, MuonClipContext
+from .hooks import (
+    ensure_llama_attention_instrumentation,
+    ensure_qwen_attention_instrumentation,
+)
+from .math import muon_orthogonal_update, newton_schulz_orthogonalize
+from .parameters import (
+    MuonParameterInfo,
+    ParameterTagSummary,
+    tag_parameters_for_muon,
+)
+from .state import MuonStateStore
+
+__all__ = [
+    "tag_parameters_for_muon",
+    "MuonParameterInfo",
+    "ParameterTagSummary",
+    "MuonStateStore",
+    "MuonClipController",
+    "MuonClipContext",
+    "register_attention_module",
+    "record_attention_logits",
+    "auto_register_llama_attention",
+    "ensure_llama_attention_instrumentation",
+    "ensure_qwen_attention_instrumentation",
+    "muon_orthogonal_update",
+    "newton_schulz_orthogonalize",
+]

--- a/src/axolotl/muonclip/attention.py
+++ b/src/axolotl/muonclip/attention.py
@@ -1,0 +1,122 @@
+"""Attention instrumentation utilities for MuonClip."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+if TYPE_CHECKING:  # pragma: no cover
+    from axolotl.muonclip.controller import MuonClipController
+
+BUFFER_NAME = "muonclip_max_logits"
+TRACKER_ATTR = "_muonclip_tracker"
+SUPPORTED_ATTENTION_CLASSES = {
+    "LlamaSdpaAttention",
+    "LlamaAttention",
+    "Qwen3Attention",
+}
+
+
+@dataclass
+class AttentionTracker:
+    name: str
+    num_heads: int
+    buffer_name: str = BUFFER_NAME
+    active: bool = True
+
+
+def register_attention_module(
+    module: nn.Module,
+    *,
+    name: str,
+    num_heads: int,
+    device: Optional[torch.device] = None,
+    buffer_name: str = BUFFER_NAME,
+) -> AttentionTracker:
+    """
+    Attach a per-head max-logit buffer to an attention module.
+
+    The module must call `record_attention_logits` with attention logits shaped
+    like (batch, num_heads, seq_len, seq_len).
+    """
+
+    if hasattr(module, TRACKER_ATTR):
+        tracker: AttentionTracker = getattr(module, TRACKER_ATTR)
+        return tracker
+
+    if device is None:
+        try:
+            device = next(module.parameters()).device
+        except StopIteration:  # pragma: no cover - edge case for headless modules
+            device = torch.device("cpu")
+
+    buffer = torch.zeros(num_heads, device=device)
+    module.register_buffer(buffer_name, buffer)
+    tracker = AttentionTracker(name=name, num_heads=num_heads, buffer_name=buffer_name)
+    setattr(module, TRACKER_ATTR, tracker)
+    return tracker
+
+
+def record_attention_logits(
+    module: nn.Module,
+    logits: torch.Tensor,
+    *,
+    buffer_name: str = BUFFER_NAME,
+) -> None:
+    """
+    Update the per-head max logit buffer using the provided attention logits tensor.
+
+    Args:
+        module: attention module previously instrumented via `register_attention_module`.
+        logits: tensor shaped (batch, num_heads, query_len, key_len) or (num_heads, seq, seq).
+    """
+
+    tracker: AttentionTracker | None = getattr(module, TRACKER_ATTR, None)
+    if tracker is None or not tracker.active:
+        return
+
+    buffer: torch.Tensor = getattr(module, buffer_name)
+    vals = logits.detach().float()
+    if vals.dim() == 4:
+        batch, heads, q_len, k_len = vals.shape
+        vals = vals.reshape(batch, heads, q_len * k_len)
+        max_per_head = vals.amax(dim=(0, 2))
+    elif vals.dim() == 3:
+        heads, q_len, k_len = vals.shape
+        vals = vals.reshape(1, heads, q_len * k_len)
+        max_per_head = vals.amax(dim=(0, 2))
+    elif vals.dim() == 2:
+        max_per_head = vals.amax(dim=0)
+    elif vals.dim() == 1:
+        max_per_head = vals
+    else:  # pragma: no cover - unexpected shape
+        raise ValueError(f"Unsupported logits shape for QK-Clip tracking: {vals.shape}")
+
+    buffer.copy_(torch.maximum(buffer, max_per_head.to(buffer.dtype)))
+
+
+def auto_register_llama_attention(
+    model: nn.Module,
+    controller: "MuonClipController",
+) -> int:
+    """
+    Automatically attach trackers to HuggingFace Llama attention modules.
+    """
+
+    registered = 0
+    for name, module in model.named_modules():
+        if module.__class__.__name__ not in SUPPORTED_ATTENTION_CLASSES:
+            continue
+        num_heads = (
+            getattr(module, "num_heads", None)
+            or getattr(module, "num_attention_heads", None)
+            or (getattr(module, "config", None) and getattr(module.config, "num_attention_heads", None))
+        )
+        if not num_heads:
+            continue
+        controller.register_attention(module, name=name, num_heads=int(num_heads))
+        registered += 1
+    return registered

--- a/src/axolotl/muonclip/controller.py
+++ b/src/axolotl/muonclip/controller.py
@@ -1,0 +1,144 @@
+"""MuonClip controller handling Muon orthogonalization and QK-Clip."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import torch
+import torch.nn as nn
+
+from axolotl.muonclip.attention import AttentionTracker, register_attention_module
+from axolotl.muonclip.math import muon_orthogonal_update
+from axolotl.muonclip.parameters import tag_parameters_for_muon
+from axolotl.muonclip.state import MuonStateStore
+from axolotl.muonclip.zero_utils import gather_full_param
+from axolotl.utils.logging import get_logger
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+LOG = get_logger(__name__)
+
+
+@dataclass
+class MuonClipContext:
+    """Holds model, config, and tagging metadata for the controller."""
+
+    model: nn.Module
+    config: MuonClipConfig
+    metadata: Mapping[str, object]
+    state_store: MuonStateStore
+
+
+class MuonClipController:
+    """Responsible for executing Muon orthogonalization and QK-Clip after optimizer.step()."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        config: MuonClipConfig,
+        *,
+        state_store: MuonStateStore | None = None,
+        learning_rate: float | None = None,
+    ):
+        self.model = model
+        self.config = config
+        metadata, _ = tag_parameters_for_muon(model, config)
+        self.metadata = metadata
+        ref_param = next(model.parameters())
+        self.state_store = state_store or MuonStateStore(
+            device=ref_param.device,
+            dtype=ref_param.dtype,
+        )
+        self.attention_trackers: dict[str, AttentionTracker] = {}
+        self.attention_modules: dict[str, nn.Module] = {}
+        self.learning_rate = learning_rate or 1e-4
+        self._steps = 0
+        self._qk_clip_active = bool(config.qk_clip)
+
+    def post_optimizer_step(self):
+        if not self.config.enabled:
+            return
+
+        self._steps += 1
+        self._apply_muon_updates()
+        if self._qk_clip_active and self.attention_trackers:
+            self._apply_qk_clip()
+            self._maybe_deactivate_qk_clip()
+
+    def register_attention(self, module: nn.Module, *, name: str, num_heads: int):
+        tracker = register_attention_module(module, name=name, num_heads=num_heads)
+        self.attention_trackers[name] = tracker
+        self.attention_modules[name] = module
+        return tracker
+
+    def _apply_muon_updates(self):
+        for name, param in self.model.named_parameters():
+            info = self.metadata.get(name)
+            if not info or not info.use_muon or param.grad is None:
+                continue
+
+            with gather_full_param(param):
+                state = self.state_store.get_or_create(param)
+                update = muon_orthogonal_update(
+                    param.grad.detach(),
+                    state.momentum,
+                    beta=self.config.momentum,
+                    ns_steps=self.config.ns_steps,
+                    rms_scale=self.config.rms_scale,
+                )
+                if self.config.weight_decay:
+                    param.data.mul_(1 - self.learning_rate * self.config.weight_decay)
+                param.data.add_(update, alpha=-self.learning_rate)
+
+    def _apply_qk_clip(self):
+        tau = self.config.qk_clip_tau
+        alpha = self.config.qk_clip_alpha
+        for name, tracker in self.attention_trackers.items():
+            if not tracker.active:
+                continue
+            module = self.attention_modules.get(name)
+            if module is None:
+                continue
+            buffer = getattr(module, tracker.buffer_name, None)
+            if buffer is None:
+                continue
+            max_logits = buffer.detach()
+            eta = (tau / max_logits.clamp(min=1e-6)).clamp(max=1.0)
+            if torch.allclose(eta, torch.ones_like(eta)):
+                buffer.zero_()
+                continue
+            if hasattr(module, "q_proj"):
+                with gather_full_param(module.q_proj.weight):
+                    self._scale_projection(module.q_proj.weight, eta, alpha)
+            if hasattr(module, "k_proj"):
+                with gather_full_param(module.k_proj.weight):
+                    self._scale_projection(module.k_proj.weight, eta, 1 - alpha)
+            buffer.zero_()
+
+    def _scale_projection(self, weight: torch.Tensor, eta: torch.Tensor, exponent: float):
+        if exponent == 0:
+            return
+        num_heads = eta.numel()
+        head_dim = weight.size(0) // num_heads
+        with torch.no_grad():
+            reshaped = weight.view(num_heads, head_dim, weight.size(1))
+            scale = eta.view(num_heads, 1, 1).pow(exponent)
+            reshaped.mul_(scale)
+
+    def _maybe_deactivate_qk_clip(self):
+        max_steps = self.config.qk_clip_max_steps
+        if not self._qk_clip_active or not max_steps:
+            return
+        if self._steps >= max_steps:
+            self._deactivate_qk_clip(reason=f"reached qk_clip_max_steps={max_steps}")
+
+    def _deactivate_qk_clip(self, *, reason: str | None = None):
+        if not self._qk_clip_active:
+            return
+        self._qk_clip_active = False
+        for tracker in self.attention_trackers.values():
+            tracker.active = False
+        if reason:
+            LOG.info("MuonClip QK-Clip deactivated (%s)", reason)
+        else:
+            LOG.info("MuonClip QK-Clip deactivated")

--- a/src/axolotl/muonclip/controller.py
+++ b/src/axolotl/muonclip/controller.py
@@ -44,10 +44,13 @@ class MuonClipController:
         self.config = config
         metadata, _ = tag_parameters_for_muon(model, config)
         self.metadata = metadata
-        ref_param = next(model.parameters())
+        try:
+            ref_param = next(model.parameters())
+        except StopIteration:  # pragma: no cover - models without parameters
+            ref_param = None
         self.state_store = state_store or MuonStateStore(
-            device=ref_param.device,
-            dtype=ref_param.dtype,
+            device=ref_param.device if ref_param else None,
+            dtype=ref_param.dtype if ref_param else None,
         )
         self.attention_trackers: dict[str, AttentionTracker] = {}
         self.attention_modules: dict[str, nn.Module] = {}

--- a/src/axolotl/muonclip/controller.py
+++ b/src/axolotl/muonclip/controller.py
@@ -91,6 +91,8 @@ class MuonClipController:
             for param in group.get("params", []):
                 if param is None:
                     continue
+                if getattr(param, "use_muon", False) and lr_value == 0:
+                    continue
                 lr_map[id(param)] = lr_value
         return lr_map or None
 

--- a/src/axolotl/muonclip/hooks.py
+++ b/src/axolotl/muonclip/hooks.py
@@ -1,0 +1,200 @@
+"""Monkeypatches for integrating MuonClip with HuggingFace attention modules."""
+
+from __future__ import annotations
+
+from functools import wraps
+
+import torch
+
+LLAMA_PATCH_FLAG = "_muonclip_llama_patched"
+QWEN_PATCH_FLAG = "_muonclip_qwen_patched"
+MAX_LOGIT_CHUNK = 512
+
+
+def _repeat_kv(hidden_states: torch.Tensor, num_key_value_groups: int) -> torch.Tensor:
+    """
+    Expand grouped key/value heads to match the number of query heads.
+    """
+
+    if num_key_value_groups == 1 or hidden_states.size(1) == 0:
+        return hidden_states
+
+    batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
+    expanded = hidden_states[:, :, None, :, :].expand(
+        batch,
+        num_kv_heads,
+        num_key_value_groups,
+        seq_len,
+        head_dim,
+    )
+    return expanded.reshape(batch, num_kv_heads * num_key_value_groups, seq_len, head_dim)
+
+
+def _headwise_max_logits(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    scaling: float,
+    *,
+    chunk_size: int = MAX_LOGIT_CHUNK,
+) -> torch.Tensor:
+    """
+    Compute per-head max logits without materializing the full attention matrix.
+    """
+
+    batch, num_heads, seq_len, _ = query_states.shape
+    key_transposed = key_states.transpose(-2, -1)
+    chunk = max(1, min(int(chunk_size), seq_len))
+    max_vals = torch.full(
+        (batch, num_heads),
+        float("-inf"),
+        dtype=torch.float32,
+        device=query_states.device,
+    )
+    for start in range(0, seq_len, chunk):
+        q_chunk = query_states[:, :, start : start + chunk, :]
+        logits = torch.matmul(q_chunk, key_transposed) * scaling
+        chunk_max = logits.amax(dim=(2, 3)).to(torch.float32)
+        max_vals = torch.maximum(max_vals, chunk_max)
+    return max_vals
+
+
+def ensure_llama_attention_instrumentation():
+    """Patch `LlamaAttention.forward` to record attention logits for MuonClip."""
+
+    try:
+        from transformers.models.llama.modeling_llama import (
+            LlamaAttention,
+            apply_rotary_pos_emb,
+        )
+    except ImportError:  # pragma: no cover - not available in minimal envs
+        return
+
+    if getattr(LlamaAttention, LLAMA_PATCH_FLAG, False):
+        return
+
+    original_forward = LlamaAttention.forward
+
+    @wraps(original_forward)
+    def wrapped(
+        self,
+        hidden_states,
+        position_embeddings,
+        attention_mask=None,
+        past_key_values=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        tracker = getattr(self, "_muonclip_tracker", None)
+        record_logits = (
+            tracker is not None
+            and getattr(tracker, "active", False)
+            and position_embeddings is not None
+            and past_key_values is None
+        )
+        logits = None
+        if record_logits:
+            logits = _compute_llama_logits(self, hidden_states, position_embeddings, apply_rotary_pos_emb)
+        outputs = original_forward(
+            self,
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        if record_logits and logits is not None:
+            from axolotl.muonclip.attention import record_attention_logits
+
+            record_attention_logits(self, logits)
+        return outputs
+
+    LlamaAttention.forward = wrapped
+    setattr(LlamaAttention, LLAMA_PATCH_FLAG, True)
+
+
+@torch.no_grad()
+def _compute_llama_logits(module, hidden_states, position_embeddings, rotary_fn):
+    head_dim = module.head_dim
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, head_dim)
+
+    query_states = module.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    key_states = module.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    cos, sin = position_embeddings
+    query_states, key_states = rotary_fn(query_states, key_states, cos, sin)
+    num_kv_groups = getattr(module, "num_key_value_groups", 1)
+    if key_states.size(1) != query_states.size(1):
+        key_states = _repeat_kv(key_states, num_kv_groups)
+    return _headwise_max_logits(query_states, key_states, module.scaling)
+
+
+def ensure_qwen_attention_instrumentation():
+    """Patch Qwen3 attention layers to record logits for MuonClip."""
+
+    try:  # pragma: no cover
+        from transformers.models.qwen3.modeling_qwen3 import (
+            Qwen3Attention,
+            apply_rotary_pos_emb as qwen_apply_rotary,
+        )
+    except ImportError:  # pragma: no cover
+        return
+
+    if getattr(Qwen3Attention, QWEN_PATCH_FLAG, False):
+        return
+
+    original_forward = Qwen3Attention.forward
+
+    @wraps(original_forward)
+    def wrapped(
+        self,
+        hidden_states,
+        position_embeddings,
+        attention_mask=None,
+        past_key_values=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        tracker = getattr(self, "_muonclip_tracker", None)
+        record_logits = (
+            tracker is not None
+            and getattr(tracker, "active", False)
+            and position_embeddings is not None
+            and past_key_values is None
+        )
+        logits = None
+        if record_logits:
+            logits = _compute_qwen_logits(self, hidden_states, position_embeddings, qwen_apply_rotary)
+        outputs = original_forward(
+            self,
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        if record_logits and logits is not None:
+            from axolotl.muonclip.attention import record_attention_logits
+
+            record_attention_logits(self, logits)
+        return outputs
+
+    Qwen3Attention.forward = wrapped
+    setattr(Qwen3Attention, QWEN_PATCH_FLAG, True)
+
+
+@torch.no_grad()
+def _compute_qwen_logits(module, hidden_states, position_embeddings, rotary_fn):
+    head_dim = module.head_dim
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, head_dim)
+
+    query_states = module.q_norm(module.q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+    key_states = module.k_norm(module.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+    cos, sin = position_embeddings
+    query_states, key_states = rotary_fn(query_states, key_states, cos, sin)
+    num_kv_groups = getattr(module, "num_key_value_groups", 1)
+    if key_states.size(1) != query_states.size(1):
+        key_states = _repeat_kv(key_states, num_kv_groups)
+    return _headwise_max_logits(query_states, key_states, module.scaling)

--- a/src/axolotl/muonclip/math.py
+++ b/src/axolotl/muonclip/math.py
@@ -1,0 +1,69 @@
+"""Muon math utilities (Newton–Schulz orthogonalization, updates)."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+NEWTON_A = 3.4445
+NEWTON_B = -4.7750
+NEWTON_C = 2.0315
+
+
+def newton_schulz_orthogonalize(
+    matrix: torch.Tensor,
+    *,
+    steps: int,
+    eps: float = 1e-7,
+) -> torch.Tensor:
+    """
+    Approximate the orthogonal factor of `matrix` using Newton–Schulz iterations.
+    """
+
+    if matrix.ndim != 2:
+        raise ValueError(f"Expected 2D tensor, got {matrix.shape}")
+
+    X = matrix.detach().float()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.transpose(-2, -1)
+
+    denom = X.norm(dim=(-2, -1), keepdim=True) + eps
+    X = X / denom
+
+    for _ in range(steps):
+        A = X @ X.transpose(-2, -1)
+        B = NEWTON_B * A + NEWTON_C * (A @ A)
+        X = NEWTON_A * X + B @ X
+
+    if transposed:
+        X = X.transpose(-2, -1)
+    return X.to(matrix.dtype)
+
+
+def muon_orthogonal_update(
+    grad: torch.Tensor,
+    momentum: torch.Tensor,
+    *,
+    beta: float,
+    ns_steps: int,
+    rms_scale: float | None = None,
+) -> torch.Tensor:
+    """
+    Compute the Muon orthogonalization update using the given gradient and momentum buffer.
+    """
+
+    momentum.lerp_(grad, 1 - beta)
+    update = grad.lerp(momentum, beta)
+
+    original_shape = update.shape
+    update_2d = update.view(update.shape[0], -1)
+    update_2d = newton_schulz_orthogonalize(update_2d, steps=ns_steps)
+
+    scale = rms_scale
+    if scale is None:
+        scale = math.sqrt(max(update_2d.size(0), update_2d.size(1)) * 0.4)
+    update_2d = update_2d * scale
+
+    return update_2d.view(original_shape)

--- a/src/axolotl/muonclip/parameters.py
+++ b/src/axolotl/muonclip/parameters.py
@@ -1,0 +1,123 @@
+"""Utilities for tagging parameters that should receive Muon updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Sequence
+
+import torch
+import torch.nn as nn
+
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+
+@dataclass(frozen=True)
+class MuonParameterInfo:
+    """Metadata describing how a parameter should be handled by MuonClip."""
+
+    name: str
+    shape: torch.Size
+    use_muon: bool
+    reason: str
+
+
+@dataclass
+class ParameterTagSummary:
+    """Aggregate counts for Muon vs non-Muon parameters."""
+
+    total: int = 0
+    muon: int = 0
+    non_muon: int = 0
+
+    def record(self, use_muon: bool) -> None:
+        self.total += 1
+        if use_muon:
+            self.muon += 1
+        else:
+            self.non_muon += 1
+
+
+def tag_parameters_for_muon(
+    module_or_named_params: nn.Module
+    | Iterable[tuple[str, nn.Parameter]],
+    config: MuonClipConfig,
+    *,
+    min_ndim: int = 2,
+) -> tuple[dict[str, MuonParameterInfo], ParameterTagSummary]:
+    """
+    Inspect parameters and set `param.use_muon` so DeepSpeed/FSDP can split optimizer paths.
+
+    Returns dictionaries keyed by parameter name plus a summary with aggregate counts.
+    """
+
+    named_params = _resolve_named_parameters(module_or_named_params)
+    metadata: dict[str, MuonParameterInfo] = {}
+    summary = ParameterTagSummary()
+
+    include_filters = config.apply_to or []
+    exclude_filters = config.exclude or []
+
+    for name, param in named_params:
+        use_muon, reason = _should_use_muon(
+            name,
+            param,
+            include_filters=include_filters,
+            exclude_filters=exclude_filters,
+            min_ndim=min_ndim,
+        )
+        setattr(param, "use_muon", use_muon)
+        info = MuonParameterInfo(
+            name=name,
+            shape=param.shape,
+            use_muon=use_muon,
+            reason=reason,
+        )
+        metadata[name] = info
+        summary.record(use_muon)
+
+    return metadata, summary
+
+
+def _resolve_named_parameters(
+    module_or_named_params: nn.Module
+    | Iterable[tuple[str, nn.Parameter]],
+) -> Iterator[tuple[str, nn.Parameter]]:
+    if isinstance(module_or_named_params, nn.Module):
+        return module_or_named_params.named_parameters()
+    return iter(module_or_named_params)
+
+
+def _matches_filter(name: str, filters: Sequence[str]) -> str | None:
+    for flt in filters:
+        if flt and flt in name:
+            return flt
+    return None
+
+
+def _should_use_muon(
+    name: str,
+    param: nn.Parameter,
+    *,
+    include_filters: Sequence[str],
+    exclude_filters: Sequence[str],
+    min_ndim: int,
+) -> tuple[bool, str]:
+    if not param.requires_grad:
+        return False, "requires_grad_false"
+
+    include_match = _matches_filter(name, include_filters)
+    exclude_match = _matches_filter(name, exclude_filters)
+
+    if include_match:
+        if param.ndim < min_ndim:
+            # Explicit opt-in but still warn through reason for logging.
+            return True, f"forced:{include_match}"
+        return True, f"include:{include_match}"
+
+    if exclude_match:
+        return False, f"exclude:{exclude_match}"
+
+    if param.ndim < min_ndim:
+        return False, f"ndim<{min_ndim}"
+
+    return True, "default"

--- a/src/axolotl/muonclip/state.py
+++ b/src/axolotl/muonclip/state.py
@@ -1,0 +1,99 @@
+"""State management helpers for MuonClip momentum/RMS buffers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import torch
+
+
+@dataclass
+class MuonParameterState:
+    """Holds momentum/RMS buffers for a single parameter."""
+
+    momentum: torch.Tensor
+    rms: Optional[torch.Tensor] = None
+
+
+class MuonStateStore:
+    """
+    Lightweight registry that tracks optimizer-style buffers per parameter.
+
+    Fallbacks to CPU when requested so unit tests can exercise logic without GPUs.
+    """
+
+    def __init__(
+        self,
+        *,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        pin_memory: bool = False,
+    ):
+        self.device = device
+        self.dtype = dtype
+        self.pin_memory = pin_memory
+        self._states: Dict[int, MuonParameterState] = {}
+
+    def get_or_create(
+        self,
+        param: torch.nn.Parameter,
+        *,
+        with_rms: bool = False,
+    ) -> MuonParameterState:
+        key = id(param)
+        if key in self._states:
+            state = self._states[key]
+            if with_rms and state.rms is None:
+                state.rms = self._allocate_like(param)
+            self._ensure_device(state, param)
+            return state
+
+        momentum = self._allocate_like(param)
+        rms = self._allocate_like(param) if with_rms else None
+        state = MuonParameterState(momentum=momentum, rms=rms)
+        self._states[key] = state
+        self._ensure_device(state, param)
+        return state
+
+    def _ensure_device(self, state: MuonParameterState, param: torch.nn.Parameter):
+        target_device = param.device
+        if state.momentum.device != target_device:
+            state.momentum = state.momentum.to(target_device)
+        if state.rms is not None and state.rms.device != target_device:
+            state.rms = state.rms.to(target_device)
+
+    def _allocate_like(self, param: torch.nn.Parameter) -> torch.Tensor:
+        data = param.data
+        device = self.device if self.device is not None else data.device
+        dtype = self.dtype if self.dtype is not None else data.dtype
+        buffer = torch.zeros_like(data, device=device, dtype=dtype)
+        if self.pin_memory and buffer.device.type == "cpu":
+            buffer = buffer.pin_memory()
+        return buffer
+
+    def state_dict(self) -> Dict[str, torch.Tensor]:
+        """
+        Serialize buffers into a dict keyed by tensor id - checkpoint integration will rehydrate.
+        """
+
+        result: Dict[str, torch.Tensor] = {}
+        for key, state in self._states.items():
+            result[f"{key}:momentum"] = state.momentum
+            if state.rms is not None:
+                result[f"{key}:rms"] = state.rms
+        return result
+
+    def load_state_dict(self, buffers: Dict[str, torch.Tensor]) -> None:
+        for key, tensor in buffers.items():
+            ptr_str, kind = key.split(":")
+            ptr = int(ptr_str)
+            state = self._states.get(ptr)
+            if state is None:
+                continue
+            if kind == "momentum":
+                state.momentum.copy_(tensor)
+            elif kind == "rms":
+                if state.rms is None:
+                    state.rms = torch.zeros_like(tensor)
+                state.rms.copy_(tensor)

--- a/src/axolotl/muonclip/state.py
+++ b/src/axolotl/muonclip/state.py
@@ -56,6 +56,13 @@ class MuonStateStore:
         self._ensure_device(state, param)
         return state
 
+    def peek(self, param: torch.nn.Parameter) -> MuonParameterState | None:
+        """
+        Return the existing state entry for `param` without creating new buffers.
+        """
+
+        return self._states.get(id(param))
+
     def _ensure_device(self, state: MuonParameterState, param: torch.nn.Parameter):
         target_device = param.device
         if state.momentum.device != target_device:

--- a/src/axolotl/muonclip/zero_utils.py
+++ b/src/axolotl/muonclip/zero_utils.py
@@ -1,0 +1,42 @@
+"""Gather helpers for DeepSpeed ZeRO and FSDP."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import torch
+
+try:  # pragma: no cover - optional dependency
+    from deepspeed.runtime.zero.partition_parameters import GatheredParameters
+except ImportError:  # pragma: no cover
+    GatheredParameters = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+except ImportError:  # pragma: no cover
+    FSDP = None  # type: ignore
+
+
+@contextmanager
+def gather_full_param(param: torch.nn.Parameter) -> Iterator[torch.nn.Parameter]:
+    """
+    Context manager that temporarily gathers a full parameter tensor for ZeRO/FSDP.
+    """
+
+    module = param._replicated_tensor_module if hasattr(param, "_replicated_tensor_module") else None
+
+    if FSDP is not None and module is not None and isinstance(module, FSDP):
+        with module.summon_full_params([param], writeback=True):
+            yield param
+        return
+
+    if GatheredParameters is not None and getattr(param, "ds_status", None) is not None:
+        try:
+            with GatheredParameters([param], modifier_rank=None, enabled=True):
+                yield param
+            return
+        except Exception:  # pragma: no cover - fallback to default
+            pass
+
+    yield param

--- a/src/axolotl/utils/callbacks/muonclip.py
+++ b/src/axolotl/utils/callbacks/muonclip.py
@@ -24,7 +24,8 @@ class MuonClipCallback(TrainerCallback):
         **kwargs,
     ) -> TrainerControl:
         try:
-            self.controller.post_optimizer_step()
+            optimizer = kwargs.get("optimizer")
+            self.controller.post_optimizer_step(optimizer=optimizer)
         except Exception as exc:  # pragma: no cover - defensive logging
             LOG.exception("MuonClip controller failed during optimizer step: %s", exc)
             raise

--- a/src/axolotl/utils/callbacks/muonclip.py
+++ b/src/axolotl/utils/callbacks/muonclip.py
@@ -32,8 +32,8 @@ class MuonClipCallback(TrainerCallback):
         try:
             optimizer = kwargs.get("optimizer")
             self.controller.post_optimizer_step(optimizer=optimizer)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            LOG.exception("MuonClip controller failed during optimizer step: %s", exc)
+        except Exception:  # pragma: no cover - defensive logging
+            LOG.exception("MuonClip controller failed during optimizer step")
             raise
         return control
 

--- a/src/axolotl/utils/callbacks/muonclip.py
+++ b/src/axolotl/utils/callbacks/muonclip.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import torch
 from transformers import TrainerCallback, TrainerControl, TrainerState, TrainingArguments
+from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR
 
 from axolotl.muonclip.controller import MuonClipController
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
+
+STATE_FILENAME_TEMPLATE = "muonclip_state_rank{rank}.pt"
 
 
 class MuonClipCallback(TrainerCallback):
@@ -30,3 +36,48 @@ class MuonClipCallback(TrainerCallback):
             LOG.exception("MuonClip controller failed during optimizer step: %s", exc)
             raise
         return control
+
+    def on_save(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ) -> TrainerControl:
+        checkpoint_dir = Path(args.output_dir) / f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}"
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        buffers = self.controller.state_dict()
+        if not buffers:
+            return control
+
+        process_index = getattr(state, "process_index", 0)
+        state_path = self._state_file(checkpoint_dir, process_index)
+        torch.save(buffers, state_path)
+        return control
+
+    def load_state_from_checkpoint(
+        self,
+        checkpoint_dir: str | Path,
+        *,
+        process_index: int = 0,
+    ) -> None:
+        """
+        Load Muon optimizer buffers from a checkpoint directory.
+        """
+
+        state_path = self._state_file(Path(checkpoint_dir), process_index)
+        if not state_path.exists():
+            LOG.debug("MuonClip state file %s not found; skipping restore", state_path)
+            return
+
+        try:
+            buffers = torch.load(state_path, map_location="cpu")
+        except OSError as exc:
+            LOG.warning("Failed loading MuonClip state from %s: %s", state_path, exc)
+            return
+        self.controller.load_state_dict(buffers)
+
+    @staticmethod
+    def _state_file(directory: Path, process_index: int) -> Path:
+        return directory / STATE_FILENAME_TEMPLATE.format(rank=process_index)

--- a/src/axolotl/utils/callbacks/muonclip.py
+++ b/src/axolotl/utils/callbacks/muonclip.py
@@ -1,0 +1,31 @@
+"""Trainer callback for invoking MuonClip controller logic."""
+
+from __future__ import annotations
+
+from transformers import TrainerCallback, TrainerControl, TrainerState, TrainingArguments
+
+from axolotl.muonclip.controller import MuonClipController
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+class MuonClipCallback(TrainerCallback):
+    """Calls into the MuonClip controller after each optimizer step."""
+
+    def __init__(self, controller: MuonClipController):
+        self.controller = controller
+
+    def on_optimizer_step(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ) -> TrainerControl:
+        try:
+            self.controller.post_optimizer_step()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOG.exception("MuonClip controller failed during optimizer step: %s", exc)
+            raise
+        return control

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -41,6 +41,7 @@ from axolotl.utils.schemas.model import (
     SpecialTokensConfig,
 )
 from axolotl.utils.schemas.multimodal import MultiModalConfig
+from axolotl.utils.schemas.muon import MuonClipConfig
 from axolotl.utils.schemas.peft import LoraConfig, ReLoRAConfig
 from axolotl.utils.schemas.quantization import PTQConfig, QATConfig
 from axolotl.utils.schemas.training import HyperparametersConfig, JaggedLRConfig
@@ -137,6 +138,12 @@ class AxolotlInputConfig(
     )
     qat: QATConfig | None = None
     quantization: PTQConfig | None = None
+    muonclip: MuonClipConfig = Field(
+        default_factory=MuonClipConfig,
+        json_schema_extra={
+            "description": "MuonClip controller configuration enabling Muon/QK-Clip under ZeRO-3 or FSDP"
+        },
+    )
     reward_model: bool | None = Field(
         default=None,
         json_schema_extra={"description": "Reward modelling: `True` or `False`"},

--- a/src/axolotl/utils/schemas/muon.py
+++ b/src/axolotl/utils/schemas/muon.py
@@ -1,0 +1,71 @@
+"""Pydantic schema for Muon/MuonClip configuration."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class MuonClipConfig(BaseModel):
+    """Configuration for MuonClip orthogonalization and QK-Clip."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable the MuonClip controller (required for ZeRO-3/FSDP support).",
+    )
+    momentum: float = Field(
+        default=0.95,
+        description="Momentum coefficient used for Muon updates.",
+    )
+    weight_decay: float = Field(
+        default=0.0,
+        description="Weight decay applied during Muon updates (set 0 to keep optimizer decay).",
+    )
+    ns_steps: int = Field(
+        default=5,
+        description="Number of Newton–Schulz iterations for orthogonalization.",
+        ge=1,
+        le=16,
+    )
+    rms_scale: float | None = Field(
+        default=None,
+        description="Override the RMS scaling coefficient (defaults to Muon heuristic).",
+    )
+    apply_to: list[str] | None = Field(
+        default=None,
+        description="List of parameter name substrings to force-enable Muon updates.",
+    )
+    exclude: list[str] | None = Field(
+        default_factory=lambda: ["embed", "lm_head"],
+        description="Parameter name substrings to exclude from Muon updates.",
+    )
+    qk_clip: bool = Field(
+        default=False,
+        description="Whether to apply Moonshot-style QK-Clip to attention projections (currently instrumented for Llama/Qwen3).",
+    )
+    qk_clip_tau: float = Field(
+        default=50.0,
+        description="Attention logit threshold τ for QK-Clip.",
+        gt=0,
+    )
+    qk_clip_alpha: float = Field(
+        default=0.5,
+        description="Blend between scaling query vs key weights (0=keys only,1=queries only).",
+        ge=0.0,
+        le=1.0,
+    )
+    qk_clip_max_steps: int | None = Field(
+        default=None,
+        description="Maximum number of optimizer steps to keep QK-Clip active before automatically disabling it.",
+        ge=1,
+    )
+    gather_strategy: Literal["auto", "deepspeed", "fsdp", "none"] = Field(
+        default="auto",
+        description="Manual override for parameter gathering backend.",
+    )
+
+    @field_validator("apply_to", "exclude", mode="after")
+    @classmethod
+    def _dedupe(cls, value):
+        if not value:
+            return value
+        return sorted(set(value))

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from torch.optim import AdamW
 
 from axolotl.common.datasets import load_datasets
 from axolotl.core.builders import HFCausalTrainerBuilder, HFRLTrainerBuilder
@@ -474,13 +475,8 @@ def rand_reward_func(prompts, completions) -> list[float]:
 
             assert trainer.optimizer_cls_and_kwargs is not None
 
-            from axolotl.contribs.mit.muon import (
-                Muon,
-                MuonOptimizerFactory,
-            )
-
             optimizer_cls, optimizer_kwargs = trainer.optimizer_cls_and_kwargs
-            assert optimizer_cls is MuonOptimizerFactory
+            assert optimizer_cls is AdamW
             assert optimizer_kwargs["lr"] == 0.00005
             assert optimizer_kwargs["weight_decay"] == 0.01
             assert optimizer_kwargs["betas"] == (0.998, 0.9)
@@ -488,7 +484,7 @@ def rand_reward_func(prompts, completions) -> list[float]:
 
             # Ensure optimizer is created with correct class
             optim = trainer.create_optimizer()
-            assert isinstance(optim, Muon)
+            assert isinstance(optim, AdamW)
 
         finally:
             # remove imported module from path
@@ -556,13 +552,8 @@ class TestHFCausalTrainerBuilder:
 
         assert trainer.optimizer_cls_and_kwargs is not None
 
-        from axolotl.contribs.mit.muon import (
-            Muon,
-            MuonOptimizerFactory,
-        )
-
         optimizer_cls, optimizer_kwargs = trainer.optimizer_cls_and_kwargs
-        assert optimizer_cls is MuonOptimizerFactory
+        assert optimizer_cls is AdamW
         assert optimizer_kwargs["lr"] == 0.00005
         assert optimizer_kwargs["weight_decay"] == 0.01
         assert optimizer_kwargs["betas"] == (0.998, 0.9)
@@ -570,7 +561,7 @@ class TestHFCausalTrainerBuilder:
 
         # Ensure optimizer is created with correct class
         optim = trainer.create_optimizer()
-        assert isinstance(optim, Muon)
+        assert isinstance(optim, AdamW)
 
 
 class TestTrainerClsPlugin:

--- a/tests/e2e/test_muonclip.py
+++ b/tests/e2e/test_muonclip.py
@@ -1,0 +1,113 @@
+"""End-to-end checks for MuonClip training."""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from axolotl.common.datasets import load_datasets
+from axolotl.train import train
+from axolotl.utils.config import normalize_config, validate_config
+from axolotl.utils.dict import DictDefault
+
+SKIP_REMOTE = os.environ.get("AXOLOTL_SKIP_REMOTE_DOWNLOADS", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+def with_temp_dir(test_func):
+    def wrapper(*args, **kwargs):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test_func(*args, temp_dir=temp_dir, **kwargs)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    return wrapper
+
+
+class TestMuonClipE2E(unittest.TestCase):
+    """
+    Smoke tests comparing AdamW and MuonClip training on a tiny Qwen3 model.
+    """
+
+    def _base_cfg(self, output_dir: Path) -> DictDefault:
+        return DictDefault(
+            {
+                "base_model": "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+                "sequence_len": 64,
+                "val_set_size": 0,
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    }
+                ],
+                "special_tokens": {
+                    "bos_token": "<s>",
+                    "eos_token": "</s>",
+                    "unk_token": "<unk>",
+                },
+                "num_epochs": 1,
+                "max_steps": 2,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "learning_rate": 5e-4,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "output_dir": str(output_dir),
+                "save_steps": 0,
+                "eval_steps": 0,
+                "save_first_step": False,
+                "flash_attention": False,
+                "bf16": False,
+                "fp16": False,
+                "muonclip": {"enabled": False},
+            }
+        )
+
+    def _run_training(self, cfg: DictDefault) -> dict:
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        state_path = Path(cfg.output_dir) / "trainer_state.json"
+        if not state_path.exists():
+            checkpoints = sorted(Path(cfg.output_dir).glob("checkpoint-*/trainer_state.json"))
+            if checkpoints:
+                state_path = checkpoints[-1]
+        if state_path.exists():
+            with open(state_path, "r", encoding="utf-8") as state_fin:
+                return json.load(state_fin)
+        return {"global_step": cfg.max_steps}
+
+    @with_temp_dir
+    @unittest.skipIf(
+        SKIP_REMOTE, "MuonClip smoke test requires model artifacts from HuggingFace"
+    )
+    def test_muonclip_smoke(self, temp_dir):
+        temp_dir = Path(temp_dir)
+
+        adam_cfg = self._base_cfg(temp_dir / "adamw")
+        adam_state = self._run_training(adam_cfg)
+
+        muon_cfg = self._base_cfg(temp_dir / "muonclip")
+        muon_cfg.optimizer = "muon"
+        muon_cfg.muonclip = {
+            "enabled": True,
+            "momentum": 0.95,
+            "weight_decay": 0.0,
+            "qk_clip": True,
+            "qk_clip_tau": 10.0,
+        }
+        muon_state = self._run_training(muon_cfg)
+
+        assert (
+            adam_state["global_step"]
+            == muon_state["global_step"]
+            == muon_cfg.max_steps
+        )

--- a/tests/test_muonclip_attention.py
+++ b/tests/test_muonclip_attention.py
@@ -1,0 +1,203 @@
+"""Tests for attention instrumentation helpers."""
+
+import torch
+import torch.nn as nn
+
+import torch
+import torch.nn as nn
+
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaAttention, LlamaRotaryEmbedding
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.qwen3.modeling_qwen3 import (
+    Qwen3Attention,
+    Qwen3RotaryEmbedding,
+)
+
+from axolotl.muonclip import (
+    MuonClipController,
+    ensure_llama_attention_instrumentation,
+    ensure_qwen_attention_instrumentation,
+)
+from axolotl.muonclip.attention import (
+    BUFFER_NAME,
+    auto_register_llama_attention,
+    register_attention_module,
+    record_attention_logits,
+)
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+
+class _ToyAttention(nn.Module):
+    def __init__(self, num_heads: int = 2):
+        super().__init__()
+        self.num_heads = num_heads
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, logits):
+        record_attention_logits(self, logits)
+        return logits
+
+
+def test_register_attention_module_adds_buffer():
+    attn = _ToyAttention()
+
+    tracker = register_attention_module(attn, name="toy", num_heads=attn.num_heads)
+
+    assert tracker.name == "toy"
+    assert hasattr(attn, BUFFER_NAME)
+    assert getattr(attn, BUFFER_NAME).shape[0] == attn.num_heads
+
+
+def test_record_attention_logits_updates_buffer():
+    attn = _ToyAttention()
+    register_attention_module(attn, name="toy", num_heads=attn.num_heads)
+
+    logits = torch.tensor(
+        [
+            [  # batch 0
+                [[1.0, 2.0], [3.0, 4.0]],  # head 0
+                [[0.5, 0.1], [0.2, 0.3]],  # head 1
+            ]
+        ]
+    )
+    attn(logits)
+    buffer = getattr(attn, BUFFER_NAME)
+    assert torch.allclose(buffer, torch.tensor([4.0, 0.5]))
+
+    logits2 = torch.tensor(
+        [
+            [
+                [[5.0, 1.0], [0.0, 2.0]],
+                [[0.4, 0.6], [0.8, 0.7]],
+            ]
+        ]
+    )
+    attn(logits2)
+    buffer = getattr(attn, BUFFER_NAME)
+    assert torch.allclose(buffer, torch.tensor([5.0, 0.8]))
+
+
+def test_record_attention_logits_accepts_vector():
+    attn = _ToyAttention()
+    register_attention_module(attn, name="toy", num_heads=attn.num_heads)
+
+    head_max = torch.tensor([1.0, 2.5])
+    record_attention_logits(attn, head_max)
+    buffer = getattr(attn, BUFFER_NAME)
+    assert torch.allclose(buffer, head_max)
+
+
+def test_record_attention_logits_accepts_batch_head_matrix():
+    attn = _ToyAttention()
+    register_attention_module(attn, name="toy", num_heads=attn.num_heads)
+
+    batch_head = torch.tensor([[1.0, 0.5], [0.1, 3.2]])
+    record_attention_logits(attn, batch_head)
+    buffer = getattr(attn, BUFFER_NAME)
+    assert torch.allclose(buffer, torch.tensor([1.0, 3.2]))
+
+
+class LlamaSdpaAttention(nn.Module):
+    def __init__(self, heads=2):
+        super().__init__()
+        self.num_heads = heads
+        self.weight = nn.Parameter(torch.ones(1))
+
+
+class _ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attn = LlamaSdpaAttention()
+
+
+def test_auto_register_llama_attention_tracks_modules():
+    model = _ToyModel()
+    controller = MuonClipController(model, MuonClipConfig(enabled=True))
+
+    count = auto_register_llama_attention(model, controller)
+
+    assert count == 1
+    assert hasattr(model.attn, BUFFER_NAME)
+
+
+def test_llama_attention_patch_installs():
+    ensure_llama_attention_instrumentation()
+    from transformers.models.llama.modeling_llama import LlamaAttention
+
+    assert getattr(LlamaAttention, "_muonclip_llama_patched", False)
+
+
+def test_qwen_attention_patch_installs():
+    ensure_qwen_attention_instrumentation()
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
+
+    assert getattr(Qwen3Attention, "_muonclip_qwen_patched", False)
+
+
+def test_llama_qk_clip_handles_grouped_query_attention():
+    ensure_llama_attention_instrumentation()
+    config = LlamaConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=1,
+        max_position_embeddings=32,
+    )
+    config._attn_implementation = "eager"
+    attn = LlamaAttention(config, layer_idx=0)
+    register_attention_module(attn, name="llama", num_heads=config.num_attention_heads)
+
+    rotary = LlamaRotaryEmbedding(config)
+    seq_len = 4
+    hidden_states = torch.arange(1 * seq_len * config.hidden_size, dtype=torch.float32).reshape(
+        1, seq_len, config.hidden_size
+    )
+    position_ids = torch.zeros(1, seq_len, dtype=torch.long)
+    position_embeddings = rotary(hidden_states, position_ids)
+
+    attn(
+        hidden_states=hidden_states,
+        position_embeddings=position_embeddings,
+        attention_mask=None,
+        past_key_values=None,
+        cache_position=None,
+    )
+    buffer = getattr(attn, BUFFER_NAME)
+    assert buffer.numel() == config.num_attention_heads
+    assert torch.all(torch.isfinite(buffer))
+
+
+def test_qwen_qk_clip_handles_grouped_query_attention():
+    ensure_qwen_attention_instrumentation()
+    config = Qwen3Config(
+        hidden_size=48,
+        intermediate_size=64,
+        num_attention_heads=6,
+        num_key_value_heads=3,
+        num_hidden_layers=1,
+        max_position_embeddings=32,
+    )
+    config._attn_implementation = "eager"
+    attn = Qwen3Attention(config, layer_idx=0)
+    register_attention_module(attn, name="qwen3", num_heads=config.num_attention_heads)
+
+    rotary = Qwen3RotaryEmbedding(config)
+    seq_len = 4
+    hidden_states = torch.arange(1 * seq_len * config.hidden_size, dtype=torch.float32).reshape(
+        1, seq_len, config.hidden_size
+    )
+    position_ids = torch.zeros(1, seq_len, dtype=torch.long)
+    position_embeddings = rotary(hidden_states, position_ids)
+
+    attn(
+        hidden_states=hidden_states,
+        position_embeddings=position_embeddings,
+        attention_mask=None,
+        past_key_values=None,
+        cache_position=None,
+    )
+    buffer = getattr(attn, BUFFER_NAME)
+    assert buffer.numel() == config.num_attention_heads
+    assert torch.all(torch.isfinite(buffer))

--- a/tests/test_muonclip_callback.py
+++ b/tests/test_muonclip_callback.py
@@ -1,0 +1,40 @@
+"""Tests for MuonClip callback checkpointing."""
+
+from pathlib import Path
+
+import torch
+from transformers import TrainerControl, TrainerState, TrainingArguments
+
+from axolotl.muonclip import MuonClipController
+from axolotl.utils.callbacks.muonclip import MuonClipCallback
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+from .test_muonclip_controller import _TinyModel
+
+
+def test_muonclip_callback_saves_and_restores(tmp_path):
+    model = _TinyModel()
+    cfg = MuonClipConfig(enabled=True, momentum=0.9)
+    controller = MuonClipController(model, cfg, learning_rate=0.05)
+    callback = MuonClipCallback(controller)
+
+    param = model.linear.weight
+    param.grad = torch.ones_like(param)
+    controller.post_optimizer_step()
+
+    args = TrainingArguments(output_dir=str(tmp_path), learning_rate=1e-4, per_device_train_batch_size=1)
+    state = TrainerState()
+    state.global_step = 2
+    state.process_index = 0
+
+    callback.on_save(args, state, TrainerControl())
+    checkpoint_dir = Path(tmp_path) / "checkpoint-2"
+    state_file = checkpoint_dir / "muonclip_state_rank0.pt"
+    assert state_file.exists()
+
+    before = controller.state_store.get_or_create(param).momentum.clone()
+    controller.state_store.get_or_create(param).momentum.zero_()
+    callback.load_state_from_checkpoint(checkpoint_dir)
+    after = controller.state_store.get_or_create(param).momentum
+
+    assert torch.allclose(before, after)

--- a/tests/test_muonclip_controller.py
+++ b/tests/test_muonclip_controller.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the MuonClipController skeleton."""
+
+import torch.nn as nn
+
+import torch
+import torch.nn as nn
+
+from axolotl.muonclip import MuonClipController
+from axolotl.muonclip.attention import BUFFER_NAME
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+
+class _FakeAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(4, 4, bias=False)
+        self.k_proj = nn.Linear(4, 4, bias=False)
+        self.num_heads = 2
+
+
+class _TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+        self.attn = _FakeAttention()
+
+
+def test_controller_initializes_metadata_and_state_store():
+    model = _TinyModel()
+    cfg = MuonClipConfig(enabled=True)
+
+    controller = MuonClipController(model, cfg)
+
+    assert controller.metadata, "Expected parameter metadata to be populated"
+    assert controller.state_store is not None
+    tracker = controller.register_attention(model.linear, name="attn", num_heads=1)
+    assert tracker.name == "attn"
+    assert hasattr(model.linear, BUFFER_NAME)
+    controller.post_optimizer_step()  # currently a noop
+
+
+def test_muon_update_applies_change():
+    model = _TinyModel()
+    cfg = MuonClipConfig(enabled=True, momentum=0.9)
+    controller = MuonClipController(model, cfg, learning_rate=0.01)
+
+    before = model.linear.weight.clone()
+    model.linear.weight.grad = torch.ones_like(model.linear.weight)
+    controller.post_optimizer_step()
+    after = model.linear.weight
+    assert not torch.allclose(before, after)
+
+
+def test_qk_clip_scales_projections():
+    model = _TinyModel()
+    cfg = MuonClipConfig(enabled=True, qk_clip=True, qk_clip_tau=1.0, qk_clip_alpha=0.5)
+    controller = MuonClipController(model, cfg, learning_rate=0.0)
+
+    tracker = controller.register_attention(model.attn, name="attn", num_heads=2)
+    buffer = getattr(model.attn, tracker.buffer_name)
+    buffer.copy_(torch.tensor([2.0, 0.5]))
+
+    before_q = model.attn.q_proj.weight.clone()
+    controller.post_optimizer_step()
+    after_q = model.attn.q_proj.weight
+    assert not torch.allclose(before_q, after_q)
+
+
+def test_qk_clip_deactivates_after_max_steps():
+    model = _TinyModel()
+    cfg = MuonClipConfig(
+        enabled=True,
+        qk_clip=True,
+        qk_clip_tau=1.0,
+        qk_clip_alpha=0.5,
+        qk_clip_max_steps=1,
+    )
+    controller = MuonClipController(model, cfg, learning_rate=0.0)
+
+    tracker = controller.register_attention(model.attn, name="attn", num_heads=2)
+    buffer = getattr(model.attn, tracker.buffer_name)
+    buffer.copy_(torch.tensor([2.0, 0.5]))
+
+    before = model.attn.q_proj.weight.clone()
+    controller.post_optimizer_step()
+    after_first = model.attn.q_proj.weight.clone()
+    assert not torch.allclose(before, after_first)
+
+    buffer.copy_(torch.tensor([2.0, 0.5]))
+    controller.post_optimizer_step()
+    after_second = model.attn.q_proj.weight.clone()
+    assert torch.allclose(after_first, after_second), "QK-Clip should be inactive after max steps"

--- a/tests/test_muonclip_math.py
+++ b/tests/test_muonclip_math.py
@@ -1,0 +1,27 @@
+"""Tests for Muon math helpers."""
+
+import torch
+
+from axolotl.muonclip.math import muon_orthogonal_update, newton_schulz_orthogonalize
+
+
+def test_newton_schulz_returns_orthogonal_matrix():
+    tensor = torch.randn(4, 4)
+    ortho = newton_schulz_orthogonalize(tensor, steps=4)
+    prod = ortho @ ortho.transpose(-2, -1)
+    off_diag = prod - torch.diag(torch.diagonal(prod))
+    assert torch.allclose(
+        torch.zeros_like(off_diag), off_diag, atol=0.3
+    ), "Off-diagonal terms should stay small"
+
+
+def test_muon_orthogonal_update_shapes_match():
+    grad = torch.randn(2, 3, requires_grad=False)
+    momentum = torch.zeros_like(grad)
+    update = muon_orthogonal_update(
+        grad,
+        momentum,
+        beta=0.95,
+        ns_steps=2,
+    )
+    assert update.shape == grad.shape

--- a/tests/test_muonclip_math.py
+++ b/tests/test_muonclip_math.py
@@ -1,5 +1,7 @@
 """Tests for Muon math helpers."""
 
+import math
+
 import torch
 
 from axolotl.muonclip.math import muon_orthogonal_update, newton_schulz_orthogonalize
@@ -25,3 +27,42 @@ def test_muon_orthogonal_update_shapes_match():
         ns_steps=2,
     )
     assert update.shape == grad.shape
+
+
+def _reference_muon_update(
+    grad: torch.Tensor,
+    momentum: torch.Tensor,
+    *,
+    beta: float,
+    ns_steps: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    momentum_ref = momentum.clone()
+    momentum_ref.lerp_(grad, 1 - beta)
+    update = torch.lerp(grad, momentum_ref, beta)
+    update_2d = update.view(update.shape[0], -1)
+    update_2d = newton_schulz_orthogonalize(update_2d, steps=ns_steps)
+    scale = math.sqrt(max(update_2d.size(0), update_2d.size(1)) * 0.4)
+    update_2d = update_2d * scale
+    return update_2d.view_as(grad), momentum_ref
+
+
+def test_muon_update_matches_reference():
+    torch.manual_seed(0)
+    grad = torch.randn(4, 6)
+    beta = 0.95
+    ns_steps = 5
+
+    reference_update, reference_momentum = _reference_muon_update(
+        grad, torch.zeros_like(grad), beta=beta, ns_steps=ns_steps
+    )
+    momentum = torch.zeros_like(grad)
+    update = muon_orthogonal_update(
+        grad.clone(),
+        momentum,
+        beta=beta,
+        ns_steps=ns_steps,
+        rms_scale=None,
+    )
+
+    assert torch.allclose(update, reference_update, atol=1e-4, rtol=1e-3)
+    assert torch.allclose(momentum, reference_momentum, atol=1e-5, rtol=1e-3)

--- a/tests/test_muonclip_parameters.py
+++ b/tests/test_muonclip_parameters.py
@@ -1,0 +1,139 @@
+"""Tests for Muon parameter tagging helpers."""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from axolotl.core.builders.base import TrainerBuilderBase
+from axolotl.muonclip import MuonClipController, tag_parameters_for_muon
+from axolotl.utils.callbacks.muonclip import MuonClipCallback
+from axolotl.utils.schemas.muon import MuonClipConfig
+
+
+class _TinyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(8, 4)
+        self.linear = nn.Linear(4, 4, bias=True)
+        self.proj = nn.Linear(4, 2, bias=False)
+
+
+class LlamaSdpaAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_heads = 2
+        self.weight = nn.Parameter(torch.ones(1))
+
+
+class _TinyLlamaModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attn = LlamaSdpaAttention()
+
+
+class _DummyBuilder(TrainerBuilderBase):
+    def build(self, total_num_steps):  # pragma: no cover - not used in tests
+        return None
+
+
+def _make_cfg(**overrides):
+    defaults = {
+        "muonclip": MuonClipConfig(),
+        "optimizer": "muon",
+        "learning_rate": 0.01,
+        "gc_steps": None,
+        "use_wandb": False,
+        "use_mlflow": False,
+        "use_comet": False,
+        "use_otel_metrics": False,
+        "save_first_step": False,
+        "profiler_steps": None,
+        "plugins": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_default_tagging_prefers_ndim_and_excludes_embed():
+    model = _TinyModel()
+    cfg = MuonClipConfig()
+
+    metadata, summary = tag_parameters_for_muon(model, cfg)
+
+    assert summary.total == len(list(model.named_parameters()))
+    assert metadata["linear.weight"].use_muon
+    assert metadata["proj.weight"].use_muon
+    assert metadata["linear.bias"].use_muon is False
+    assert metadata["linear.bias"].reason.startswith("ndim<")
+    assert metadata["embed.weight"].use_muon is False
+    assert metadata["embed.weight"].reason.startswith("exclude:")
+    assert hasattr(model.linear.weight, "use_muon") and model.linear.weight.use_muon
+
+
+def test_apply_to_forces_parameters_into_muon_bucket():
+    model = _TinyModel()
+    cfg = MuonClipConfig(apply_to=["bias"], exclude=[])
+
+    metadata, summary = tag_parameters_for_muon(model, cfg, min_ndim=2)
+
+    assert summary.muon == 4  # embed weight, linear weight, proj weight, forced bias
+    assert metadata["linear.bias"].use_muon
+    assert metadata["linear.bias"].reason.startswith("forced:")
+
+
+def test_trainer_builder_initializes_muon_tags_once():
+    cfg = _make_cfg()
+    builder = _DummyBuilder(cfg, _TinyModel(), tokenizer=None)
+
+    metadata_first, summary_first = builder._ensure_muon_param_tags()
+    assert summary_first.muon >= 2
+    assert "linear.weight" in metadata_first
+    assert metadata_first["linear.weight"].use_muon
+
+    metadata_second, summary_second = builder._ensure_muon_param_tags()
+    assert metadata_first is metadata_second
+    assert summary_first is summary_second
+
+
+def test_builder_provides_muon_state_store():
+    cfg = _make_cfg()
+    builder = _DummyBuilder(cfg, _TinyModel(), tokenizer=None)
+
+    store_first = builder._get_muon_state_store()
+    assert store_first is builder._get_muon_state_store()
+
+
+def test_builder_controller_lazily_constructed():
+    cfg = _make_cfg(muonclip=MuonClipConfig(enabled=True))
+    builder = _DummyBuilder(cfg, _TinyModel(), tokenizer=None)
+
+    controller = builder._get_muon_controller()
+    assert isinstance(controller, MuonClipController)
+    assert controller is builder._get_muon_controller()
+
+
+def test_builder_auto_registers_attention_modules_when_qk_clip_enabled():
+    cfg = _make_cfg(muonclip=MuonClipConfig(enabled=True, qk_clip=True))
+    builder = _DummyBuilder(cfg, _TinyLlamaModel(), tokenizer=None)
+
+    controller = builder._get_muon_controller()
+    assert controller.attention_trackers
+
+
+def test_get_callbacks_includes_muonclip_callback():
+    cfg = _make_cfg(muonclip=MuonClipConfig(enabled=True, qk_clip=False))
+    builder = _DummyBuilder(cfg, _TinyModel(), tokenizer=None)
+
+    callbacks = builder.get_callbacks()
+    assert any(isinstance(cb, MuonClipCallback) for cb in callbacks)
+
+
+def test_qk_clip_warns_when_no_supported_attention(caplog):
+    cfg = _make_cfg(muonclip=MuonClipConfig(enabled=True, qk_clip=True))
+    builder = _DummyBuilder(cfg, _TinyModel(), tokenizer=None)
+
+    with caplog.at_level("WARNING"):
+        builder._get_muon_controller()
+
+    assert any("no supported attention modules" in rec.message for rec in caplog.records)

--- a/tests/test_muonclip_state.py
+++ b/tests/test_muonclip_state.py
@@ -1,0 +1,47 @@
+"""Tests for MuonClip state helpers."""
+
+import torch
+
+from axolotl.muonclip.state import MuonStateStore
+
+
+def test_state_store_allocates_buffers_like_param():
+    param = torch.nn.Parameter(torch.ones(2, 3, dtype=torch.float32))
+    store = MuonStateStore()
+
+    state = store.get_or_create(param, with_rms=True)
+
+    assert state.momentum.shape == param.shape
+    assert torch.all(state.momentum == 0)
+    assert state.momentum.device == param.device
+    assert state.rms is not None
+    assert state.rms.shape == param.shape
+
+
+def test_state_store_reuses_existing_entries():
+    param = torch.nn.Parameter(torch.ones(4))
+    store = MuonStateStore()
+
+    first = store.get_or_create(param)
+    first.momentum.add_(1)
+
+    second = store.get_or_create(param)
+    assert torch.all(second.momentum == 1)
+    assert first is second
+
+
+def test_state_dict_round_trip_cpu():
+    param = torch.nn.Parameter(torch.ones(4))
+    store = MuonStateStore(device=torch.device("cpu"))
+    state = store.get_or_create(param, with_rms=True)
+    state.momentum.add_(2)
+    state.rms.add_(3)
+
+    payload = store.state_dict()
+
+    new_store = MuonStateStore(device=torch.device("cpu"))
+    new_store.get_or_create(param, with_rms=True)
+    new_store.load_state_dict(payload)
+    restored = new_store.get_or_create(param, with_rms=True)
+    assert torch.allclose(restored.momentum, torch.full_like(restored.momentum, 2))
+    assert torch.allclose(restored.rms, torch.full_like(restored.rms, 3))

--- a/tests/test_muonclip_zero_utils.py
+++ b/tests/test_muonclip_zero_utils.py
@@ -1,0 +1,14 @@
+"""Tests for ZeRO/FSDP gather helpers."""
+
+import torch
+
+from axolotl.muonclip.zero_utils import gather_full_param
+
+
+def test_gather_full_param_noop_on_cpu():
+    param = torch.nn.Parameter(torch.randn(2, 2))
+    before = param.clone()
+    with gather_full_param(param) as full, torch.no_grad():
+        assert full is param
+        full.add_(1.0)
+    assert torch.allclose(param, before + 1.0)


### PR DESCRIPTION
While chasing down some numeric irregularities, I wanted to try to use Muon and realized I couldn't due to using DeepSpeed. DeepSpeed added Muon support for ZeRO<3 in August, I enabled it here: https://github.com/axolotl-ai-cloud/axolotl/pull/3258

But it got me curious if we could do better (and maybe add Muon Clip support while we were at it).  I named it "muonclip" but maybe this just should be "muon". Here' the new implementation highlights

- This is a drop-in replacement for the previous muon implementation. If you use a config pointing to "muon" it now uses muonclip
- This has full support for FSDP and DeepSpeed (including ZeRO-3) - Muon orthogonalization now runs as a post-step controller on top of standard AdamW
- Numerics exactly matches DeepSpeed implementation
- When testing on 8x5090 it performs faster than other implementations (by 10-15%), its tok/s/gpu matches `adamw_torch` (fused)
- There is `qk_clip` support (Moonshot AI's "Muon Clip" adaptation as described in the Kimi K2 paper) which supports a qk_clip_max_steps to disengage after a warmup window, but it is disabled by default as it's quite slow atm (fast qk_clip requires modifying the attention kernel, qk_clip probably not necessary if not doing a pretrain)
  - qk_clip instruments only llama/qwen3 attention layers, other arch logs a warning and skips, really, this is a curiousity though - efficient qk-clip requires access to the attention logits, basically you would need to expose from the FA kernel, you could rip out the attention recomputing then
  - Current testing shows throughput is about 8X slower for 8K seq length otherwise... 
- Fully tested (unit test, e2e test, real test runs on 1epoch of a 200K sample dataset on Llama 3.2 1B)

Loss:
<img width="3160" height="1660" alt="W B Chart 11_14_2025, 1_16_23 PM" src="https://github.com/user-attachments/assets/68dfdbd8-1379-46db-8f53-d1f8d75d644b" />

Speed:
<img width="3160" height="1660" alt="W B Chart 11_14_2025, 1_17_30 PM" src="https://github.com/user-attachments/assets/aa6d07a3-8181-4a91-9729-126c5afcf54d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MuonClip optimizer integration for advanced orthogonal parameter updates and attention-aware clipping during training.
  * Introduced configurable QK-Clip module for selective query/key projection scaling on Llama and Qwen models.
  * Added MuonClip configuration options including momentum, weight decay, and per-parameter tagging controls.

* **Bug Fixes**
  * Fixed validation logic for optimizer/DeepSpeed/FSDP compatibility.

* **Tests**
  * Added comprehensive test coverage for MuonClip functionality and attention instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->