### PR TITLE
feat: add dataset weight support for weighted data mixing

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -403,6 +403,29 @@ def _load_and_process_single_dataset(
             num_shards=dataset_config.shards, index=shards_idx
         )
 
+    # Apply weight-based subsampling before tokenization to save compute
+    if (
+        dataset_config.weight is not None
+        and dataset_config.weight < 1.0
+        and not streaming
+    ):
+        original_len = len(dataset)
+        if original_len == 0:
+            LOG.warning(
+                f"Skipping weight subsampling for dataset "
+                f"'{dataset_config.path}' because it is empty."
+            )
+        else:
+            num_samples = min(
+                original_len,
+                max(1, int(original_len * dataset_config.weight)),
+            )
+            dataset = dataset.shuffle(seed=seed).select(range(num_samples))
+            LOG.info(
+                f"Applied weight={dataset_config.weight} to dataset "
+                f"'{dataset_config.path}': {original_len} -> {num_samples} samples"
+            )
+
     # Apply dataset wrapper
     dataset_wrapper, dataset_prompter = get_dataset_wrapper(
         dataset_config=dataset_config,

--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -520,7 +520,7 @@ def generate_dataset_hash_from_config(
         f"{cfg.sequence_len}@{cfg.sample_packing}@{cfg.eval_sample_packing}@"
         f"{cfg.group_by_length}@{cfg.kd_temperature or 1.0}@"
         f"{cfg.dataset_exact_deduplication or False}|"
-        f"{'|'.join(sorted([f'{d.path}:{d.type}:{d.shards}:{d.conversation}:{d.split}:{d.temperature or 1.0}' for d in cfg_datasets]))}"
+        f"{'|'.join(sorted([f'{d.path}:{d.type}:{d.shards}:{d.conversation}:{d.split}:{d.temperature or 1.0}:{d.weight or 1.0}' for d in cfg_datasets]))}"
         f"|{tokenizer_name}"
     )
     return str(md5(config_str))

--- a/src/axolotl/utils/schemas/datasets.py
+++ b/src/axolotl/utils/schemas/datasets.py
@@ -194,6 +194,17 @@ class SFTDataset(BaseModel):
             "description": "The specific revision of the dataset to use when loading from the Hugging Face Hub. This can be a commit hash, tag, or branch name. If not specified, the latest version will be used. This parameter is ignored for local datasets."
         },
     )
+    weight: float | None = Field(
+        default=None,
+        gt=0.0,
+        le=1.0,
+        json_schema_extra={
+            "description": "Sampling weight for dataset mixing. A float between 0 (exclusive) and 1 (inclusive). "
+            "When set, the dataset is shuffled and subsampled to (weight * dataset_size) examples before "
+            "merging with other datasets. For example, weight=0.5 uses 50% of the dataset. "
+            "If not set, the entire dataset is used (equivalent to weight=1.0)."
+        },
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1209,6 +1209,24 @@ class PretrainingValidationMixin:
             )
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_streaming_w_dataset_weight(cls, data):
+        if data.get("streaming") and data.get("datasets"):
+            for ds_cfg in data["datasets"]:
+                weight = (
+                    ds_cfg.get("weight")
+                    if isinstance(ds_cfg, dict)
+                    else getattr(ds_cfg, "weight", None)
+                )
+                if weight is not None and weight < 1.0:
+                    LOG.warning(
+                        "Dataset weight is not supported with streaming datasets and will be ignored. "
+                        "Use non-streaming mode for weighted dataset mixing."
+                    )
+                    break
+        return data
+
 
 class ModelCompatibilityValidationMixin:
     """Validation methods for specific model compatibility."""

--- a/tests/test_dataset_weight.py
+++ b/tests/test_dataset_weight.py
@@ -1,0 +1,388 @@
+"""Tests for dataset weight-based subsampling feature."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+from pydantic import ValidationError
+
+from axolotl.utils.config import validate_config
+from axolotl.utils.data.shared import generate_dataset_hash_from_config, merge_datasets
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.schemas.datasets import SFTDataset
+
+
+class TestSFTDatasetWeightSchema(unittest.TestCase):
+    """Test the weight field on SFTDataset Pydantic schema."""
+
+    def test_weight_none_by_default(self):
+        ds = SFTDataset(path="test/dataset", type="alpaca")
+        assert ds.weight is None
+
+    def test_weight_valid_values(self):
+        ds = SFTDataset(path="test/dataset", type="alpaca", weight=1.0)
+        assert ds.weight == 1.0
+
+        ds = SFTDataset(path="test/dataset", type="alpaca", weight=0.5)
+        assert ds.weight == 0.5
+
+        ds = SFTDataset(path="test/dataset", type="alpaca", weight=0.01)
+        assert ds.weight == 0.01
+
+    def test_weight_rejects_zero(self):
+        with pytest.raises(ValidationError, match="greater than 0"):
+            SFTDataset(path="test/dataset", type="alpaca", weight=0.0)
+
+    def test_weight_rejects_negative(self):
+        with pytest.raises(ValidationError, match="greater than 0"):
+            SFTDataset(path="test/dataset", type="alpaca", weight=-0.5)
+
+    def test_weight_rejects_above_one(self):
+        with pytest.raises(ValidationError, match="less than or equal to 1"):
+            SFTDataset(path="test/dataset", type="alpaca", weight=1.5)
+
+
+class TestWeightSurvivesValidation(unittest.TestCase):
+    """Ensure the weight field is preserved through the config validation pipeline."""
+
+    def _make_cfg(self, weight=None):
+        ds = {"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"}
+        if weight is not None:
+            ds["weight"] = weight
+        return DictDefault(
+            {
+                "base_model": "TinyLlama/TinyLlama-1.1B-Chat-v0.6",
+                "learning_rate": 0.000001,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "datasets": [ds],
+            }
+        )
+
+    def test_weight_preserved_after_validation(self):
+        cfg = self._make_cfg(weight=0.5)
+        checked = validate_config(cfg)
+        assert checked.datasets[0].weight == 0.5
+
+    def test_weight_preserved_with_capabilities(self):
+        cfg = self._make_cfg(weight=0.3)
+        checked = validate_config(
+            cfg,
+            capabilities={
+                "bf16": "false",
+                "n_gpu": 1,
+                "compute_capability": "8.0",
+            },
+            env_capabilities={"torch_version": "2.6.0"},
+        )
+        assert checked.datasets[0].weight == 0.3
+
+    def test_no_weight_means_none(self):
+        cfg = self._make_cfg()
+        checked = validate_config(cfg)
+        assert checked.datasets[0].weight is None
+
+
+class TestWeightSubsampling(unittest.TestCase):
+    """Test the actual subsampling logic in _load_and_process_single_dataset."""
+
+    def _make_dataset(self, n=100):
+        return Dataset.from_dict(
+            {
+                "instruction": [f"instruction_{i}" for i in range(n)],
+                "output": [f"output_{i}" for i in range(n)],
+            }
+        )
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_subsamples_dataset(self, mock_load, mock_wrapper):
+        """When weight < 1.0, the dataset is shuffled and subsampled."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(100)
+        mock_load.return_value = original_ds
+        mock_wrapper.return_value = (original_ds, None)
+
+        dataset_config = DictDefault(
+            {"path": "test/ds", "type": "alpaca", "weight": 0.5}
+        )
+        cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+        # The wrapper is called with the subsampled dataset
+        def capture_wrapper(**kwargs):
+            ds = kwargs.get("dataset")
+            return (ds, None)
+
+        mock_wrapper.side_effect = capture_wrapper
+
+        result_ds, _ = _load_and_process_single_dataset(
+            dataset_config=dataset_config,
+            cfg=cfg,
+            tokenizer=MagicMock(),
+            split="train",
+            seed=42,
+        )
+
+        assert len(result_ds) == 50
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_none_uses_full_dataset(self, mock_load, mock_wrapper):
+        """When weight is None, the full dataset is used."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(100)
+        mock_load.return_value = original_ds
+
+        def capture_wrapper(**kwargs):
+            return (kwargs.get("dataset"), None)
+
+        mock_wrapper.side_effect = capture_wrapper
+
+        dataset_config = DictDefault({"path": "test/ds", "type": "alpaca"})
+        cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+        result_ds, _ = _load_and_process_single_dataset(
+            dataset_config=dataset_config,
+            cfg=cfg,
+            tokenizer=MagicMock(),
+            split="train",
+            seed=42,
+        )
+
+        assert len(result_ds) == 100
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_one_uses_full_dataset(self, mock_load, mock_wrapper):
+        """When weight == 1.0, no subsampling occurs."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(100)
+        mock_load.return_value = original_ds
+
+        def capture_wrapper(**kwargs):
+            return (kwargs.get("dataset"), None)
+
+        mock_wrapper.side_effect = capture_wrapper
+
+        dataset_config = DictDefault(
+            {"path": "test/ds", "type": "alpaca", "weight": 1.0}
+        )
+        cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+        result_ds, _ = _load_and_process_single_dataset(
+            dataset_config=dataset_config,
+            cfg=cfg,
+            tokenizer=MagicMock(),
+            split="train",
+            seed=42,
+        )
+
+        assert len(result_ds) == 100
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_minimum_one_sample(self, mock_load, mock_wrapper):
+        """Even with very small weights, at least 1 sample is kept."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(5)
+        mock_load.return_value = original_ds
+
+        def capture_wrapper(**kwargs):
+            return (kwargs.get("dataset"), None)
+
+        mock_wrapper.side_effect = capture_wrapper
+
+        dataset_config = DictDefault(
+            {"path": "test/ds", "type": "alpaca", "weight": 0.01}
+        )
+        cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+        result_ds, _ = _load_and_process_single_dataset(
+            dataset_config=dataset_config,
+            cfg=cfg,
+            tokenizer=MagicMock(),
+            split="train",
+            seed=42,
+        )
+
+        assert len(result_ds) >= 1
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_skipped_for_streaming(self, mock_load, mock_wrapper):
+        """Weight-based subsampling is skipped for streaming datasets."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(100)
+        mock_load.return_value = original_ds
+
+        def capture_wrapper(**kwargs):
+            return (kwargs.get("dataset"), None)
+
+        mock_wrapper.side_effect = capture_wrapper
+
+        dataset_config = DictDefault(
+            {"path": "test/ds", "type": "alpaca", "weight": 0.5}
+        )
+        cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+        result_ds, _ = _load_and_process_single_dataset(
+            dataset_config=dataset_config,
+            cfg=cfg,
+            tokenizer=MagicMock(),
+            split="train",
+            seed=42,
+            streaming=True,
+        )
+
+        # For streaming, len() would fail, but since we mock it returns a Dataset
+        # The key test: weight is NOT applied in streaming mode
+        assert len(result_ds) == 100
+
+    @patch("axolotl.utils.data.sft.get_dataset_wrapper")
+    @patch("axolotl.utils.data.sft.load_dataset_with_config")
+    def test_weight_deterministic_with_seed(self, mock_load, mock_wrapper):
+        """Same weight + seed produces the same subset."""
+        from axolotl.utils.data.sft import _load_and_process_single_dataset
+
+        original_ds = self._make_dataset(100)
+
+        results = []
+        for _ in range(2):
+            mock_load.return_value = original_ds
+
+            def capture_wrapper(**kwargs):
+                return (kwargs.get("dataset"), None)
+
+            mock_wrapper.side_effect = capture_wrapper
+
+            dataset_config = DictDefault(
+                {"path": "test/ds", "type": "alpaca", "weight": 0.3}
+            )
+            cfg = DictDefault({"hf_use_auth_token": False, "seed": 42})
+
+            result_ds, _ = _load_and_process_single_dataset(
+                dataset_config=dataset_config,
+                cfg=cfg,
+                tokenizer=MagicMock(),
+                split="train",
+                seed=42,
+            )
+            results.append(result_ds["instruction"])
+
+        assert results[0] == results[1]
+
+
+class TestDatasetHashIncludesWeight(unittest.TestCase):
+    """Ensure dataset weight affects the cache hash."""
+
+    def _make_cfg(self):
+        return DictDefault(
+            {
+                "sequence_len": 1024,
+                "sample_packing": False,
+                "eval_sample_packing": False,
+                "group_by_length": False,
+                "kd_temperature": None,
+            }
+        )
+
+    def test_different_weights_produce_different_hashes(self):
+        cfg = self._make_cfg()
+        ds_no_weight = [
+            DictDefault(
+                {
+                    "path": "test/ds",
+                    "type": "alpaca",
+                    "shards": None,
+                    "conversation": None,
+                    "split": "train",
+                    "temperature": None,
+                    "weight": None,
+                }
+            )
+        ]
+        ds_with_weight = [
+            DictDefault(
+                {
+                    "path": "test/ds",
+                    "type": "alpaca",
+                    "shards": None,
+                    "conversation": None,
+                    "split": "train",
+                    "temperature": None,
+                    "weight": 0.5,
+                }
+            )
+        ]
+
+        hash1 = generate_dataset_hash_from_config(cfg, ds_no_weight, "test-tokenizer")
+        hash2 = generate_dataset_hash_from_config(cfg, ds_with_weight, "test-tokenizer")
+
+        assert hash1 != hash2
+
+    def test_same_weight_produces_same_hash(self):
+        cfg = self._make_cfg()
+        ds1 = [
+            DictDefault(
+                {
+                    "path": "test/ds",
+                    "type": "alpaca",
+                    "shards": None,
+                    "conversation": None,
+                    "split": "train",
+                    "temperature": None,
+                    "weight": 0.5,
+                }
+            )
+        ]
+        ds2 = [
+            DictDefault(
+                {
+                    "path": "test/ds",
+                    "type": "alpaca",
+                    "shards": None,
+                    "conversation": None,
+                    "split": "train",
+                    "temperature": None,
+                    "weight": 0.5,
+                }
+            )
+        ]
+
+        hash1 = generate_dataset_hash_from_config(cfg, ds1, "test-tokenizer")
+        hash2 = generate_dataset_hash_from_config(cfg, ds2, "test-tokenizer")
+
+        assert hash1 == hash2
+
+
+class TestMergeWithWeightedDatasets(unittest.TestCase):
+    """Integration test: verify weighted datasets merge correctly."""
+
+    def test_weighted_datasets_merged_proportionally(self):
+        ds1 = Dataset.from_dict({"text": [f"ds1_{i}" for i in range(100)]})
+        ds2 = Dataset.from_dict({"text": [f"ds2_{i}" for i in range(100)]})
+
+        # Simulate weight application: subsample ds2 to 50%
+        ds2_subsampled = ds2.shuffle(seed=42).select(range(50))
+
+        cfg = DictDefault(
+            {
+                "shuffle_merged_datasets": True,
+                "shuffle_before_merging_datasets": False,
+                "seed": 42,
+                "curriculum_sampling": False,
+            }
+        )
+
+        merged = merge_datasets([ds1, ds2_subsampled], cfg)
+        assert len(merged) == 150  # 100 + 50
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a `weight` field (0 < weight <= 1.0) to `SFTDataset` config for per-dataset sampling proportion when mixing multiple datasets
- When weight < 1.0, the dataset is shuffled and subsampled to `weight * size` examples **before tokenization** (saves compute)
- Includes weight in dataset cache hash for correct invalidation
- Adds validation warning when weight is used with streaming (not yet supported)
- 17 unit tests covering schema validation, config pipeline, subsampling logic, determinism, caching, and merge

## Motivation
When training on a mixture of datasets, it's common to want different proportions from each dataset. For example, using 100% of a small curated dataset but only 2% of a large general dataset. This is a feature that was not available in Axolotl.

## Usage
```yaml
datasets:
  - path: curated/small-dataset
    type: chat_template
    weight: 1.0      # use 100%
  - path: general/large-dataset
    type: chat_template
    weight: 0.5      # use 50%
  - path: noisy/huge-dataset
    type: chat_template
    weight: 0.02     # use 2%
```

## Implementation
- **Schema**: `weight` field on `SFTDataset` with Pydantic `gt=0.0, le=1.0` validation
- **Subsampling**: Applied in `_load_and_process_single_dataset` after sharding but before tokenization (`get_dataset_wrapper`), using `dataset.shuffle(seed).select(range(n))`
- **Caching**: `weight` included in `generate_dataset_hash_from_config` so cached datasets are invalidated when weights change
- **Streaming**: Weight is not applied for streaming datasets (warning emitted during validation)

## Test plan
- [x] Schema validation: valid weights accepted, invalid (0, negative, >1) rejected
- [x] Config pipeline: weight survives `validate_config` with and without capabilities
- [x] Subsampling: correct size reduction, full dataset when weight=None or 1.0, minimum 1 sample
- [x] Determinism: same seed + weight produces identical subsets
- [x] Streaming: weight skipped for streaming datasets
- [x] Cache hash: different weights produce different hashes
- [x] Merge: weighted datasets merge correctly
- [x] Existing tests: all 64 validation tests pass, no regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional dataset weight parameter (0 < weight ≤ 1.0) for proportional dataset mixing and deterministic subsampling

* **Validation**
  * Added warning when weight is specified with streaming datasets, as they are not compatible

* **Tests**
  * Added comprehensive unit tests validating weight-based subsampling behavior and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->