### PR TITLE
fix: add guard for _initialize_missing_keys patch

### DIFF
--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -498,6 +498,9 @@ def patch_initialize_missing_keys_for_fsdp():
     from transformers import PreTrainedModel
     from transformers.modeling_utils import is_fsdp_enabled, is_local_dist_rank_0
 
+    if getattr(PreTrainedModel._initialize_missing_keys, "_axolotl_patched", False):
+        return
+
     _original_initialize_missing_keys = PreTrainedModel._initialize_missing_keys
 
     def _patched_initialize_missing_keys(self, is_quantized: bool) -> None:
@@ -510,6 +513,7 @@ def patch_initialize_missing_keys_for_fsdp():
         _original_initialize_missing_keys(self, is_quantized)
 
     PreTrainedModel._initialize_missing_keys = _patched_initialize_missing_keys
+    PreTrainedModel._initialize_missing_keys._axolotl_patched = True
 
 
 def patch_accelerate_fsdp2():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Small followup for https://github.com/axolotl-ai-cloud/axolotl/pull/3464 adds a guard to prevent re-patch and a recursive `patch_fn(patch_fn(original_fn))` scenario

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a system patch could be applied multiple times during repeated invocations, which could cause unintended side effects. The patch now applies only once, ensuring consistent and stable behavior across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->