### PR TITLE
fix: add save_safetensors to AxolotlTrainingArguments

### DIFF
--- a/src/axolotl/core/training_args.py
+++ b/src/axolotl/core/training_args.py
@@ -24,6 +24,10 @@ class AxolotlTrainingArguments(AxolotlTrainingMixins, TrainingArguments):
     default value so it can't be used as a mixin.
     """
 
+    save_safetensors: bool = field(
+        default=True, metadata={"help": "If True, save model checkpoints in safetensors format"}
+    )
+
 
 @dataclass
 class AxolotlORPOConfig(AxolotlTrainingMixins, ORPOConfig):


### PR DESCRIPTION

**Fixes:** [#3315](https://github.com/axolotl-ai-cloud/axolotl/issues/3315)

# Description

Adds the missing `save_safetensors: bool` field to the `AxolotlTrainingArguments` dataclass in `src/axolotl/core/training_args.py`.
This fixes the `TypeError: AxolotlTrainingArguments.__init__() got an unexpected keyword argument 'save_safetensors'` when training with configs that include this argument.

# Motivation

Without this field, configurations using `save_safetensors` fail. Adding it ensures the argument is recognized and training can proceed normally.

# Testing

Verified that the `TypeError` no longer occurs when `save_safetensors` is present in the configuration.

# Type of change

* [x] Bug fix (non-breaking)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new training configuration option to enable safetensors checkpoint saving during model training (enabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->