### PR TITLE
fix(validation): add validation for lora target linear with quantize experts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## 🎉 Latest Updates
 
 - 2026/03:
-  - New model support has been added in Axolotl for Qwen3.5, Qwen3.5 MoE, [GLM-4.7-Flash](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm47-flash), [GLM-4.6V](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm46v), and [GLM-4.5-Air](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm45).
+  - New model support has been added in Axolotl for [Qwen3.5, Qwen3.5 MoE](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/qwen3.5), [GLM-4.7-Flash](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm47-flash), [GLM-4.6V](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm46v), and [GLM-4.5-Air](https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/glm45).
   - [MoE expert quantization](https://docs.axolotl.ai/docs/expert_quantization.html) support (via `quantize_moe_experts: true`) greatly reduces VRAM when training MoE models (FSDP2 compat).
 - 2026/02:
   - [ScatterMoE LoRA](https://github.com/axolotl-ai-cloud/axolotl/pull/3410) support. LoRA fine-tuning directly on MoE expert weights using custom Triton kernels.

--- a/docs/expert_quantization.qmd
+++ b/docs/expert_quantization.qmd
@@ -45,6 +45,7 @@ lora_target_parameters:
 
 ## Limitations
 
+- `lora_target_linear` is not compatible with `quantize_moe_experts`.
 - `cpu_ram_efficient_loading` hangs / takes long time with FSDP2 + QLoRA.
 - Total model parameter count may display incorrectly (trainable param count is correct).
 - FSDP LoRA (8-bit) may have a large initial VRAM spike at the first 1-2 steps, which then drops. QLoRA does not exhibit this.

--- a/docs/expert_quantization.qmd
+++ b/docs/expert_quantization.qmd
@@ -45,7 +45,7 @@ lora_target_parameters:
 
 ## Limitations
 
-- `lora_target_linear` is not compatible with `quantize_moe_experts`.
+- `lora_target_linear` is not compatible with `quantize_moe_experts`. See [Expert LoRA targeting](#expert-lora-targeting) instead.
 - `cpu_ram_efficient_loading` hangs / takes long time with FSDP2 + QLoRA.
 - Total model parameter count may display incorrectly (trainable param count is correct).
 - FSDP LoRA (8-bit) may have a large initial VRAM spike at the first 1-2 steps, which then drops. QLoRA does not exhibit this.

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -674,8 +674,8 @@ class ModelLoader:
                 del self.model_kwargs["device_map"]
 
             transformers.modeling_utils.is_deepspeed_zero3_enabled = lambda: True
-            transformers.integrations.deepspeed.is_deepspeed_zero3_enabled = (
-                lambda: True
+            transformers.integrations.deepspeed.is_deepspeed_zero3_enabled = lambda: (
+                True
             )
 
         return hf_ds_cfg

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1304,6 +1304,11 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
     @classmethod
     def check_quantize_moe_experts(cls, data):
         if data.get("quantize_moe_experts"):
+            if data.get("lora_target_linear"):
+                raise ValueError(
+                    "lora_target_linear is not compatible with quantize_moe_experts. "
+                    "Use lora_target_parameters to target expert weights instead."
+                )
             if data.get("adapter") not in ("lora", "qlora"):
                 raise ValueError("quantize_moe_experts requires adapter: lora or qlora")
             if not (data.get("load_in_4bit") or data.get("load_in_8bit")):

--- a/tests/telemetry/test_runtime_metrics.py
+++ b/tests/telemetry/test_runtime_metrics.py
@@ -52,8 +52,8 @@ def mock_torch():
         mock_torch.cuda.device_count.return_value = 2
 
         # Mock memory allocated per device (1GB for device 0, 2GB for device 1)
-        mock_torch.cuda.memory_allocated.side_effect = (
-            lambda device: (device + 1) * 1024 * 1024 * 1024
+        mock_torch.cuda.memory_allocated.side_effect = lambda device: (
+            (device + 1) * 1024 * 1024 * 1024
         )
 
         yield mock_torch
@@ -292,8 +292,8 @@ class TestRuntimeMetricsTracker:
         mock_memory_info = mock_process.memory_info.return_value
         mock_memory_info.rss = 0.5 * 1024 * 1024 * 1024  # 0.5GB
 
-        mock_torch.cuda.memory_allocated.side_effect = (
-            lambda device: (device + 0.5) * 1024 * 1024 * 1024
+        mock_torch.cuda.memory_allocated.side_effect = lambda device: (
+            (device + 0.5) * 1024 * 1024 * 1024
         )
 
         # Update memory metrics again
@@ -307,8 +307,8 @@ class TestRuntimeMetricsTracker:
         # Change mocked memory values to be higher
         mock_memory_info.rss = 2 * 1024 * 1024 * 1024  # 2GB
 
-        mock_torch.cuda.memory_allocated.side_effect = (
-            lambda device: (device + 2) * 1024 * 1024 * 1024
+        mock_torch.cuda.memory_allocated.side_effect = lambda device: (
+            (device + 2) * 1024 * 1024 * 1024
         )
 
         # Update memory metrics again

--- a/tests/utils/schemas/validation/test_moe_quant.py
+++ b/tests/utils/schemas/validation/test_moe_quant.py
@@ -79,6 +79,20 @@ class TestQuantizeMoeExpertsValidation:
         result = validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
         assert result["quantize_moe_experts"] is False
 
+    def test_rejects_lora_target_linear(self, min_base_cfg, gpu_caps, env_caps):
+        """quantize_moe_experts with lora_target_linear should fail."""
+        cfg = (
+            DictDefault(
+                quantize_moe_experts=True,
+                adapter="qlora",
+                load_in_4bit=True,
+                lora_target_linear=True,
+            )
+            | min_base_cfg
+        )
+        with pytest.raises(ValueError, match="lora_target_linear is not compatible"):
+            validate_config(cfg, capabilities=gpu_caps, env_capabilities=env_caps)
+
     def test_default_is_false(self, min_base_cfg, gpu_caps, env_caps):
         """quantize_moe_experts should default to false."""
         cfg = DictDefault({}) | min_base_cfg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Had two users running into problem below. Let's fail earlier with config reason, so they can fix it, and append to doc.

```
ValueError: Target module ParametrizationList(
[rank0]:   (0): Bnb4bitParametrization()
[rank0]: ) is not supported. Currently, only the following modules are supported: `torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv1d`, `torch.nn.Conv2d`, `torch.nn.Conv3d`, `transformers.pytorch_utils
.Conv1D`, `torch.nn.MultiheadAttention.`.
```

Ref:

https://github.com/axolotl-ai-cloud/axolotl/issues/3374#issuecomment-4008684227
https://discord.com/channels/1104757954588196865/1104757955204743201/1479378637311578213



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent using `lora_target_linear` with `quantize_moe_experts`. Users who attempt this combination will now receive an error with guidance to use `lora_target_parameters` instead.

* **Documentation**
  * Updated limitations section to document the incompatibility between `lora_target_linear` and `quantize_moe_experts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->