### PR TITLE
fix: correct total_num_steps and batch_size calculation with context parallelism

### DIFF
--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -119,7 +119,8 @@ def normalize_config(cfg):
     if cfg.world_size != 1:
         cfg.device_map = {"": int(os.environ.get("LOCAL_RANK", 0))}
         if cfg.fsdp or cfg.fsdp_config or cfg.ddp:
-            cfg.batch_size = cfg.batch_size * cfg.world_size
+            effective_world_size = cfg.world_size // (cfg.context_parallel_size or 1)
+            cfg.batch_size = cfg.batch_size * effective_world_size
 
     if not cfg.use_ray:
         # delay resolving dtype until on worker node when launching with ray

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -457,7 +457,6 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
                     - 1
                 )
                 * cfg.num_epochs
-                * cfg.context_parallel_size
                 * cfg.tensor_parallel_size
             )
             LOG.debug(
@@ -498,12 +497,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             # FIXME: is there a bug here somewhere? the total num steps depends
             # on the agreed on value for sample_packing_eff_est
             total_num_steps = int(
-                math.floor(
-                    data_loader_len
-                    * cfg.num_epochs
-                    * cfg.context_parallel_size
-                    * cfg.tensor_parallel_size
-                )
+                math.floor(data_loader_len * cfg.num_epochs * cfg.tensor_parallel_size)
             )
             if cfg.dataloader_drop_last:
                 # drop the last batch for each epoch
@@ -528,7 +522,6 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
             math.ceil(
                 len(train_dataset)
                 * cfg.num_epochs
-                * cfg.context_parallel_size
                 * cfg.tensor_parallel_size
                 / cfg.batch_size
             )

--- a/tests/test_context_parallel_batch_size.py
+++ b/tests/test_context_parallel_batch_size.py
@@ -1,0 +1,56 @@
+"""Tests for batch_size calculation with context parallelism."""
+
+import sys
+import types
+
+import pytest
+
+from axolotl.utils.config import normalize_config, validate_config
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.fixture(name="cp_base_cfg")
+def fixture_cp_base_cfg(min_base_cfg):
+    return (
+        DictDefault(
+            micro_batch_size=2,
+            gradient_accumulation_steps=4,
+            sequence_len=2048,
+            num_epochs=1,
+            flash_attention=True,
+        )
+        | min_base_cfg
+    )
+
+
+class TestContextParallelBatchSize:
+    """Verify batch_size scales by effective dp world_size when using context parallelism."""
+
+    @pytest.mark.parametrize(
+        "world_size, context_parallel_size, expected_batch_size",
+        [
+            (4, 1, 32),  # no CP: 2*4*4 = 32
+            (4, 2, 16),  # CP=2: 2*4*(4//2) = 16
+            (4, 4, 8),  # CP=4: 2*4*(4//4) = 8
+            (2, 2, 8),  # CP=ws: 2*4*(2//2) = 8 (no scaling)
+        ],
+    )
+    def test_batch_size_with_context_parallelism(
+        self,
+        cp_base_cfg,
+        monkeypatch,
+        world_size,
+        context_parallel_size,
+        expected_batch_size,
+    ):
+        monkeypatch.setenv("WORLD_SIZE", str(world_size))
+        # Mock ring_flash_attn since it's not installable on CPU,
+        # but required by schema validation when context_parallel_size > 1.
+        if "ring_flash_attn" not in sys.modules:
+            monkeypatch.setitem(
+                sys.modules, "ring_flash_attn", types.ModuleType("ring_flash_attn")
+            )
+        cp_base_cfg["context_parallel_size"] = context_parallel_size
+        cfg = validate_config(cp_base_cfg)
+        normalize_config(cfg)
+        assert cfg.batch_size == expected_batch_size


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Fix total_num_steps and batch_size calculation with context parallelism</h1>
<h1>Description</h1>
<p>Two bugs in <code>calculate_total_num_steps()</code> and <code>normalize_config()</code> caused incorrect epoch counting when using <code>context_parallel_size</code>.</p>
<p><strong>Bug 1 — <code>normalize_config()</code> in <code>config/__init__.py</code>:</strong>
<code>batch_size</code> was multiplied by <code>world_size</code>, but with context parallelism the effective data-parallel world size is <code>world_size // context_parallel_size</code>. With CP=2 on 2 GPUs, <code>batch_size</code> was 8 instead of 4, causing the model to process only 50% of the dataset per epoch.</p>
<p><strong>Bug 2 — <code>calculate_total_num_steps()</code> in <code>trainer.py</code>:</strong>
<code>total_num_steps</code> was multiplied by <code>context_parallel_size</code> at 3 locations. This was a compensatory workaround for Bug 1, but it inflated <code>max_steps</code>, causing the HF Trainer to report ~5.4 epochs instead of ~1.0 (as reported in #3218).</p>
<p><strong>Fix:</strong></p>
<ul>
<li><code>config/__init__.py</code>: compute <code>effective_world_size = world_size // (context_parallel_size or 1)</code> and use it for <code>batch_size</code></li>
<li><code>trainer.py</code>: remove the 3 <code>* cfg.context_parallel_size</code> multiplications in <code>calculate_total_num_steps()</code></li>
</ul>
<p>This is consistent with how HuggingFace Trainer computes <code>dp_world_size</code> internally (<code>world_size // tp_size // cp_size // sp_size</code>).</p>
<h2>Motivation and Context</h2>
<p>Fixes #3218</p>
<h2>How has this been tested?</h2>
<p>Tested on 2x H100 SXM (NVLink) with TinyLlama-1.1B, <code>mhenrichsen/alpaca_2k_test</code> dataset, DeepSpeed ZeRO-1, <code>num_epochs: 1</code>.</p>

Config | batch_size | total_num_steps | tokens processed | epoch
-- | -- | -- | -- | --
CP=2 (before fix) | 8 | 250 | 1,024,000 (50%) | 1.0
CP=2 (after fix) | 4 | 500 | 2,048,000 (100%) | 2.0*
No CP (reference) | 8 | 500 | 2,048,000 (100%) | 1.0


<p>*The reported epoch=2.0 with CP is a separate issue: <code>DistributedSampler</code> shards by <code>world_size</code> instead of <code>dp_world_size</code>, so the Trainer sees 250 steps per "dataloader epoch" and counts 500/250=2. This affects epoch display and LR schedule but not the actual data processed. Fixing the sampler would require a custom <code>DistributedSampler</code> for CP groups (similar to the pattern in <code>core/trainers/grpo/sampler.py</code>), which is a deeper change best addressed separately.</p>
<h2>AI Usage Disclaimer</h2>
<p>Yes — Claude was used for code analysis and test planning.</p>
<h2>Types of changes</h2>
<ul>
<li>[x] Bug fix (non-breaking change which fixes an issue)</li>
</ul></body></html><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch size scaling calculation in distributed training with context parallelism, now using an effective world size computation.
  * Corrected total training step calculations by removing incorrect context parallel size factors, affecting step estimation across different training configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->