### PR TITLE
fix: position_ids casted to int64 for qwen35 patch

### DIFF
--- a/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
@@ -36,8 +36,8 @@ def get_cu_seqlens(position_ids):
         position_ids = position_ids[0]
 
     tensor_kwargs = {"dtype": torch.int32, "device": position_ids.device}
-    position_ids = position_ids.reshape(-1)
-    indices_q = (position_ids == 0).nonzero().reshape(-1)
+    position_ids = position_ids.view(-1)
+    indices_q = (position_ids == 0).nonzero().view(-1)
     return torch.cat(
         (
             indices_q.to(**tensor_kwargs),

--- a/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
@@ -35,7 +35,7 @@ def get_cu_seqlens(position_ids):
     if position_ids.ndim == 3:
         position_ids = position_ids[0]
 
-    tensor_kwargs = {"dtype": torch.long, "device": position_ids.device}
+    tensor_kwargs = {"dtype": torch.int32, "device": position_ids.device}
     position_ids = position_ids.reshape(-1)
     indices_q = (position_ids == 0).nonzero().reshape(-1)
     return torch.cat(

--- a/tests/test_tensor_parallel_batch_size.py
+++ b/tests/test_tensor_parallel_batch_size.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import addict
 import pytest
+
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

FLA and prior qwen3_next patch works with int32 position_ids. Some migration caused it to be swapped to int64. This PR fixes it.

Error otherwise: https://discord.com/channels/1104757954588196865/1104757955204743201/1479463364060250163

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tensor data type handling in Qwen 3.5 model inference for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->