### PR TITLE
allow users to set ndigits for rounding of metrics when logging

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -604,6 +604,7 @@ class AxolotlTrainer(
         """
         # logs either has 'loss' or 'eval_loss'
         train_eval = "train" if "loss" in logs else "eval"
+        metric_ndigits = int(os.getenv("AXOLOTL_METRIC_NDIGITS", "5"))
 
         for key, metric_data in self._stored_metrics[train_eval].items():
             values = torch.tensor(metric_data["values"])  # type: ignore[arg-type]
@@ -614,17 +615,16 @@ class AxolotlTrainer(
                 raise NotImplementedError(
                     "Metric reduction must be one of [mean, min, max, sum]"
                 )
-            METRIC_PRECISION = int(os.getenv("AXOLOTL_METRIC_PRECISION", "8"))
-            logs[key] = round(fn(values).item(), METRIC_PRECISION)
+            logs[key] = round(fn(values).item(), metric_ndigits)
 
         if "loss" in logs:
             try:
-                logs["ppl"] = round(math.exp(logs["loss"]), METRIC_PRECISION)
+                logs["ppl"] = round(math.exp(logs["loss"]), metric_ndigits)
             except OverflowError:
                 logs["ppl"] = float("inf")
         if "eval_loss" in logs:
             try:
-                logs["eval_ppl"] = round(math.exp(logs["eval_loss"]), METRIC_PRECISION)
+                logs["eval_ppl"] = round(math.exp(logs["eval_loss"]), metric_ndigits)
             except OverflowError:
                 logs["eval_ppl"] = float("inf")
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -614,16 +614,17 @@ class AxolotlTrainer(
                 raise NotImplementedError(
                     "Metric reduction must be one of [mean, min, max, sum]"
                 )
-            logs[key] = round(fn(values).item(), 4)
+            METRIC_PRECISION = int(os.getenv("AXOLOTL_METRIC_PRECISION", "8"))
+            logs[key] = round(fn(values).item(), METRIC_PRECISION)
 
         if "loss" in logs:
             try:
-                logs["ppl"] = round(math.exp(logs["loss"]), 4)
+                logs["ppl"] = round(math.exp(logs["loss"]), METRIC_PRECISION)
             except OverflowError:
                 logs["ppl"] = float("inf")
         if "eval_loss" in logs:
             try:
-                logs["eval_ppl"] = round(math.exp(logs["eval_loss"]), 4)
+                logs["eval_ppl"] = round(math.exp(logs["eval_loss"]), METRIC_PRECISION)
             except OverflowError:
                 logs["eval_ppl"] = float("inf")
 


### PR DESCRIPTION
# Description
```
METRIC_PRECISION = int(os.getenv("AXOLOTL_METRIC_PRECISION", "8"))
logs[key] = round(fn(values).item(), METRIC_PRECISION)
```

#3320 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric precision in logging and evaluation outputs is now configurable through an environment variable, enabling users to customize the rounding precision for their metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->