### PR TITLE
Add Liger Kernel Support for qwen3_vl

### DIFF
--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -168,6 +168,22 @@ class LigerPlugin(BasePlugin):
                 rms_norm=cfg.liger_rms_norm,
                 layer_norm=cfg.liger_layer_norm,
             )
+        elif cfg.model_config_type == "qwen3_vl":
+            """
+            Apply Liger kernels for Qwen3 Vision-Language models.
+            
+            Note: The parameter 'swiglu' is used instead of 'glu_activation' to match
+            the Liger kernel API for vision-language models.
+            """
+            from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
+
+            apply_liger_kernel_to_qwen3_vl(
+                rope=cfg.liger_rope,
+                cross_entropy=cfg.liger_cross_entropy,
+                fused_linear_cross_entropy=cfg.liger_fused_linear_cross_entropy,
+                rms_norm=cfg.liger_rms_norm,
+                swiglu=cfg.liger_glu_activation,  # Note: qwen3_vl uses swiglu parameter name
+            )
         elif cfg.model_config_type == "qwen3_moe":
             from axolotl.integrations.liger.models.qwen3_moe import (
                 apply_liger_kernel_to_qwen3_moe,


### PR DESCRIPTION
# Add Liger Kernel Support for qwen3_vl

# Description

This PR adds native support for Qwen3 Vision-Language (non-MOE) models with Liger kernel optimizations. The implementation aligns with the upstream Liger Kernel commit [6cd9fd64](https://github.com/linkedin/Liger-Kernel/commit/6cd9fd64a51e26b27a7dc9cc33c9b7ed1ac567cc) that introduced `apply_liger_kernel_to_qwen3_vl`.

## Key Changes:

1. **Added Qwen3-VL Support in Liger Plugin** (`src/axolotl/integrations/liger/plugin.py`):
   - Import `apply_liger_kernel_to_qwen3_vl` from `liger_kernel.transformers`
   - Add configuration case for `qwen3_vl` model type
   - Include all supported Liger optimizations with proper parameter mapping

  2. **Parameter Mapping**:
     - `rope`: Rotary position embeddings optimization
     - `cross_entropy`: Standard cross-entropy loss optimization (mutually
  exclusive with fused_linear_cross_entropy)
     - `fused_linear_cross_entropy`: Memory-efficient fused implementation
  - combines final linear layer with cross-entropy loss
     - `rms_norm`: RMSNorm layer optimization
     - `swiglu`: SwiGLU activation optimization (note: qwen3_vl uses
  `swiglu` parameter name instead of `glu_activation`)

## Motivation and Context

**Problem:** Qwen3_vl models were not supported by Axolotl's Liger integration, resulting in the warning:
```
[WARNING] [axolotl.integrations.liger.plugin] Unsupported model config type: qwen3_vl. Liger not applied.
```

This prevented users from leveraging Liger's performance optimizations when training Qwen3-VL models.

**Solution:** The fix adds explicit support for the `qwen3_vl` model configuration type, enabling Liger optimizations that are compatible with vision-language models from the Liger upstream.

## How has this been tested?

**Testing Approach:**
1. Verified that the warning no longer appears when using `model_config_type: qwen3_vl`, trainging and eval steps are successful
2. Confirmed that Liger optimizations are correctly applied during model initialization
3. Checked compatibility with existing Liger configuration options
4. Ensured parameter mapping matches upstream Liger implementation
5. Witnessed presence of liger kernels in PyTorch compiler (Dynamo)

**Configuration Example:**
```yaml
base_model: Qwen/Qwen3-VL-4B-Instruct
model_config_type: qwen3_vl

# Liger optimizations
liger_rope: true
liger_rms_norm: true
liger_fused_linear_cross_entropy: true
liger_glu_activation: true  # Maps to swiglu parameter
liger_use_token_scaling: true  # Forces token scaling in FLC
```

## Screenshots (if appropriate)
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Qwen3 Vision-Language model support with LIGER kernel optimizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->