### PR TITLE
Fix: excess_length_strategy truncation  method

### DIFF
--- a/src/axolotl/utils/data/utils.py
+++ b/src/axolotl/utils/data/utils.py
@@ -207,7 +207,7 @@ def _should_skip_processing(dataset: Dataset) -> bool:
 
 def _log_dataset_stats(dataset: Dataset) -> None:
     """Log min/max sequence lengths for debugging."""
-    with contextlib.suppress(AttributeError):
+    with contextlib.suppress(AttributeError, ValueError):
         ds_lengths = get_dataset_lengths(dataset, from_arrow=True)
         LOG.info(f"min_input_len: {np.min(ds_lengths)}")
         LOG.info(f"max_input_len: {np.max(ds_lengths)}")

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -205,47 +205,13 @@ def add_length(sample):
     return sample
 
 
-def check_max_seq_length(sample, sequence_len=2048, raise_on_long=False):
+def filter_sequences_by_length(
+    sample, sequence_len=2048, min_sequence_len=2, raise_on_drop=False
+):
     """
-    Check if samples exceed the maximum sequence length.
+    Filter sequences outside valid length range [min_sequence_len, sequence_len].
 
-    Works for both single-example (list[int]) or batched (list[list[int]]).
-
-    If raise_on_long is set, raises a ValueError if a sample exceeds sequence_len.
-    Otherwise returns True if sample is within limit, False if too long.
-    """
-    input_ids = sample["input_ids"]
-
-    # Edge case: if input_ids is empty, keep it (filtering short samples is separate)
-    if not input_ids:
-        return True
-
-    # Check if single example or batched by looking at the first element
-    if isinstance(input_ids[0], int):
-        # Single example (input_ids is a list of int)
-        length = len(input_ids)
-        if raise_on_long and length > sequence_len:
-            raise ValueError(
-                f"Sequence encountered with {length} tokens, which exceeds the maximum {sequence_len}."
-            )
-        return length <= sequence_len
-
-    # Batched (input_ids is a list of lists)
-    results = []
-    for seq in input_ids:
-        length = len(seq)
-        if raise_on_long and length > sequence_len:
-            raise ValueError(
-                f"Sequence encountered with {length} tokens, which exceeds the maximum {sequence_len}."
-            )
-        results.append(length <= sequence_len)
-    return results
-
-
-def drop_long_seq(sample, sequence_len=2048, min_sequence_len=2, raise_on_drop=False):
-    """
-    Drop samples whose sequence length is either too long (> sequence_len)
-    or too short (< min_sequence_len).
+    Drops samples that are either too short (< min_sequence_len) or too long (> sequence_len).
 
     Works for both single-example (list[int]) or batched (list[list[int]]).
 
@@ -420,10 +386,10 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
 def process_pretraining_datasets_for_packing(
     train_dataset, sequence_len, skip_position_ids=True, drop_attention_mask=False
 ):
-    drop_long = partial(drop_long_seq, sequence_len=sequence_len)
+    drop_outside_range = partial(filter_sequences_by_length, sequence_len=sequence_len)
 
     train_dataset = train_dataset.filter(
-        drop_long,
+        drop_outside_range,
         desc="Dropping Long Sequences",
         load_from_cache_file=False,
     )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,7 +7,7 @@ import unittest
 from transformers import LlamaTokenizer
 
 from axolotl.utils.data import encode_streaming, md5
-from axolotl.utils.trainer import drop_long_seq
+from axolotl.utils.trainer import filter_sequences_by_length
 
 from tests.hf_offline_utils import enable_hf_offline
 
@@ -70,17 +70,19 @@ class TestEncodePretraining(unittest.TestCase):
         # -- single sequence --
         # This should work
         data = {"input_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]}
-        drop_long_seq(data, 32, raise_on_drop=True)
+        filter_sequences_by_length(data, 32, raise_on_drop=True)
 
         # This should return True, since data fits
-        dropped = drop_long_seq(data, 32)
+        dropped = filter_sequences_by_length(data, 32)
         self.assertTrue(dropped)
 
         # This should raise
-        self.assertRaises(ValueError, drop_long_seq, data, 15, raise_on_drop=True)
+        self.assertRaises(
+            ValueError, filter_sequences_by_length, data, 15, raise_on_drop=True
+        )
 
         # This should return False, since data doesn't fit
-        dropped = drop_long_seq(data, 15)
+        dropped = filter_sequences_by_length(data, 15)
         self.assertFalse(dropped)
 
         # -- batch sequence --
@@ -91,13 +93,15 @@ class TestEncodePretraining(unittest.TestCase):
                 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             ]
         }
-        drop_long_seq(data, 32, raise_on_drop=True)
+        filter_sequences_by_length(data, 32, raise_on_drop=True)
 
         # This should raise
-        self.assertRaises(ValueError, drop_long_seq, data, 15, raise_on_drop=True)
+        self.assertRaises(
+            ValueError, filter_sequences_by_length, data, 15, raise_on_drop=True
+        )
 
         # This should keep the first but drop the second entry
-        dropped = drop_long_seq(data, 15)
+        dropped = filter_sequences_by_length(data, 15)
         self.assertEqual(dropped, [True, False])
 
 

--- a/tests/utils/data/test_utils.py
+++ b/tests/utils/data/test_utils.py
@@ -378,13 +378,8 @@ class TestHandleLongSeqInDataset(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["input_ids"], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    @unittest.mock.patch("axolotl.utils.data.utils._log_dataset_stats")
-    def test_empty_dataset(self, _mock_log):
-        """Test that an empty dataset is handled gracefully.
-
-        Note: _log_dataset_stats is patched out because it crashes on empty
-        datasets due to np.vectorize not supporting size-0 inputs.
-        """
+    def test_empty_dataset(self):
+        """Test that an empty dataset is handled gracefully"""
         dataset = Dataset.from_dict({"input_ids": []})
 
         cfg = DictDefault(

--- a/tests/utils/data/test_utils.py
+++ b/tests/utils/data/test_utils.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for data utility functions
+"""
+
+import unittest
+
+from datasets import Dataset
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.data.utils import handle_long_seq_in_dataset
+
+
+class TestHandleLongSeqInDataset(unittest.TestCase):
+    """
+    Test class for handle_long_seq_in_dataset function
+    """
+
+    def test_drop_strategy_removes_long_sequences(self):
+        """Test that 'drop' strategy removes sequences longer than sequence_len"""
+        # Create dataset with mixed length sequences
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1, 2, 3],           # length 3 - keep
+                [1, 2, 3, 4, 5],     # length 5 - keep
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # length 11 - drop
+                [1, 2],              # length 2 - keep
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "drop",
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should have dropped the sequence with length 11
+        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result[0]["input_ids"]), 3)
+        self.assertEqual(len(result[1]["input_ids"]), 5)
+        self.assertEqual(len(result[2]["input_ids"]), 2)
+
+    def test_drop_strategy_is_default(self):
+        """Test that 'drop' is the default strategy when not specified"""
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1, 2, 3],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # length 11 - should drop
+            ]
+        })
+
+        cfg = DictDefault({
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should have dropped the long sequence
+        self.assertEqual(len(result), 1)
+
+    def test_truncate_strategy_truncates_long_sequences(self):
+        """Test that 'truncate' strategy truncates sequences to sequence_len"""
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1, 2, 3],           # length 3 - keep as is
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],  # length 12 - truncate to 10
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "truncate",
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should have 2 samples
+        self.assertEqual(len(result), 2)
+        # First sample unchanged
+        self.assertEqual(len(result[0]["input_ids"]), 3)
+        # Second sample truncated to 10
+        self.assertEqual(len(result[1]["input_ids"]), 10)
+        self.assertEqual(result[1]["input_ids"], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+    def test_raise_strategy_raises_on_long_sequences(self):
+        """Test that 'raise' strategy raises ValueError when encountering long sequences"""
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1, 2, 3],
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # length 11 - should raise
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "raise",
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        with self.assertRaises(ValueError):
+            handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+    def test_min_sequence_len_filters_short_sequences(self):
+        """Test that sequences shorter than min_sample_len are filtered out"""
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1],                 # length 1 - drop (< min_sample_len=3)
+                [1, 2],              # length 2 - drop
+                [1, 2, 3],           # length 3 - keep
+                [1, 2, 3, 4, 5],     # length 5 - keep
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "drop",
+            "min_sample_len": 3,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should only keep sequences with length >= 3
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]["input_ids"]), 3)
+        self.assertEqual(len(result[1]["input_ids"]), 5)
+
+    def test_dataset_without_input_ids_column(self):
+        """Test that datasets without 'input_ids' column are returned unchanged"""
+        dataset = Dataset.from_dict({
+            "chosen": [1, 2, 3],
+            "rejected": [4, 5, 6],
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "drop",
+            "min_sample_len": 2,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Dataset should be unchanged
+        self.assertEqual(len(result), len(dataset))
+        self.assertListEqual(list(result.column_names), ["chosen", "rejected"])
+
+    def test_truncate_filters_short_before_truncating(self):
+        """Test that truncate strategy filters short sequences before truncating long ones
+
+        This is important for efficiency - we should not waste time truncating
+        sequences that will be filtered out anyway.
+        """
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1],                 # length 1 - filter out first
+                [1, 2, 3],           # length 3 - keep, no truncation needed
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],  # length 12 - keep and truncate
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "truncate",
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should have filtered out the first (short) sequence
+        self.assertEqual(len(result), 2)
+        # Second sample unchanged
+        self.assertEqual(len(result[0]["input_ids"]), 3)
+        # Third sample truncated to 10
+        self.assertEqual(len(result[1]["input_ids"]), 10)
+
+    def test_case_insensitive_strategy(self):
+        """Test that excess_length_strategy is case-insensitive"""
+        dataset = Dataset.from_dict({
+            "input_ids": [
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            ]
+        })
+
+        cfg = DictDefault({
+            "excess_length_strategy": "TRUNCATE",  # uppercase
+            "min_sample_len": 2,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        result = handle_long_seq_in_dataset(dataset, sequence_len=10, cfg=cfg)
+
+        # Should still truncate
+        self.assertEqual(len(result[0]["input_ids"]), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Fix the sample truncation used in handle_long_seq_in_dataset invoked by setting excess_length_strategy to 'truncation' in the config. This is called during the SFT _load_raw_datasets function when sample_packing is False, skip_prepare_dataset is False, and streaming is false  at: 
https://github.com/axolotl-ai-cloud/axolotl/blob/06ac407b92168f79c512df33d42387b6af5aa7f9/src/axolotl/utils/data/sft.py#L346-L360


# Description

Removes the minimum sequence length filtering from the truncate_long_samples function, and converts the truncate_long_samples function called in handle_long_seq_in_dataset to use map. As flagged 4-5 times by the AI review in the [initial PR that introduced this feature](https://github.com/axolotl-ai-cloud/axolotl/pull/3068/changes#diff-dc284316c84f597e4e7126d804cf388e9df82a9ad29bb6f56a48e255d1cf5d54), filtering won't preserve the applied truncations, so they are never actually applied to the dataset. Instead map must be used. 

Additionally the PR adds test cases for handle_long_seq_in_dataset to validate that the initial code implementation does not correctly truncate, and that the new code from this PR does. 

## Motivation and Context

As above, this was flagged during the feature creation. I ran into this issue trying to train with long sequences, and truncate using excess_length_strategy='truncate', and setting increasingly small sequence_len values, but I keep running into OOM when the forward pass tried to allocate ~20gb for logits. I checked that manually truncating the samples to <~512 tokens did not produce an OOM, whereas setting excess_length_strategy='truncate', and sequence_len of 512 and smaller still caused OOM errors. 

## How has this been tested?

I tested this by writing test cases for handle_long_seq_in_dataset and running them directly with UV. 

I am testing in a local clone of the repo on mac osx. 



## AI Usage Disclaimer
Yes;
AI (Claude Code with Opus 4.6) was used to generate and assist with this PR. I asked Claude write the unit tests, to remove the low sample length filter from the truncate_long_samples function, and to reimplement it as a filter + map. I ran the tests, and reviewed the tests to validate they covered what I expected and reviewed the code changes to validate they were as expected


## Types of changes
[x] Bug Fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filtering of sequences that fall below the minimum required length from input datasets

* **Bug Fixes**
  * Improved sequence truncation handling with a more efficient two-stage processing approach: filtering sequences below minimum length before truncating those exceeding maximum length limits

* **Tests**
  * Comprehensive test coverage for all sequence processing strategies, edge cases, and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->