### PR TITLE
Fix(misc): address PYTORCH_CUDA_ALLOC_CONF deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## 🎉 Latest Updates
 
-- 2025/12: Axolotl now includes support for [Olmo3](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/olmo3), [Trinity](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/trinity), and [Ministral3](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/ministral).
+- 2025/12: Axolotl now includes support for [Olmo3](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/olmo3), [Trinity](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/trinity), and [Ministral3](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/ministral3).
 - 2025/10: New model support has been added in Axolotl for: [Qwen3 Next](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/qwen3-next), [Qwen2.5-vl, Qwen3-vl](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/qwen2_5-vl), [Qwen3, Qwen3MoE](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/qwen3), [Granite 4](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/granite4), [HunYuan](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/hunyuan), [Magistral 2509](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/magistral#vision), [Apertus](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/apertus), and [Seed-OSS](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/seed-oss).
 - 2025/09: Axolotl now has text diffusion training. Read more [here](https://github.com/axolotl-ai-cloud/axolotl/tree/main/src/axolotl/integrations/diffusion).
 - 2025/08: QAT has been updated to include NVFP4 support. See [PR](https://github.com/axolotl-ai-cloud/axolotl/pull/3107).

--- a/examples/colab-notebooks/colab-axolotl-example.ipynb
+++ b/examples/colab-notebooks/colab-axolotl-example.ipynb
@@ -253,7 +253,6 @@
    "source": [
     "from axolotl.utils import set_pytorch_cuda_alloc_conf\n",
     "\n",
-    "# Set \"PYTORCH_CUDA_ALLOC_CONF\" env to save memory\n",
     "set_pytorch_cuda_alloc_conf()"
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,4 +72,4 @@ axolotl-contribs-mit==0.0.5
 # telemetry
 posthog==6.7.11
 
-mistral-common==1.8.5
+mistral-common==1.8.6

--- a/src/axolotl/utils/__init__.py
+++ b/src/axolotl/utils/__init__.py
@@ -41,18 +41,15 @@ def get_pytorch_version() -> tuple[int, int, int]:
 
 
 def set_pytorch_cuda_alloc_conf():
-    """Set up CUDA allocation config if using PyTorch >= 2.2"""
-    torch_version = torch.__version__.split(".")
-    torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
-    if torch_major == 2 and torch_minor >= 2:
-        # PYTORCH_CUDA_ALLOC_CONF is deprecated and left for BC
-        if (
-            os.getenv("PYTORCH_ALLOC_CONF") is None
-            and os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None
-        ):
-            os.environ["PYTORCH_ALLOC_CONF"] = (
-                "expandable_segments:True,roundup_power2_divisions:16"
-            )
+    """Set up CUDA allocation config"""
+    # Set both PYTORCH_ALLOC_CONF and PYTORCH_CUDA_ALLOC_CONF for compatibility
+    if (
+        os.getenv("PYTORCH_ALLOC_CONF") is None
+        and os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None
+    ):
+        config_value = "expandable_segments:True,roundup_power2_divisions:16"
+        os.environ["PYTORCH_ALLOC_CONF"] = config_value
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = config_value
 
 
 def get_not_null(value, default=None):

--- a/src/axolotl/utils/__init__.py
+++ b/src/axolotl/utils/__init__.py
@@ -45,8 +45,12 @@ def set_pytorch_cuda_alloc_conf():
     torch_version = torch.__version__.split(".")
     torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
     if torch_major == 2 and torch_minor >= 2:
-        if os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None:
-            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = (
+        # PYTORCH_CUDA_ALLOC_CONF is deprecated and left for BC
+        if (
+            os.getenv("PYTORCH_ALLOC_CONF") is None
+            and os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None
+        ):
+            os.environ["PYTORCH_ALLOC_CONF"] = (
                 "expandable_segments:True,roundup_power2_divisions:16"
             )
 

--- a/src/axolotl/utils/__init__.py
+++ b/src/axolotl/utils/__init__.py
@@ -42,13 +42,20 @@ def get_pytorch_version() -> tuple[int, int, int]:
 
 def set_pytorch_cuda_alloc_conf():
     """Set up CUDA allocation config"""
-    # Set both PYTORCH_ALLOC_CONF and PYTORCH_CUDA_ALLOC_CONF for compatibility
+    torch_version = torch.__version__.split(".")
+    torch_major, torch_minor = int(torch_version[0]), int(torch_version[1])
+    config_value = "expandable_segments:True,roundup_power2_divisions:16"
     if (
-        os.getenv("PYTORCH_ALLOC_CONF") is None
+        torch_major == 2
+        and torch_minor >= 9
+        and os.getenv("PYTORCH_ALLOC_CONF") is None
+    ):
+        os.environ["PYTORCH_ALLOC_CONF"] = config_value
+    elif (
+        torch_major == 2
+        and torch_minor >= 2
         and os.getenv("PYTORCH_CUDA_ALLOC_CONF") is None
     ):
-        config_value = "expandable_segments:True,roundup_power2_divisions:16"
-        os.environ["PYTORCH_ALLOC_CONF"] = config_value
         os.environ["PYTORCH_CUDA_ALLOC_CONF"] = config_value
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

```
Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead
```

TODO:
- [x] Find the doc link that mentions this deprecation

New docs on env : https://github.com/pytorch/pytorch/blob/b53d925706e5d862494951dbcfe2767c29132723/docs/source/cuda_environment_variables.rst#L16

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Ministral3 example URL in README for proper reference.

* **Bug Fixes**
  * Updated mistral-common dependency to 1.8.6 for improved compatibility.
  * Enhanced PyTorch memory allocation handling for version 2.2 and later.

* **Chores**
  * Removed outdated comment from Colab example notebook.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->