### PR TITLE
Fix double sequence partition during training with context-parallel

### DIFF
--- a/src/axolotl/monkeypatch/accelerate/parallelism_config.py
+++ b/src/axolotl/monkeypatch/accelerate/parallelism_config.py
@@ -78,30 +78,21 @@ def patch_parallelism_config():
 
 
 def patch_prepare_cp():
-    import functools
+    import contextlib
 
-    import torch
     from accelerate import Accelerator
 
     def patched_prepare_cp(self, *args):
         if self.parallelism_config.cp_backend == "deepspeed":
             return args
 
-        from accelerate.big_modeling import _attach_context_parallel_hooks
-        from torch.distributed.tensor.experimental import context_parallel
-        from torch.distributed.tensor.experimental._attention import set_rotate_method
+        @contextlib.contextmanager
+        def _noop_cp_context(
+            buffers=None, buffer_seq_dims=None, no_restore_buffers=None
+        ):
+            yield
 
-        cp_comm_strategy = self.parallelism_config.cp_handler.cp_comm_strategy
-        set_rotate_method(cp_comm_strategy)
-
-        self._cp_context = functools.partial(
-            context_parallel, mesh=self.torch_device_mesh["cp"]
-        )
-
-        for arg in args:
-            if isinstance(arg, torch.nn.Module):
-                _attach_context_parallel_hooks(arg)
-
+        self._cp_context = _noop_cp_context
         return args
 
     Accelerator._prepare_cp = patched_prepare_cp


### PR DESCRIPTION
# Description
This PR fixes an issue caused by double context partitioning when both Accelerate native Context Parallelism (CP) and the SequenceParallelContextManager are applied simultaneously.

## Motivation and Context

During training with context parallelism enabled, the token sequence was unintentionally split by a factor of 1 / cp_size².

This happened because:
	•	SequenceParallelContextManager already partitions the sequence by 1 / cp_size.
	•	At the same time, Accelerate applies additional context partitioning through maybe_context_parallel.

As a result, the sequence was partitioned twice, leading to an incorrect effective sequence length.

This patch prevents the double partitioning and ensures the sequence is split only once as intended.


## How has this been tested?

The fix was tested using a CP configuration with 8 GPUs.

Testing consisted of debugging the apply_sequence_parallelism function with and without the patch. Without the fix, the training loss was consistently higher than the evaluation loss, indicating incorrect training behavior. After applying the patch, the losses behaved as expected.

## AI Usage Disclaimer
Yes — Opus was used to assist with debugging.

## Screenshots (if appropriate)

## Types of changes

Bug fix

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated context parallel initialization handling in the accelerate integration for parallelism configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->