### PR TITLE
fix num_labels= 1 test fail 

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -423,7 +423,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             ]
         # TRL's RewardTrainer validates num_labels=1 on pre-loaded models; ensure the
         # config reflects this regardless of how the model was instantiated.
-        if self.cfg.reward_model and getattr(self.model.config, "num_labels", None) != 1:
+        if (
+            self.cfg.reward_model
+            and getattr(self.model.config, "num_labels", None) != 1
+        ):
             self.model.config.num_labels = 1
         trainer = trainer_cls(
             model=self.model,

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -421,6 +421,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             trainer_kwargs["dataset_tags"] = [
                 d["path"] for d in self.cfg.datasets if not Path(d["path"]).is_dir()
             ]
+        # TRL's RewardTrainer validates num_labels=1 on pre-loaded models; ensure the
+        # config reflects this regardless of how the model was instantiated.
+        if self.cfg.reward_model and getattr(self.model.config, "num_labels", None) != 1:
+            self.model.config.num_labels = 1
         trainer = trainer_cls(
             model=self.model,
             train_dataset=self.train_dataset,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -256,6 +256,23 @@ class TrainingValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
+    def set_reward_model_defaults(cls, data):
+        if data.get("reward_model"):
+            if data.get("num_labels") is None:
+                data["num_labels"] = 1
+            if not (data.get("type_of_model") or data.get("model_type")):
+                data["model_type"] = "AutoModelForSequenceClassification"
+
+        if data.get("process_reward_model"):
+            if data.get("num_labels") is None:
+                data["num_labels"] = 2
+            if not (data.get("type_of_model") or data.get("model_type")):
+                data["model_type"] = "AutoModelForTokenClassification"
+
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_gas_bsz(cls, data):
         if data.get("gradient_accumulation_steps") and data.get("batch_size"):
             raise ValueError(

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -536,7 +536,7 @@ class TestHFCausalTrainerBuilder:
         "cfg_string",
         [
             "sft_cfg",
-            # "rm_cfg",  # TODO fix for num_labels = 2 vs 1
+            "rm_cfg",
             "prm_cfg",
         ],
     )

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -277,6 +277,34 @@ class TestValidation(BaseValidation):
         new_cfg = validate_config(cfg)
         assert new_cfg.type_of_model == "AutoModelForCausalLM"
 
+    def test_reward_model_defaults(self, minimal_cfg):
+        cfg = (
+            DictDefault(
+                {
+                    "reward_model": True,
+                }
+            )
+            | minimal_cfg
+        )
+
+        new_cfg = validate_config(cfg)
+        assert new_cfg.num_labels == 1
+        assert new_cfg.type_of_model == "AutoModelForSequenceClassification"
+
+    def test_process_reward_model_defaults(self, minimal_cfg):
+        cfg = (
+            DictDefault(
+                {
+                    "process_reward_model": True,
+                }
+            )
+            | minimal_cfg
+        )
+
+        new_cfg = validate_config(cfg)
+        assert new_cfg.num_labels == 2
+        assert new_cfg.type_of_model == "AutoModelForTokenClassification"
+
     def test_model_revision_remap(self, minimal_cfg):
         cfg = (
             DictDefault(


### PR DESCRIPTION

# Description
Add a `set_reward_model_defaults` model validator in `validation.py` that automatically sets num_labels=1 for reward_model: True and num_labels=2 for process_reward_model: True, and defaults the model_type to the appropriate AutoModel class.

Re-enable rm_cfg in test_builder_w_rm_trainers which was previously disabled pending this fix.


## How has this been tested?

` test_reward_model_defaults` 
` test_process_reward_model_defaults`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic default configuration for reward model settings, intelligently setting model type and label counts based on configuration context.

* **Tests**
  * Enhanced validation test coverage for reward model defaults to ensure configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->