### PR TITLE
removed unused "scikit-learn==1.4.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,6 @@ numpy>=2.2.6
 # qlora things
 evaluate==0.4.1
 scipy
-scikit-learn==1.4.2
 nvidia-ml-py==12.560.30
 art
 tensorboard


### PR DESCRIPTION

# Description
removed unused "scikit-learn==1.4.2"

## Motivation and Context

#3276



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the explicit scikit-learn dependency version constraint from requirements, allowing for more flexible dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->