### PR TITLE
feature: raise on long sequence drop

### DIFF
--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -188,7 +188,10 @@ def handle_long_seq_in_dataset(
         cfg: Dictionary mapping `axolotl` config keys to values.
 
     Returns:
-        Filtered dataset with long sequences removed.
+        Filtered dataset with long sequences handled according to the excess_length_strategy value:
+            'drop' (default)    excludes any sequence longer than sequence_len
+            'truncate'          truncates them down to sequence_len
+            'raise'             raises a ValueError if any sequence was found that was longer than sequence_len
     """
     if (
         hasattr(dataset, "column_names")

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -234,7 +234,12 @@ def handle_long_seq_in_dataset(
 
     drop_long_kwargs = {}
     if filter_map_kwargs:
-        drop_long_kwargs["desc"] = f"Dropping Long Sequences (>{sequence_len})"
+        action = (
+            "Checking Sequence Lengths"
+            if excess_length_strategy == "raise"
+            else "Dropping Long Sequences"
+        )
+        drop_long_kwargs["desc"] = f"{action} (>{sequence_len})"
 
     if excess_length_strategy == "truncate":
         process_fn = functools.partial(

--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -206,10 +206,13 @@ def handle_long_seq_in_dataset(
         )
         return dataset
 
+    excess_length_strategy = (cfg.excess_length_strategy or "drop").lower()
+
     drop_long = functools.partial(
         drop_long_seq,
         sequence_len=sequence_len,
         min_sequence_len=cfg.min_sample_len,
+        raise_on_drop=excess_length_strategy == "raise",
     )
 
     with contextlib.suppress(AttributeError):
@@ -230,7 +233,6 @@ def handle_long_seq_in_dataset(
     if filter_map_kwargs:
         drop_long_kwargs["desc"] = f"Dropping Long Sequences (>{sequence_len})"
 
-    excess_length_strategy = (cfg.excess_length_strategy or "drop").lower()
     if excess_length_strategy == "truncate":
         process_fn = functools.partial(
             truncate_long_seq,

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -451,10 +451,10 @@ class AxolotlInputConfig(
             "description": "The maximum length of an input to train with, this should typically be less than 2048 as most models have a token/context limit of 2048"
         },
     )
-    excess_length_strategy: Literal["drop", "truncate"] | None = Field(
+    excess_length_strategy: Literal["drop", "truncate", "raise"] | None = Field(
         default=None,
         json_schema_extra={
-            "description": "What to do when a tokenized row exceeds sequence_len. 'drop' removes the row; 'truncate' slices tensors to sequence_len. Defaults to 'drop' for backward compatibility."
+            "description": "What to do when a tokenized row exceeds sequence_len. 'drop' removes the row; 'truncate' slices tensors to sequence_len; 'raise' raises a ValueError. Defaults to 'drop' for backward compatibility."
         },
     )
     eval_sequence_len: int | None = Field(

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -205,12 +205,15 @@ def add_length(sample):
     return sample
 
 
-def drop_long_seq(sample, sequence_len=2048, min_sequence_len=2):
+def drop_long_seq(sample, sequence_len=2048, min_sequence_len=2, raise_on_drop=False):
     """
     Drop samples whose sequence length is either too long (> sequence_len)
     or too short (< min_sequence_len).
 
     Works for both single-example (list[int]) or batched (list[list[int]]).
+
+    If raise_on_drop is set, the code raises a ValueError if a sample is
+    encountered that is too long and would have been dropped.
     """
     min_sequence_len = min_sequence_len or 2
 
@@ -225,12 +228,20 @@ def drop_long_seq(sample, sequence_len=2048, min_sequence_len=2):
     if isinstance(input_ids[0], int):
         # Single example (input_ids is a list of int)
         length = len(input_ids)
+        if raise_on_drop and length > sequence_len:
+            raise ValueError(
+                f"Sequence encountered with {length} tokens, which exceeds the maximum {sequence_len}."
+            )
         return min_sequence_len <= length <= sequence_len
 
     # Batched (input_ids is a list of lists)
     results = []
     for seq in input_ids:
         length = len(seq)
+        if raise_on_drop and length > sequence_len:
+            raise ValueError(
+                f"Sequence encountered with {length} tokens, which exceeds the maximum {sequence_len}."
+            )
         results.append(min_sequence_len <= length <= sequence_len)
     return results
 

--- a/tests/hf_offline_utils.py
+++ b/tests/hf_offline_utils.py
@@ -6,7 +6,7 @@ import os
 from contextlib import contextmanager
 from functools import wraps
 
-# from huggingface_hub.utils import reset_sessions
+from huggingface_hub.utils import reset_sessions
 
 
 def reload_modules(hf_hub_offline):
@@ -21,7 +21,7 @@ def reload_modules(hf_hub_offline):
     huggingface_hub.constants.HF_HUB_OFFLINE = hf_hub_offline
     importlib.reload(datasets.config)
     datasets.config.HF_HUB_OFFLINE = hf_hub_offline
-    # reset_sessions()
+    reset_sessions()
 
 
 def enable_hf_offline(test_func):

--- a/tests/hf_offline_utils.py
+++ b/tests/hf_offline_utils.py
@@ -6,7 +6,7 @@ import os
 from contextlib import contextmanager
 from functools import wraps
 
-from huggingface_hub.utils import reset_sessions
+# from huggingface_hub.utils import reset_sessions
 
 
 def reload_modules(hf_hub_offline):
@@ -21,7 +21,7 @@ def reload_modules(hf_hub_offline):
     huggingface_hub.constants.HF_HUB_OFFLINE = hf_hub_offline
     importlib.reload(datasets.config)
     datasets.config.HF_HUB_OFFLINE = hf_hub_offline
-    reset_sessions()
+    # reset_sessions()
 
 
 def enable_hf_offline(test_func):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ import unittest
 from transformers import LlamaTokenizer
 
 from axolotl.utils.data import encode_streaming, md5
+from axolotl.utils.trainer import drop_long_seq
 
 from tests.hf_offline_utils import enable_hf_offline
 
@@ -62,6 +63,42 @@ class TestEncodePretraining(unittest.TestCase):
         self.assertEqual(
             md5("hello world", "utf-8"), "5eb63bbbe01eeed093cb22bb8f5acdc3"
         )
+
+    def test_excess_length_strategy(self):
+        """Test that excess_length_strategy results in a value error when set to 'raise'."""
+
+        # -- single sequence --
+        # This should work
+        data = {"input_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]}
+        drop_long_seq(data, 32, raise_on_drop=True)
+
+        # This should return True, since data fits
+        dropped = drop_long_seq(data, 32)
+        self.assertTrue(dropped)
+
+        # This should raise
+        self.assertRaises(ValueError, drop_long_seq, data, 15, raise_on_drop=True)
+
+        # This should return False, since data doesn't fit
+        dropped = drop_long_seq(data, 15)
+        self.assertFalse(dropped)
+
+        # -- batch sequence --
+        # This should work
+        data = {
+            "input_ids": [
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            ]
+        }
+        drop_long_seq(data, 32, raise_on_drop=True)
+
+        # This should raise
+        self.assertRaises(ValueError, drop_long_seq, data, 15, raise_on_drop=True)
+
+        # This should keep the first but drop the second entry
+        dropped = drop_long_seq(data, 15)
+        self.assertEqual(dropped, [True, False])
 
 
 if __name__ == "__main__":

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -543,3 +543,17 @@ class TestDatasetPreparation:
             except ValueError:
                 raised = True
             assert raised
+
+        from axolotl.utils.trainer import drop_long_seq
+
+        # This should work
+        data = {"input_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]}
+        drop_long_seq(data, 32, raise_on_drop=True)
+
+        # This should not
+        raised = False
+        try:
+            drop_long_seq(data, 15, raise_on_drop=True)
+        except ValueError:
+            raised = True
+        assert raised

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -17,7 +17,6 @@ from axolotl.utils.data.sft import (
     _load_tokenized_prepared_datasets,
 )
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.trainer import drop_long_seq
 
 from tests.constants import (
     ALPACA_MESSAGES_CONFIG_OG,
@@ -488,42 +487,3 @@ class TestDatasetPreparation:
             assert "attention_mask" in dataset.features
             assert "labels" in dataset.features
             shutil.rmtree(tmp_ds_path)
-
-    @enable_hf_offline
-    def test_excess_length_strategy(self):
-        """Test that excess_length_strategy results in a value error when set to 'raise'."""
-
-        # -- single sequence --
-        # This should work
-        data = {"input_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]}
-        drop_long_seq(data, 32, raise_on_drop=True)
-
-        # This should return True, since data fits
-        dropped = drop_long_seq(data, 32)
-        assert dropped is True
-
-        # This should raise
-        with pytest.raises(ValueError):
-            drop_long_seq(data, 15, raise_on_drop=True)
-
-        # This should return False, since data doesn't fit
-        dropped = drop_long_seq(data, 15)
-        assert dropped is False
-
-        # -- batch sequence --
-        # This should work
-        data = {
-            "input_ids": [
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-            ]
-        }
-        drop_long_seq(data, 32, raise_on_drop=True)
-
-        # This should raise
-        with pytest.raises(ValueError):
-            drop_long_seq(data, 15, raise_on_drop=True)
-
-        # This should keep the first but drop the second entry
-        dropped = drop_long_seq(data, 15)
-        assert dropped == [True, False]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -490,6 +490,7 @@ class TestDatasetPreparation:
             assert "labels" in dataset.features
             shutil.rmtree(tmp_ds_path)
 
+    @enable_hf_offline
     def test_excess_length_strategy(self):
         """Test that excess_length_strategy results in a value error when set to 'raise'."""
         cfg = DictDefault(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -527,8 +527,6 @@ class TestDatasetPreparation:
                 normalize_config(cfg)
                 return cfg
 
-            from axolotl.loaders import load_tokenizer
-
             cfg = cfg_with(sequence_len=2048)
             tokenizer = load_tokenizer(cfg)
 
@@ -537,12 +535,8 @@ class TestDatasetPreparation:
 
             # This should not
             cfg = cfg_with(sequence_len=512)
-            raised = False
-            try:
+            with pytest.raises(ValueError):
                 prepare_datasets(cfg, tokenizer=tokenizer)
-            except ValueError:
-                raised = True
-            assert raised
 
         from axolotl.utils.trainer import drop_long_seq
 
@@ -551,9 +545,5 @@ class TestDatasetPreparation:
         drop_long_seq(data, 32, raise_on_drop=True)
 
         # This should not
-        raised = False
-        try:
+        with pytest.raises(ValueError):
             drop_long_seq(data, 15, raise_on_drop=True)
-        except ValueError:
-            raised = True
-        assert raised


### PR DESCRIPTION
# Description

It is sometimes not desired that sequences are silently dropped from the dataset, especially when the dataset has been carefully crafted and pre-fitted for the training context. This would then suggest that an error occurred somewhere in the process. This feature adds a third value for excess_length_strategy called 'raise', which will raise a ValueError if a sequence is encountered that is too long and would have normally been dropped/truncated.

## Motivation and Context

If the user has already pre-fitted the training data for the target context size, they would want to know if there were dropped sequences. Truncating and dropping are both inadequate in this use case.

## How has this been tested?

I tested this by providing a config with a too-big sequence length and set the strategy to 'raise'.

I have also added a new unit test to `test_data.py` which tests the new behavior.

## Types of changes

Adds new option to existing configuration parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "raise" option for handling inputs that exceed the maximum sequence length so the system can surface an error instead of truncating or dropping.

* **Improvements**
  * Made decision logic for excess-length handling consistent during dataset filtering so the chosen strategy is applied reliably.

* **Tests**
  * Added tests to verify excess-length behavior and updated public exports to support dataset/config workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->