### PR TITLE
Compatibility: torch 2.10 baseline and transformers>=5 interoperability (v2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,9 @@ jobs:
       matrix:
         python_version: ["3.11", "3.12"]
         pytorch_version: ["2.8.0", "2.9.0", "2.9.1"]
+        include:
+          - python_version: "3.11"
+            pytorch_version: "2.10.0"
         exclude:
           - python_version: "3.12"
             pytorch_version: "2.8.0"
@@ -151,6 +154,9 @@ jobs:
       matrix:
         python_version: ["3.11", "3.12"]
         pytorch_version: ["2.8.0", "2.9.0", "2.9.1"]
+        include:
+          - python_version: "3.11"
+            pytorch_version: "2.10.0"
         exclude:
           - python_version: "3.12"
             pytorch_version: "2.8.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ packaging==26.0
 huggingface_hub>=1.1.7
 peft>=0.18.1
 tokenizers>=0.22.1
-transformers==5.0.0
+transformers==5.1.0
 accelerate==1.12.0
 datasets==4.5.0
 deepspeed>=0.18.3
@@ -63,7 +63,7 @@ langdetect==1.0.9
 immutabledict==4.2.0
 antlr4-python3-runtime==4.13.2
 
-torchao==0.13.0
+torchao==0.16.0
 openenv-core==0.1.0
 schedulefree==1.4.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ transformers==5.1.0
 accelerate==1.12.0
 datasets==4.5.0
 deepspeed>=0.18.3
-trl==0.27.1
+trl==0.28.0
 hf_xet==1.2.0
 kernels==0.11.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ packaging==26.0
 huggingface_hub>=1.1.7
 peft>=0.18.1
 tokenizers>=0.22.1
-transformers==5.1.0
+transformers>=5.0.0,<6
 accelerate==1.12.0
 datasets==4.5.0
 deepspeed>=0.18.3
@@ -72,4 +72,4 @@ axolotl-contribs-mit==0.0.6
 # telemetry
 posthog==6.7.11
 
-mistral-common==1.8.8
+mistral-common>=1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ packaging==26.0
 huggingface_hub>=1.1.7
 peft>=0.18.1
 tokenizers>=0.22.1
-transformers>=5.0.0,<6
+transformers>=5.0.0
 accelerate==1.12.0
 datasets==4.5.0
 deepspeed>=0.18.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 
 # START section of dependencies that don't install on Darwin/MacOS
 bitsandbytes==0.49.1
-triton>=3.0.0
+triton>=3.4.0
 mamba-ssm==1.2.0.post1
 xformers>=0.0.23.post1
-liger-kernel==0.6.4
+liger-kernel==0.7.0
 # END section
 
 packaging==26.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def parse_requirements(extras_require_map):
             try:
                 torch_version = version("torch")
             except PackageNotFoundError:
-                torch_version = "2.8.0"  # default to torch 2.8.0
+                torch_version = "2.10.0"  # default to torch 2.10.0
             _install_requires.append(f"torch=={torch_version}")
 
             version_match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", torch_version)
@@ -69,15 +69,24 @@ def parse_requirements(extras_require_map):
                     f"https://download.pytorch.org/whl/{torch_cuda_version}"
                 )
 
-            if (major, minor) >= (2, 9):
+            if (major, minor) >= (2, 10):
                 extras_require_map.pop("fbgemm-gpu")
                 extras_require_map["fbgemm-gpu"] = [
                     "fbgemm-gpu==1.4.0",
                     "fbgemm-gpu-genai==1.4.2",
                 ]
-                extras_require_map["vllm"] = ["vllm==0.11.1"]
+                # No vLLM release on PyPI currently supports transformers>=5.
+                # Install vLLM from source (for example, local editable install)
+                # when using this torch/transformers baseline.
+                extras_require_map.pop("vllm")
                 if not install_xformers:
                     _install_requires.pop(_install_requires.index(xformers_version))
+            elif (major, minor) >= (2, 9):
+                extras_require_map.pop("fbgemm-gpu")
+                extras_require_map["fbgemm-gpu"] = [
+                    "fbgemm-gpu==1.4.0",
+                    "fbgemm-gpu-genai==1.4.2",
+                ]
                 extras_require_map["vllm"] = ["vllm==0.13.0"]
                 if patch == 0:
                     extras_require_map["vllm"] = ["vllm==0.13.0"]

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -246,7 +246,8 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             ddp_find_unused_parameters
         )
 
-        training_arguments_kwargs["group_by_length"] = self.cfg.group_by_length
+        if self.cfg.group_by_length:
+            training_arguments_kwargs["train_sampling_strategy"] = "group_by_length"
         training_arguments_kwargs["curriculum_sampling"] = self.cfg.curriculum_sampling
 
         training_arguments_kwargs["sample_packing"] = bool(self.cfg.sample_packing)

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -247,7 +247,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
         )
 
         if self.cfg.group_by_length:
-            training_arguments_kwargs["train_sampling_strategy"] = "group_by_length"
+            training_arguments_kwargs["group_by_length"] = True
         training_arguments_kwargs["curriculum_sampling"] = self.cfg.curriculum_sampling
 
         training_arguments_kwargs["sample_packing"] = bool(self.cfg.sample_packing)

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -134,13 +134,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             if self.cfg.cpo_alpha is not None:
                 training_args_kwargs["cpo_alpha"] = self.cfg.cpo_alpha
 
-            # Handle when max_prompt_length == max_length from defaults
-            # CPOTrainer requires strictly less than
-            if (
-                training_args_kwargs["max_prompt_length"]
-                == training_args_kwargs["max_length"]
-            ):
-                training_args_kwargs["max_prompt_length"] -= 1
+            blocklist_args_kwargs.append("max_prompt_length")
 
         elif self.cfg.rl is RLType.ORPO:
             training_args_cls = AxolotlORPOConfig

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -144,10 +144,12 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
         elif self.cfg.rl is RLType.ORPO:
             training_args_cls = AxolotlORPOConfig
 
+            blocklist_args_kwargs.append("max_prompt_length")
+
         elif self.cfg.rl is RLType.KTO:
             training_args_cls = AxolotlKTOConfig
             # KTOConfig in TRL >= 0.27.0 no longer accepts max_prompt_length
-            blocklist_args_kwargs = ["max_prompt_length"]
+            blocklist_args_kwargs.append("max_prompt_length")
 
             training_args_kwargs["desirable_weight"] = (
                 self.cfg.kto_desirable_weight or 1.0

--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -11,7 +11,6 @@ from axolotl.core.trainers import (
 )
 from axolotl.core.trainers.dpo import DPOStrategy
 from axolotl.core.trainers.dpo.args import AxolotlDPOConfig
-from axolotl.core.trainers.grpo import GRPOStrategy
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders.utils import ensure_dtype
 from axolotl.utils.callbacks.qat import QATCallback
@@ -53,6 +52,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
         trainer_cls_args = [self.model]
 
         if self.cfg.rl in {RLType.GRPO, RLType.GDPO}:
+            from axolotl.core.trainers.grpo import GRPOStrategy
+
             trainer_cls = GRPOStrategy.get_trainer_class(
                 sequence_parallel=self.cfg.context_parallel_size > 1
             )
@@ -159,6 +160,8 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             )
 
         elif self.cfg.rl in {RLType.GRPO, RLType.GDPO}:
+            from axolotl.core.trainers.grpo import GRPOStrategy
+
             training_args_cls = GRPOStrategy.get_training_args_class()
             training_args_kwargs.update(GRPOStrategy.set_training_args_kwargs(self.cfg))
             blocklist_args_kwargs = GRPOStrategy.get_blocklist_args_kwargs()

--- a/src/axolotl/core/trainers/dpo/trainer.py
+++ b/src/axolotl/core/trainers/dpo/trainer.py
@@ -57,16 +57,18 @@ class AxolotlDPOTrainer(
     def tokenize_row(
         features,
         processing_class,
-        max_prompt_length,
-        max_completion_length,
-        add_special_tokens,
+        max_prompt_length: int | None = None,
+        max_completion_length: int | None = None,
+        add_special_tokens: bool = True,
+        is_chat: bool = False,
     ) -> Dict:
         res = DPOTrainer.tokenize_row(
             features,
             processing_class,
-            max_prompt_length,
-            max_completion_length,
-            add_special_tokens,
+            max_prompt_length=max_prompt_length,
+            max_completion_length=max_completion_length,
+            add_special_tokens=add_special_tokens,
+            is_chat=is_chat,
         )
         # fix when the tokenizer doesn't have a bos_token_id, e.g. Qwen
         if processing_class.bos_token is None and res["prompt_input_ids"][0] is None:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -10,6 +10,7 @@ from functools import cached_property
 import addict
 import transformers
 from transformers import PretrainedConfig, PreTrainedModel
+from transformers.modeling_flash_attention_utils import is_flash_attn_available
 
 from axolotl.integrations.base import PluginManager
 from axolotl.monkeypatch.multipack import (
@@ -500,6 +501,7 @@ class PatchManager:
             and not self.cfg.trust_remote_code
             and not self.cfg.gptq
             and self.cfg.flash_attention
+            and is_flash_attn_available()
             and not self.inference
         ):
             # TODO(MengqingCao): split these patches separately

--- a/src/axolotl/monkeypatch/transformers/trainer_loss_calc.py
+++ b/src/axolotl/monkeypatch/transformers/trainer_loss_calc.py
@@ -28,8 +28,12 @@ PATCHED_EVAL_CODE = {
     "array": 'metrics[f"{metric_key_prefix}_loss"] = np.nanmean(all_losses).item()',
 }
 
-ORIGINAL_MAYBE_CODE = "tr_loss_scalar = self._nested_gather(tr_loss).mean().item()"
-PATCHED_MAYBE_CODE = "tr_loss_scalar = self._nested_gather(tr_loss).nanmean().item()"
+ORIGINAL_MAYBE_CODE = (
+    "tr_loss_scalar = nested_gather(tr_loss, self.args.parallel_mode).mean().item()"
+)
+PATCHED_MAYBE_CODE = (
+    "tr_loss_scalar = nested_gather(tr_loss, self.args.parallel_mode).nanmean().item()"
+)
 
 
 def check_evaluation_loop_is_patchable() -> bool:

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -300,7 +300,6 @@ class TestHFRLTrainerBuilder:
         self._test_common_training_arguments(training_arguments, rl=orpo_cfg.rl)
         # ORPO specific
         assert training_arguments.beta == 0.1  # maps from orpo_alpha
-        assert training_arguments.max_prompt_length == 512
 
     def test_kto_training_arguments(self, kto_cfg, model, tokenizer):
         builder = HFRLTrainerBuilder(kto_cfg, model, tokenizer)

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -525,6 +525,15 @@ class TestHFCausalTrainerBuilder:
         assert training_arguments.sample_packing is False
         assert training_arguments.eval_sample_packing is False
 
+    def test_training_arguments_with_group_by_length(self, sft_cfg, model, tokenizer):
+        cfg = sft_cfg.copy()
+        cfg["group_by_length"] = True
+        builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
+        trainer = builder.build(100)
+        training_arguments = trainer.args
+
+        assert training_arguments.group_by_length is True
+
     @pytest.mark.parametrize(
         "cfg_string",
         [


### PR DESCRIPTION
## Summary
This PR updates Axolotl to the requested compatibility baseline:
- `torch 2.10`
- `transformers>=5.0.0`

It also keeps interoperability with latest source-installed vLLM and includes one follow-up fix from automated review feedback (`group_by_length` argument path).

## File-by-file changes
- `.github/workflows/tests.yml`
  - Add explicit `python 3.11 + torch 2.10.0` lanes to both `pytest` and `pytest-sdist` matrices.
- `requirements.txt`
  - Align key dependency versions for the new baseline.
- `setup.py`
  - Default torch fallback is now `2.10.0`.
  - For `torch>=2.10`, remove pip `vllm` extra pin because current pip vLLM releases do not support `transformers>=5`; this path uses source-installed vLLM.
- `src/axolotl/core/builders/causal.py`
  - Use valid `group_by_length` training argument (fixes runtime risk when `group_by_length=true`).
- `src/axolotl/core/builders/rl.py`
  - Adapt RL trainer args for TRL 0.28 config API behavior.
- `src/axolotl/core/trainers/dpo/trainer.py`
  - Adapt DPO tokenize call signature for newer TRL.
- `src/axolotl/loaders/patch_manager.py`
  - Guard flash-attn patching by runtime availability check.
- `src/axolotl/monkeypatch/gradient_checkpointing/offload_cpu.py`
  - Handle tensor vs tuple checkpoint outputs for newer HF model internals.
- `src/axolotl/monkeypatch/transformers/trainer_loss_calc.py`
  - Support both upstream Trainer gather-source variants.
- `tests/core/test_builders.py`
  - Update ORPO expectations for TRL 0.28 config schema and add regression coverage for `group_by_length`.

## Dependency delta (changed)
- `triton`: `>=3.0.0` -> `>=3.4.0`
- `liger-kernel`: `0.6.4` -> `0.7.0`
- `transformers`: `==5.0.0` -> `>=5.0.0`
- `trl`: `0.27.1` -> `0.28.0`
- `torchao`: `0.13.0` -> `0.16.0`
- `mistral-common`: `1.8.8` -> `>=1.9.1`
- setup fallback torch: `2.8.0` -> `2.10.0`

## Dependency status (unchanged examples)
- `accelerate==1.12.0`
- `datasets==4.5.0`
- `deepspeed>=0.18.3`
- `tokenizers>=0.22.1`

## Validation
- Pre-commit checks pass.
- `tests/core/test_builders.py` passes on current branch.
- Smoke training succeeded with `Qwen/Qwen3-0.6B` on `torch 2.10.0+cu130` + `transformers 5.1.0`.
- End-to-end base+LoRA flow with latest source vLLM passed on the same baseline.

## Historical compatibility note
- A known older compatible pair is `axolotl v0.14.0` with `vllm 0.11.0` on older torch/transformers lanes.
- This update moves Axolotl to the current mainline dependency baseline.

## Credits
This branch incorporates and extends upstream compatibility work authored by **Wing Lian (@winglian)** in prior commits, including:
- `ddda0e5d`, `e66aef69`, `09c1c196`, `f3476232`, `1f24dcd4`, `ff967b92`, `baf59b5d`, `1641a2d6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended support for PyTorch 2.10 release series with tailored dependency configurations

* **Bug Fixes**
  * Improved Flash Attention integration robustness
  * Better handling of gradient checkpointing with newer model output formats
  * Fixed parameter handling for RL training modes

* **Chores**
  * Updated core dependencies (triton, transformers, liger-kernel, trl, torchao, mistral-common) to newer versions
  * Expanded CI/CD test coverage for additional PyTorch and dependency combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->