### PR TITLE
Fix: quantize and target moe layers in transformers v5 for adapters and many misc fixes

### DIFF
--- a/examples/colab-notebooks/colab-axolotl-example.ipynb
+++ b/examples/colab-notebooks/colab-axolotl-example.ipynb
@@ -40,7 +40,7 @@
     "%%capture\n",
     "# This step can take ~5-10 minutes to install dependencies\n",
     "!pip install --no-build-isolation axolotl[flash-attn]>=0.9.1\n",
-    "!pip install \"cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@58d6572\""
+    "!pip install \"cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@a668583\""
    ]
   },
   {

--- a/examples/glm4.7-flash/README.md
+++ b/examples/glm4.7-flash/README.md
@@ -49,8 +49,8 @@ lora_target_parameters:
 
 - **FSDP VRAM**: FSDP2 may use more VRAM per GPU than single GPU training. We suspect not all layers are properly sharded across ranks.
 - **FSDP initial spike**: FSDP LoRA (8-bit) may have a large initial VRAM spike at the first 1-2 steps that then drops. FSDP QLoRA (4-bit) does not exhibit this.
-- **cpu_ram_efficient_loading**: Must be set to `false` with FSDP2 — causes `AttributeError: e_score_correction_bias is not an nn.Parameter` due to modeling source.
-- **lora_target_linear**: incompatible for this model.
+- **cpu_ram_efficient_loading**: Must be set to `false` with FSDP2 — causes hang otherwise.
+- **lora_target_linear**: Incompatible for this model.
 - **LoRA kernels**: Incompatible with this model due to non-standard attention projections (DSA). Must be explicitly disabled (`lora_*_kernel: false`).
 
 

--- a/examples/glm4.7-flash/README.md
+++ b/examples/glm4.7-flash/README.md
@@ -1,0 +1,77 @@
+# Finetune Z.ai's GLM-4.7-Flash with Axolotl
+
+[GLM-4.7-Flash](https://huggingface.co/zai-org/GLM-4.7-Flash) is a 30B-A3B MoE model by Z.ai.
+
+This guide shows how to fine-tune it with Axolotl.
+
+## Getting started
+
+1. Install Axolotl following the [installation guide](https://docs.axolotl.ai/docs/installation.html).
+
+2. Install [Cut Cross Entropy](https://docs.axolotl.ai/docs/custom_integrations.html#cut-cross-entropy) to reduce training VRAM usage.
+
+3. Run the finetuning example:
+
+```bash
+# QLoRA
+# - no target experts (1x48GB @ ~24GiB/GPU)
+# - target experts (1x48GB @ ~34GiB/GPU)
+axolotl train examples/glm4.7-flash/qlora.yaml
+
+# QLoRA FSDP2 no target experts (2x48GB @ ~29GiB/GPU)
+axolotl train examples/glm4.7-flash/qlora_fsdp.yaml
+```
+
+```bash
+# LoRA
+# - no target experts (1x48GB @ ~35GiB/GPU)
+# - target experts (1x48GB @ OOM. Projected ~45-50GiB/GPU)
+axolotl train examples/glm4.7-flash/lora.yaml
+
+# LoRA FSDP2 no target experts (2x48GB @ ~43GiB/GPU)
+axolotl train examples/glm4.7-flash/lora_fsdp.yaml
+```
+
+### Expert LoRA
+
+To also apply LoRA adapters to expert weights, add `lora_target_parameters` to your config.
+
+Note: `lora_dropout` must be `0` when using `lora_target_parameters`.
+
+```yaml
+lora_target_parameters:
+  - mlp.experts.gate_up_proj
+  - mlp.experts.down_proj
+  # - mlp.gate.weight  # router, untested but should work, not normally targeted
+```
+
+## Limitations
+
+- **FSDP VRAM**: FSDP2 may use more VRAM per GPU than single GPU training. We suspect not all layers are properly sharded across ranks.
+- **FSDP initial spike**: FSDP LoRA (8-bit) may have a large initial VRAM spike at the first 1-2 steps that then drops. FSDP QLoRA (4-bit) does not exhibit this.
+- **cpu_ram_efficient_loading**: Must be set to `false` with FSDP2 — causes `AttributeError: e_score_correction_bias is not an nn.Parameter` due to modeling source.
+- **lora_target_linear**: incompatible for this model.
+- **LoRA kernels**: Incompatible with this model due to non-standard attention projections (DSA). Must be explicitly disabled (`lora_*_kernel: false`).
+
+
+### TIPS
+
+- For inference, the official Z.ai team recommends these default settings (most tasks):
+  - `temperature: 1.0`
+  - `top_p: 0.95`
+  - `max_new_tokens: 131072`
+- You can run a full finetuning by removing the `adapter: qlora` and `load_in_4bit: true` from the FSDP2 config. This is heavy, so we have not tested this.
+- Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
+
+## Optimization Guides
+
+Please check the [Optimizations doc](https://docs.axolotl.ai/docs/optimizations.html).
+
+## Related Resources
+
+- [GLM-4.7-Flash on HuggingFace](https://huggingface.co/zai-org/GLM-4.7-Flash)
+- [GLM-4.7 Blog](https://z.ai/blog/glm-4.7)
+- [Axolotl Docs](https://docs.axolotl.ai)
+- [Axolotl Website](https://axolotl.ai)
+- [Axolotl GitHub](https://github.com/axolotl-ai-cloud/axolotl)
+- [Axolotl Discord](https://discord.gg/7m9sfhzaf3)

--- a/examples/glm4.7-flash/README.md
+++ b/examples/glm4.7-flash/README.md
@@ -60,7 +60,7 @@ lora_target_parameters:
   - `temperature: 1.0`
   - `top_p: 0.95`
   - `max_new_tokens: 131072`
-- You can run a full finetuning by removing the `adapter: qlora` and `load_in_4bit: true` from the FSDP2 config. This is heavy, so we have not tested this.
+- You can run a full finetuning by removing `adapter: qlora`, `load_in_4bit: true`, and `quantize_moe_experts: true` from the config. This is heavy, so we have not tested this.
 - Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
 
 ## Optimization Guides

--- a/examples/glm4.7-flash/lora.yaml
+++ b/examples/glm4.7-flash/lora.yaml
@@ -1,0 +1,61 @@
+base_model: zai-org/GLM-4.7-Flash
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+load_in_8bit: true
+quantize_moe_experts: true
+
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.1
+output_dir: ./outputs/glm4.7-flash-lora-8bit-out
+
+adapter: lora
+lora_model_dir:
+
+sequence_len: 2048
+sample_packing: true
+
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - v_proj
+  - k_proj
+  - o_proj
+# lora_target_parameters:
+#   - mlp.experts.gate_up_proj
+#   - mlp.experts.down_proj
+lora_mlp_kernel: false
+lora_qkv_kernel: false
+lora_o_kernel: false
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: false
+
+gradient_checkpointing: true
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 1
+saves_per_epoch: 1

--- a/examples/glm4.7-flash/lora.yaml
+++ b/examples/glm4.7-flash/lora.yaml
@@ -28,9 +28,13 @@ lora_target_modules:
   - v_proj
   - k_proj
   - o_proj
+
+# Uncomment to also target MoE expert weights:
 # lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
+
+# LoRA kernels incompatible with DSA attention
 lora_mlp_kernel: false
 lora_qkv_kernel: false
 lora_o_kernel: false

--- a/examples/glm4.7-flash/lora_fsdp.yaml
+++ b/examples/glm4.7-flash/lora_fsdp.yaml
@@ -1,0 +1,71 @@
+base_model: zai-org/GLM-4.7-Flash
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+load_in_8bit: true
+quantize_moe_experts: true
+
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.1
+output_dir: ./outputs/glm4.7-flash-lora-8bit-fsdp-out
+
+adapter: lora
+lora_model_dir:
+
+sequence_len: 2048
+sample_packing: true
+
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - v_proj
+  - k_proj
+  - o_proj
+# lora_target_parameters:
+#   - mlp.experts.gate_up_proj
+#   - mlp.experts.down_proj
+lora_mlp_kernel: false
+lora_qkv_kernel: false
+lora_o_kernel: false
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: false
+
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 1
+saves_per_epoch: 1
+
+fsdp_config:
+  fsdp_version: 2
+  offload_params: false
+  cpu_ram_efficient_loading: false
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: Glm4MoeLiteDecoderLayer
+  state_dict_type: FULL_STATE_DICT
+  sharding_strategy: FULL_SHARD
+  reshard_after_forward: true
+  activation_checkpointing: true

--- a/examples/glm4.7-flash/lora_fsdp.yaml
+++ b/examples/glm4.7-flash/lora_fsdp.yaml
@@ -28,9 +28,13 @@ lora_target_modules:
   - v_proj
   - k_proj
   - o_proj
+
+# Uncomment to also target MoE expert weights:
 # lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
+
+# LoRA kernels incompatible with DSA attention
 lora_mlp_kernel: false
 lora_qkv_kernel: false
 lora_o_kernel: false

--- a/examples/glm4.7-flash/qlora.yaml
+++ b/examples/glm4.7-flash/qlora.yaml
@@ -1,0 +1,61 @@
+base_model: zai-org/GLM-4.7-Flash
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+load_in_4bit: true
+quantize_moe_experts: true
+
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.1
+output_dir: ./outputs/glm4.7-flash-qlora-out
+
+adapter: qlora
+lora_model_dir:
+
+sequence_len: 2048
+sample_packing: true
+
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - v_proj
+  - k_proj
+  - o_proj
+# lora_target_parameters:
+#   - mlp.experts.gate_up_proj
+#   - mlp.experts.down_proj
+lora_mlp_kernel: false
+lora_qkv_kernel: false
+lora_o_kernel: false
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: false
+
+gradient_checkpointing: true
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 1
+saves_per_epoch: 1

--- a/examples/glm4.7-flash/qlora.yaml
+++ b/examples/glm4.7-flash/qlora.yaml
@@ -28,9 +28,13 @@ lora_target_modules:
   - v_proj
   - k_proj
   - o_proj
+
+# Uncomment to also target MoE expert weights:
 # lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
+
+# LoRA kernels incompatible with DSA attention
 lora_mlp_kernel: false
 lora_qkv_kernel: false
 lora_o_kernel: false

--- a/examples/glm4.7-flash/qlora_fsdp.yaml
+++ b/examples/glm4.7-flash/qlora_fsdp.yaml
@@ -1,0 +1,71 @@
+base_model: zai-org/GLM-4.7-Flash
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+
+load_in_4bit: true
+quantize_moe_experts: true
+
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.1
+output_dir: ./outputs/glm4.7-flash-qlora-fsdp-out
+
+adapter: qlora
+lora_model_dir:
+
+sequence_len: 2048
+sample_packing: true
+
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - v_proj
+  - k_proj
+  - o_proj
+# lora_target_parameters:
+#   - mlp.experts.gate_up_proj
+#   - mlp.experts.down_proj
+lora_mlp_kernel: false
+lora_qkv_kernel: false
+lora_o_kernel: false
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 4
+micro_batch_size: 2
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: false
+
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 1
+saves_per_epoch: 1
+
+fsdp_config:
+  fsdp_version: 2
+  offload_params: false
+  cpu_ram_efficient_loading: false
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: Glm4MoeLiteDecoderLayer
+  state_dict_type: FULL_STATE_DICT
+  sharding_strategy: FULL_SHARD
+  reshard_after_forward: true
+  activation_checkpointing: true

--- a/examples/glm4.7-flash/qlora_fsdp.yaml
+++ b/examples/glm4.7-flash/qlora_fsdp.yaml
@@ -28,9 +28,13 @@ lora_target_modules:
   - v_proj
   - k_proj
   - o_proj
+
+# Uncomment to also target MoE expert weights:
 # lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
+
+# LoRA kernels incompatible with DSA attention
 lora_mlp_kernel: false
 lora_qkv_kernel: false
 lora_o_kernel: false

--- a/examples/trinity/README.md
+++ b/examples/trinity/README.md
@@ -8,13 +8,15 @@ This guide shows how to fine-tune it with Axolotl with multi-turn conversations 
 
 1. Install Axolotl following the main from the [installation guide](https://docs.axolotl.ai/docs/installation.html#sec-edge-build).
 
-2. Run the finetuning example:
+2. Install [Cut Cross Entropy](https://docs.axolotl.ai/docs/custom_integrations.html#cut-cross-entropy) to reduce training VRAM usage.
+
+3. Run the finetuning example:
 
     ```bash
     axolotl train examples/trinity/trinity-nano-preview-qlora.yaml
     ```
 
-This config uses about 24.9 GiB VRAM.
+This config uses about 24.9 GiB VRAM (w/o CCE).
 
 Let us know how it goes. Happy finetuning! 🚀
 
@@ -28,10 +30,6 @@ Let us know how it goes. Happy finetuning! 🚀
 ## Optimization Guides
 
 Please check the [Optimizations doc](https://docs.axolotl.ai/docs/optimizations.html).
-
-## Limitations
-
-**Cut Cross Entropy (CCE)**: Currently not supported. We plan to include CCE support for Trinity in the near future.
 
 ## Related Resources
 

--- a/examples/trinity/trinity-nano-preview-qlora.yaml
+++ b/examples/trinity/trinity-nano-preview-qlora.yaml
@@ -1,5 +1,4 @@
 base_model: arcee-ai/Trinity-Nano-Preview
-trust_remote_code: true
 revision_of_model: 2ee94b0
 
 # Automatically upload checkpoint and final model to HF

--- a/scripts/cutcrossentropy_install.py
+++ b/scripts/cutcrossentropy_install.py
@@ -29,5 +29,5 @@ UV_PREFIX = "uv " if USE_UV else ""
 
 print(
     UNINSTALL_PREFIX
-    + f'{UV_PREFIX}pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@58d6572"'
+    + f'{UV_PREFIX}pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@a668583"'
 )

--- a/src/axolotl/common/architectures.py
+++ b/src/axolotl/common/architectures.py
@@ -18,4 +18,7 @@ MOE_ARCH_BLOCK = {
     "gpt_oss": "GptOssDecoderLayer",
     "lfm2_moe": "Lfm2MoeSparseMoeBlock",
     "afmoe": "AfmoeMoE",
+    "glm4_moe": "Glm4MoeDecoderLayer",
+    "glm4_moe_lite": "Glm4MoeLiteDecoderLayer",
+    "glm_moe_dsa": "GlmMoeDsaDecoderLayer",
 }

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -725,7 +725,7 @@ class AxolotlTrainer(
             state_dict = self.accelerator.get_state_dict(self.model)
         if state_dict is not None:
             state_dict = {
-                k: v.clone() if isinstance(v, torch.Tensor) else v
+                k: v.detach().cpu() if isinstance(v, torch.Tensor) else v
                 for k, v in state_dict.items()
             }
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -720,10 +720,14 @@ class AxolotlTrainer(
         os.makedirs(output_dir, exist_ok=True)
         LOG.info(f"Saving model checkpoint to {output_dir}")
 
-        # fix for Context Parallel save
-        if state_dict is None:
-            state_dict = self.accelerator.get_state_dict(self.model)
-        if state_dict is not None:
+        # fix for Context Parallel save: CP eval invalidates tensor storage
+        # pointers, so clone to CPU to get fresh valid storage for safetensors
+        if (
+            state_dict is not None
+            and self.axolotl_cfg
+            and self.axolotl_cfg.context_parallel_size
+            and self.axolotl_cfg.context_parallel_size > 1
+        ):
             state_dict = {
                 k: v.detach().cpu() if isinstance(v, torch.Tensor) else v
                 for k, v in state_dict.items()

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -765,7 +765,11 @@ class AxolotlTrainer(
                     metadata={"format": "pt"},
                 )
         else:
-            self.model.save_pretrained(output_dir, state_dict=state_dict)
+            self.model.save_pretrained(
+                output_dir,
+                state_dict=state_dict,
+                is_main_process=self.accelerator.is_main_process,
+            )
 
         if self.processing_class is not None:
             self.processing_class.save_pretrained(output_dir)

--- a/src/axolotl/integrations/cut_cross_entropy/README.md
+++ b/src/axolotl/integrations/cut_cross_entropy/README.md
@@ -19,7 +19,7 @@ python scripts/cutcrossentropy_install.py | sh
 
 - If you are installing from pip
 ```bash
-pip3 uninstall -y cut-cross-entropy && pip3 install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@58d6572"
+pip3 uninstall -y cut-cross-entropy && pip3 install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@a668583"
 ```
 
 ## Usage
@@ -88,9 +88,9 @@ plugins:
 - qwen2_vl
 - qwen3
 - qwen3_5
+- qwen3_5_text
 - qwen3_5_moe
-- qwen3_5_moe_vl
-- qwen3_5_vl
+- qwen3_5_moe_text
 - qwen3_moe
 - qwen3_next
 - qwen3_vl

--- a/src/axolotl/integrations/cut_cross_entropy/__init__.py
+++ b/src/axolotl/integrations/cut_cross_entropy/__init__.py
@@ -35,7 +35,7 @@ LOG = get_logger(__name__)
 
 _CCE_INSTALL_MESSAGE = (
     "Please install Axolotl's fork of cut_cross_entropy with transformers support using "
-    '`pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@58d6572"`'
+    '`pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@a668583"`'
 )
 
 

--- a/src/axolotl/integrations/kernels/README.md
+++ b/src/axolotl/integrations/kernels/README.md
@@ -39,6 +39,8 @@ This works for any MoE model in transformers that uses a `SparseMoeBlock` class 
 
 ScatterMoE uses a softmax -> topk routing, so results may be different for some model arch as baseline (GPT-OSS, GLM_MOE_DSA).
 
+ScatterMoE does not work for GLM4.7 Flash (glm4_moe_lite) atm.
+
 ## Note on MegaBlocks
 
 We tested [MegaBlocks](https://huggingface.co/kernels-community/megablocks) but were unable to ensure numerical accuracy, so we did not integrate it. It was also incompatible with many newer model architectures in transformers.

--- a/src/axolotl/loaders/adapter.py
+++ b/src/axolotl/loaders/adapter.py
@@ -34,7 +34,7 @@ def setup_quantized_meta_for_peft(model: torch.nn.Module):
         return self
 
     for param in model.parameters():
-        if isinstance(param, Params4bit):
+        if isinstance(param, Params4bit) and param.quant_state is not None:
             param.quant_state._orig_to = param.quant_state.to
             param.quant_state.to = types.MethodType(temp_to_method, param.quant_state)
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -175,10 +175,12 @@ class ModelLoader:
 
         # Activate loading-time quantization for 3D MoE expert params before
         # from_pretrained() runs.  This patches set_param_for_module so each
-        # expert weight is quantized to 4-bit as it's loaded, keeping peak
-        # VRAM to one expert param in bf16 at a time.
+        # expert weight is quantized (4-bit or 8-bit) as it's loaded, keeping
+        # peak VRAM to one expert param in bf16 at a time.
         moe_quant_active = False
-        if self.cfg.adapter in ("qlora", "lora") and self.cfg.load_in_4bit:
+        if self.cfg.adapter in ("qlora", "lora") and (
+            self.cfg.load_in_4bit or self.cfg.load_in_8bit
+        ):
             from axolotl.monkeypatch.moe_quant import patch_moe_quantization_on_load
 
             patch_moe_quantization_on_load(self.cfg)

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -173,33 +173,8 @@ class ModelLoader:
         PLUGIN_MANAGER.pre_model_load(self.cfg)
         self.patch_manager.apply_post_plugin_pre_model_load_patches()
 
-        # Activate loading-time quantization for 3D MoE expert params before
-        # from_pretrained() runs.  This patches set_param_for_module so each
-        # expert weight is quantized (4-bit or 8-bit) as it's loaded, keeping
-        # peak VRAM to one expert param in bf16 at a time.
-        moe_quant_active = False
-        if self.cfg.adapter in ("qlora", "lora") and (
-            self.cfg.load_in_4bit or self.cfg.load_in_8bit
-        ):
-            from axolotl.monkeypatch.moe_quant import patch_moe_quantization_on_load
-
-            patch_moe_quantization_on_load(self.cfg)
-            moe_quant_active = True
-
         skip_move_to_device = self._build_model()
-
-        # Check if any MoE expert params were quantized during loading.
-        self.model._moe_experts_quantized = False
-        if moe_quant_active:
-            from axolotl.monkeypatch.moe_quant import (
-                get_moe_quantized_count,
-                patch_peft_target_parameters_matching,
-            )
-
-            if get_moe_quantized_count() > 0:
-                self.model._moe_experts_quantized = True
-                patch_peft_target_parameters_matching()
-                torch.cuda.empty_cache()
+        self.patch_manager.apply_post_model_build_patches(self.model)
 
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -172,18 +172,30 @@ class ModelLoader:
         # Build the model
         PLUGIN_MANAGER.pre_model_load(self.cfg)
         self.patch_manager.apply_post_plugin_pre_model_load_patches()
+
+        # Activate loading-time quantization for 3D MoE expert params before
+        # from_pretrained() runs.  This patches set_param_for_module so each
+        # expert weight is quantized to 4-bit as it's loaded, keeping peak
+        # VRAM to one expert param in bf16 at a time.
+        moe_quant_active = False
+        if self.cfg.adapter in ("qlora", "lora") and self.cfg.load_in_4bit:
+            from axolotl.monkeypatch.moe_quant import patch_moe_quantization_on_load
+
+            patch_moe_quantization_on_load(self.cfg)
+            moe_quant_active = True
+
         skip_move_to_device = self._build_model()
 
-        # Quantize 3D MoE expert nn.Parameter tensors that BnB skips during loading.
+        # Check if any MoE expert params were quantized during loading.
         self.model._moe_experts_quantized = False
-        if self.cfg.adapter in ("qlora", "lora") and self.cfg.load_in_4bit:
+        if moe_quant_active:
             from axolotl.monkeypatch.moe_quant import (
+                get_moe_quantized_count,
                 patch_peft_target_parameters_matching,
-                quantize_moe_expert_params,
             )
 
-            self.model._moe_experts_quantized = quantize_moe_expert_params(self.model)
-            if self.model._moe_experts_quantized:
+            if get_moe_quantized_count() > 0:
+                self.model._moe_experts_quantized = True
                 patch_peft_target_parameters_matching()
 
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -197,6 +197,7 @@ class ModelLoader:
             if get_moe_quantized_count() > 0:
                 self.model._moe_experts_quantized = True
                 patch_peft_target_parameters_matching()
+                torch.cuda.empty_cache()
 
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -173,6 +173,14 @@ class ModelLoader:
         PLUGIN_MANAGER.pre_model_load(self.cfg)
         self.patch_manager.apply_post_plugin_pre_model_load_patches()
         skip_move_to_device = self._build_model()
+
+        # Quantize 3D MoE expert nn.Parameter tensors that BnB skips during loading.
+        self.model._moe_experts_quantized = False
+        if self.cfg.adapter in ("qlora", "lora") and self.cfg.load_in_4bit:
+            from axolotl.monkeypatch.moe_quant import quantize_moe_expert_params
+
+            self.model._moe_experts_quantized = quantize_moe_expert_params(self.model)
+
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
 
         # Post-build model configuration
@@ -858,6 +866,10 @@ class ModelLoader:
             or is_deepspeed_zero3_enabled()
         ):
             # Make sure everything is in the same dtype
+            skip_prepare_model_for_kbit_training = True
+
+        if getattr(self.model, "_moe_experts_quantized", False):
+            # Parametrized expert tensors dequantize on access — would OOM.
             skip_prepare_model_for_kbit_training = True
 
         if (

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -177,9 +177,14 @@ class ModelLoader:
         # Quantize 3D MoE expert nn.Parameter tensors that BnB skips during loading.
         self.model._moe_experts_quantized = False
         if self.cfg.adapter in ("qlora", "lora") and self.cfg.load_in_4bit:
-            from axolotl.monkeypatch.moe_quant import quantize_moe_expert_params
+            from axolotl.monkeypatch.moe_quant import (
+                patch_peft_target_parameters_matching,
+                quantize_moe_expert_params,
+            )
 
             self.model._moe_experts_quantized = quantize_moe_expert_params(self.model)
+            if self.model._moe_experts_quantized:
+                patch_peft_target_parameters_matching()
 
         PLUGIN_MANAGER.post_model_build(self.cfg, self.model)
 

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -352,7 +352,7 @@ class PatchManager:
         if (
             self.cfg.fsdp_config
             and str(self.cfg.fsdp_version) == "2"
-            and self.cfg.adapter == "qlora"
+            and (self.cfg.load_in_4bit or self.cfg.load_in_8bit)
         ):
             from axolotl.monkeypatch.fsdp2_qlora import (
                 apply_init_dtype_attrs_patch,

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -355,12 +355,14 @@ class PatchManager:
             and self.cfg.adapter == "qlora"
         ):
             from axolotl.monkeypatch.fsdp2_qlora import (
+                apply_init_dtype_attrs_patch,
                 apply_init_sharded_param_patch,
                 apply_init_unsharded_param_patch,
             )
 
             apply_init_sharded_param_patch()
             apply_init_unsharded_param_patch()
+            apply_init_dtype_attrs_patch()
 
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -118,6 +118,7 @@ class PatchManager:
     def apply_post_plugin_pre_model_load_patches(self):
         """Apply post plugin-pre_model_load load patches based on config."""
         self._apply_tiled_mlp(self.cfg.model_config_type)
+        self._apply_moe_expert_quantization_patch()
 
     def _apply_transformers_patches(self):
         from axolotl.monkeypatch.transformers.trainer_loss_calc import (
@@ -134,6 +135,10 @@ class PatchManager:
             )
 
             patch_prepare_context_parallel_inputs()
+
+    def apply_post_model_build_patches(self, model: PreTrainedModel):
+        """Apply patches right after model build, before post-load setup."""
+        self._finalize_moe_expert_quantization(model)
 
     def apply_post_model_load_patches(self, model: PreTrainedModel):
         """Apply patches that require the model instance."""
@@ -366,6 +371,37 @@ class PatchManager:
             apply_init_dtype_attrs_patch()
             if self.cfg.load_in_8bit:
                 apply_linear8bitlt_save_patch()
+
+    def _apply_moe_expert_quantization_patch(self):
+        """Patch transformers weight loading to quantize MoE expert params on-the-fly."""
+        if not self.cfg.quantize_moe_experts:
+            return
+
+        from axolotl.monkeypatch.moe_quant import (
+            patch_moe_quantization_on_load,
+            patch_peft_target_parameters_matching,
+        )
+
+        patch_moe_quantization_on_load(self.cfg)
+        patch_peft_target_parameters_matching()
+
+    def _finalize_moe_expert_quantization(self, model: PreTrainedModel):
+        """Log quantization results and set model flag for downstream use."""
+        import torch
+
+        model._moe_experts_quantized = False
+        if self.cfg.quantize_moe_experts:
+            from axolotl.monkeypatch.moe_quant import get_moe_quantized_count
+
+            count = get_moe_quantized_count()
+            if count > 0:
+                model._moe_experts_quantized = True
+                LOG.info(
+                    "Quantized %d MoE expert parameter(s) to %s during model loading",
+                    count,
+                    "4-bit" if self.cfg.load_in_4bit else "8-bit",
+                )
+                torch.cuda.empty_cache()
 
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -358,11 +358,14 @@ class PatchManager:
                 apply_init_dtype_attrs_patch,
                 apply_init_sharded_param_patch,
                 apply_init_unsharded_param_patch,
+                apply_linear8bitlt_save_patch,
             )
 
             apply_init_sharded_param_patch()
             apply_init_unsharded_param_patch()
             apply_init_dtype_attrs_patch()
+            if self.cfg.load_in_8bit:
+                apply_linear8bitlt_save_patch()
 
     def _apply_tiled_mlp(self, model_type: str):
         if self.cfg.tiled_mlp:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -395,12 +395,15 @@ class PatchManager:
 
             count = get_moe_quantized_count()
             if count > 0:
+                import gc
+
                 model._moe_experts_quantized = True
                 LOG.info(
                     "Quantized %d MoE expert parameter(s) to %s during model loading",
                     count,
                     "4-bit" if self.cfg.load_in_4bit else "8-bit",
                 )
+                gc.collect()
                 torch.cuda.empty_cache()
 
     def _apply_tiled_mlp(self, model_type: str):

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -175,9 +175,14 @@ class PatchManager:
 
             patch_parallelism_config()
         if self.cfg.fsdp_config and str(self.cfg.fsdp_version) == "2":
-            from axolotl.monkeypatch.accelerate.fsdp2 import patch_accelerate_fsdp2
+            from axolotl.monkeypatch.accelerate.fsdp2 import (
+                patch_accelerate_fsdp2,
+                patch_tied_keys_for_meta_device,
+            )
 
             patch_accelerate_fsdp2()
+            if self.cfg.fsdp_config.cpu_ram_efficient_loading:
+                patch_tied_keys_for_meta_device()
             if self.cfg.rl:
                 from axolotl.monkeypatch.trainer.trl import patch_trl_prepare_fsdp2
 

--- a/src/axolotl/models/mamba/modeling_mamba.py
+++ b/src/axolotl/models/mamba/modeling_mamba.py
@@ -111,6 +111,7 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         self,
         save_directory: Union[str, os.PathLike],
         state_dict: Optional[dict] = None,
+        **kwargs,
     ):
         if state_dict is None:
             state_dict = self.state_dict()

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -150,13 +150,17 @@ def get_state_dict(self, model, unwrap=True):
             )
     elif self.is_fsdp2:
         # https://github.com/pytorch/torchtune/blob/main/torchtune/training/_distributed.py#L465
+        from torch.distributed.tensor import DTensor
+
         state_dict = {}
         sharded_state_dict = model.state_dict()
         for param_name, param in sharded_state_dict.items():
             if param.is_cpu:
                 param = param.to(torch.device("cuda"))
 
-            param = param.full_tensor()
+            if isinstance(param, DTensor):
+                param = param.full_tensor()
+
             if torch.distributed.get_rank() == 0:
                 state_dict[param_name] = param.cpu()
             torch.distributed.barrier()

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -182,9 +182,56 @@ def get_state_dict(self, model, unwrap=True):
     return state_dict
 
 
+def patch_peft_param_wrapper_for_fsdp2():
+    """Patch PEFT's _LoraParameterProxy.forward for FSDP2 DTensor compatibility.
+
+    PEFT's ParamWrapper applies LoRA via torch.nn.utils.parametrize, which adds
+    delta_weight to the base weight W inside _LoraParameterProxy.forward().
+    Under FSDP2, W may be a DTensor (from FSDP unshard) while delta_weight is a
+    regular Tensor (or vice versa), causing a RuntimeError on mixed types.
+
+    This patch promotes the non-DTensor operand to match the DTensor's spec
+    using DTensor.from_local(), which is free for Replicate placement (just
+    metadata wrapping, no communication).
+    """
+    from peft.tuners.lora.layer import _LoraParameterProxy
+
+    if getattr(_LoraParameterProxy, "_axolotl_fsdp2_patched", False):
+        return
+
+    _original_forward = _LoraParameterProxy.forward
+
+    def _patched_forward(self, W):
+        from torch.distributed.tensor import DTensor
+
+        delta = self.delta_weight
+        w_is_dt = isinstance(W, DTensor)
+        d_is_dt = isinstance(delta, DTensor)
+
+        with torch.nn.utils.parametrize.cached():
+            if w_is_dt == d_is_dt:
+                return W + delta
+            if w_is_dt:
+                return W + DTensor.from_local(delta, W.device_mesh, W.placements)
+            return DTensor.from_local(W, delta.device_mesh, delta.placements) + delta
+
+    _LoraParameterProxy.forward = _patched_forward
+    _LoraParameterProxy._axolotl_fsdp2_patched = True
+    LOG.info("Patched PEFT _LoraParameterProxy.forward for FSDP2 DTensor compatibility")
+
+
 def _process_lora_module_for_fsdp(module, fsdp2_kwargs):
     """Helper function to process LoRA modules for FSDP2."""
+    from peft.tuners.lora.layer import ParamWrapper
     from torch.distributed.fsdp import fully_shard
+
+    # ParamWrapper's lora_A/B are only accessed via .weight in get_delta_weight(),
+    # not through forward().  Independent sharding leaves them as sharded DTensors
+    # outside the unshard context, causing incorrect reshape/einsum results.
+    # The parent decoder layer's FSDP wrapper manages them instead — properly
+    # unsharded (Replicate) during forward.
+    if isinstance(module, ParamWrapper):
+        return False
 
     log_bias_dtype_mismatch = False
 
@@ -326,6 +373,14 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             model.tie_weights()
 
     is_peft_model = isinstance(model, PeftModel)
+
+    # Patch PEFT's _LoraParameterProxy for DTensor compatibility if any
+    # ParamWrapper modules exist (used for target_parameters / 3D expert params).
+    if is_peft_model:
+        from peft.tuners.lora.layer import ParamWrapper
+
+        if any(isinstance(m, ParamWrapper) for m in model.modules()):
+            patch_peft_param_wrapper_for_fsdp2()
 
     auto_wrap_policy = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
     log_bias_dtype_mismatch = False

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -205,6 +205,7 @@ def patch_peft_param_wrapper_for_fsdp2():
 
     _original_forward = _LoraParameterProxy.forward
 
+    # NOTE: Replaces (not wraps) forward; assumes original is just `W + self.delta_weight`.
     def _patched_forward(self, W):
         from torch.distributed.tensor import DTensor
 

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -229,11 +229,9 @@ def _process_lora_module_for_fsdp(module, fsdp2_kwargs):
     from peft.tuners.lora.layer import ParamWrapper
     from torch.distributed.fsdp import fully_shard
 
-    # ParamWrapper's lora_A/B are only accessed via .weight in get_delta_weight(),
-    # not through forward().  Independent sharding leaves them as sharded DTensors
-    # outside the unshard context, causing incorrect reshape/einsum results.
-    # The parent decoder layer's FSDP wrapper manages them instead — properly
-    # unsharded (Replicate) during forward.
+    # Skip ParamWrapper — its lora_A/B must not be independently sharded.
+    # The parent decoder layer's FSDP wrapper handles unsharding them.
+    # TODO: review if we even need to shard them separately in first place.
     if isinstance(module, ParamWrapper):
         return False
 

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -434,6 +434,43 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     return model
 
 
+def patch_tied_keys_for_meta_device():
+    """Patch _adjust_tied_keys_with_tied_pointers to skip meta tensors.
+
+    Meta tensors all share data_ptr()==0, causing every parameter to be incorrectly
+    grouped as "tied". Skipping them is safe since they have no real storage.
+    """
+    from collections import defaultdict
+
+    from transformers import PreTrainedModel
+
+    def _patched_adjust_tied_keys_with_tied_pointers(self, missing_keys):
+        param_pointers = defaultdict(list)
+        for param_name, param_value in self.state_dict().items():
+            if param_value.is_meta:
+                continue
+            param_pointers[param_value.data_ptr()].append(param_name)
+
+        tied_param_names = [
+            names
+            for names in param_pointers.values()
+            if len(names) > 1
+            and not any(name in self.all_tied_weights_keys.keys() for name in names)
+            and not all(name in missing_keys for name in names)
+        ]
+
+        tied_weights_keys_by_pointers = {
+            param_name: group[0]
+            for group in tied_param_names
+            for param_name in group[1:]
+        }
+        self.all_tied_weights_keys.update(tied_weights_keys_by_pointers)
+
+    PreTrainedModel._adjust_tied_keys_with_tied_pointers = (
+        _patched_adjust_tied_keys_with_tied_pointers
+    )
+
+
 def patch_accelerate_fsdp2():
     import accelerate
 

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -18,7 +18,7 @@ LOG = get_logger(__name__)
 
 def apply_init_sharded_param_patch():
     """Apply patch to FSDPParam._init_sharded_param to support Params4bit."""
-    if getattr(apply_init_sharded_param_patch, "_patched", False):
+    if getattr(apply_init_sharded_param_patch, "_axolotl_patched", False):
         return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 
@@ -95,7 +95,7 @@ def apply_init_sharded_param_patch():
 
 def apply_init_unsharded_param_patch():
     """Apply patch to FSDPParam.init_unsharded_param to support Params4bit."""
-    if getattr(apply_init_unsharded_param_patch, "_patched", False):
+    if getattr(apply_init_unsharded_param_patch, "_axolotl_patched", False):
         return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 
@@ -177,7 +177,7 @@ def apply_linear8bitlt_save_patch():
     doesn't proxy custom attribute access to its _local_tensor. This patch
     temporarily unwraps the DTensor during saving so BnB can find the SCB attribute.
     """
-    if getattr(apply_linear8bitlt_save_patch, "_patched", False):
+    if getattr(apply_linear8bitlt_save_patch, "_axolotl_patched", False):
         return
     import bitsandbytes as bnb
     from torch.distributed.tensor import DTensor
@@ -214,7 +214,7 @@ def apply_init_dtype_attrs_patch():
     parametrize-based expert quantization uses plain nn.Parameter(uint8/int8)
     without extensions.
     """
-    if getattr(apply_init_dtype_attrs_patch, "_patched", False):
+    if getattr(apply_init_dtype_attrs_patch, "_axolotl_patched", False):
         return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -18,6 +18,8 @@ LOG = get_logger(__name__)
 
 def apply_init_sharded_param_patch():
     """Apply patch to FSDPParam._init_sharded_param to support Params4bit."""
+    if getattr(apply_init_sharded_param_patch, "_patched", False):
+        return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 
     # Get original source
@@ -85,6 +87,7 @@ def apply_init_sharded_param_patch():
 
         # Replace the method
         FSDPParam._init_sharded_param = patched_init_sharded_param
+        apply_init_sharded_param_patch._axolotl_patched = True
         LOG.info("Successfully applied FSDP _init_sharded_param patch")
     else:
         LOG.warning("Could not find target code for _init_sharded_param patching")
@@ -92,6 +95,8 @@ def apply_init_sharded_param_patch():
 
 def apply_init_unsharded_param_patch():
     """Apply patch to FSDPParam.init_unsharded_param to support Params4bit."""
+    if getattr(apply_init_unsharded_param_patch, "_patched", False):
+        return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 
     # Get original source
@@ -158,6 +163,7 @@ def apply_init_unsharded_param_patch():
 
         # Replace the method
         FSDPParam.init_unsharded_param = patched_init_unsharded_param
+        apply_init_unsharded_param_patch._axolotl_patched = True
         LOG.info("Successfully applied FSDP init_unsharded_param patch")
     else:
         LOG.warning("Could not find target code for patching")
@@ -171,6 +177,8 @@ def apply_linear8bitlt_save_patch():
     doesn't proxy custom attribute access to its _local_tensor. This patch
     temporarily unwraps the DTensor during saving so BnB can find the SCB attribute.
     """
+    if getattr(apply_linear8bitlt_save_patch, "_patched", False):
+        return
     import bitsandbytes as bnb
     from torch.distributed.tensor import DTensor
 
@@ -190,6 +198,7 @@ def apply_linear8bitlt_save_patch():
                 self._parameters["weight"] = weight
 
     bnb.nn.Linear8bitLt._save_to_state_dict = _patched_save_to_state_dict
+    apply_linear8bitlt_save_patch._axolotl_patched = True
     LOG.info("Patched Linear8bitLt._save_to_state_dict for DTensor compatibility")
 
 
@@ -205,6 +214,8 @@ def apply_init_dtype_attrs_patch():
     parametrize-based expert quantization uses plain nn.Parameter(uint8/int8)
     without extensions.
     """
+    if getattr(apply_init_dtype_attrs_patch, "_patched", False):
+        return
     from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
 
     original_init_dtype_attrs = FSDPParam.init_dtype_attrs
@@ -221,4 +232,5 @@ def apply_init_dtype_attrs_patch():
                 self.param_dtype = None
 
     FSDPParam.init_dtype_attrs = patched_init_dtype_attrs
+    apply_init_dtype_attrs_patch._axolotl_patched = True
     LOG.info("Patched FSDPParam.init_dtype_attrs for non-float quantized params")

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -177,8 +177,7 @@ def apply_linear8bitlt_save_patch():
     original_save = bnb.nn.Linear8bitLt._save_to_state_dict
 
     def _patched_save_to_state_dict(self, destination, prefix, keep_vars):
-        # Bypass nn.Module.__setattr__ which rejects non-Parameter assignments.
-        # Directly manipulate _parameters dict to swap DTensor ↔ Int8Params.
+        # Use _parameters dict directly to bypass nn.Module.__setattr__ type check.
         weight = self._parameters["weight"]
         unwrapped = False
         if isinstance(weight, DTensor) and hasattr(weight, "_local_tensor"):
@@ -212,10 +211,8 @@ def apply_init_dtype_attrs_patch():
 
     def patched_init_dtype_attrs(self, mp_policy):
         original_init_dtype_attrs(self, mp_policy)
-        # Non-float params without FSDP2 extensions (e.g., uint8/int8 from
-        # parametrize-based MoE expert quantization) must not be cast to
-        # param_dtype. The parametrization chain dequantizes after unshard.
-        # Params with extensions (e.g., Params4bit) handle their own dtype.
+        # Skip casting non-float quantized params (uint8/int8) without FSDP2
+        # extensions — the parametrization chain handles dequantization.
         if self.param_dtype is not None and not self.sharded_param.is_floating_point():
             local = self.sharded_param
             if hasattr(local, "_local_tensor"):

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -1,9 +1,10 @@
 """
-Monkeypatch to add Params4bit support to FSDP2. This enables QLoRA + FSDP2, as well as
-our LoRA / QLoRA Triton kernels to work with FSDP2.
+Monkeypatch to add Params4bit and Int8Params support to FSDP2. This enables QLoRA + FSDP2
+and 8-bit LoRA + FSDP2, as well as our LoRA / QLoRA Triton kernels to work with FSDP2.
 
-This patch modifies the _init_sharded_param method in FSDPParam to handle bitsandbytes
-Params4bit parameters.
+This patch modifies the _init_sharded_param and init_unsharded_param methods in FSDPParam
+to handle bitsandbytes Params4bit and Int8Params parameters, preserving their quantization
+metadata through the FSDP2 shard/unshard cycle.
 """
 
 import importlib
@@ -39,6 +40,15 @@ def apply_init_sharded_param_patch():
             quant_storage=param.quant_storage,
             module=param.module,
             bnb_quantized=param.bnb_quantized,
+        )
+        self.sharded_param = self.to_sharded_dtensor(self.sharded_param)
+    elif isinstance(param, bnb.nn.modules.Int8Params):
+        self.sharded_param = bnb.nn.modules.Int8Params(
+            data=sharded_param,
+            requires_grad=param.requires_grad,
+            has_fp16_weights=param.has_fp16_weights,
+            CB=None,
+            SCB=param.SCB,
         )
         self.sharded_param = self.to_sharded_dtensor(self.sharded_param)
     else:
@@ -106,6 +116,14 @@ def apply_init_unsharded_param_patch():
                 quant_storage=local_tensor.quant_storage,
                 module=local_tensor.module,
                 bnb_quantized=local_tensor.bnb_quantized,
+            )
+        elif isinstance(local_tensor, bnb.nn.modules.Int8Params):
+            self._unsharded_param = bnb.nn.modules.Int8Params(
+                data=unsharded_param,
+                requires_grad=self.sharded_param.requires_grad,
+                has_fp16_weights=local_tensor.has_fp16_weights,
+                CB=unsharded_param,
+                SCB=local_tensor.SCB,
             )
         else:
             self._unsharded_param = nn.Parameter(

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -177,16 +177,18 @@ def apply_linear8bitlt_save_patch():
     original_save = bnb.nn.Linear8bitLt._save_to_state_dict
 
     def _patched_save_to_state_dict(self, destination, prefix, keep_vars):
-        weight = self.weight
+        # Bypass nn.Module.__setattr__ which rejects non-Parameter assignments.
+        # Directly manipulate _parameters dict to swap DTensor ↔ Int8Params.
+        weight = self._parameters["weight"]
         unwrapped = False
         if isinstance(weight, DTensor) and hasattr(weight, "_local_tensor"):
-            self.weight = weight._local_tensor
+            self._parameters["weight"] = weight._local_tensor
             unwrapped = True
         try:
             original_save(self, destination, prefix, keep_vars)
         finally:
             if unwrapped:
-                self.weight = weight
+                self._parameters["weight"] = weight
 
     bnb.nn.Linear8bitLt._save_to_state_dict = _patched_save_to_state_dict
     LOG.info("Patched Linear8bitLt._save_to_state_dict for DTensor compatibility")

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -163,6 +163,35 @@ def apply_init_unsharded_param_patch():
         LOG.warning("Could not find target code for patching")
 
 
+def apply_linear8bitlt_save_patch():
+    """Patch Linear8bitLt._save_to_state_dict to handle DTensor-wrapped Int8Params.
+
+    After FSDP2 sharding, Linear8bitLt.weight is a DTensor wrapping Int8Params.
+    BnB's _save_to_state_dict accesses self.weight.SCB directly, but DTensor
+    doesn't proxy custom attribute access to its _local_tensor. This patch
+    temporarily unwraps the DTensor during saving so BnB can find the SCB attribute.
+    """
+    import bitsandbytes as bnb
+    from torch.distributed.tensor import DTensor
+
+    original_save = bnb.nn.Linear8bitLt._save_to_state_dict
+
+    def _patched_save_to_state_dict(self, destination, prefix, keep_vars):
+        weight = self.weight
+        unwrapped = False
+        if isinstance(weight, DTensor) and hasattr(weight, "_local_tensor"):
+            self.weight = weight._local_tensor
+            unwrapped = True
+        try:
+            original_save(self, destination, prefix, keep_vars)
+        finally:
+            if unwrapped:
+                self.weight = weight
+
+    bnb.nn.Linear8bitLt._save_to_state_dict = _patched_save_to_state_dict
+    LOG.info("Patched Linear8bitLt._save_to_state_dict for DTensor compatibility")
+
+
 def apply_init_dtype_attrs_patch():
     """Prevent FSDP2 mixed precision from casting non-float quantized params.
 

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -143,3 +143,36 @@ def apply_init_unsharded_param_patch():
         LOG.info("Successfully applied FSDP init_unsharded_param patch")
     else:
         LOG.warning("Could not find target code for patching")
+
+
+def apply_init_dtype_attrs_patch():
+    """Prevent FSDP2 mixed precision from casting non-float quantized params.
+
+    When mixed precision is enabled (e.g., bf16), FSDP2's init_dtype_attrs sets
+    param_dtype=bf16 for ALL params. During all-gather, _to_dtype_if_needed casts
+    the sharded param to param_dtype. For non-float params (uint8 packed 4-bit,
+    int8 quantized) without FSDP2 extensions, this destroys the quantized data.
+
+    Params4bit handles this via fsdp_pre/post_all_gather extensions, but our
+    parametrize-based expert quantization uses plain nn.Parameter(uint8/int8)
+    without extensions.
+    """
+    from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
+
+    original_init_dtype_attrs = FSDPParam.init_dtype_attrs
+
+    def patched_init_dtype_attrs(self, mp_policy):
+        original_init_dtype_attrs(self, mp_policy)
+        # Non-float params without FSDP2 extensions (e.g., uint8/int8 from
+        # parametrize-based MoE expert quantization) must not be cast to
+        # param_dtype. The parametrization chain dequantizes after unshard.
+        # Params with extensions (e.g., Params4bit) handle their own dtype.
+        if self.param_dtype is not None and not self.sharded_param.is_floating_point():
+            local = self.sharded_param
+            if hasattr(local, "_local_tensor"):
+                local = local._local_tensor
+            if not hasattr(local, "fsdp_pre_all_gather"):
+                self.param_dtype = None
+
+    FSDPParam.init_dtype_attrs = patched_init_dtype_attrs
+    LOG.info("Patched FSDPParam.init_dtype_attrs for non-float quantized params")

--- a/src/axolotl/monkeypatch/fsdp2_qlora.py
+++ b/src/axolotl/monkeypatch/fsdp2_qlora.py
@@ -42,8 +42,10 @@ def apply_init_sharded_param_patch():
         )
         self.sharded_param = self.to_sharded_dtensor(self.sharded_param)
     else:
-        self.sharded_param = nn.Parameter(self.to_sharded_dtensor(sharded_param))
-        self.sharded_param.requires_grad_(param.requires_grad)"""
+        self.sharded_param = nn.Parameter(
+            self.to_sharded_dtensor(sharded_param),
+            requires_grad=param.requires_grad,
+        )"""
 
     # Apply the replacement
     if original_param_creation in original_source:

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -1,0 +1,86 @@
+"""
+Post-load quantization for MoE expert weights stored as 3D nn.Parameter tensors.
+
+In transformers v5, many MoE models store expert weights as fused 3D nn.Parameter
+tensors instead of individual nn.Linear modules. BnB 4-bit quantization only targets
+nn.Linear, so these expert weights are skipped during model loading, causing OOM.
+
+This module provides a post-load fixup that quantizes those skipped parameters using
+bitsandbytes.nn.parametrize.replace_parameter_4bit (requires bitsandbytes >= 0.48.0).
+PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quantized
+params via stacked parametrizations.
+"""
+
+import bitsandbytes as bnb
+import torch
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def find_unquantized_expert_params(model):
+    """Find 3D+ nn.Parameter tensors that BnB quantization skipped.
+
+    Returns:
+        List of (module, param_name) tuples to quantize.
+    """
+    params_to_quantize = []
+    for _, module in model.named_modules():
+        if isinstance(module, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
+            continue
+        for param_name, param in module.named_parameters(recurse=False):
+            if param.ndim >= 3 and any(
+                kw in param_name for kw in ("experts", "gate_up_proj", "down_proj")
+            ):
+                params_to_quantize.append((module, param_name))
+    return params_to_quantize
+
+
+def quantize_moe_expert_params(model, quant_type=None, compress_statistics=None):
+    """Quantize 3D nn.Parameter expert weights that BnB skips during model loading.
+
+    Reads quant_type and compress_statistics from the model's quantization_config
+    when not explicitly provided, so that the same settings used for nn.Linear
+    quantization are applied to the MoE expert parameters.
+    """
+    from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+    params_to_quantize = find_unquantized_expert_params(model)
+    if not params_to_quantize:
+        return False
+
+    # Derive settings from model's BnB config if not explicitly provided
+    if quant_type is None or compress_statistics is None:
+        bnb_config = getattr(model.config, "quantization_config", None)
+        if bnb_config is not None:
+            if quant_type is None:
+                quant_type = getattr(bnb_config, "bnb_4bit_quant_type", "nf4")
+            if compress_statistics is None:
+                compress_statistics = getattr(
+                    bnb_config, "bnb_4bit_use_double_quant", True
+                )
+    # Final defaults
+    if quant_type is None:
+        quant_type = "nf4"
+    if compress_statistics is None:
+        compress_statistics = True
+
+    count = 0
+    for module, param_name in params_to_quantize:
+        replace_parameter_4bit(
+            module,
+            param_name,
+            compress_statistics=compress_statistics,
+            quant_type=quant_type,
+        )
+        count += 1
+
+    torch.cuda.empty_cache()
+    LOG.info(
+        "Quantized %d MoE expert parameters to 4-bit (quant_type=%s, compress_statistics=%s)",
+        count,
+        quant_type,
+        compress_statistics,
+    )
+    return True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -53,17 +53,25 @@ def patch_moe_quantization_on_load(cfg):
         LOG.debug("MoE loading-time quantization patch already active")
         return
 
-    import os
-
     import transformers.core_model_loading
+    import transformers.modeling_utils
     from bitsandbytes.nn.parametrize import replace_parameter_4bit
 
-    # Disable transformers' async weight loading thread pool. Without this,
-    # the ThreadPoolExecutor pre-fetches tensors to CUDA faster than the main
-    # loop can quantize them, causing all expert weights to accumulate in bf16
-    # on GPU — defeating the purpose of loading-time quantization.
-    os.environ["HF_DEACTIVATE_ASYNC_LOAD"] = "1"
-    LOG.info("Disabled async weight loading (HF_DEACTIVATE_ASYNC_LOAD=1)")
+    # Patch caching_allocator_warmup to be a no-op. This function pre-allocates
+    # a single huge GPU tensor equal to the model's total param bytes to warm the
+    # CUDA caching allocator. For MoE models, it calculates expert params at bf16
+    # size (BnB doesn't know we'll quantize them), causing a ~50+ GiB reservation
+    # that defeats loading-time quantization. Disabling it trades slightly slower
+    # weight loading for dramatically lower peak VRAM.
+    _original_warmup = transformers.modeling_utils.caching_allocator_warmup
+
+    def _noop_warmup(*args, **kwargs):
+        LOG.info(
+            "Skipped caching_allocator_warmup (MoE loading-time quantization active)"
+        )
+
+    transformers.modeling_utils.caching_allocator_warmup = _noop_warmup
+    LOG.info("Patched caching_allocator_warmup to no-op for MoE quantization")
 
     # Read quantization settings from config
     quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"
@@ -77,44 +85,27 @@ def patch_moe_quantization_on_load(cfg):
 
     original_set_param = transformers.core_model_loading.set_param_for_module
 
-    _first_call = [True]
-
     def _patched_set_param_for_module(model, target_name, param_value, *args, **kwargs):
-        if _first_call[0]:
-            LOG.info(
-                "MoE quant patch: set_param_for_module intercepted (first call) "
-                "(alloc=%.2f GiB, reserved=%.2f GiB, max_alloc=%.2f GiB)",
-                torch.cuda.memory_allocated() / 1024**3,
-                torch.cuda.memory_reserved() / 1024**3,
-                torch.cuda.max_memory_allocated() / 1024**3,
-            )
-            _first_call[0] = False
-
         original_set_param(model, target_name, param_value, *args, **kwargs)
 
         # Quantize 3D+ expert params that BnB skipped (only on CUDA).
-        if param_value.ndim >= 3:
-            LOG.info(
-                "MoE quant patch: 3D param %s shape=%s cuda=%s",
-                target_name,
-                param_value.shape,
-                param_value.is_cuda,
-            )
-            if param_value.is_cuda:
-                mod_path, _, pname = target_name.rpartition(".")
-                mod = model.get_submodule(mod_path) if mod_path else model
-                if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
-                    replace_parameter_4bit(
-                        mod,
-                        pname,
-                        compress_statistics=_moe_load_state["compress_statistics"],
-                        quant_type=_moe_load_state["quant_type"],
-                    )
-                    torch.cuda.empty_cache()
-                    _moe_load_state["count"] += 1
+        if param_value.ndim >= 3 and param_value.is_cuda:
+            mod_path, _, pname = target_name.rpartition(".")
+            mod = model.get_submodule(mod_path) if mod_path else model
+            if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
+                replace_parameter_4bit(
+                    mod,
+                    pname,
+                    compress_statistics=_moe_load_state["compress_statistics"],
+                    quant_type=_moe_load_state["quant_type"],
+                )
+                torch.cuda.empty_cache()
+                _moe_load_state["count"] += 1
+                if _moe_load_state["count"] % 10 == 1:
                     LOG.info(
-                        "Quantized 3D expert param: %s "
+                        "Quantized expert param #%d: %s "
                         "(alloc=%.2f GiB, reserved=%.2f GiB)",
+                        _moe_load_state["count"],
                         target_name,
                         torch.cuda.memory_allocated() / 1024**3,
                         torch.cuda.memory_reserved() / 1024**3,
@@ -122,11 +113,6 @@ def patch_moe_quantization_on_load(cfg):
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True
-    LOG.info(
-        "Pre-load GPU memory: alloc=%.2f GiB, reserved=%.2f GiB",
-        torch.cuda.memory_allocated() / 1024**3,
-        torch.cuda.memory_reserved() / 1024**3,
-    )
     LOG.info(
         "Activated MoE loading-time quantization patch "
         "(quant_type=%s, compress_statistics=%s)",

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -117,8 +117,10 @@ def quantize_moe_expert_params(model, quant_type=None, compress_statistics=None)
             quant_type=quant_type,
         )
         count += 1
+        # Free the bf16 → 4-bit conversion buffers after each parameter
+        # to avoid accumulating peak reserved VRAM.
+        torch.cuda.empty_cache()
 
-    torch.cuda.empty_cache()
     LOG.info(
         "Quantized %d MoE expert parameters to 4-bit (quant_type=%s, compress_statistics=%s)",
         count,

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -81,7 +81,13 @@ def patch_moe_quantization_on_load(cfg):
 
     def _patched_set_param_for_module(model, target_name, param_value, *args, **kwargs):
         if _first_call[0]:
-            LOG.info("MoE quant patch: set_param_for_module intercepted (first call)")
+            LOG.info(
+                "MoE quant patch: set_param_for_module intercepted (first call) "
+                "(alloc=%.2f GiB, reserved=%.2f GiB, max_alloc=%.2f GiB)",
+                torch.cuda.memory_allocated() / 1024**3,
+                torch.cuda.memory_reserved() / 1024**3,
+                torch.cuda.max_memory_allocated() / 1024**3,
+            )
             _first_call[0] = False
 
         original_set_param(model, target_name, param_value, *args, **kwargs)
@@ -116,6 +122,11 @@ def patch_moe_quantization_on_load(cfg):
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True
+    LOG.info(
+        "Pre-load GPU memory: alloc=%.2f GiB, reserved=%.2f GiB",
+        torch.cuda.memory_allocated() / 1024**3,
+        torch.cuda.memory_reserved() / 1024**3,
+    )
     LOG.info(
         "Activated MoE loading-time quantization patch "
         "(quant_type=%s, compress_statistics=%s)",

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -16,6 +16,8 @@ PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quan
 params via stacked parametrizations.
 """
 
+import gc
+
 import bitsandbytes as bnb
 import torch
 import torch.nn.utils.parametrize as P
@@ -184,8 +186,16 @@ def patch_moe_quantization_on_load(cfg):
                     )
                 else:
                     replace_parameter_8bit(mod, pname)
-                torch.cuda.empty_cache()
                 _moe_load_state["count"] += 1
+
+                # Release the bf16 CUDA storage. After quantization, the
+                # module holds the quantized parametrization — but the
+                # caller's references (loop var + dict) keep the bf16 CUDA
+                # storage alive past empty_cache(). Replacing .data frees
+                # the CUDA memory immediately regardless of Python refcount.
+                param_value.data = torch.empty(0, device="cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -63,15 +63,10 @@ def patch_moe_quantization_on_load(cfg):
     # size (BnB doesn't know we'll quantize them), causing a ~50+ GiB reservation
     # that defeats loading-time quantization. Disabling it trades slightly slower
     # weight loading for dramatically lower peak VRAM.
-    _original_warmup = transformers.modeling_utils.caching_allocator_warmup
-
     def _noop_warmup(*args, **kwargs):
-        LOG.info(
-            "Skipped caching_allocator_warmup (MoE loading-time quantization active)"
-        )
+        pass
 
     transformers.modeling_utils.caching_allocator_warmup = _noop_warmup
-    LOG.info("Patched caching_allocator_warmup to no-op for MoE quantization")
 
     # Read quantization settings from config
     quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"
@@ -101,24 +96,9 @@ def patch_moe_quantization_on_load(cfg):
                 )
                 torch.cuda.empty_cache()
                 _moe_load_state["count"] += 1
-                if _moe_load_state["count"] % 10 == 1:
-                    LOG.info(
-                        "Quantized expert param #%d: %s "
-                        "(alloc=%.2f GiB, reserved=%.2f GiB)",
-                        _moe_load_state["count"],
-                        target_name,
-                        torch.cuda.memory_allocated() / 1024**3,
-                        torch.cuda.memory_reserved() / 1024**3,
-                    )
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True
-    LOG.info(
-        "Activated MoE loading-time quantization patch "
-        "(quant_type=%s, compress_statistics=%s)",
-        quant_type,
-        compress_statistics,
-    )
 
 
 def get_moe_quantized_count():

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -77,27 +77,42 @@ def patch_moe_quantization_on_load(cfg):
 
     original_set_param = transformers.core_model_loading.set_param_for_module
 
+    _first_call = [True]
+
     def _patched_set_param_for_module(model, target_name, param_value, *args, **kwargs):
+        if _first_call[0]:
+            LOG.info("MoE quant patch: set_param_for_module intercepted (first call)")
+            _first_call[0] = False
+
         original_set_param(model, target_name, param_value, *args, **kwargs)
 
         # Quantize 3D+ expert params that BnB skipped (only on CUDA).
-        if param_value.ndim >= 3 and param_value.is_cuda:
-            mod_path, _, pname = target_name.rpartition(".")
-            mod = model.get_submodule(mod_path) if mod_path else model
-            if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
-                replace_parameter_4bit(
-                    mod,
-                    pname,
-                    compress_statistics=_moe_load_state["compress_statistics"],
-                    quant_type=_moe_load_state["quant_type"],
-                )
-                torch.cuda.empty_cache()
-                _moe_load_state["count"] += 1
-                LOG.debug(
-                    "Quantized 3D expert param during loading: %s (shape %s)",
-                    target_name,
-                    param_value.shape,
-                )
+        if param_value.ndim >= 3:
+            LOG.info(
+                "MoE quant patch: 3D param %s shape=%s cuda=%s",
+                target_name,
+                param_value.shape,
+                param_value.is_cuda,
+            )
+            if param_value.is_cuda:
+                mod_path, _, pname = target_name.rpartition(".")
+                mod = model.get_submodule(mod_path) if mod_path else model
+                if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
+                    replace_parameter_4bit(
+                        mod,
+                        pname,
+                        compress_statistics=_moe_load_state["compress_statistics"],
+                        quant_type=_moe_load_state["quant_type"],
+                    )
+                    torch.cuda.empty_cache()
+                    _moe_load_state["count"] += 1
+                    LOG.info(
+                        "Quantized 3D expert param: %s "
+                        "(alloc=%.2f GiB, reserved=%.2f GiB)",
+                        target_name,
+                        torch.cuda.memory_allocated() / 1024**3,
+                        torch.cuda.memory_reserved() / 1024**3,
+                    )
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -1,14 +1,20 @@
 """
-Post-load quantization for MoE expert weights stored as 3D nn.Parameter tensors.
+Loading-time quantization for MoE expert weights stored as 3D nn.Parameter tensors.
 
 In transformers v5, many MoE models store expert weights as fused 3D nn.Parameter
 tensors instead of individual nn.Linear modules. BnB 4-bit quantization only targets
-nn.Linear, so these expert weights are skipped during model loading, causing OOM.
+nn.Linear, so these expert weights are loaded in full precision, causing high peak VRAM.
 
-This module provides a post-load fixup that quantizes those skipped parameters using
-bitsandbytes.nn.parametrize.replace_parameter_4bit (requires bitsandbytes >= 0.48.0).
+This module patches transformers' weight loading to quantize 3D expert parameters
+on-the-fly as they're assigned to modules, using bitsandbytes.nn.parametrize.
+replace_parameter_4bit (requires bitsandbytes >= 0.48.0). This reduces peak VRAM
+from "all experts in bf16" to "one expert param in bf16 at a time."
+
 PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quantized
 params via stacked parametrizations.
+
+Note: FSDP2 cpu ram efficient loading and Tensor Parallel (DTensor) compatibility
+with parametrization is untested.
 """
 
 import bitsandbytes as bnb
@@ -17,6 +23,86 @@ import torch
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
+
+# Module-level state for the loading-time quantization patch.
+_moe_load_state = {
+    "count": 0,
+    "quant_type": "nf4",
+    "compress_statistics": True,
+    "patched": False,
+}
+
+
+def patch_moe_quantization_on_load(cfg):
+    """Patch transformers' weight loading to quantize 3D MoE expert params on-the-fly.
+
+    Wraps ``transformers.core_model_loading.set_param_for_module`` so that after each
+    parameter is assigned to its module, any 3D+ tensor on CUDA that BnB skipped
+    (i.e. not inside a Linear4bit/Linear8bitLt) is immediately quantized via
+    ``replace_parameter_4bit``. This keeps peak VRAM to one expert param in bf16
+    at a time, instead of loading all experts in bf16 first.
+
+    The patch stays active permanently — the ``ndim >= 3`` and ``is_cuda`` checks
+    make it safe for non-MoE models (no false positives).
+
+    Args:
+        cfg: Axolotl DictDefault config. Reads bnb_4bit_quant_type and
+             bnb_4bit_use_double_quant for quantization settings.
+    """
+    if _moe_load_state["patched"]:
+        LOG.debug("MoE loading-time quantization patch already active")
+        return
+
+    import transformers.core_model_loading
+    from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+    # Read quantization settings from config
+    quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"
+    compress_statistics = getattr(cfg, "bnb_4bit_use_double_quant", None)
+    if compress_statistics is None:
+        compress_statistics = True
+
+    _moe_load_state["quant_type"] = quant_type
+    _moe_load_state["compress_statistics"] = compress_statistics
+    _moe_load_state["count"] = 0
+
+    original_set_param = transformers.core_model_loading.set_param_for_module
+
+    def _patched_set_param_for_module(model, target_name, param_value, *args, **kwargs):
+        original_set_param(model, target_name, param_value, *args, **kwargs)
+
+        # Quantize 3D+ expert params that BnB skipped (only on CUDA).
+        if param_value.ndim >= 3 and param_value.is_cuda:
+            mod_path, _, pname = target_name.rpartition(".")
+            mod = model.get_submodule(mod_path) if mod_path else model
+            if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
+                replace_parameter_4bit(
+                    mod,
+                    pname,
+                    compress_statistics=_moe_load_state["compress_statistics"],
+                    quant_type=_moe_load_state["quant_type"],
+                )
+                torch.cuda.empty_cache()
+                _moe_load_state["count"] += 1
+                LOG.debug(
+                    "Quantized 3D expert param during loading: %s (shape %s)",
+                    target_name,
+                    param_value.shape,
+                )
+
+    transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
+    _moe_load_state["patched"] = True
+    LOG.info(
+        "Activated MoE loading-time quantization patch "
+        "(quant_type=%s, compress_statistics=%s)",
+        quant_type,
+        compress_statistics,
+    )
+
+
+def get_moe_quantized_count():
+    """Return the number of expert parameters quantized during loading."""
+    return _moe_load_state["count"]
 
 
 def patch_peft_target_parameters_matching():
@@ -59,72 +145,3 @@ def patch_peft_target_parameters_matching():
 
     BaseTuner._inject_parameters = _patched_inject_parameters
     LOG.info("Patched PEFT _inject_parameters for parametrized module suffix matching")
-
-
-def find_unquantized_expert_params(model):
-    """Find 3D+ nn.Parameter tensors that BnB quantization skipped.
-
-    Returns:
-        List of (module, param_name) tuples to quantize.
-    """
-    params_to_quantize = []
-    for _, module in model.named_modules():
-        if isinstance(module, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
-            continue
-        for param_name, param in module.named_parameters(recurse=False):
-            if param.ndim >= 3 and any(
-                kw in param_name for kw in ("experts", "gate_up_proj", "down_proj")
-            ):
-                params_to_quantize.append((module, param_name))
-    return params_to_quantize
-
-
-def quantize_moe_expert_params(model, quant_type=None, compress_statistics=None):
-    """Quantize 3D nn.Parameter expert weights that BnB skips during model loading.
-
-    Reads quant_type and compress_statistics from the model's quantization_config
-    when not explicitly provided, so that the same settings used for nn.Linear
-    quantization are applied to the MoE expert parameters.
-    """
-    from bitsandbytes.nn.parametrize import replace_parameter_4bit
-
-    params_to_quantize = find_unquantized_expert_params(model)
-    if not params_to_quantize:
-        return False
-
-    # Derive settings from model's BnB config if not explicitly provided
-    if quant_type is None or compress_statistics is None:
-        bnb_config = getattr(model.config, "quantization_config", None)
-        if bnb_config is not None:
-            if quant_type is None:
-                quant_type = getattr(bnb_config, "bnb_4bit_quant_type", "nf4")
-            if compress_statistics is None:
-                compress_statistics = getattr(
-                    bnb_config, "bnb_4bit_use_double_quant", True
-                )
-    # Final defaults
-    if quant_type is None:
-        quant_type = "nf4"
-    if compress_statistics is None:
-        compress_statistics = True
-
-    count = 0
-    for module, param_name in params_to_quantize:
-        replace_parameter_4bit(
-            module,
-            param_name,
-            compress_statistics=compress_statistics,
-            quant_type=quant_type,
-        )
-        count += 1
-        # Free the bf16 → 4-bit conversion buffers after each parameter
-        # to avoid accumulating peak reserved VRAM.
-        torch.cuda.empty_cache()
-
-    LOG.info(
-        "Quantized %d MoE expert parameters to 4-bit (quant_type=%s, compress_statistics=%s)",
-        count,
-        quant_type,
-        compress_statistics,
-    )
-    return True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -51,7 +51,14 @@ class Bnb8bitParametrization(torch.nn.Module):
 
     @torch.no_grad()
     def forward(self, quantized_param: torch.Tensor) -> torch.Tensor:
-        return bnb.functional.int8_vectorwise_dequant(quantized_param, self.row_stats)
+        # BnB's int8_vectorwise_dequant uses stats.view(-1, 1) which only works
+        # for 2D tensors. For 3D+ expert weights (num_experts, out, in), flatten
+        # leading dims to 2D, dequant, then reshape back.
+        orig_shape = quantized_param.shape
+        if quantized_param.ndim > 2:
+            quantized_param = quantized_param.reshape(-1, orig_shape[-1])
+        result = bnb.functional.int8_vectorwise_dequant(quantized_param, self.row_stats)
+        return result.reshape(orig_shape)
 
 
 def _enable_parametrization_cache(module, inputs):

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -79,20 +79,16 @@ def patch_moe_quantization_on_load(cfg):
     Wraps ``set_param_for_module`` so that 3D+ CUDA tensors with "expert" in their
     name are quantized (4-bit or 8-bit) as they're loaded, keeping peak VRAM low.
     """
+    mode = "8bit" if getattr(cfg, "load_in_8bit", False) else "4bit"
+    _moe_load_state["mode"] = mode
+    _moe_load_state["count"] = 0
+
     if _moe_load_state["patched"]:
         LOG.debug("MoE loading-time quantization patch already active")
         return
 
     import transformers.core_model_loading
     import transformers.modeling_utils
-
-    if getattr(cfg, "load_in_8bit", False):
-        mode = "8bit"
-    else:
-        mode = "4bit"
-
-    _moe_load_state["mode"] = mode
-    _moe_load_state["count"] = 0
 
     if mode == "4bit":
         from bitsandbytes.nn.parametrize import replace_parameter_4bit

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -19,6 +19,48 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 
+def patch_peft_target_parameters_matching():
+    """Fix PEFT's _inject_parameters to use suffix matching for parametrized modules.
+
+    PEFT's parametrized-module branch uses exact name match for target_parameters,
+    but the standard branch uses endswith. This means suffix-style paths like
+    "mlp.experts.gate_up_proj" fail to match parametrized modules whose full path
+    is "model.layers.0.mlp.experts.gate_up_proj". This patch makes the parametrized
+    branch consistent with the standard branch.
+    """
+    from peft.tuners.tuners_utils import BaseTuner
+
+    original_inject = BaseTuner._inject_parameters
+
+    def _patched_inject_parameters(
+        self, peft_config, model, adapter_name, low_cpu_mem_usage
+    ):
+        # Patch target_parameters to use full paths for parametrized modules
+        original_targets = list(peft_config.target_parameters)
+        expanded = set(original_targets)
+
+        for module_name, module in model.named_modules():
+            if not hasattr(module, "parametrizations"):
+                continue
+            for target in original_targets:
+                mod_path, _, param_name = target.rpartition(".")
+                if (
+                    module_name == mod_path or module_name.endswith("." + mod_path)
+                ) and hasattr(module, param_name):
+                    expanded.add(f"{module_name}.{param_name}")
+
+        peft_config.target_parameters = sorted(expanded)
+        try:
+            return original_inject(
+                self, peft_config, model, adapter_name, low_cpu_mem_usage
+            )
+        finally:
+            peft_config.target_parameters = original_targets
+
+    BaseTuner._inject_parameters = _patched_inject_parameters
+    LOG.info("Patched PEFT _inject_parameters for parametrized module suffix matching")
+
+
 def find_unquantized_expert_params(model):
     """Find 3D+ nn.Parameter tensors that BnB quantization skipped.
 

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -16,6 +16,8 @@ PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quan
 params via stacked parametrizations.
 """
 
+import gc
+
 import bitsandbytes as bnb
 import torch
 import torch.nn.utils.parametrize as P
@@ -186,16 +188,14 @@ def patch_moe_quantization_on_load(cfg):
                     replace_parameter_8bit(mod, pname)
                 _moe_load_state["count"] += 1
 
-                # Release the bf16 CUDA storage immediately. After
-                # quantization, the module holds the quantized
-                # parametrization, but the caller's references (loop var
-                # + realized_value dict) keep the bf16 storage alive.
-                # Replacing .data frees it regardless of Python refcount.
-                # We intentionally skip empty_cache() here so the CUDA
-                # caching allocator can reuse the freed block for the
-                # next expert param (same size). Cleanup happens after
-                # loading completes (model.py:202 and model.py:456-458).
+                # Release the bf16 CUDA storage. After quantization, the
+                # module holds the quantized parametrization — but the
+                # caller's references (loop var + dict) keep the bf16 CUDA
+                # storage alive past empty_cache(). Replacing .data frees
+                # the CUDA memory immediately regardless of Python refcount.
                 param_value.data = torch.empty(0, device="cpu")
+                gc.collect()
+                torch.cuda.empty_cache()
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -7,8 +7,6 @@ on-the-fly (4-bit via bitsandbytes parametrize, 8-bit via custom int8 parametriz
 reducing peak VRAM from "all experts in bf16" to "one expert at a time."
 """
 
-import gc
-
 import bitsandbytes as bnb
 import torch
 import torch.nn.utils.parametrize as P
@@ -69,8 +67,10 @@ def replace_parameter_8bit(module, param_name):
     )
 
     # Cache dequantized values during forward to avoid redundant dequantization.
-    module.register_forward_pre_hook(_enable_parametrization_cache)
-    module.register_forward_hook(_disable_parametrization_cache)
+    if not getattr(module, "_axolotl_8bit_hooks_registered", False):
+        module.register_forward_pre_hook(_enable_parametrization_cache)
+        module.register_forward_hook(_disable_parametrization_cache)
+        module._axolotl_8bit_hooks_registered = True
 
 
 def patch_moe_quantization_on_load(cfg):
@@ -139,7 +139,6 @@ def patch_moe_quantization_on_load(cfg):
 
                 # Release the bf16 tensor so CUDA memory is freed immediately.
                 param_value.data = torch.empty(0, device="cpu")
-                gc.collect()
                 torch.cuda.empty_cache()
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
@@ -153,6 +152,8 @@ def get_moe_quantized_count():
 
 def patch_peft_target_parameters_matching():
     """Fix PEFT's _inject_parameters to use suffix matching for parametrized modules."""
+    if getattr(patch_peft_target_parameters_matching, "_axolotl_patched", False):
+        return
     from peft.tuners.tuners_utils import BaseTuner
 
     original_inject = BaseTuner._inject_parameters
@@ -183,4 +184,5 @@ def patch_peft_target_parameters_matching():
             peft_config.target_parameters = original_targets
 
     BaseTuner._inject_parameters = _patched_inject_parameters
+    patch_peft_target_parameters_matching._axolotl_patched = True
     LOG.info("Patched PEFT _inject_parameters for parametrized module suffix matching")

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -16,8 +16,6 @@ PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quan
 params via stacked parametrizations.
 """
 
-import gc
-
 import bitsandbytes as bnb
 import torch
 import torch.nn.utils.parametrize as P
@@ -188,14 +186,16 @@ def patch_moe_quantization_on_load(cfg):
                     replace_parameter_8bit(mod, pname)
                 _moe_load_state["count"] += 1
 
-                # Release the bf16 CUDA storage. After quantization, the
-                # module holds the quantized parametrization — but the
-                # caller's references (loop var + dict) keep the bf16 CUDA
-                # storage alive past empty_cache(). Replacing .data frees
-                # the CUDA memory immediately regardless of Python refcount.
+                # Release the bf16 CUDA storage immediately. After
+                # quantization, the module holds the quantized
+                # parametrization, but the caller's references (loop var
+                # + realized_value dict) keep the bf16 storage alive.
+                # Replacing .data frees it regardless of Python refcount.
+                # We intentionally skip empty_cache() here so the CUDA
+                # caching allocator can reuse the freed block for the
+                # next expert param (same size). Cleanup happens after
+                # loading completes (model.py:202 and model.py:456-458).
                 param_value.data = torch.empty(0, device="cpu")
-                gc.collect()
-                torch.cuda.empty_cache()
 
     transformers.core_model_loading.set_param_for_module = _patched_set_param_for_module
     _moe_load_state["patched"] = True

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -1,19 +1,10 @@
 """
 Loading-time quantization for MoE expert weights stored as 3D nn.Parameter tensors.
 
-In transformers v5, many MoE models store expert weights as fused 3D nn.Parameter
-tensors instead of individual nn.Linear modules. BnB quantization only targets
-nn.Linear, so these expert weights are loaded in full precision, causing high peak VRAM.
-
-This module patches transformers' weight loading to quantize 3D expert parameters
-on-the-fly as they're assigned to modules. For 4-bit, it uses
-bitsandbytes.nn.parametrize.replace_parameter_4bit (requires bitsandbytes >= 0.48.0).
-For 8-bit, it uses a custom parametrization built on bitsandbytes.functional's
-int8_vectorwise_quant/dequant (row-wise absmax scaling). Both reduce peak VRAM from
-"all experts in bf16" to "one expert param in bf16 at a time."
-
-PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quantized
-params via stacked parametrizations.
+In transformers v5, MoE models store expert weights as fused 3D tensors that BnB
+skips (only targets nn.Linear). This module patches weight loading to quantize them
+on-the-fly (4-bit via bitsandbytes parametrize, 8-bit via custom int8 parametrization),
+reducing peak VRAM from "all experts in bf16" to "one expert at a time."
 """
 
 import gc
@@ -37,13 +28,7 @@ _moe_load_state = {
 
 
 class Bnb8bitParametrization(torch.nn.Module):
-    """Parametrization that dequantizes int8 row-wise quantized data on access.
-
-    Mirrors ``Bnb4bitParametrization`` from ``bitsandbytes.nn.parametrize`` but for
-    int8 row-wise (absmax) quantization.  Stores the per-row scales as a buffer and
-    delegates to ``bitsandbytes.functional.int8_vectorwise_dequant`` which computes
-    ``int8_data * row_stats * (1/127)``.
-    """
+    """Parametrization that dequantizes int8 row-wise quantized data on access."""
 
     def __init__(self, row_stats: torch.Tensor):
         super().__init__()
@@ -51,9 +36,7 @@ class Bnb8bitParametrization(torch.nn.Module):
 
     @torch.no_grad()
     def forward(self, quantized_param: torch.Tensor) -> torch.Tensor:
-        # BnB's int8_vectorwise_dequant uses stats.view(-1, 1) which only works
-        # for 2D tensors. For 3D+ expert weights (num_experts, out, in), flatten
-        # leading dims to 2D, dequant, then reshape back.
+        # Flatten 3D+ to 2D for BnB's dequant, then reshape back.
         orig_shape = quantized_param.shape
         if quantized_param.ndim > 2:
             quantized_param = quantized_param.reshape(-1, orig_shape[-1])
@@ -72,16 +55,7 @@ def _disable_parametrization_cache(module, inputs, output):
 
 
 def replace_parameter_8bit(module, param_name):
-    """Replace a module parameter with an 8-bit quantized version using parametrization.
-
-    Mirrors ``bitsandbytes.nn.parametrize.replace_parameter_4bit`` but for int8
-    row-wise (absmax) quantization.  Uses ``int8_vectorwise_quant`` which supports
-    N-D tensors natively (scales shape = ``prod(shape[:-1])``).
-
-    Args:
-        module: The module containing the parameter to quantize.
-        param_name: Name of the parameter within the module.
-    """
+    """Replace a module parameter with an 8-bit quantized version using parametrization."""
     original_param = getattr(module, param_name)
     int8_data, row_stats, _ = bnb.functional.int8_vectorwise_quant(
         original_param.data.to(torch.float16)
@@ -94,47 +68,16 @@ def replace_parameter_8bit(module, param_name):
         module, param_name, Bnb8bitParametrization(row_stats), unsafe=True
     )
 
-    # Register caching hooks (same pattern as BnB 4-bit). Caching avoids
-    # redundant dequantization when the same param is accessed multiple times
-    # in a single forward pass.
+    # Cache dequantized values during forward to avoid redundant dequantization.
     module.register_forward_pre_hook(_enable_parametrization_cache)
     module.register_forward_hook(_disable_parametrization_cache)
 
 
-def _8bit_state_dict_post_hook(
-    module, state_dict, prefix, local_metadata, *, param_name
-):
-    """Placeholder for 8-bit state_dict serialization hook.
-
-    For LoRA/QLoRA training, only adapter weights (lora_A/B) are saved — base model
-    weights including quantized experts are not serialized. State dict hooks for 8-bit
-    are therefore not needed for the primary use case. If full-model saving with 8-bit
-    quantized expert params is needed, this hook should store int8 data + row_stats.
-    """
-    raise NotImplementedError(
-        "State dict serialization for 8-bit quantized expert parameters is not yet "
-        "implemented. This is not needed for LoRA/QLoRA training (only adapter weights "
-        "are saved). If you need to save the full model with 8-bit quantized experts, "
-        "please open an issue."
-    )
-
-
 def patch_moe_quantization_on_load(cfg):
-    """Patch transformers' weight loading to quantize 3D MoE expert params on-the-fly.
+    """Patch transformers' weight loading to quantize MoE expert params on-the-fly.
 
-    Wraps ``transformers.core_model_loading.set_param_for_module`` so that after each
-    parameter is assigned to its module, any 3D+ tensor on CUDA that BnB skipped
-    (i.e. not inside a Linear4bit/Linear8bitLt) is immediately quantized via
-    ``replace_parameter_4bit`` (for 4-bit) or ``replace_parameter_8bit`` (for 8-bit).
-    This keeps peak VRAM to one expert param in bf16 at a time, instead of loading
-    all experts in bf16 first.
-
-    The patch stays active permanently — the ``ndim >= 3`` and ``is_cuda`` checks
-    make it safe for non-MoE models (no false positives).
-
-    Args:
-        cfg: Axolotl DictDefault config. For 4-bit, reads bnb_4bit_quant_type and
-             bnb_4bit_use_double_quant. For 8-bit, no additional settings needed.
+    Wraps ``set_param_for_module`` so that 3D+ CUDA tensors with "expert" in their
+    name are quantized (4-bit or 8-bit) as they're loaded, keeping peak VRAM low.
     """
     if _moe_load_state["patched"]:
         LOG.debug("MoE loading-time quantization patch already active")
@@ -143,7 +86,6 @@ def patch_moe_quantization_on_load(cfg):
     import transformers.core_model_loading
     import transformers.modeling_utils
 
-    # Determine quantization mode from config.
     if getattr(cfg, "load_in_8bit", False):
         mode = "8bit"
     else:
@@ -163,12 +105,8 @@ def patch_moe_quantization_on_load(cfg):
         _moe_load_state["quant_type"] = quant_type
         _moe_load_state["compress_statistics"] = compress_statistics
 
-    # Patch caching_allocator_warmup to be a no-op. This function pre-allocates
-    # a single huge GPU tensor equal to the model's total param bytes to warm the
-    # CUDA caching allocator. For MoE models, it calculates expert params at bf16
-    # size (BnB doesn't know we'll quantize them), causing a ~50+ GiB reservation
-    # that defeats loading-time quantization. Disabling it trades slightly slower
-    # weight loading for dramatically lower peak VRAM.
+    # Disable caching_allocator_warmup — it pre-allocates a huge tensor at bf16
+    # size for all params, defeating our on-load quantization VRAM savings.
     def _noop_warmup(*args, **kwargs):
         pass
 
@@ -184,6 +122,14 @@ def patch_moe_quantization_on_load(cfg):
             mod_path, _, pname = target_name.rpartition(".")
             mod = model.get_submodule(mod_path) if mod_path else model
             if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
+                if "expert" not in target_name.lower():
+                    LOG.debug(
+                        "Skipping non-expert 3D param: %s (shape=%s)",
+                        target_name,
+                        list(param_value.shape),
+                    )
+                    return
+
                 if _moe_load_state["mode"] == "4bit":
                     replace_parameter_4bit(
                         mod,
@@ -195,11 +141,7 @@ def patch_moe_quantization_on_load(cfg):
                     replace_parameter_8bit(mod, pname)
                 _moe_load_state["count"] += 1
 
-                # Release the bf16 CUDA storage. After quantization, the
-                # module holds the quantized parametrization — but the
-                # caller's references (loop var + dict) keep the bf16 CUDA
-                # storage alive past empty_cache(). Replacing .data frees
-                # the CUDA memory immediately regardless of Python refcount.
+                # Release the bf16 tensor so CUDA memory is freed immediately.
                 param_value.data = torch.empty(0, device="cpu")
                 gc.collect()
                 torch.cuda.empty_cache()
@@ -214,14 +156,7 @@ def get_moe_quantized_count():
 
 
 def patch_peft_target_parameters_matching():
-    """Fix PEFT's _inject_parameters to use suffix matching for parametrized modules.
-
-    PEFT's parametrized-module branch uses exact name match for target_parameters,
-    but the standard branch uses endswith. This means suffix-style paths like
-    "mlp.experts.gate_up_proj" fail to match parametrized modules whose full path
-    is "model.layers.0.mlp.experts.gate_up_proj". This patch makes the parametrized
-    branch consistent with the standard branch.
-    """
+    """Fix PEFT's _inject_parameters to use suffix matching for parametrized modules."""
     from peft.tuners.tuners_utils import BaseTuner
 
     original_inject = BaseTuner._inject_parameters

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -53,8 +53,17 @@ def patch_moe_quantization_on_load(cfg):
         LOG.debug("MoE loading-time quantization patch already active")
         return
 
+    import os
+
     import transformers.core_model_loading
     from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+    # Disable transformers' async weight loading thread pool. Without this,
+    # the ThreadPoolExecutor pre-fetches tensors to CUDA faster than the main
+    # loop can quantize them, causing all expert weights to accumulate in bf16
+    # on GPU — defeating the purpose of loading-time quantization.
+    os.environ["HF_DEACTIVATE_ASYNC_LOAD"] = "1"
+    LOG.info("Disabled async weight loading (HF_DEACTIVATE_ASYNC_LOAD=1)")
 
     # Read quantization settings from config
     quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -2,23 +2,23 @@
 Loading-time quantization for MoE expert weights stored as 3D nn.Parameter tensors.
 
 In transformers v5, many MoE models store expert weights as fused 3D nn.Parameter
-tensors instead of individual nn.Linear modules. BnB 4-bit quantization only targets
+tensors instead of individual nn.Linear modules. BnB quantization only targets
 nn.Linear, so these expert weights are loaded in full precision, causing high peak VRAM.
 
 This module patches transformers' weight loading to quantize 3D expert parameters
-on-the-fly as they're assigned to modules, using bitsandbytes.nn.parametrize.
-replace_parameter_4bit (requires bitsandbytes >= 0.48.0). This reduces peak VRAM
-from "all experts in bf16" to "one expert param in bf16 at a time."
+on-the-fly as they're assigned to modules. For 4-bit, it uses
+bitsandbytes.nn.parametrize.replace_parameter_4bit (requires bitsandbytes >= 0.48.0).
+For 8-bit, it uses a custom parametrization built on bitsandbytes.functional's
+int8_vectorwise_quant/dequant (row-wise absmax scaling). Both reduce peak VRAM from
+"all experts in bf16" to "one expert param in bf16 at a time."
 
 PEFT's target_parameters / ParamWrapper can then apply LoRA on top of these quantized
 params via stacked parametrizations.
-
-Note: FSDP2 cpu ram efficient loading and Tensor Parallel (DTensor) compatibility
-with parametrization is untested.
 """
 
 import bitsandbytes as bnb
 import torch
+import torch.nn.utils.parametrize as P
 
 from axolotl.utils.logging import get_logger
 
@@ -27,10 +27,87 @@ LOG = get_logger(__name__)
 # Module-level state for the loading-time quantization patch.
 _moe_load_state = {
     "count": 0,
+    "mode": "4bit",
     "quant_type": "nf4",
     "compress_statistics": True,
     "patched": False,
 }
+
+
+class Bnb8bitParametrization(torch.nn.Module):
+    """Parametrization that dequantizes int8 row-wise quantized data on access.
+
+    Mirrors ``Bnb4bitParametrization`` from ``bitsandbytes.nn.parametrize`` but for
+    int8 row-wise (absmax) quantization.  Stores the per-row scales as a buffer and
+    delegates to ``bitsandbytes.functional.int8_vectorwise_dequant`` which computes
+    ``int8_data * row_stats * (1/127)``.
+    """
+
+    def __init__(self, row_stats: torch.Tensor):
+        super().__init__()
+        self.register_buffer("row_stats", row_stats)
+
+    @torch.no_grad()
+    def forward(self, quantized_param: torch.Tensor) -> torch.Tensor:
+        return bnb.functional.int8_vectorwise_dequant(quantized_param, self.row_stats)
+
+
+def _enable_parametrization_cache(module, inputs):
+    P._cache_enabled += 1
+
+
+def _disable_parametrization_cache(module, inputs, output):
+    P._cache_enabled -= 1
+    if not P._cache_enabled:
+        P._cache = {}
+
+
+def replace_parameter_8bit(module, param_name):
+    """Replace a module parameter with an 8-bit quantized version using parametrization.
+
+    Mirrors ``bitsandbytes.nn.parametrize.replace_parameter_4bit`` but for int8
+    row-wise (absmax) quantization.  Uses ``int8_vectorwise_quant`` which supports
+    N-D tensors natively (scales shape = ``prod(shape[:-1])``).
+
+    Args:
+        module: The module containing the parameter to quantize.
+        param_name: Name of the parameter within the module.
+    """
+    original_param = getattr(module, param_name)
+    int8_data, row_stats, _ = bnb.functional.int8_vectorwise_quant(
+        original_param.data.to(torch.float16)
+    )
+
+    setattr(module, param_name, torch.nn.Parameter(int8_data, requires_grad=False))
+    del original_param
+
+    P.register_parametrization(
+        module, param_name, Bnb8bitParametrization(row_stats), unsafe=True
+    )
+
+    # Register caching hooks (same pattern as BnB 4-bit). Caching avoids
+    # redundant dequantization when the same param is accessed multiple times
+    # in a single forward pass.
+    module.register_forward_pre_hook(_enable_parametrization_cache)
+    module.register_forward_hook(_disable_parametrization_cache)
+
+
+def _8bit_state_dict_post_hook(
+    module, state_dict, prefix, local_metadata, *, param_name
+):
+    """Placeholder for 8-bit state_dict serialization hook.
+
+    For LoRA/QLoRA training, only adapter weights (lora_A/B) are saved — base model
+    weights including quantized experts are not serialized. State dict hooks for 8-bit
+    are therefore not needed for the primary use case. If full-model saving with 8-bit
+    quantized expert params is needed, this hook should store int8 data + row_stats.
+    """
+    raise NotImplementedError(
+        "State dict serialization for 8-bit quantized expert parameters is not yet "
+        "implemented. This is not needed for LoRA/QLoRA training (only adapter weights "
+        "are saved). If you need to save the full model with 8-bit quantized experts, "
+        "please open an issue."
+    )
 
 
 def patch_moe_quantization_on_load(cfg):
@@ -39,15 +116,16 @@ def patch_moe_quantization_on_load(cfg):
     Wraps ``transformers.core_model_loading.set_param_for_module`` so that after each
     parameter is assigned to its module, any 3D+ tensor on CUDA that BnB skipped
     (i.e. not inside a Linear4bit/Linear8bitLt) is immediately quantized via
-    ``replace_parameter_4bit``. This keeps peak VRAM to one expert param in bf16
-    at a time, instead of loading all experts in bf16 first.
+    ``replace_parameter_4bit`` (for 4-bit) or ``replace_parameter_8bit`` (for 8-bit).
+    This keeps peak VRAM to one expert param in bf16 at a time, instead of loading
+    all experts in bf16 first.
 
     The patch stays active permanently — the ``ndim >= 3`` and ``is_cuda`` checks
     make it safe for non-MoE models (no false positives).
 
     Args:
-        cfg: Axolotl DictDefault config. Reads bnb_4bit_quant_type and
-             bnb_4bit_use_double_quant for quantization settings.
+        cfg: Axolotl DictDefault config. For 4-bit, reads bnb_4bit_quant_type and
+             bnb_4bit_use_double_quant. For 8-bit, no additional settings needed.
     """
     if _moe_load_state["patched"]:
         LOG.debug("MoE loading-time quantization patch already active")
@@ -55,7 +133,26 @@ def patch_moe_quantization_on_load(cfg):
 
     import transformers.core_model_loading
     import transformers.modeling_utils
-    from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+    # Determine quantization mode from config.
+    if getattr(cfg, "load_in_8bit", False):
+        mode = "8bit"
+    else:
+        mode = "4bit"
+
+    _moe_load_state["mode"] = mode
+    _moe_load_state["count"] = 0
+
+    if mode == "4bit":
+        from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+        quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"
+        compress_statistics = getattr(cfg, "bnb_4bit_use_double_quant", None)
+        if compress_statistics is None:
+            compress_statistics = True
+
+        _moe_load_state["quant_type"] = quant_type
+        _moe_load_state["compress_statistics"] = compress_statistics
 
     # Patch caching_allocator_warmup to be a no-op. This function pre-allocates
     # a single huge GPU tensor equal to the model's total param bytes to warm the
@@ -68,16 +165,6 @@ def patch_moe_quantization_on_load(cfg):
 
     transformers.modeling_utils.caching_allocator_warmup = _noop_warmup
 
-    # Read quantization settings from config
-    quant_type = getattr(cfg, "bnb_4bit_quant_type", None) or "nf4"
-    compress_statistics = getattr(cfg, "bnb_4bit_use_double_quant", None)
-    if compress_statistics is None:
-        compress_statistics = True
-
-    _moe_load_state["quant_type"] = quant_type
-    _moe_load_state["compress_statistics"] = compress_statistics
-    _moe_load_state["count"] = 0
-
     original_set_param = transformers.core_model_loading.set_param_for_module
 
     def _patched_set_param_for_module(model, target_name, param_value, *args, **kwargs):
@@ -88,12 +175,15 @@ def patch_moe_quantization_on_load(cfg):
             mod_path, _, pname = target_name.rpartition(".")
             mod = model.get_submodule(mod_path) if mod_path else model
             if not isinstance(mod, (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt)):
-                replace_parameter_4bit(
-                    mod,
-                    pname,
-                    compress_statistics=_moe_load_state["compress_statistics"],
-                    quant_type=_moe_load_state["quant_type"],
-                )
+                if _moe_load_state["mode"] == "4bit":
+                    replace_parameter_4bit(
+                        mod,
+                        pname,
+                        compress_statistics=_moe_load_state["compress_statistics"],
+                        quant_type=_moe_load_state["quant_type"],
+                    )
+                else:
+                    replace_parameter_8bit(mod, pname)
                 torch.cuda.empty_cache()
                 _moe_load_state["count"] += 1
 

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1310,6 +1310,14 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 raise ValueError(
                     "quantize_moe_experts requires load_in_4bit or load_in_8bit"
                 )
+            if (
+                data.get("capabilities")
+                and data["capabilities"].get("compute_capability")
+                and not data["capabilities"]["compute_capability"].startswith("sm_")
+            ):
+                raise ValueError(
+                    "quantize_moe_experts requires CUDA (not compatible with ROCm or other backends)"
+                )
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -629,6 +629,17 @@ class AxolotlInputConfig(
         },
     )
 
+    quantize_moe_experts: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": "Quantize MoE expert weights on load to reduce VRAM. "
+            "Requires adapter (lora/qlora) with load_in_4bit or load_in_8bit. "
+            "Requires CUDA (not compatible with ROCm or other backends). "
+            "Note: total parameter count may be reported incorrectly when enabled "
+            "(trainable param count is correct)."
+        },
+    )
+
     scaling_softmax: bool | None = Field(
         default=None,
         json_schema_extra={
@@ -1287,6 +1298,18 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                     raise ValueError(
                         "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with FSDP1."
                     )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_quantize_moe_experts(cls, data):
+        if data.get("quantize_moe_experts"):
+            if data.get("adapter") not in ("lora", "qlora"):
+                raise ValueError("quantize_moe_experts requires adapter: lora or qlora")
+            if not (data.get("load_in_4bit") or data.get("load_in_8bit")):
+                raise ValueError(
+                    "quantize_moe_experts requires load_in_4bit or load_in_8bit"
+                )
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/peft.py
+++ b/src/axolotl/utils/schemas/peft.py
@@ -209,6 +209,19 @@ class LoraConfig(BaseModel):
             data["lora_dropout"] = 0.0
         return data
 
+    @model_validator(mode="after")
+    def validate_lora_target_parameters_dropout(self):
+        if (
+            self.lora_target_parameters
+            and self.lora_dropout
+            and self.lora_dropout != 0.0
+        ):
+            raise ValueError(
+                "lora_dropout must be 0 when lora_target_parameters is set. "
+                "PEFT's ParamWrapper does not support lora_dropout != 0."
+            )
+        return self
+
 
 class ReLoRAConfig(BaseModel):
     """ReLoRA configuration subset"""

--- a/tests/utils/schemas/validation/test_moe_quant.py
+++ b/tests/utils/schemas/validation/test_moe_quant.py
@@ -1,0 +1,142 @@
+"""Tests for MoE expert quantization config validation and PEFT patch idempotency."""
+
+import pytest
+
+from axolotl.utils.config import validate_config
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.fixture()
+def gpu_caps():
+    return {"compute_capability": "sm_89", "bf16": True, "n_gpu": 1, "n_node": 1}
+
+
+@pytest.fixture()
+def env_caps():
+    return {"torch_version": "2.7.0"}
+
+
+class TestQuantizeMoeExpertsValidation:
+    """Test suite for quantize_moe_experts config validator."""
+
+    def test_requires_adapter(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts without adapter should fail."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=True,
+            )
+            | min_base_cfg
+        )
+        with pytest.raises(ValueError, match="requires adapter"):
+            validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+
+    def test_requires_quantization(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts without load_in_4bit/8bit should fail."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=True,
+                adapter="lora",
+            )
+            | min_base_cfg
+        )
+        with pytest.raises(ValueError, match="requires load_in_4bit or load_in_8bit"):
+            validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+
+    def test_valid_qlora_4bit(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts with qlora + 4bit should pass."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=True,
+                adapter="qlora",
+                load_in_4bit=True,
+            )
+            | min_base_cfg
+        )
+        result = validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+        assert result["quantize_moe_experts"] is True
+
+    def test_valid_lora_8bit(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts with lora + 8bit should pass."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=True,
+                adapter="lora",
+                load_in_8bit=True,
+            )
+            | min_base_cfg
+        )
+        result = validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+        assert result["quantize_moe_experts"] is True
+
+    def test_false_skips_validation(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts=false should not check adapter/quantization."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=False,
+            )
+            | min_base_cfg
+        )
+        result = validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+        assert result["quantize_moe_experts"] is False
+
+    def test_default_is_false(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts should default to false."""
+        cfg = DictDefault({}) | min_base_cfg
+        result = validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+        assert result["quantize_moe_experts"] is False
+
+
+class TestLoraTargetParametersDropout:
+    """Test that lora_dropout must be 0 when lora_target_parameters is set."""
+
+    def test_rejects_nonzero_dropout(self, min_base_cfg):
+        """lora_dropout > 0 with lora_target_parameters should fail."""
+        cfg = (
+            DictDefault(
+                adapter="lora",
+                lora_target_parameters=["mlp.experts.gate_up_proj"],
+                lora_dropout=0.1,
+                load_in_8bit=True,
+            )
+            | min_base_cfg
+        )
+        with pytest.raises(ValueError, match="lora_dropout must be 0"):
+            validate_config(cfg)
+
+    def test_zero_dropout_passes(self, min_base_cfg):
+        """lora_dropout=0 with lora_target_parameters should pass."""
+        cfg = (
+            DictDefault(
+                adapter="lora",
+                lora_target_parameters=["mlp.experts.gate_up_proj"],
+                lora_dropout=0.0,
+                load_in_8bit=True,
+            )
+            | min_base_cfg
+        )
+        result = validate_config(cfg)
+        assert result["lora_dropout"] == 0.0
+
+
+class TestPeftPatchIdempotency:
+    """Test that patch_peft_target_parameters_matching is idempotent."""
+
+    def test_double_call_does_not_stack_wrappers(self):
+        """Calling patch twice should not double-wrap _inject_parameters."""
+        from peft.tuners.tuners_utils import BaseTuner
+
+        from axolotl.monkeypatch.moe_quant import (
+            patch_peft_target_parameters_matching,
+        )
+
+        original = BaseTuner._inject_parameters
+        try:
+            patch_peft_target_parameters_matching()
+            first_patched = BaseTuner._inject_parameters
+            patch_peft_target_parameters_matching()
+            second_patched = BaseTuner._inject_parameters
+            # Should be same function, not double-wrapped
+            assert first_patched is second_patched
+        finally:
+            BaseTuner._inject_parameters = original
+            patch_peft_target_parameters_matching._axolotl_patched = False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Closes https://github.com/axolotl-ai-cloud/axolotl/issues/3374 #3370 

Problem: Experts aren't properly targeted with the normal `lora_target_modules`, we need to use `lora_target_parameters`. Additionally, expert layers aren't being quantized by bnb.

Based on #3395 work by ved (without the lora kernels changes) and contains additional fixes:
- quantizes experts on-load (reduces reserved memory)
  - qlora 4bit support
  - lora 8bit support
  - ensure target_parameter works (names are expanded otherwise)
- fsdp2 support 
  - qlora 4bit
  - lora 8bit
- experts properly targeted with quantized experts
  - qlora 4bit
  - lora 8bit

### How to use

(see included configs)

```yaml
quantize_moe_experts: true

#lora_target_parameters:
#    - mlp.experts.gate_up_proj
#    - mlp.experts.down_proj
#    - mlp.gate.weight  # router

``` 


### Results

From a QLoRA training using 127GiB peak memory, we managed to reduce till 23GiB.

<img width="1322" height="670" alt="image" src="https://github.com/user-attachments/assets/a65765c2-ab68-4ad1-ba03-eb2ff79c71f5" />

Loss line differs as we swapped optim (`adamw_bnb_8bit` -> `adamw_torch_8bit`)+ nodes while working on this. Verified that without our fix, the prior line is consistent.

We also incorporated these changes onto LoRA and FSDP2 LoRA/QLoRA trainings.

### Limitation

- cpu ram efficient loading fsdp2 doesn't work with qlora (did not test lora): `AttributeError: `e_score_correction_bias` is not an nn.Parameter` due to how it's instantiated
- total param count for model is wrong; trainable param is correct (due to how we handle quantize experts). This is only cosmetic bug, it still target correct number of params
- fsdp lora will have huge initial vram spike at first 1-2 steps then drop (unclear reason atm). fsdp qlora was fine
- Deepspeed not tested.
- `bf16` lora not tested
- Model may take longer to load due to quantize on demand, even for consecutive runs. May need to consider caching in future work.

### Misc:
- re-adds saving changes that were accidentally removed in #3410 
- CCE updates to include fixes for qwen3_5 and qwen3_5_moe
- on-save, state dict cloned onto gpu which doubles vram usage. This PR ensures it's moved onto cpu and only for CP

## How to use

See included example yamls and README

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Training loss consistent with our on-load quantize as the previous post-quantize change. Tested across single GPU for LoRA and QLoRA respectively. Also ensured FSDP/DDP loss were within reasonable expectations.

TODO (ongoing):
- merge adapters to base (should work as before as we don't apply any quantize on load)
  - [x] qlora
  - [x] lora
- inference on adapters (loss / ppl / grad norm looks fine)
  - [x] qlora
  - [x] lora


## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

Claude heavily while checking result via manual runs

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->

Thanks to ved for original PR to base off and help test throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GLM-4.7-Flash model support with multiple fine-tuning configurations (LoRA, QLoRA, and distributed training variants).
  * Enabled MoE expert quantization to reduce VRAM usage during training.
  * Added FSDP2-based distributed training support for large models.

* **Bug Fixes**
  * Fixed checkpoint saving for context-parallel setups.
  * Fixed DTensor compatibility issues with distributed training.

* **Documentation**
  * Added comprehensive guides for GLM-4.7-Flash fine-tuning with various configurations.
  * Updated installation instructions and setup steps.
  * Added limitation notes for new model architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->