### PR TITLE
feat: cheap ppl metric

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Literal, Optional
 import datasets
 import safetensors
 import torch
+import math
 from accelerate.state import AcceleratorState
 from datasets import Dataset
 from peft import PeftModel
@@ -614,6 +615,11 @@ class AxolotlTrainer(
                     "Metric reduction must be one of [mean, min, max, sum]"
                 )
             logs[key] = round(fn(values).item(), 4)
+
+        if "loss" in logs:
+            logs["ppl"] = math.exp(logs["loss"])
+        if "eval_loss" in logs:
+            logs["eval_ppl"] = math.exp(logs["eval_loss"])
 
         if is_main_process():
             # Add memory usage

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -618,12 +618,12 @@ class AxolotlTrainer(
 
         if "loss" in logs:
             try:
-                logs["ppl"] = math.exp(logs["loss"])
+                logs["ppl"] = round(math.exp(logs["loss"]), 4)
             except OverflowError:
                 logs["ppl"] = float("inf")
         if "eval_loss" in logs:
             try:
-                logs["eval_ppl"] = math.exp(logs["eval_loss"])
+                logs["eval_ppl"] = round(math.exp(logs["eval_loss"]), 4)
             except OverflowError:
                 logs["eval_ppl"] = float("inf")
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -620,12 +620,12 @@ class AxolotlTrainer(
             try:
                 logs["ppl"] = math.exp(logs["loss"])
             except OverflowError:
-                logs["ppl"] = float('inf')
+                logs["ppl"] = float("inf")
         if "eval_loss" in logs:
             try:
                 logs["eval_ppl"] = math.exp(logs["eval_loss"])
             except OverflowError:
-                logs["eval_ppl"] = float('inf')
+                logs["eval_ppl"] = float("inf")
 
         if is_main_process():
             # Add memory usage

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from collections import defaultdict
 from functools import partial, wraps
@@ -10,7 +11,6 @@ from typing import Any, Callable, Literal, Optional
 import datasets
 import safetensors
 import torch
-import math
 from accelerate.state import AcceleratorState
 from datasets import Dataset
 from peft import PeftModel

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -617,9 +617,15 @@ class AxolotlTrainer(
             logs[key] = round(fn(values).item(), 4)
 
         if "loss" in logs:
-            logs["ppl"] = math.exp(logs["loss"])
+            try:
+                logs["ppl"] = math.exp(logs["loss"])
+            except OverflowError:
+                logs["ppl"] = float('inf')
         if "eval_loss" in logs:
-            logs["eval_ppl"] = math.exp(logs["eval_loss"])
+            try:
+                logs["eval_ppl"] = math.exp(logs["eval_loss"])
+            except OverflowError:
+                logs["eval_ppl"] = float('inf')
 
         if is_main_process():
             # Add memory usage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

better way of doing #3288

doesn't mess with `eval_causal_lm_metrics`, so it uses `ppl` and `eval_ppl` to differentiate itself.

`{'eval_loss': 3.87862491607666, 'eval_runtime': 173.5787, 'eval_samples_per_second': 2.765, 'eval_steps_per_second': 0.346, 'eval_ppl': 48.35767347232679, 'memory/max_active (GiB)': 7.38, 'memory/max_allocated (GiB)': 7.38, 'memory/device_reserved (GiB)': 8.71, 'epoch': 0}`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic perplexity metric computation added to training logs, derived from both standard and evaluation loss values during model training.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->