### PR TITLE
feat: add auto-chunking support for streaming pretraining datasets

### DIFF
--- a/src/axolotl/utils/data/streaming.py
+++ b/src/axolotl/utils/data/streaming.py
@@ -24,27 +24,89 @@ def encode_streaming(
     text_column: str = "text",
     concatenate: bool = True,
 ) -> Dict[str, List]:
-    res = tokenizer(
+    """
+    Encode streaming examples with auto-chunking support.
+
+    Tokenizes text without truncation, appends EOS/PAD document boundary tokens,
+    then splits into max_tokens-sized chunks. This ensures no data is lost from
+    long sequences while preserving document boundaries for pretraining.
+
+    Note: When concatenate=False, individual samples that exceed max_tokens will
+    be split into multiple chunks (rather than truncated), so the output may have
+    more rows than the input.
+
+    Note: Tokenization is performed without truncation so that long documents can
+    be chunked rather than silently lost. The streaming buffer size
+    (streaming_multipack_buffer_size) controls how many examples are batched at
+    once, limiting peak memory usage.
+
+    Args:
+        examples: Dictionary containing text samples
+        tokenizer: The tokenizer to use
+        max_tokens: Maximum sequence length for each chunk
+        text_column: Name of the text column in examples
+        concatenate: If True, concatenate all samples before chunking
+
+    Returns:
+        Dictionary with input_ids, labels, and attention_mask lists
+    """
+    # Tokenize without truncation to preserve all data
+    full_inputs = tokenizer(
         examples[text_column],
-        truncation=True,
-        max_length=max_tokens - 2,
         add_special_tokens=True,
     )
+
     # Convert to PyTorch tensors
-    input_ids = [torch.tensor(seq) for seq in res["input_ids"]]
-    targets = [torch.tensor(seq) for seq in res["input_ids"]]
-    attention_mask = [torch.tensor(seq) for seq in res["attention_mask"]]
+    input_ids = [
+        torch.tensor(sample, dtype=torch.long) for sample in full_inputs["input_ids"]
+    ]
+    targets = [
+        torch.tensor(sample, dtype=torch.long) for sample in full_inputs["input_ids"]
+    ]
+    attention_mask = [
+        torch.tensor(sample, dtype=torch.long)
+        for sample in full_inputs["attention_mask"]
+    ]
+
     if not concatenate:
+        # Without concatenation, chunk each sample independently into max_tokens pieces
+        pad_id = (
+            tokenizer.pad_token_id
+            if tokenizer.pad_token_id is not None
+            else (tokenizer.eos_token_id or 0)
+        )
+        new_input_ids = []
+        new_labels = []
+        new_attention_mask = []
+
+        for ids, tgts, mask in zip(input_ids, targets, attention_mask, strict=False):
+            sample_len = ids.numel()
+            for start in range(0, sample_len, max_tokens):
+                end = min(start + max_tokens, sample_len)
+                chunk_len = end - start
+
+                chunk_ids = torch.full((max_tokens,), pad_id, dtype=torch.long)
+                chunk_labels = torch.full((max_tokens,), -100, dtype=torch.long)
+                chunk_mask = torch.zeros((max_tokens,), dtype=torch.long)
+
+                chunk_ids[:chunk_len] = ids[start:end]
+                chunk_labels[:chunk_len] = tgts[start:end]
+                chunk_mask[:chunk_len] = mask[start:end]
+
+                new_input_ids.append(chunk_ids)
+                new_labels.append(chunk_labels)
+                new_attention_mask.append(chunk_mask)
+
+        LOG.debug("encode_streaming (no concat): created %d chunks", len(new_input_ids))
         return {
-            "input_ids": [seq.tolist() for seq in input_ids],
-            "labels": [seq.tolist() for seq in targets],
-            "attention_mask": [seq.tolist() for seq in attention_mask],
+            "input_ids": [seq.tolist() for seq in new_input_ids],
+            "labels": [seq.tolist() for seq in new_labels],
+            "attention_mask": [seq.tolist() for seq in new_attention_mask],
         }
 
-    new_input_ids = []
-    new_labels = []
-    new_attention_mask = []
-    # Append EOS and PAD tokens to input_ids, and correct attention_mask
+    # --- concatenate=True path ---
+
+    # Append EOS and PAD tokens to mark document boundaries (before concatenation)
     for i, _ in enumerate(input_ids):
         input_ids[i] = torch.cat(
             (
@@ -62,118 +124,53 @@ def encode_streaming(
         )
         attention_mask[i] = torch.cat((attention_mask[i], torch.tensor([1, 0])), dim=0)
 
-    # Concatenate tokens so that their lengths are less than max_tokens
-    buffer_input_ids = torch.tensor([], dtype=torch.long)
-    buffer_labels = torch.tensor([], dtype=torch.long)
-    buffer_attention_mask = torch.tensor([], dtype=torch.long)
+    # Concatenate all samples into a single stream
+    all_input_ids = torch.cat(input_ids, dim=0)
+    all_targets = torch.cat(targets, dim=0)
+    all_attention_mask = torch.cat(attention_mask, dim=0)
 
-    for ids, labels, mask in zip(input_ids, targets, attention_mask, strict=False):
-        if buffer_input_ids.numel() == max_tokens:
-            new_input_ids.append(buffer_input_ids)
-            new_labels.append(buffer_labels)
-            new_attention_mask.append(buffer_attention_mask)
-            buffer_input_ids = torch.tensor([], dtype=torch.long)
-            buffer_labels = torch.tensor([], dtype=torch.long)
-            buffer_attention_mask = torch.tensor([], dtype=torch.long)
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
-        elif buffer_input_ids.numel() + ids.numel() <= max_tokens:
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
-        else:
-            buffer_input_ids = torch.cat(
-                (
-                    buffer_input_ids,
-                    torch.full(
-                        (max_tokens - buffer_input_ids.numel(),),
-                        tokenizer.pad_token_id,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_labels = torch.cat(
-                (
-                    buffer_labels,
-                    torch.full(
-                        (max_tokens - buffer_labels.numel(),),
-                        -100,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_attention_mask = torch.cat(
-                (
-                    buffer_attention_mask,
-                    torch.full(
-                        (max_tokens - buffer_attention_mask.numel(),),
-                        0,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            new_input_ids.append(buffer_input_ids)
-            new_labels.append(buffer_labels)
-            new_attention_mask.append(buffer_attention_mask)
-            buffer_input_ids = torch.tensor([], dtype=torch.long)
-            buffer_labels = torch.tensor([], dtype=torch.long)
-            buffer_attention_mask = torch.tensor([], dtype=torch.long)
+    total_len = all_input_ids.numel()
 
-            buffer_input_ids = torch.cat((buffer_input_ids, ids), dim=0)
-            buffer_labels = torch.cat((buffer_labels, labels), dim=0)
-            buffer_attention_mask = torch.cat((buffer_attention_mask, mask), dim=0)
+    # Resolve a safe pad token id for chunk padding
+    pad_id = (
+        tokenizer.pad_token_id
+        if tokenizer.pad_token_id is not None
+        else (tokenizer.eos_token_id or 0)
+    )
 
-    if buffer_input_ids.numel() > 0:  # for any leftover tokens
-        while buffer_input_ids.numel() < max_tokens:  # make all sequences equal in size
-            buffer_input_ids = torch.cat(
-                (
-                    buffer_input_ids,
-                    torch.full(
-                        (max_tokens - buffer_input_ids.numel(),),
-                        tokenizer.pad_token_id,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_labels = torch.cat(
-                (
-                    buffer_labels,
-                    torch.full(
-                        (max_tokens - buffer_labels.numel(),),
-                        -100,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-            buffer_attention_mask = torch.cat(
-                (
-                    buffer_attention_mask,
-                    torch.full(
-                        (max_tokens - buffer_attention_mask.numel(),),
-                        0,
-                        dtype=torch.long,
-                    ),
-                ),
-                dim=0,
-            )
-        new_input_ids.append(buffer_input_ids)
-        new_labels.append(buffer_labels)
-        new_attention_mask.append(buffer_attention_mask)
+    if tokenizer.pad_token_id is None:
+        LOG.warning(
+            "tokenizer.pad_token_id is None; falling back to %s for padding", pad_id
+        )
 
-    ret = {
+    new_input_ids = []
+    new_labels = []
+    new_attention_mask = []
+
+    # Split the concatenated stream into max_tokens-sized chunks
+    for start in range(0, total_len, max_tokens):
+        end = min(start + max_tokens, total_len)
+        chunk_len = end - start
+
+        chunk_ids = torch.full((max_tokens,), pad_id, dtype=torch.long)
+        chunk_labels = torch.full((max_tokens,), -100, dtype=torch.long)
+        chunk_mask = torch.zeros((max_tokens,), dtype=torch.long)
+
+        chunk_ids[:chunk_len] = all_input_ids[start:end]
+        chunk_labels[:chunk_len] = all_targets[start:end]
+        chunk_mask[:chunk_len] = all_attention_mask[start:end]
+
+        new_input_ids.append(chunk_ids)
+        new_labels.append(chunk_labels)
+        new_attention_mask.append(chunk_mask)
+
+    LOG.debug("encode_streaming: created %d chunks", len(new_input_ids))
+
+    return {
         "input_ids": [seq.tolist() for seq in new_input_ids],
         "labels": [seq.tolist() for seq in new_labels],
         "attention_mask": [seq.tolist() for seq in new_attention_mask],
     }
-
-    LOG.debug(len(ret["input_ids"]))
-    return ret
 
 
 def wrap_streaming_dataset(
@@ -182,6 +179,7 @@ def wrap_streaming_dataset(
     cfg,
     ds_wrapper_fn,
 ):
+    """Wrap a streaming dataset with encoding/packing logic."""
     if cfg.sample_packing:
         # For SFT (non-pretraining) datasets, always use multipack_attn=True to ensure
         # attention isolation between packed sequences
@@ -204,6 +202,7 @@ def wrap_streaming_dataset(
             batch_size=cfg.micro_batch_size,
             multipack_attn=multipack_attn,
             bin_size=cfg.sample_packing_bin_size,
+            is_pretraining=bool(cfg.pretraining_dataset),
         )
 
         # Set this to 1 so downstream data_loader doesn't try to increase the batch size
@@ -251,6 +250,88 @@ def wrap_streaming_dataset(
     return dataset
 
 
+def _chunk_long_sequences(
+    train_dataset: Dataset,
+    max_seq_length: int,
+) -> Dataset:
+    """
+    Chunk sequences longer than max_seq_length into multiple smaller sequences.
+
+    Instead of dropping long sequences (which loses data), this function splits
+    them into max_seq_length-sized chunks. This is especially useful for pretraining
+    datasets with very long samples (e.g., millions of tokens per example).
+
+    Note: This should only be used for pretraining. For SFT, long sequences should
+    be dropped to maintain complete instruction-response pairs.
+
+    Note: The last chunk of a split sequence may be shorter than max_seq_length.
+    This is intentional to preserve all data; the downstream packer handles
+    variable-length sequences.
+
+    Args:
+        train_dataset: Dataset with input_ids, attention_mask, and optionally labels
+        max_seq_length: Maximum sequence length for each chunk
+
+    Returns:
+        Dataset with all sequences <= max_seq_length
+    """
+    columns = train_dataset.column_names
+    has_labels = "labels" in columns
+    has_attention_mask = "attention_mask" in columns
+
+    # Use batch column access for performance (avoids per-element __getitem__)
+    all_input_ids: list = train_dataset["input_ids"]
+    all_attention_mask: list = (
+        train_dataset["attention_mask"] if has_attention_mask else []
+    )
+    all_labels: list = train_dataset["labels"] if has_labels else []
+
+    total_samples = len(all_input_ids)
+
+    new_data = defaultdict(list)
+    total_chunks = 0
+    long_samples = 0
+
+    for i in range(total_samples):
+        input_ids = all_input_ids[i]
+        seq_len = len(input_ids)
+
+        if seq_len <= max_seq_length:
+            new_data["input_ids"].append(input_ids)
+            if has_attention_mask:
+                new_data["attention_mask"].append(all_attention_mask[i])
+            if has_labels:
+                new_data["labels"].append(all_labels[i])
+            total_chunks += 1
+        else:
+            long_samples += 1
+            num_chunks = (seq_len + max_seq_length - 1) // max_seq_length
+            for chunk_idx in range(num_chunks):
+                start = chunk_idx * max_seq_length
+                end = min(start + max_seq_length, seq_len)
+
+                new_data["input_ids"].append(input_ids[start:end])
+                if has_attention_mask:
+                    new_data["attention_mask"].append(all_attention_mask[i][start:end])
+                if has_labels:
+                    new_data["labels"].append(all_labels[i][start:end])
+                total_chunks += 1
+
+    if long_samples == 0:
+        return train_dataset
+
+    LOG.info(
+        "Chunked %d/%d sequences exceeding max_seq_length=%d: %d samples -> %d chunks",
+        long_samples,
+        total_samples,
+        max_seq_length,
+        total_samples,
+        total_chunks,
+    )
+
+    return Dataset.from_dict(dict(new_data))
+
+
 def encode_packed_streaming(
     collate_fn,
     ds_wrapper: Callable,
@@ -259,17 +340,40 @@ def encode_packed_streaming(
     max_seq_length: int = 2048,
     batch_size: int = 4,
     multipack_attn: Optional[bool] = True,
+    is_pretraining: bool = False,
 ) -> Dict[str, List]:
-    # tokenize all the examples
-    # rows get split with stride (overlap)
+    """
+    Encode examples for sample packing with streaming support.
+
+    This function tokenizes examples, optionally chunks long sequences (for pretraining),
+    and then packs them together efficiently using MultipackBatchSampler.
+
+    For pretraining: long sequences are chunked to preserve data.
+    For SFT: long sequences are dropped to maintain complete instruction-response pairs.
+
+    Args:
+        collate_fn: Collator function for batching
+        ds_wrapper: Dataset wrapper function for tokenization
+        examples: Raw examples to process
+        bin_size: Bin size for multipack sampler
+        max_seq_length: Maximum sequence length
+        batch_size: Micro batch size
+        multipack_attn: Whether to use multipack attention
+        is_pretraining: If True, chunk long sequences; if False, let them be dropped
+    """
+    # Tokenize all the examples
     train_dataset = ds_wrapper(dataset=Dataset.from_dict(examples))[0]
 
+    # Only chunk long sequences for pretraining (preserves data)
+    # For SFT, we want to drop long sequences to keep complete examples
+    if is_pretraining:
+        train_dataset = _chunk_long_sequences(train_dataset, max_seq_length)
+
+    # Process for packing - sequences are now all <= max_seq_length
     train_dataset = process_pretraining_datasets_for_packing(
         train_dataset,
         max_seq_length,
         skip_position_ids=not multipack_attn,
-        # FIXME using attention mask unpad/pad with trainer and packed pretraining is broken atm
-        # workaround by using the position id logic for now in trainer
         drop_attention_mask=multipack_attn,
     )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -116,10 +116,10 @@ class TestChunkLongSequences(unittest.TestCase):
             }
         )
         result = _chunk_long_sequences(ds, max_seq_length=5)
-        # Should return the same dataset unchanged
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3])
-        self.assertEqual(result[1]["input_ids"], [4, 5, 6])
+        # Should return the same data unchanged
+        self.assertEqual(len(result["input_ids"]), 2)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3])
+        self.assertEqual(result["input_ids"][1], [4, 5, 6])
 
     def test_sequence_exactly_at_max(self):
         """Sequences exactly at max_seq_length should not be chunked."""
@@ -131,8 +131,8 @@ class TestChunkLongSequences(unittest.TestCase):
             }
         )
         result = _chunk_long_sequences(ds, max_seq_length=5)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3, 4, 5])
+        self.assertEqual(len(result["input_ids"]), 1)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3, 4, 5])
 
     def test_sequence_requires_multiple_chunks(self):
         """A long sequence should be split into max_seq_length-sized chunks."""
@@ -145,13 +145,13 @@ class TestChunkLongSequences(unittest.TestCase):
         )
         result = _chunk_long_sequences(ds, max_seq_length=4)
         # 10 tokens / 4 = 3 chunks (4, 4, 2)
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3, 4])
-        self.assertEqual(result[1]["input_ids"], [5, 6, 7, 8])
-        self.assertEqual(result[2]["input_ids"], [9, 10])
+        self.assertEqual(len(result["input_ids"]), 3)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3, 4])
+        self.assertEqual(result["input_ids"][1], [5, 6, 7, 8])
+        self.assertEqual(result["input_ids"][2], [9, 10])
         # Check attention_mask and labels are chunked the same way
-        self.assertEqual(result[0]["attention_mask"], [1, 1, 1, 1])
-        self.assertEqual(result[2]["labels"], [9, 10])
+        self.assertEqual(result["attention_mask"][0], [1, 1, 1, 1])
+        self.assertEqual(result["labels"][2], [9, 10])
 
     def test_trailing_short_chunk(self):
         """The last chunk of a split can be shorter than max_seq_length."""
@@ -163,10 +163,10 @@ class TestChunkLongSequences(unittest.TestCase):
         )
         result = _chunk_long_sequences(ds, max_seq_length=3)
         # 7 tokens / 3 = 3 chunks (3, 3, 1)
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3])
-        self.assertEqual(result[1]["input_ids"], [4, 5, 6])
-        self.assertEqual(result[2]["input_ids"], [7])
+        self.assertEqual(len(result["input_ids"]), 3)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3])
+        self.assertEqual(result["input_ids"][1], [4, 5, 6])
+        self.assertEqual(result["input_ids"][2], [7])
 
     def test_mixed_short_and_long(self):
         """Mix of short and long sequences; only long ones are chunked."""
@@ -181,11 +181,11 @@ class TestChunkLongSequences(unittest.TestCase):
         # First sample (2 tokens): kept as is
         # Second sample (6 tokens): split into 2 chunks (4, 2)
         # Third sample (2 tokens): kept as is
-        self.assertEqual(len(result), 4)
-        self.assertEqual(result[0]["input_ids"], [1, 2])
-        self.assertEqual(result[1]["input_ids"], [3, 4, 5, 6])
-        self.assertEqual(result[2]["input_ids"], [7, 8])
-        self.assertEqual(result[3]["input_ids"], [9, 10])
+        self.assertEqual(len(result["input_ids"]), 4)
+        self.assertEqual(result["input_ids"][0], [1, 2])
+        self.assertEqual(result["input_ids"][1], [3, 4, 5, 6])
+        self.assertEqual(result["input_ids"][2], [7, 8])
+        self.assertEqual(result["input_ids"][3], [9, 10])
 
     def test_without_labels(self):
         """Chunking should work when labels column is absent."""
@@ -196,10 +196,10 @@ class TestChunkLongSequences(unittest.TestCase):
             }
         )
         result = _chunk_long_sequences(ds, max_seq_length=4)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3, 4])
-        self.assertEqual(result[1]["input_ids"], [5, 6])
-        self.assertNotIn("labels", result.column_names)
+        self.assertEqual(len(result["input_ids"]), 2)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3, 4])
+        self.assertEqual(result["input_ids"][1], [5, 6])
+        self.assertNotIn("labels", result)
 
     def test_without_attention_mask(self):
         """Chunking should work when attention_mask column is absent."""
@@ -210,10 +210,10 @@ class TestChunkLongSequences(unittest.TestCase):
             }
         )
         result = _chunk_long_sequences(ds, max_seq_length=4)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0]["input_ids"], [1, 2, 3, 4])
-        self.assertEqual(result[1]["labels"], [5, 6])
-        self.assertNotIn("attention_mask", result.column_names)
+        self.assertEqual(len(result["input_ids"]), 2)
+        self.assertEqual(result["input_ids"][0], [1, 2, 3, 4])
+        self.assertEqual(result["labels"][1], [5, 6])
+        self.assertNotIn("attention_mask", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds auto-truncation support for streaming pretraining datasets, ensuring no data is lost from long sequences.

Based on PR #3081 (feature/pretraining-auto-truncate) but:
1. Updated for the refactored codebase (pretraining.py → streaming.py, encode_pretraining → encode_streaming)
2. Extended to support `sample_packing: true` via a new `_chunk_long_sequences()` function

## Changes

### `encode_streaming` (for `sample_packing: false`)
- Tokenizes without truncation to preserve all data
- Automatically splits long sequences into `max_tokens`-sized chunks
- Handles pad token fallback gracefully

### `_chunk_long_sequences` (NEW - for `sample_packing: true`)
- Chunks sequences longer than `max_seq_length` instead of dropping them
- Called in `encode_packed_streaming` before sample packing
- Preserves all data that would otherwise be lost by the "Dropping Long Sequences" filter

## Motivation

The original PR #3081 only addressed non-packed streaming. When `sample_packing: true`, long sequences were still being dropped silently. This PR ensures data preservation for both code paths.

## Test plan

- [x] Tested with `sample_packing: false` - sequences are chunked correctly
- [x] Tested with `sample_packing: true` - long sequences are chunked before packing instead of dropped
- [x] Verified no data loss with datasets containing very long samples

## Related

- Builds on #3081 (not merged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced streaming data processing with an improved sequence chunking strategy that uses fixed-size chunks instead of truncation-based approaches, providing significantly better handling of long input sequences during training data preparation workflows.
  * Implemented enhanced padding logic for more robust and stable processing of variable-length sequences in the data pipeline infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->