### PR TITLE
feat: add support and end-to-end tests for multiple custom optimizers…

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -353,6 +353,30 @@ class TrainerBuilderBase(abc.ABC):
                 adam_kwargs["eps"] = (eps1, eps2)
 
                 optimizer_kwargs.update(adam_kwargs)
+            elif self.cfg.optimizer == "flash_adamw":
+                from flashoptim import FlashAdamW
+
+                optimizer_cls = FlashAdamW
+                optimizer_kwargs.update(adam_kwargs)
+            elif self.cfg.optimizer == "flash_adam":
+                from flashoptim import FlashAdam
+
+                optimizer_cls = FlashAdam
+                optimizer_kwargs.update(adam_kwargs)
+            elif self.cfg.optimizer == "flash_sgd":
+                from flashoptim import FlashSGD
+
+                optimizer_cls = FlashSGD
+            elif self.cfg.optimizer == "flash_sgdw":
+                from flashoptim import FlashSGDW
+
+                optimizer_cls = FlashSGDW
+            elif self.cfg.optimizer == "flash_lion":
+                from flashoptim import FlashLion
+
+                optimizer_cls = FlashLion
+                if "betas" in adam_kwargs:
+                    optimizer_kwargs["betas"] = adam_kwargs["betas"]
             else:
                 raise ValueError(
                     f"Unhandled optimizer: {self.cfg.optimizer}. Please raise an Issue."

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -83,6 +83,11 @@ class CustomSupportedOptimizers(str, Enum):
     came_pytorch = "came_pytorch"
     muon = "muon"
     dion = "dion"
+    flash_adamw = "flash_adamw"
+    flash_adam = "flash_adam"
+    flash_sgd = "flash_sgd"
+    flash_sgdw = "flash_sgdw"
+    flash_lion = "flash_lion"
 
 
 class RingAttnFunc(str, Enum):

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -809,15 +809,20 @@ class OptimizationValidationMixin:
     @model_validator(mode="before")
     @classmethod
     def check_flashoptim_deepspeed_fsdp(cls, data):
-        if data.get("optimizer", "").startswith("flash_"):
+        optimizer = data.get("optimizer") or ""
+        if str(optimizer).startswith("flash_"):
             if data.get("deepspeed"):
                 raise ValueError(
                     "FlashOptim optimizers are currently incompatible with DeepSpeed"
                 )
             if data.get("fsdp") or data.get("fsdp_config"):
-                fsdp_version = data.get("fsdp_version")
-                if fsdp_version is None:
-                    fsdp_version = data.get("fsdp_config", {}).get("fsdp_version", 1)
+                fsdp_config = data.get("fsdp_config") or {}
+                fsdp_version = (
+                    data.get("fsdp_version")
+                    or fsdp_config.get("version")
+                    or fsdp_config.get("fsdp_version")
+                    or 1
+                )
                 if str(fsdp_version) != "2":
                     raise ValueError(
                         "FlashOptim optimizers are only compatible with FSDP2. "

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -788,6 +788,14 @@ class OptimizationValidationMixin:
             LOG.warning("adamw hyperparameters found, but no adamw optimizer set")
         return self
 
+    @staticmethod
+    def _resolve_fsdp_version(data):
+        """Resolve FSDP version from top-level fsdp_version or fsdp_config.fsdp_version."""
+        fsdp_version = data.get("fsdp_version")
+        if fsdp_version is None:
+            fsdp_version = data.get("fsdp_config", {}).get("fsdp_version", 1)
+        return fsdp_version
+
     @model_validator(mode="before")
     @classmethod
     def check_muon_deepspeed_fsdp(cls, data):
@@ -797,9 +805,7 @@ class OptimizationValidationMixin:
                     "Muon optimizer is currently incompatible with DeepSpeed"
                 )
             if data.get("fsdp") or data.get("fsdp_config"):
-                fsdp_version = data.get("fsdp_version")
-                if fsdp_version is None:
-                    fsdp_version = data.get("fsdp_config", {}).get("fsdp_version", 1)
+                fsdp_version = cls._resolve_fsdp_version(data)
                 if str(fsdp_version) != "2":
                     raise ValueError(
                         "Muon optimizer is only compatible with FSDP2. Set fsdp_version: 2 to use Muon with FSDP."
@@ -813,20 +819,15 @@ class OptimizationValidationMixin:
         if str(optimizer).startswith("flash_"):
             if data.get("deepspeed"):
                 raise ValueError(
-                    "FlashOptim optimizers are currently incompatible with DeepSpeed"
+                    f"{optimizer} optimizer is incompatible with DeepSpeed. "
+                    "Flash optimizers only support DDP and FSDP2."
                 )
             if data.get("fsdp") or data.get("fsdp_config"):
-                fsdp_config = data.get("fsdp_config") or {}
-                fsdp_version = (
-                    data.get("fsdp_version")
-                    or fsdp_config.get("version")
-                    or fsdp_config.get("fsdp_version")
-                    or 1
-                )
+                fsdp_version = cls._resolve_fsdp_version(data)
                 if str(fsdp_version) != "2":
                     raise ValueError(
-                        "FlashOptim optimizers are only compatible with FSDP2. "
-                        "Set fsdp_version: 2 to use FlashOptim with FSDP."
+                        f"{optimizer} optimizer is only compatible with FSDP2. "
+                        "Set fsdp_version: 2 to use flash optimizers with FSDP."
                     )
         return data
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -808,6 +808,25 @@ class OptimizationValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
+    def check_flashoptim_deepspeed_fsdp(cls, data):
+        if data.get("optimizer", "").startswith("flash_"):
+            if data.get("deepspeed"):
+                raise ValueError(
+                    "FlashOptim optimizers are currently incompatible with DeepSpeed"
+                )
+            if data.get("fsdp") or data.get("fsdp_config"):
+                fsdp_version = data.get("fsdp_version")
+                if fsdp_version is None:
+                    fsdp_version = data.get("fsdp_config", {}).get("fsdp_version", 1)
+                if str(fsdp_version) != "2":
+                    raise ValueError(
+                        "FlashOptim optimizers are only compatible with FSDP2. "
+                        "Set fsdp_version: 2 to use FlashOptim with FSDP."
+                    )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_batch_flattening_fa(cls, data):
         if data.get("batch_flattening"):
             batch_flattening_auto = data.get("batch_flattening") == "auto"

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -282,3 +282,47 @@ class TestCustomOptimizers(unittest.TestCase):
 
         train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
+
+    @with_temp_dir
+    def test_flash_adamw(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "flash_adamw",
+                "max_steps": 5,
+                "lr_scheduler": "cosine",
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "FlashAdamW" in trainer.optimizer.optimizer.__class__.__name__

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -4,8 +4,6 @@ E2E tests for custom optimizers using Llama
 
 import unittest
 
-import pytest
-
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
@@ -288,56 +286,55 @@ class TestCustomOptimizers(unittest.TestCase):
 
     @with_temp_dir
     @require_torch_2_7_0
-    @pytest.mark.parametrize(
-        "optimizer_name,expected_class,learning_rate",
-        [
+    def test_flash_optimizers(self, temp_dir):
+        flash_optimizers = [
             ("flash_adamw", "FlashAdamW", 0.00001),
             ("flash_adam", "FlashAdam", 0.00001),
             ("flash_sgd", "FlashSGD", 0.01),
             ("flash_sgdw", "FlashSGDW", 0.01),
             ("flash_lion", "FlashLion", 0.0001),
-        ],
-    )
-    def test_flash_optimizers(self, temp_dir, optimizer_name, expected_class, learning_rate):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
-                },
-                "datasets": [
+        ]
+        for optimizer_name, expected_class, learning_rate in flash_optimizers:
+            with self.subTest(optimizer=optimizer_name):
+                cfg = DictDefault(
                     {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": learning_rate,
-                "optimizer": optimizer_name,
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
+                        "base_model": "HuggingFaceTB/SmolLM2-135M",
+                        "model_type": "AutoModelForCausalLM",
+                        "tokenizer_type": "AutoTokenizer",
+                        "sequence_len": 1024,
+                        "load_in_8bit": True,
+                        "adapter": "lora",
+                        "lora_r": 8,
+                        "lora_alpha": 16,
+                        "lora_dropout": 0.05,
+                        "lora_target_linear": True,
+                        "val_set_size": 0.02,
+                        "special_tokens": {
+                            "pad_token": "<|endoftext|>",
+                        },
+                        "datasets": [
+                            {
+                                "path": "mhenrichsen/alpaca_2k_test",
+                                "type": "alpaca",
+                            },
+                        ],
+                        "num_epochs": 1,
+                        "micro_batch_size": 8,
+                        "gradient_accumulation_steps": 1,
+                        "output_dir": temp_dir,
+                        "learning_rate": learning_rate,
+                        "optimizer": optimizer_name,
+                        "optim_args": {"master_weight_bits": None},
+                        "max_steps": 5,
+                        "lr_scheduler": "cosine",
+                        "save_first_step": False,
+                    }
+                )
 
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
+                cfg = validate_config(cfg)
+                normalize_config(cfg)
+                dataset_meta = load_datasets(cfg=cfg)
 
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert expected_class in trainer.optimizer.optimizer.__class__.__name__
+                _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+                check_model_output_exists(temp_dir, cfg)
+                assert expected_class in trainer.optimizer.optimizer.__class__.__name__

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -5,9 +5,6 @@ E2E tests for custom optimizers using Llama
 import unittest
 
 import pytest
-import torch
-from packaging import version
-
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
@@ -289,10 +286,7 @@ class TestCustomOptimizers(unittest.TestCase):
 
 
 
-@pytest.mark.skipif(
-    version.parse(torch.__version__) < version.parse("2.7.0"),
-    reason="test requires torch>=2.7.0",
-)
+@require_torch_2_7_0
 @pytest.mark.parametrize(
     "optimizer_name,expected_class,learning_rate",
     [
@@ -333,7 +327,6 @@ def test_flash_optimizers(tmp_path, optimizer_name, expected_class, learning_rat
             "output_dir": temp_dir,
             "learning_rate": learning_rate,
             "optimizer": optimizer_name,
-            "optim_args": {"master_weight_bits": None},
             "max_steps": 5,
             "lr_scheduler": "cosine",
             "save_first_step": False,

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -5,6 +5,8 @@ E2E tests for custom optimizers using Llama
 import unittest
 
 import pytest
+import torch
+from packaging import version
 
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
@@ -286,58 +288,62 @@ class TestCustomOptimizers(unittest.TestCase):
         check_model_output_exists(temp_dir, cfg)
 
 
-    @with_temp_dir
-    @require_torch_2_7_0
-    @pytest.mark.parametrize(
-        "optimizer_name,expected_class,learning_rate",
-        [
-            ("flash_adamw", "FlashAdamW", 0.00001),
-            ("flash_adam", "FlashAdam", 0.00001),
-            ("flash_sgd", "FlashSGD", 0.01),
-            ("flash_sgdw", "FlashSGDW", 0.01),
-            ("flash_lion", "FlashLion", 0.0001),
-        ],
-    )
-    def test_flash_optimizers(self, temp_dir, optimizer_name, expected_class, learning_rate):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("2.7.0"),
+    reason="test requires torch>=2.7.0",
+)
+@pytest.mark.parametrize(
+    "optimizer_name,expected_class,learning_rate",
+    [
+        ("flash_adamw", "FlashAdamW", 0.00001),
+        ("flash_adam", "FlashAdam", 0.00001),
+        ("flash_sgd", "FlashSGD", 0.01),
+        ("flash_sgdw", "FlashSGDW", 0.01),
+        ("flash_lion", "FlashLion", 0.0001),
+    ],
+)
+def test_flash_optimizers(tmp_path, optimizer_name, expected_class, learning_rate):
+    temp_dir = str(tmp_path)
+    cfg = DictDefault(
+        {
+            "base_model": "HuggingFaceTB/SmolLM2-135M",
+            "model_type": "AutoModelForCausalLM",
+            "tokenizer_type": "AutoTokenizer",
+            "sequence_len": 1024,
+            "load_in_8bit": True,
+            "adapter": "lora",
+            "lora_r": 8,
+            "lora_alpha": 16,
+            "lora_dropout": 0.05,
+            "lora_target_linear": True,
+            "val_set_size": 0.02,
+            "special_tokens": {
+                "pad_token": "<|endoftext|>",
+            },
+            "datasets": [
+                {
+                    "path": "mhenrichsen/alpaca_2k_test",
+                    "type": "alpaca",
                 },
-                "datasets": [
-                    {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": learning_rate,
-                "optimizer": optimizer_name,
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
+            ],
+            "num_epochs": 1,
+            "micro_batch_size": 8,
+            "gradient_accumulation_steps": 1,
+            "output_dir": temp_dir,
+            "learning_rate": learning_rate,
+            "optimizer": optimizer_name,
+            "optim_args": {"master_weight_bits": None},
+            "max_steps": 5,
+            "lr_scheduler": "cosine",
+            "save_first_step": False,
+        }
+    )
 
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
+    cfg = validate_config(cfg)
+    normalize_config(cfg)
+    dataset_meta = load_datasets(cfg=cfg)
 
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert expected_class in trainer.optimizer.optimizer.__class__.__name__
+    _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+    check_model_output_exists(temp_dir, cfg)
+    assert expected_class in trainer.optimizer.optimizer.__class__.__name__

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -346,4 +346,4 @@ def test_flash_optimizers(tmp_path, optimizer_name, expected_class, learning_rat
 
     _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
     check_model_output_exists(temp_dir, cfg)
-    assert expected_class in trainer.optimizer.optimizer.__class__.__name__
+    assert trainer.optimizer.optimizer.__class__.__name__ == expected_class

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -5,6 +5,7 @@ E2E tests for custom optimizers using Llama
 import unittest
 
 import pytest
+
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
@@ -283,7 +284,6 @@ class TestCustomOptimizers(unittest.TestCase):
 
         train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
-
 
 
 @require_torch_2_7_0

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -4,6 +4,8 @@ E2E tests for custom optimizers using Llama
 
 import unittest
 
+import pytest
+
 from axolotl.common.datasets import load_datasets
 from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
@@ -286,7 +288,17 @@ class TestCustomOptimizers(unittest.TestCase):
 
     @with_temp_dir
     @require_torch_2_7_0
-    def test_flash_adamw(self, temp_dir):
+    @pytest.mark.parametrize(
+        "optimizer_name,expected_class,learning_rate",
+        [
+            ("flash_adamw", "FlashAdamW", 0.00001),
+            ("flash_adam", "FlashAdam", 0.00001),
+            ("flash_sgd", "FlashSGD", 0.01),
+            ("flash_sgdw", "FlashSGDW", 0.01),
+            ("flash_lion", "FlashLion", 0.0001),
+        ],
+    )
+    def test_flash_optimizers(self, temp_dir, optimizer_name, expected_class, learning_rate):
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",
@@ -313,8 +325,8 @@ class TestCustomOptimizers(unittest.TestCase):
                 "micro_batch_size": 8,
                 "gradient_accumulation_steps": 1,
                 "output_dir": temp_dir,
-                "learning_rate": 0.00001,
-                "optimizer": "flash_adamw",
+                "learning_rate": learning_rate,
+                "optimizer": optimizer_name,
                 "optim_args": {"master_weight_bits": None},
                 "max_steps": 5,
                 "lr_scheduler": "cosine",
@@ -328,188 +340,4 @@ class TestCustomOptimizers(unittest.TestCase):
 
         _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
-        assert "FlashAdamW" in trainer.optimizer.optimizer.__class__.__name__
-
-    @with_temp_dir
-    @require_torch_2_7_0
-    def test_flash_adam(self, temp_dir):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
-                },
-                "datasets": [
-                    {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": 0.00001,
-                "optimizer": "flash_adam",
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
-
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
-
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert "FlashAdam" in trainer.optimizer.optimizer.__class__.__name__
-
-    @with_temp_dir
-    @require_torch_2_7_0
-    def test_flash_sgd(self, temp_dir):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
-                },
-                "datasets": [
-                    {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": 0.01,
-                "optimizer": "flash_sgd",
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
-
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
-
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert "FlashSGD" in trainer.optimizer.optimizer.__class__.__name__
-
-    @with_temp_dir
-    @require_torch_2_7_0
-    def test_flash_sgdw(self, temp_dir):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
-                },
-                "datasets": [
-                    {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": 0.01,
-                "optimizer": "flash_sgdw",
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
-
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
-
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert "FlashSGDW" in trainer.optimizer.optimizer.__class__.__name__
-
-    @with_temp_dir
-    @require_torch_2_7_0
-    def test_flash_lion(self, temp_dir):
-        cfg = DictDefault(
-            {
-                "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "model_type": "AutoModelForCausalLM",
-                "tokenizer_type": "AutoTokenizer",
-                "sequence_len": 1024,
-                "load_in_8bit": True,
-                "adapter": "lora",
-                "lora_r": 8,
-                "lora_alpha": 16,
-                "lora_dropout": 0.05,
-                "lora_target_linear": True,
-                "val_set_size": 0.02,
-                "special_tokens": {
-                    "pad_token": "<|endoftext|>",
-                },
-                "datasets": [
-                    {
-                        "path": "mhenrichsen/alpaca_2k_test",
-                        "type": "alpaca",
-                    },
-                ],
-                "num_epochs": 1,
-                "micro_batch_size": 8,
-                "gradient_accumulation_steps": 1,
-                "output_dir": temp_dir,
-                "learning_rate": 0.0001,
-                "optimizer": "flash_lion",
-                "optim_args": {"master_weight_bits": None},
-                "max_steps": 5,
-                "lr_scheduler": "cosine",
-                "save_first_step": False,
-            }
-        )
-
-        cfg = validate_config(cfg)
-        normalize_config(cfg)
-        dataset_meta = load_datasets(cfg=cfg)
-
-        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
-        check_model_output_exists(temp_dir, cfg)
-        assert "FlashLion" in trainer.optimizer.optimizer.__class__.__name__
+        assert expected_class in trainer.optimizer.optimizer.__class__.__name__

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -283,7 +283,9 @@ class TestCustomOptimizers(unittest.TestCase):
         train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
 
+
     @with_temp_dir
+    @require_torch_2_7_0
     def test_flash_adamw(self, temp_dir):
         cfg = DictDefault(
             {
@@ -313,6 +315,7 @@ class TestCustomOptimizers(unittest.TestCase):
                 "output_dir": temp_dir,
                 "learning_rate": 0.00001,
                 "optimizer": "flash_adamw",
+                "optim_args": {"master_weight_bits": None},
                 "max_steps": 5,
                 "lr_scheduler": "cosine",
                 "save_first_step": False,
@@ -326,3 +329,187 @@ class TestCustomOptimizers(unittest.TestCase):
         _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
         assert "FlashAdamW" in trainer.optimizer.optimizer.__class__.__name__
+
+    @with_temp_dir
+    @require_torch_2_7_0
+    def test_flash_adam(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "flash_adam",
+                "optim_args": {"master_weight_bits": None},
+                "max_steps": 5,
+                "lr_scheduler": "cosine",
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "FlashAdam" in trainer.optimizer.optimizer.__class__.__name__
+
+    @with_temp_dir
+    @require_torch_2_7_0
+    def test_flash_sgd(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.01,
+                "optimizer": "flash_sgd",
+                "optim_args": {"master_weight_bits": None},
+                "max_steps": 5,
+                "lr_scheduler": "cosine",
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "FlashSGD" in trainer.optimizer.optimizer.__class__.__name__
+
+    @with_temp_dir
+    @require_torch_2_7_0
+    def test_flash_sgdw(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.01,
+                "optimizer": "flash_sgdw",
+                "optim_args": {"master_weight_bits": None},
+                "max_steps": 5,
+                "lr_scheduler": "cosine",
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "FlashSGDW" in trainer.optimizer.optimizer.__class__.__name__
+
+    @with_temp_dir
+    @require_torch_2_7_0
+    def test_flash_lion(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.0001,
+                "optimizer": "flash_lion",
+                "optim_args": {"master_weight_bits": None},
+                "max_steps": 5,
+                "lr_scheduler": "cosine",
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "FlashLion" in trainer.optimizer.optimizer.__class__.__name__


### PR DESCRIPTION
… including Optimi AdamW, ADOPT AdamW, Muon, Dion, Schedule-Free AdamW, CAME PyTorch, and Flash AdamW.
Feature support with test case for flashoptim's  FlashAdamW, FlashAdam, FlashSGD,  FlashSGDW, FlashLion

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->
Added features for 'flashoptim' usage
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#3451 
## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Still untested


## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->
Claude


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for five Flash-based optimizers for training: FlashAdamW, FlashAdam, FlashSGD, FlashSGDW, and FlashLion; identifiers added to supported options.

* **Validation**
  * Prevents using Flash optimizers with incompatible distributed backends and enforces FSDP version compatibility when FSDP is enabled.

* **Tests**
  * Added end-to-end tests verifying each Flash optimizer is selectable and integrated during training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->