### PR TITLE
fix: 'save_jinja_files' not supported by MistralCommonBackend.save_pretrained

### DIFF
--- a/src/axolotl/utils/mistral/mistral_tokenizer.py
+++ b/src/axolotl/utils/mistral/mistral_tokenizer.py
@@ -218,3 +218,10 @@ class HFMistralTokenizer(MistralCommonBackend):
             model_input_names=model_input_names,
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
         )
+
+    def save_pretrained(self, *args, **kwargs) -> tuple[str, ...]:
+        """
+        Patches to remove save_jinja_files from being passed onwards.
+        """
+        kwargs.pop("save_jinja_files", None)
+        return super().save_pretrained(*args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

```
  File "/workspace/axolotl/src/axolotl/train.py", line 592, in train

    save_initial_configs(cfg, tokenizer, model, peft_config, processor)

  File "/workspace/axolotl/src/axolotl/train.py", line 418, in save_initial_configs

    tokenizer.save_pretrained(

  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/tokenization_mistral_common.py", line 1948, in save_pretrained

    raise ValueError(

ValueError: Kwargs ['save_jinja_files'] are not supported by `MistralCommonBackend.save_pretrained`.
```

This PR adds a passthrough.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually run

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->
