### PR TITLE
fix generic patch for cce

### DIFF
--- a/src/axolotl/integrations/cut_cross_entropy/__init__.py
+++ b/src/axolotl/integrations/cut_cross_entropy/__init__.py
@@ -104,7 +104,7 @@ class CutCrossEntropyPlugin(BasePlugin):
 
     def patch_llama_like(
         self,
-        model_type: str,
+        model_type_to_patch: str,
     ) -> None:
         """
         Generic patch for model architectures with causal lm similar to llama
@@ -112,7 +112,10 @@ class CutCrossEntropyPlugin(BasePlugin):
         from cut_cross_entropy.transformers.patch import PATCH_FNS
 
         def patch_generic(
-            maybe_model, patch_options, model_type: str, remote_model_id: str | None
+            maybe_model,
+            patch_options,
+            remote_model_id: str | None,
+            model_type: str,
         ):
             import cut_cross_entropy.transformers.llama
             from cut_cross_entropy.transformers.llama import cce_forward
@@ -136,11 +139,13 @@ class CutCrossEntropyPlugin(BasePlugin):
                     f"Error: {str(e)}"
                 ) from e
 
-        if model_type not in PATCH_FNS:
+        if model_type_to_patch not in PATCH_FNS:
             LOG.warning_once(
-                "Setting up generic cce patch for model type: %s", model_type
+                "Setting up generic cce patch for model type: %s", model_type_to_patch
             )
             LOG.warning_once(
-                f"Generic Cut Cross Entropy + {model_type} support is experimental and may not work as expected."
+                f"Generic Cut Cross Entropy + {model_type_to_patch} support is experimental and may not work as expected."
             )
-            PATCH_FNS[model_type] = partial(patch_generic, model_type=model_type)
+            PATCH_FNS[model_type_to_patch] = partial(
+                patch_generic, model_type=model_type_to_patch
+            )


### PR DESCRIPTION
https://github.com/axolotl-ai-cloud/ml-cross-entropy/pull/35 broke the ability to patch arbitrary models that we don't have "official" patches for yet, this fixes the args so we don't get the error below:

```
  File "/workspace/axolotl/src/axolotl/train.py", line 85, in setup_model_and_tokenizer
    model, peft_config = model_loader.load()
                         ^^^^^^^^^^^^^^^^^^^
  File "/workspace/axolotl/src/axolotl/telemetry/errors.py", line 127, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/axolotl/src/axolotl/loaders/model.py", line 173, in load
    PLUGIN_MANAGER.pre_model_load(self.cfg)
  File "/workspace/axolotl/src/axolotl/integrations/base.py", line 422, in pre_model_load
    plugin.pre_model_load(cfg)
  File "/workspace/axolotl/src/axolotl/integrations/cut_cross_entropy/__init__.py", line 100, in pre_model_load
    cce_patch(
  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/cut_cross_entropy/transformers/patch.py", line 243, in cce_patch
    return patch_fn(model_type_or_model, patch_options, remote_model_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CutCrossEntropyPlugin.patch_llama_like.<locals>.patch_generic() got multiple values for argument 'model_type'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved parameter organization in the cross-entropy integration plugin for enhanced code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->