### PR TITLE
feat: add hub_revision support for specifying branch when pushing checkpoints

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -409,6 +409,9 @@ class TrainerBuilderBase(abc.ABC):
             if self.cfg.hub_strategy:
                 training_args_kwargs["hub_strategy"] = self.cfg.hub_strategy
 
+            if self.cfg.hub_revision:
+                training_args_kwargs["hub_revision"] = self.cfg.hub_revision
+
     def _configure_save_and_eval_strategy(self, training_args_kwargs: dict):
         # save_strategy and save_steps
         if self.cfg.save_steps:

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -120,6 +120,12 @@ class ModelOutputConfig(BaseModel):
         default=None,
         json_schema_extra={"description": "how to push checkpoints to hub"},
     )
+    hub_revision: str | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "branch/revision to push to on hub (default: main)"
+        },
+    )
     save_safetensors: bool | None = Field(
         default=True,
         json_schema_extra={


### PR DESCRIPTION
## Summary

Adds support for the `hub_revision` config parameter, allowing users to specify which branch/revision to push checkpoints to on Hugging Face Hub instead of always using the default branch.

## Changes

- Added `hub_revision` field to the config schema (`src/axolotl/utils/schemas/model.py`)
- Added handling for `hub_revision` in `_configure_hub_parameters` (`src/axolotl/core/builders/base.py`)

## Usage

```yaml
hub_model_id: my-org/my-model
hub_strategy: every_save
hub_revision: dev-branch  # NEW: push to specific branch instead of main
```

This passes the `hub_revision` parameter to HuggingFace's `TrainingArguments`, which already supports this feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring hub revision settings on model outputs. Users can now specify target branches and revisions when pushing models to external hubs, enabling more flexible and controlled deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->