### PR TITLE
fix: Save de-duplicated dataset during pre-processing

### DIFF
--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -246,6 +246,10 @@ def _load_split(cfg: DictDefault, split: Literal["train", "test"]) -> Dataset:
     dataset = merge_datasets(split_datasets, cfg)
 
     if not cfg.skip_prepare_dataset:
+        # Deduplicate before saving so the saved dataset is already de-duplicated
+        if cfg.dataset_exact_deduplication:
+            dataset, _ = deduplicate_and_log_datasets(dataset=dataset)
+
         # Save preprocessed dataset
         dataset_hash = generate_dataset_hash_from_config(
             cfg, datasets_configs, tokenizer.name_or_path

--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -245,6 +245,13 @@ def _load_split(cfg: DictDefault, split: Literal["train", "test"]) -> Dataset:
     # Merge datasets
     dataset = merge_datasets(split_datasets, cfg)
 
+    if cfg.skip_prepare_dataset and cfg.dataset_exact_deduplication:
+        LOG.warning(
+            "skip_prepare_dataset is enabled together with "
+            "dataset_exact_deduplication. Deduplication will be skipped "
+            "because dataset preparation is being skipped."
+        )
+
     if not cfg.skip_prepare_dataset:
         # Deduplicate before saving so the saved dataset is already de-duplicated
         if cfg.dataset_exact_deduplication:

--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -245,13 +245,6 @@ def _load_split(cfg: DictDefault, split: Literal["train", "test"]) -> Dataset:
     # Merge datasets
     dataset = merge_datasets(split_datasets, cfg)
 
-    if cfg.skip_prepare_dataset and cfg.dataset_exact_deduplication:
-        LOG.warning(
-            "skip_prepare_dataset is enabled together with "
-            "dataset_exact_deduplication. Deduplication will be skipped "
-            "because dataset preparation is being skipped."
-        )
-
     if not cfg.skip_prepare_dataset:
         # Deduplicate before saving so the saved dataset is already de-duplicated
         if cfg.dataset_exact_deduplication:

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -343,13 +343,6 @@ def _load_raw_datasets(
     # Merge datasets
     dataset = merge_datasets(datasets, cfg)
 
-    if cfg.skip_prepare_dataset and cfg.dataset_exact_deduplication:
-        LOG.warning(
-            "skip_prepare_dataset is enabled together with "
-            "dataset_exact_deduplication. Deduplication will be skipped "
-            "because dataset preparation is being skipped."
-        )
-
     if not cfg.skip_prepare_dataset and not streaming:
         if split == "test" and cfg.eval_sequence_len:
             dataset = handle_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -343,6 +343,13 @@ def _load_raw_datasets(
     # Merge datasets
     dataset = merge_datasets(datasets, cfg)
 
+    if cfg.skip_prepare_dataset and cfg.dataset_exact_deduplication:
+        LOG.warning(
+            "skip_prepare_dataset is enabled together with "
+            "dataset_exact_deduplication. Deduplication will be skipped "
+            "because dataset preparation is being skipped."
+        )
+
     if not cfg.skip_prepare_dataset and not streaming:
         if split == "test" and cfg.eval_sequence_len:
             dataset = handle_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -446,14 +446,6 @@ def _handle_train_dataset_split(
     return dataset, None
 
 
-def _handle_test_dataset_split(
-    dataset: Dataset, cfg: DictDefault
-) -> tuple[None, Dataset | None]:
-    """Handle processing for test split."""
-    # Deduplication already applied during preprocessing
-    return None, dataset
-
-
 def _apply_dataset_sharding(dataset: Dataset, cfg: DictDefault) -> Dataset:
     """Apply dataset sharding if configured.
 
@@ -510,6 +502,7 @@ def _load_and_prepare_datasets(
     if split == "train":
         train_dataset, eval_dataset = _handle_train_dataset_split(dataset, cfg)
     else:
-        train_dataset, eval_dataset = _handle_test_dataset_split(dataset, cfg)
+        # Deduplication already applied during preprocessing
+        train_dataset, eval_dataset = None, dataset
 
     return train_dataset, eval_dataset, prompters

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -520,7 +520,8 @@ def generate_dataset_hash_from_config(
     """
     config_str = (
         f"{cfg.sequence_len}@{cfg.sample_packing}@{cfg.eval_sample_packing}@"
-        f"{cfg.group_by_length}@{cfg.kd_temperature or 1.0}|"
+        f"{cfg.group_by_length}@{cfg.kd_temperature or 1.0}@"
+        f"{cfg.dataset_exact_deduplication or False}|"
         f"{'|'.join(sorted([f'{d.path}:{d.type}:{d.shards}:{d.conversation}:{d.split}:{d.temperature or 1.0}' for d in cfg_datasets]))}"
         f"|{tokenizer_name}"
     )

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1481,3 +1481,18 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 "dataset_exact_deduplication is not available for streaming datasets. "
             )
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_deduplication_with_skip_prepare(cls, data):
+        if data.get("dataset_exact_deduplication") and data.get(
+            "skip_prepare_dataset"
+        ):
+            raise ValueError(
+                "dataset_exact_deduplication=True has no effect when "
+                "skip_prepare_dataset=True. Deduplication runs as part of the "
+                "prepare pipeline, which is skipped. Either set "
+                "skip_prepare_dataset: false or disable "
+                "dataset_exact_deduplication."
+            )
+        return data

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1485,9 +1485,7 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
     @model_validator(mode="before")
     @classmethod
     def check_deduplication_with_skip_prepare(cls, data):
-        if data.get("dataset_exact_deduplication") and data.get(
-            "skip_prepare_dataset"
-        ):
+        if data.get("dataset_exact_deduplication") and data.get("skip_prepare_dataset"):
             raise ValueError(
                 "dataset_exact_deduplication=True has no effect when "
                 "skip_prepare_dataset=True. Deduplication runs as part of the "

--- a/tests/test_save_deduplicated.py
+++ b/tests/test_save_deduplicated.py
@@ -1,0 +1,196 @@
+"""Tests to verify that deduplication runs before dataset saving during preprocessing.
+
+This addresses GitHub issue #2719: Save De-duplicated Set During Pre-processing.
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from datasets import Dataset
+
+from axolotl.utils.dict import DictDefault
+
+
+class TestSFTSaveDeduplicatedBeforeSave:
+    """Verify that in SFT data loading, deduplication occurs before saving."""
+
+    @patch("axolotl.utils.data.sft.save_preprocessed_dataset")
+    @patch("axolotl.utils.data.sft.generate_dataset_hash_from_config")
+    @patch("axolotl.utils.data.sft.deduplicate_and_log_datasets")
+    @patch("axolotl.utils.data.sft.merge_datasets")
+    @patch("axolotl.utils.data.sft._load_and_process_single_dataset")
+    @patch("axolotl.utils.data.sft.datasets_with_name_generator")
+    def test_dedup_called_before_save_sft(
+        self,
+        mock_datasets_gen,
+        mock_load_single,
+        mock_merge,
+        mock_dedup,
+        mock_gen_hash,
+        mock_save,
+    ):
+        """Deduplication should be called before save_preprocessed_dataset in SFT."""
+        from axolotl.utils.data.sft import _load_raw_datasets
+
+        # Set up mock data
+        dataset = Dataset.from_dict({"text": ["a", "b", "a"], "label": [1, 2, 1]})
+        deduped_dataset = Dataset.from_dict({"text": ["a", "b"], "label": [1, 2]})
+
+        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": "alpaca"})]
+        mock_load_single.return_value = (dataset, None)
+        mock_merge.return_value = dataset
+        mock_dedup.return_value = (deduped_dataset, None)
+        mock_gen_hash.return_value = "testhash"
+
+        cfg = DictDefault({
+            "skip_prepare_dataset": False,
+            "dataset_exact_deduplication": True,
+            "sequence_len": 1024,
+            "eval_sequence_len": None,
+            "sample_packing": False,
+            "is_preprocess": False,
+            "seed": 42,
+            "datasets": [{"path": "test", "type": "alpaca"}],
+        })
+
+        tokenizer = MagicMock()
+        tokenizer.name_or_path = "test-tokenizer"
+
+        # Track call order
+        call_order = []
+        mock_dedup.side_effect = lambda **kwargs: (
+            call_order.append("dedup") or (deduped_dataset, None)
+        )
+        mock_save.side_effect = lambda *args, **kwargs: call_order.append("save")
+
+        _load_raw_datasets(
+            cfg=cfg,
+            datasets_configs=cfg.datasets,
+            tokenizer=tokenizer,
+            split="train",
+        )
+
+        # Verify dedup was called
+        assert "dedup" in call_order, "Deduplication should have been called"
+        # Verify save was called
+        assert "save" in call_order, "Save should have been called"
+        # Verify dedup happened before save
+        assert call_order.index("dedup") < call_order.index("save"), (
+            "Deduplication must occur before saving the dataset"
+        )
+
+    @patch("axolotl.utils.data.sft.save_preprocessed_dataset")
+    @patch("axolotl.utils.data.sft.generate_dataset_hash_from_config")
+    @patch("axolotl.utils.data.sft.merge_datasets")
+    @patch("axolotl.utils.data.sft._load_and_process_single_dataset")
+    @patch("axolotl.utils.data.sft.datasets_with_name_generator")
+    def test_no_dedup_when_disabled_sft(
+        self,
+        mock_datasets_gen,
+        mock_load_single,
+        mock_merge,
+        mock_gen_hash,
+        mock_save,
+    ):
+        """Deduplication should not be called when dataset_exact_deduplication is False."""
+        from axolotl.utils.data.sft import _load_raw_datasets
+
+        dataset = Dataset.from_dict({"text": ["a", "b", "a"], "label": [1, 2, 1]})
+
+        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": "alpaca"})]
+        mock_load_single.return_value = (dataset, None)
+        mock_merge.return_value = dataset
+        mock_gen_hash.return_value = "testhash"
+
+        cfg = DictDefault({
+            "skip_prepare_dataset": False,
+            "dataset_exact_deduplication": False,
+            "sequence_len": 1024,
+            "eval_sequence_len": None,
+            "sample_packing": False,
+            "is_preprocess": False,
+            "seed": 42,
+            "datasets": [{"path": "test", "type": "alpaca"}],
+        })
+
+        tokenizer = MagicMock()
+        tokenizer.name_or_path = "test-tokenizer"
+
+        with patch("axolotl.utils.data.sft.deduplicate_and_log_datasets") as mock_dedup:
+            _load_raw_datasets(
+                cfg=cfg,
+                datasets_configs=cfg.datasets,
+                tokenizer=tokenizer,
+                split="train",
+            )
+            mock_dedup.assert_not_called()
+
+
+class TestRLSaveDeduplicatedBeforeSave:
+    """Verify that in RL data loading, deduplication occurs before saving."""
+
+    @patch("axolotl.utils.data.rl.save_preprocessed_dataset")
+    @patch("axolotl.utils.data.rl.generate_dataset_hash_from_config")
+    @patch("axolotl.utils.data.rl.deduplicate_and_log_datasets")
+    @patch("axolotl.utils.data.rl.merge_datasets")
+    @patch("axolotl.utils.data.rl.load_dataset_with_config")
+    @patch("axolotl.utils.data.rl.datasets_with_name_generator")
+    @patch("axolotl.loaders.load_tokenizer")
+    def test_dedup_called_before_save_rl(
+        self,
+        mock_load_tokenizer,
+        mock_datasets_gen,
+        mock_load_dataset,
+        mock_merge,
+        mock_dedup,
+        mock_gen_hash,
+        mock_save,
+    ):
+        """Deduplication should be called before save_preprocessed_dataset in RL."""
+        from axolotl.utils.data.rl import _load_split
+
+        dataset = Dataset.from_dict({
+            "prompt": ["hi", "bye", "hi"],
+            "chosen": ["a", "b", "a"],
+            "rejected": ["c", "d", "c"],
+        })
+        deduped_dataset = Dataset.from_dict({
+            "prompt": ["hi", "bye"],
+            "chosen": ["a", "b"],
+            "rejected": ["c", "d"],
+        })
+
+        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": None})]
+        mock_load_dataset.return_value = dataset
+        mock_merge.return_value = dataset
+        mock_dedup.return_value = (deduped_dataset, None)
+        mock_gen_hash.return_value = "testhash"
+
+        tokenizer = MagicMock()
+        tokenizer.name_or_path = "test-tokenizer"
+        mock_load_tokenizer.return_value = tokenizer
+
+        cfg = DictDefault({
+            "skip_prepare_dataset": False,
+            "dataset_exact_deduplication": True,
+            "sequence_len": 1024,
+            "rl": "dpo",
+            "datasets": [{"path": "test", "type": None}],
+            "hf_use_auth_token": False,
+            "dataset_num_proc": 1,
+            "is_preprocess": False,
+        })
+
+        call_order = []
+        mock_dedup.side_effect = lambda **kwargs: (
+            call_order.append("dedup") or (deduped_dataset, None)
+        )
+        mock_save.side_effect = lambda *args, **kwargs: call_order.append("save")
+
+        _load_split(cfg, split="train")
+
+        assert "dedup" in call_order, "Deduplication should have been called"
+        assert "save" in call_order, "Save should have been called"
+        assert call_order.index("dedup") < call_order.index("save"), (
+            "Deduplication must occur before saving the dataset"
+        )

--- a/tests/test_save_deduplicated.py
+++ b/tests/test_save_deduplicated.py
@@ -3,9 +3,8 @@
 This addresses GitHub issue #2719: Save De-duplicated Set During Pre-processing.
 """
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
-import pytest
 from datasets import Dataset
 
 from axolotl.utils.dict import DictDefault
@@ -36,22 +35,26 @@ class TestSFTSaveDeduplicatedBeforeSave:
         dataset = Dataset.from_dict({"text": ["a", "b", "a"], "label": [1, 2, 1]})
         deduped_dataset = Dataset.from_dict({"text": ["a", "b"], "label": [1, 2]})
 
-        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": "alpaca"})]
+        mock_datasets_gen.return_value = [
+            DictDefault({"path": "test", "type": "alpaca"})
+        ]
         mock_load_single.return_value = (dataset, None)
         mock_merge.return_value = dataset
         mock_dedup.return_value = (deduped_dataset, None)
         mock_gen_hash.return_value = "testhash"
 
-        cfg = DictDefault({
-            "skip_prepare_dataset": False,
-            "dataset_exact_deduplication": True,
-            "sequence_len": 1024,
-            "eval_sequence_len": None,
-            "sample_packing": False,
-            "is_preprocess": False,
-            "seed": 42,
-            "datasets": [{"path": "test", "type": "alpaca"}],
-        })
+        cfg = DictDefault(
+            {
+                "skip_prepare_dataset": False,
+                "dataset_exact_deduplication": True,
+                "sequence_len": 1024,
+                "eval_sequence_len": None,
+                "sample_packing": False,
+                "is_preprocess": False,
+                "seed": 42,
+                "datasets": [{"path": "test", "type": "alpaca"}],
+            }
+        )
 
         tokenizer = MagicMock()
         tokenizer.name_or_path = "test-tokenizer"
@@ -97,26 +100,32 @@ class TestSFTSaveDeduplicatedBeforeSave:
 
         dataset = Dataset.from_dict({"text": ["a", "b", "a"], "label": [1, 2, 1]})
 
-        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": "alpaca"})]
+        mock_datasets_gen.return_value = [
+            DictDefault({"path": "test", "type": "alpaca"})
+        ]
         mock_load_single.return_value = (dataset, None)
         mock_merge.return_value = dataset
         mock_gen_hash.return_value = "testhash"
 
-        cfg = DictDefault({
-            "skip_prepare_dataset": False,
-            "dataset_exact_deduplication": False,
-            "sequence_len": 1024,
-            "eval_sequence_len": None,
-            "sample_packing": False,
-            "is_preprocess": False,
-            "seed": 42,
-            "datasets": [{"path": "test", "type": "alpaca"}],
-        })
+        cfg = DictDefault(
+            {
+                "skip_prepare_dataset": False,
+                "dataset_exact_deduplication": False,
+                "sequence_len": 1024,
+                "eval_sequence_len": None,
+                "sample_packing": False,
+                "is_preprocess": False,
+                "seed": 42,
+                "datasets": [{"path": "test", "type": "alpaca"}],
+            }
+        )
 
         tokenizer = MagicMock()
         tokenizer.name_or_path = "test-tokenizer"
 
-        with patch("axolotl.utils.data.sft.deduplicate_and_log_datasets") as mock_dedup:
+        with patch(
+            "axolotl.utils.data.sft.deduplicate_and_log_datasets"
+        ) as mock_dedup:
             _load_raw_datasets(
                 cfg=cfg,
                 datasets_configs=cfg.datasets,
@@ -135,7 +144,7 @@ class TestRLSaveDeduplicatedBeforeSave:
     @patch("axolotl.utils.data.rl.merge_datasets")
     @patch("axolotl.utils.data.rl.load_dataset_with_config")
     @patch("axolotl.utils.data.rl.datasets_with_name_generator")
-    @patch("axolotl.loaders.load_tokenizer")
+    @patch("axolotl.utils.data.rl.load_tokenizer")
     def test_dedup_called_before_save_rl(
         self,
         mock_load_tokenizer,
@@ -149,18 +158,24 @@ class TestRLSaveDeduplicatedBeforeSave:
         """Deduplication should be called before save_preprocessed_dataset in RL."""
         from axolotl.utils.data.rl import _load_split
 
-        dataset = Dataset.from_dict({
-            "prompt": ["hi", "bye", "hi"],
-            "chosen": ["a", "b", "a"],
-            "rejected": ["c", "d", "c"],
-        })
-        deduped_dataset = Dataset.from_dict({
-            "prompt": ["hi", "bye"],
-            "chosen": ["a", "b"],
-            "rejected": ["c", "d"],
-        })
+        dataset = Dataset.from_dict(
+            {
+                "prompt": ["hi", "bye", "hi"],
+                "chosen": ["a", "b", "a"],
+                "rejected": ["c", "d", "c"],
+            }
+        )
+        deduped_dataset = Dataset.from_dict(
+            {
+                "prompt": ["hi", "bye"],
+                "chosen": ["a", "b"],
+                "rejected": ["c", "d"],
+            }
+        )
 
-        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": None})]
+        mock_datasets_gen.return_value = [
+            DictDefault({"path": "test", "type": None})
+        ]
         mock_load_dataset.return_value = dataset
         mock_merge.return_value = dataset
         mock_dedup.return_value = (deduped_dataset, None)
@@ -170,16 +185,18 @@ class TestRLSaveDeduplicatedBeforeSave:
         tokenizer.name_or_path = "test-tokenizer"
         mock_load_tokenizer.return_value = tokenizer
 
-        cfg = DictDefault({
-            "skip_prepare_dataset": False,
-            "dataset_exact_deduplication": True,
-            "sequence_len": 1024,
-            "rl": "dpo",
-            "datasets": [{"path": "test", "type": None}],
-            "hf_use_auth_token": False,
-            "dataset_num_proc": 1,
-            "is_preprocess": False,
-        })
+        cfg = DictDefault(
+            {
+                "skip_prepare_dataset": False,
+                "dataset_exact_deduplication": True,
+                "sequence_len": 1024,
+                "rl": "dpo",
+                "datasets": [{"path": "test", "type": None}],
+                "hf_use_auth_token": False,
+                "dataset_num_proc": 1,
+                "is_preprocess": False,
+            }
+        )
 
         call_order = []
         mock_dedup.side_effect = lambda **kwargs: (

--- a/tests/test_save_deduplicated.py
+++ b/tests/test_save_deduplicated.py
@@ -123,9 +123,7 @@ class TestSFTSaveDeduplicatedBeforeSave:
         tokenizer = MagicMock()
         tokenizer.name_or_path = "test-tokenizer"
 
-        with patch(
-            "axolotl.utils.data.sft.deduplicate_and_log_datasets"
-        ) as mock_dedup:
+        with patch("axolotl.utils.data.sft.deduplicate_and_log_datasets") as mock_dedup:
             _load_raw_datasets(
                 cfg=cfg,
                 datasets_configs=cfg.datasets,
@@ -138,6 +136,7 @@ class TestSFTSaveDeduplicatedBeforeSave:
 class TestRLSaveDeduplicatedBeforeSave:
     """Verify that in RL data loading, deduplication occurs before saving."""
 
+    @patch.object(Dataset, "filter", lambda self, *args, **kwargs: self)
     @patch("axolotl.utils.data.rl.save_preprocessed_dataset")
     @patch("axolotl.utils.data.rl.generate_dataset_hash_from_config")
     @patch("axolotl.utils.data.rl.deduplicate_and_log_datasets")
@@ -173,9 +172,7 @@ class TestRLSaveDeduplicatedBeforeSave:
             }
         )
 
-        mock_datasets_gen.return_value = [
-            DictDefault({"path": "test", "type": None})
-        ]
+        mock_datasets_gen.return_value = [DictDefault({"path": "test", "type": None})]
         mock_load_dataset.return_value = dataset
         mock_merge.return_value = dataset
         mock_dedup.return_value = (deduped_dataset, None)


### PR DESCRIPTION
## Summary

Fixes #2719

Currently, de-duplication runs **after** the dataset is saved during preprocessing. This means the saved/cached dataset still contains duplicates, and deduplication has to run again on every subsequent load.

## Changes

Moved `deduplicate_and_log_datasets` to run **before** `save_preprocessed_dataset` in both:
- **SFT pipeline** (`sft.py` → `_load_raw_datasets`)
- **RL pipeline** (`rl.py` → `_load_split`)

Removed the now-redundant deduplication calls in `_handle_train_dataset_split` and `_handle_test_dataset_split` (SFT), since the dataset is already de-duplicated before it reaches those functions.

Note: `create_train_validation_split` in `shared.py` still has its own dedup call, which is now a harmless no-op (no duplicates left to remove) but provides a safety net.

## Tests

Added `tests/test_save_deduplicated.py` with tests verifying:
- Deduplication is called before save in SFT pipeline
- Deduplication is called before save in RL pipeline  
- Deduplication is not called when `dataset_exact_deduplication` is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized dataset deduplication to occur earlier in the preprocessing pipeline for improved data processing efficiency.

* **Tests**
  * Added unit tests to verify deduplication occurs at the correct stage in the data loading workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->