### PR TITLE
fix: high eval loss w/ sample packing 

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -348,7 +348,9 @@ def _load_raw_datasets(
             dataset = handle_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)
         else:
             dataset = handle_long_seq_in_dataset(dataset, cfg.sequence_len, cfg)
-        if cfg.sample_packing:
+        if cfg.sample_packing and not (
+            split == "test" and cfg.eval_sample_packing is False
+        ):
             dataset, _ = process_datasets_for_packing(cfg, dataset, None)
 
         # Deduplicate before saving so the saved dataset is already de-duplicated

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -348,8 +348,8 @@ def _load_raw_datasets(
             dataset = handle_long_seq_in_dataset(dataset, cfg.eval_sequence_len, cfg)
         else:
             dataset = handle_long_seq_in_dataset(dataset, cfg.sequence_len, cfg)
-        if cfg.sample_packing and not (
-            split == "test" and cfg.eval_sample_packing is False
+        if (split == "train" and cfg.sample_packing) or (
+            split == "test" and cfg.eval_sample_packing
         ):
             dataset, _ = process_datasets_for_packing(cfg, dataset, None)
 


### PR DESCRIPTION

# Description

process_datasets_for_packing() is called for ALL splits (both "train" and "test") whenever cfg.sample_packing is True
should only be done for train 

## Motivation and Context
#3465

## AI Usage Disclaimer
asked too claude to just investigate



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sample packing behavior during test evaluation to respect configuration settings. When eval_sample_packing is disabled, sample packing is now properly skipped during test runs, reducing unnecessary data processing and improving evaluation efficiency while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->