### PR TITLE
compute loss only if training and update token metric naming

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -72,7 +72,9 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         if self.cfg.include_tkps:
             callbacks.append(
                 TokensPerSecondCallback(
-                    self.cfg.tensor_parallel_size, self.cfg.context_parallel_size
+                    self.cfg.tensor_parallel_size,
+                    self.cfg.context_parallel_size,
+                    resume_from_checkpoint=self.cfg.resume_from_checkpoint,
                 )
             )
         return callbacks

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -648,9 +648,6 @@ class AxolotlTrainer(
             logs["tokens/train_per_sec_per_gpu"] = round(
                 self.state.last_tokens_per_second.item() / self.args.logging_steps, 2
             )
-            logs["tokens/total"] = int(self.state.tokens["total"].item())
-            logs["tokens/trainable"] = int(self.state.tokens["trainable"].item())
-
         del self._stored_metrics[train_eval]
 
         return super().log(logs, start_time)

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -380,7 +380,6 @@ class AxolotlTrainer(
             # Store per-step trainable tokens for throughput calculation
             self.state.tokens["trainable_tokens"] = trainable_tokens.detach().cpu()
 
-
         if self.args.orpo_alpha:
             return self.orpo_compute_loss(
                 model,
@@ -650,6 +649,7 @@ class AxolotlTrainer(
                 self.state.last_tokens_per_second.item() / self.args.logging_steps, 2
             )
             logs["tokens/total"] = int(self.state.tokens["total"].item())
+            logs["tokens/trainable"] = int(self.state.tokens["trainable"].item())
 
         del self._stored_metrics[train_eval]
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -378,7 +378,8 @@ class AxolotlTrainer(
                 self.state.tokens["total"] + torch.as_tensor(total_tokens).cpu()
             )
             # Store per-step trainable tokens for throughput calculation
-            self.state.tokens["trainable_step"] = trainable_tokens.detach().cpu()
+            self.state.tokens["trainable_tokens"] = trainable_tokens.detach().cpu()
+
 
         if self.args.orpo_alpha:
             return self.orpo_compute_loss(
@@ -645,7 +646,7 @@ class AxolotlTrainer(
         ):
             # each rank will log its own tokens per second
             # for logging_steps > 1 we obtain a moving average of this metric
-            logs["tokens/trainable_per_second_per_gpu"] = round(
+            logs["tokens/train_per_sec_per_gpu"] = round(
                 self.state.last_tokens_per_second.item() / self.args.logging_steps, 2
             )
             logs["tokens/total"] = int(self.state.tokens["total"].item())

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -371,10 +371,14 @@ class AxolotlTrainer(
                 }
 
             # trainable tokens for throughput and total token slots for summaries
-            self.state.tokens["trainable"] = trainable_tokens.detach().cpu()
+            self.state.tokens["trainable"] = (
+                self.state.tokens["trainable"] + trainable_tokens.detach().cpu()
+            )
             self.state.tokens["total"] = (
                 self.state.tokens["total"] + torch.as_tensor(total_tokens).cpu()
             )
+            # Store per-step trainable tokens for throughput calculation
+            self.state.tokens["trainable_step"] = trainable_tokens.detach().cpu()
 
         if self.args.orpo_alpha:
             return self.orpo_compute_loss(

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -348,7 +348,7 @@ class AxolotlTrainer(
         #     return (loss, outputs) if return_outputs else loss
 
         # track number of tokens for tokens per second calculation
-        if self.args.include_tkps:
+        if self.args.include_tkps and model.training:
             inputs_key = "labels" if "labels" in inputs else "input_ids"
             num_tokens = (inputs[inputs_key] != -100).sum()
             if is_distributed():

--- a/src/axolotl/utils/callbacks/tokens_per_second.py
+++ b/src/axolotl/utils/callbacks/tokens_per_second.py
@@ -95,9 +95,7 @@ class TokensPerSecondCallback(TrainerCallback):
     ):  # pylint: disable=unused-argument
         # after logging, clear the running metrics
         if hasattr(state, "last_tokens_per_second"):
-            logs["tokens/train_per_sec_per_gpu"] = (
-                state.last_tokens_per_second.item()
-            )
+            logs["tokens/train_per_sec_per_gpu"] = state.last_tokens_per_second.item()
             state.last_tokens_per_second.zero_()
         tokens = getattr(state, "tokens", None)
         # Clear per-step tokens after logging

--- a/src/axolotl/utils/callbacks/tokens_per_second.py
+++ b/src/axolotl/utils/callbacks/tokens_per_second.py
@@ -1,5 +1,7 @@
 """A callback for calculating tokens per second during training."""
 
+import json
+import os
 import time
 
 import torch
@@ -10,21 +12,50 @@ from transformers import (
     TrainingArguments,
 )
 
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+TOKENS_STATE_FILE = "tokens_state.json"
+
 
 class TokensPerSecondCallback(TrainerCallback):
     """
     A callback to measure and log tokens per second during training.
+    Also handles saving/restoring total_tokens state across checkpoint resumes.
     """
 
-    def __init__(self, tensor_parallel_size, context_parallel_size):
+    def __init__(
+        self, tensor_parallel_size, context_parallel_size, resume_from_checkpoint=None
+    ):
         super().__init__()
         self.step_time = 0.0
         self.start_time = 0.0
         self.non_data_parallel_size = 1
+        self.resume_from_checkpoint = resume_from_checkpoint
         if tensor_parallel_size is not None:
             self.non_data_parallel_size *= tensor_parallel_size
         if context_parallel_size is not None:
             self.non_data_parallel_size *= context_parallel_size
+
+    def on_train_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):  # pylint: disable=unused-argument
+        """Restore total_tokens state when resuming from checkpoint."""
+        if self.resume_from_checkpoint:
+            tokens_state_path = os.path.join(
+                self.resume_from_checkpoint, TOKENS_STATE_FILE
+            )
+            if os.path.isfile(tokens_state_path):
+                with open(tokens_state_path, "r", encoding="utf-8") as f:
+                    tokens_state = json.load(f)
+                state.total_tokens = torch.tensor(tokens_state.get("total_tokens", 0))
+                state.num_tokens = torch.tensor(tokens_state.get("num_tokens", 0))
+                LOG.info(f"Restored total_tokens: {state.total_tokens}")
 
     def on_step_begin(
         self,

--- a/src/axolotl/utils/callbacks/tokens_per_second.py
+++ b/src/axolotl/utils/callbacks/tokens_per_second.py
@@ -46,16 +46,15 @@ class TokensPerSecondCallback(TrainerCallback):
         **kwargs,
     ):  # pylint: disable=unused-argument
         """Restore total_tokens state when resuming from checkpoint."""
-        if self.resume_from_checkpoint:
-            tokens_state_path = os.path.join(
-                self.resume_from_checkpoint, TOKENS_STATE_FILE
-            )
-            if os.path.isfile(tokens_state_path):
-                with open(tokens_state_path, "r", encoding="utf-8") as f:
-                    tokens_state = json.load(f)
-                state.total_tokens = torch.tensor(tokens_state.get("total_tokens", 0))
-                state.num_tokens = torch.tensor(tokens_state.get("num_tokens", 0))
-                LOG.info(f"Restored total_tokens: {state.total_tokens}")
+        if not isinstance(self.resume_from_checkpoint, str):
+            return
+        tokens_state_path = os.path.join(self.resume_from_checkpoint, TOKENS_STATE_FILE)
+        if os.path.isfile(tokens_state_path):
+            with open(tokens_state_path, "r", encoding="utf-8") as f:
+                tokens_state = json.load(f)
+            state.total_tokens = torch.tensor(tokens_state.get("total_tokens", 0))
+            state.num_tokens = torch.tensor(tokens_state.get("num_tokens", 0))
+            LOG.info(f"Restored total_tokens: {state.total_tokens}")
 
     def on_step_begin(
         self,


### PR DESCRIPTION
fixes #3291 
<img width="1081" height="634" alt="image" src="https://github.com/user-attachments/assets/9762f271-b5e1-4567-9cfc-cd7480c2806c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token-per-second tracking to only occur when the model is actively training. Previously, tracking could run regardless of training state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->