### PR TITLE
fix uv cache subcommand

### DIFF
--- a/docker/Dockerfile-uv
+++ b/docker/Dockerfile-uv
@@ -35,7 +35,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     python scripts/unsloth_install.py --uv | sh && \
     python scripts/cutcrossentropy_install.py --uv | sh && \
     uv pip install pytest && \
-    uv pip cache purge
+    uv cache clean
 
 # fix so that git fetch/pull from remote works with shallow clone
 RUN git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && \


### PR DESCRIPTION
fix invalid `uv pip cache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container image build process with updated cache management commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->