### PR TITLE
bug-fix: use self.optimizer if optimizer not passed to SchedulerMixin.create_scheduler()

### DIFF
--- a/src/axolotl/core/trainers/mixins/scheduler.py
+++ b/src/axolotl/core/trainers/mixins/scheduler.py
@@ -46,6 +46,10 @@ class SchedulerMixin(Trainer):
         )
 
         if optimizer is None:
+            if self.optimizer is None:
+                raise ValueError(
+                    "Optimizer must be set before calling create_scheduler or passed as an argument."
+                )
             optimizer = self.optimizer
 
         # fmt: off

--- a/src/axolotl/core/trainers/mixins/scheduler.py
+++ b/src/axolotl/core/trainers/mixins/scheduler.py
@@ -45,6 +45,9 @@ class SchedulerMixin(Trainer):
             and self.args.cosine_min_lr_ratio is not None
         )
 
+        if optimizer is None:
+            optimizer = self.optimizer
+
         # fmt: off
         if self.lr_scheduler is None:  # type: ignore
             # fmt: on

--- a/src/axolotl/core/trainers/mixins/scheduler.py
+++ b/src/axolotl/core/trainers/mixins/scheduler.py
@@ -25,7 +25,7 @@ class SchedulerMixin(Trainer):
     args = None  # type: "AxolotlTrainingArguments"  # type: ignore[name-defined]
 
     def create_scheduler(
-        self, num_training_steps: int, optimizer: torch.optim.Optimizer = None
+        self, num_training_steps: int, optimizer: None | torch.optim.Optimizer = None
     ) -> LRScheduler:
         """
         Set up the scheduler. The optimizer of the trainer must have been set up either before this method is called or


### PR DESCRIPTION
Running with transformers 5.2.0, the trainer.py script calls 

```py
self.create_scheduler(num_training_steps=max_steps)
```

without passing the `optimizer`. This then barfs in `torch/optim/lr_scheduler.py` at

```py
self.lr_lambdas = [lr_lambda] * len(optimizer.param_groups)
```

This simply uses `self.optimizer` if `optimizer is None`.

# Description

If `optimizer` is unset, use `self.optimizer`.

## Motivation and Context

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank1]:   File "<frozen runpy>", line 88, in _run_code
[rank1]:   File "[...]/axolotl/src/axolotl/cli/train.py", line 121, in <module>
[rank1]:     fire.Fire(do_cli)
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/fire/core.py", line 135, in Fire
[rank1]:     component_trace = _Fire(component, args, parsed_flag_args, context, name)
[rank1]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/fire/core.py", line 468, in _Fire
[rank1]:     component, remaining_args = _CallAndUpdateTrace(
[rank1]:                                 ^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
[rank1]:     component = fn(*varargs, **kwargs)
[rank1]:                 ^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/axolotl/src/axolotl/cli/train.py", line 88, in do_cli
[rank1]:     return do_train(parsed_cfg, parsed_cli_args)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/axolotl/src/axolotl/cli/train.py", line 45, in do_train
[rank1]:     model, tokenizer, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
[rank1]:                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/axolotl/src/axolotl/telemetry/errors.py", line 124, in wrapper
[rank1]:     return func(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/axolotl/src/axolotl/train.py", line 580, in train
[rank1]:     execute_training(cfg, trainer, resume_from_checkpoint)
[rank1]:   File "[...]/axolotl/src/axolotl/train.py", line 208, in execute_training
[rank1]:     trainer.train(resume_from_checkpoint=resume_from_checkpoint)
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/transformers/trainer.py", line 1412, in train
[rank1]:     return inner_training_loop(
[rank1]:            ^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/transformers/trainer.py", line 1547, in _inner_training_loop
[rank1]:     self.create_scheduler(num_training_steps=max_steps)
[rank1]:   File "[...]/axolotl/src/axolotl/core/trainers/mixins/scheduler.py", line 110, in create_scheduler
[rank1]:     self.lr_scheduler = get_cosine_schedule_with_min_lr(
[rank1]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/axolotl/src/axolotl/utils/schedulers.py", line 219, in get_cosine_schedule_with_min_lr
[rank1]:     return LambdaLR(optimizer, lr_lambda)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "[...]/miniconda3/envs/ai/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 311, in __init__
[rank1]:     self.lr_lambdas = [lr_lambda] * len(optimizer.param_groups)
[rank1]:                                         ^^^^^^^^^^^^^^^^^^^^^^
[rank1]: AttributeError: 'NoneType' object has no attribute 'param_groups'
```

## AI Usage Disclaimer

No AI was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler initialization logic to ensure optimizer availability during scheduler creation, enhancing training stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->