### PR TITLE
Qwen3.5-MoE example config with lora_target_modules regex

### DIFF
--- a/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
@@ -27,16 +27,15 @@ lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
 lora_target_modules:
-   - q_proj
-   - k_proj
-   - v_proj
-   - o_proj
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+# Regex matching to target shared experts too
+# lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
-# Use manual regex matching to target shared experts too
-#lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
-
-# Optional
-#lora_target_parameters:
+# Target experts
+# lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
 
@@ -55,7 +54,6 @@ learning_rate: 0.0002
 
 bf16: auto
 tf32: true
-
 
 lora_mlp_kernel: false
 lora_qkv_kernel: false

--- a/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
@@ -26,14 +26,13 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-# Using lora_target_modules as is will result in a very small LoRA adapter for the Qwen3.5 MoE architecture
 lora_target_modules:
    - q_proj
    - k_proj
    - v_proj
    - o_proj
 
-# Use manual regex matching to target more modules
+# Use manual regex matching to target shared experts too
 #lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
 # Optional

--- a/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora-fsdp.yaml
@@ -74,3 +74,14 @@ evals_per_epoch: 4
 saves_per_epoch: 1
 weight_decay: 0.0
 special_tokens:
+
+fsdp_config:
+  fsdp_version: 2
+  offload_params: true
+  cpu_ram_efficient_loading: false
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: Qwen3_5MoeDecoderLayer
+  state_dict_type: FULL_STATE_DICT
+  sharding_strategy: FULL_SHARD
+  reshard_after_forward: true
+  activation_checkpointing: true

--- a/examples/qwen3.5/122b-a10b-moe-qlora.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora.yaml
@@ -26,12 +26,16 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-lora_target_modules:
-  - q_proj
-  - k_proj
-  - v_proj
-  - o_proj
+lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
+# Using lora_target_modules will not target the correct modules in the Qwen3.5 MoE architecture
+# lora_target_modules:
+#   - q_proj
+#   - k_proj
+#   - v_proj
+#   - o_proj
+
+# Optional
 #lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj

--- a/examples/qwen3.5/122b-a10b-moe-qlora.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora.yaml
@@ -27,16 +27,16 @@ lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
 lora_target_modules:
-   - q_proj
-   - k_proj
-   - v_proj
-   - o_proj
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
 
-# Use manual regex matching to target shared experts too
-#lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
+# Regex matching to target shared experts too
+# lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
-# Optional
-#lora_target_parameters:
+# Target experts
+# lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
 
@@ -55,7 +55,6 @@ learning_rate: 0.0002
 
 bf16: auto
 tf32: true
-
 
 lora_mlp_kernel: false
 lora_qkv_kernel: false

--- a/examples/qwen3.5/122b-a10b-moe-qlora.yaml
+++ b/examples/qwen3.5/122b-a10b-moe-qlora.yaml
@@ -26,14 +26,13 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-# Using lora_target_modules as is will result in a very small LoRA adapter for the Qwen3.5 MoE architecture
 lora_target_modules:
    - q_proj
    - k_proj
    - v_proj
    - o_proj
 
-# Use manual regex matching to target more modules
+# Use manual regex matching to target shared experts too
 #lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
 # Optional

--- a/examples/qwen3.5/27b-qlora-fsdp.yaml
+++ b/examples/qwen3.5/27b-qlora-fsdp.yaml
@@ -1,9 +1,7 @@
 base_model: Qwen/Qwen3.5-27B
+
 # Automatically upload checkpoint and final model to HF
 # hub_model_id: username/custom_model_name
-# Note: Qwen3.5 is an early-fusion VLM (image+text). This config fine-tunes
-# the text-only path. For multimodal (image+text) fine-tuning, add image
-# columns to your dataset following axolotl's multimodal dataset format.
 
 plugins:
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin

--- a/examples/qwen3.5/27b-qlora-fsdp.yaml
+++ b/examples/qwen3.5/27b-qlora-fsdp.yaml
@@ -1,0 +1,83 @@
+base_model: Qwen/Qwen3.5-27B
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+# Note: Qwen3.5 is an early-fusion VLM (image+text). This config fine-tunes
+# the text-only path. For multimodal (image+text) fine-tuning, add image
+# columns to your dataset following axolotl's multimodal dataset format.
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+strict: false
+
+chat_template: qwen3_5
+datasets:
+  - path: mlabonne/FineTome-100k
+    type: chat_template
+    split: train[:20%]
+    field_messages: conversations
+    message_property_mappings:
+      role: from
+      content: value
+val_set_size: 0.0
+output_dir: ./outputs/out
+dataset_prepared_path: last_run_prepared
+
+sequence_len: 2048
+sample_packing: true
+
+load_in_4bit: true
+adapter: qlora
+lora_r: 16
+lora_alpha: 32
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - down_proj
+  - up_proj
+  # Uncomment below to also target the linear attention projections.
+  # These use separate in_proj_qkv / in_proj_z / out_proj (Qwen3.5-specific).
+  # - linear_attn.in_proj_qkv
+  # - linear_attn.in_proj_z
+  # - linear_attn.out_proj
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 2
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_4bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+resume_from_checkpoint:
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 4
+saves_per_epoch: 1
+weight_decay: 0.0
+special_tokens:
+
+fsdp_config:
+  fsdp_version: 2
+  offload_params: false
+  cpu_ram_efficient_loading: false
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: Qwen3_5DecoderLayer
+  state_dict_type: FULL_STATE_DICT
+  sharding_strategy: FULL_SHARD
+  reshard_after_forward: true
+  activation_checkpointing: true

--- a/examples/qwen3.5/27b-qlora.yaml
+++ b/examples/qwen3.5/27b-qlora.yaml
@@ -1,9 +1,7 @@
 base_model: Qwen/Qwen3.5-27B
+
 # Automatically upload checkpoint and final model to HF
 # hub_model_id: username/custom_model_name
-# Note: Qwen3.5 is an early-fusion VLM (image+text). This config fine-tunes
-# the text-only path. For multimodal (image+text) fine-tuning, add image
-# columns to your dataset following axolotl's multimodal dataset format.
 
 plugins:
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin

--- a/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
@@ -27,16 +27,16 @@ lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
 lora_target_modules:
-   - q_proj
-   - k_proj
-   - v_proj
-   - o_proj
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
 
-# Use manual regex matching to target shared experts too
-#lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
+# Regex matching to target shared experts too
+# lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
-# Optional
-#lora_target_parameters:
+# Target experts
+# lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
 

--- a/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
@@ -26,14 +26,13 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-# Using lora_target_modules as is will result in a very small LoRA adapter for the Qwen3.5 MoE architecture
 lora_target_modules:
    - q_proj
    - k_proj
    - v_proj
    - o_proj
 
-# Use manual regex matching to target more modules
+# Use manual regex matching to target shared experts too
 #lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
 # Optional

--- a/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora-fsdp.yaml
@@ -1,4 +1,4 @@
-base_model: Qwen/Qwen3.5-122B-A10B
+base_model: Qwen/Qwen3.5-35B-A3B
 
 plugins:
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
@@ -57,7 +57,6 @@ learning_rate: 0.0002
 bf16: auto
 tf32: true
 
-
 lora_mlp_kernel: false
 lora_qkv_kernel: false
 lora_o_kernel: false
@@ -74,3 +73,14 @@ evals_per_epoch: 4
 saves_per_epoch: 1
 weight_decay: 0.0
 special_tokens:
+
+fsdp_config:
+  fsdp_version: 2
+  offload_params: true
+  cpu_ram_efficient_loading: false
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: Qwen3_5MoeDecoderLayer
+  state_dict_type: FULL_STATE_DICT
+  sharding_strategy: FULL_SHARD
+  reshard_after_forward: true
+  activation_checkpointing: true

--- a/examples/qwen3.5/35b-a3b-moe-qlora.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora.yaml
@@ -27,16 +27,16 @@ lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
 lora_target_modules:
-   - q_proj
-   - k_proj
-   - v_proj
-   - o_proj
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
 
-# Use manual regex matching to target shared experts too
-#lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
+# Regex matching to target shared experts too
+# lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
-# Optional
-#lora_target_parameters:
+# Target experts
+# lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj
 

--- a/examples/qwen3.5/35b-a3b-moe-qlora.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora.yaml
@@ -26,12 +26,17 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-lora_target_modules:
-  - q_proj
-  - k_proj
-  - v_proj
-  - o_proj
 
+lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
+
+# Using lora_target_modules will not target the correct modules in the Qwen3.5 MoE architecture
+# lora_target_modules:
+#   - q_proj
+#   - k_proj
+#   - v_proj
+#   - o_proj
+
+# Optional
 #lora_target_parameters:
 #   - mlp.experts.gate_up_proj
 #   - mlp.experts.down_proj

--- a/examples/qwen3.5/35b-a3b-moe-qlora.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora.yaml
@@ -26,14 +26,13 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
-# Using lora_target_modules as is will result in a very small LoRA adapter for the Qwen3.5 MoE architecture
 lora_target_modules:
    - q_proj
    - k_proj
    - v_proj
    - o_proj
 
-# Use manual regex matching to target more modules
+# Use manual regex matching to target shared experts too
 #lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
 # Optional

--- a/examples/qwen3.5/35b-a3b-moe-qlora.yaml
+++ b/examples/qwen3.5/35b-a3b-moe-qlora.yaml
@@ -26,15 +26,15 @@ adapter: qlora
 lora_r: 16
 lora_alpha: 32
 lora_dropout: 0
+# Using lora_target_modules as is will result in a very small LoRA adapter for the Qwen3.5 MoE architecture
+lora_target_modules:
+   - q_proj
+   - k_proj
+   - v_proj
+   - o_proj
 
-lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
-
-# Using lora_target_modules will not target the correct modules in the Qwen3.5 MoE architecture
-# lora_target_modules:
-#   - q_proj
-#   - k_proj
-#   - v_proj
-#   - o_proj
+# Use manual regex matching to target more modules
+#lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 
 # Optional
 #lora_target_parameters:

--- a/examples/qwen3.5/7b-lora-vision.yaml
+++ b/examples/qwen3.5/7b-lora-vision.yaml
@@ -1,10 +1,6 @@
 base_model: Qwen/Qwen3.5-7B
 processor_type: AutoProcessor
 
-# Qwen3.5-7B and above are early-fusion VLMs (Qwen3_5ForConditionalGeneration).
-# Vision and text tokens are processed together by the same transformer layers.
-# Note: Qwen3.5-2B is a text-only model — the smallest VLM is Qwen3.5-7B.
-
 # These 3 lines are required for vision/multimodal training
 skip_prepare_dataset: true
 remove_unused_columns: false
@@ -30,8 +26,6 @@ lora_r: 32
 lora_alpha: 16
 lora_dropout: 0.05
 # Targets the language model attention and MLP layers.
-# Qwen3.5 is early-fusion: all layers (including those seeing vision tokens) share
-# the same transformer stack, so standard attention targets work for both modalities.
 lora_target_modules:
   - q_proj
   - k_proj

--- a/examples/qwen3.5/README.md
+++ b/examples/qwen3.5/README.md
@@ -2,20 +2,6 @@
 
 [Qwen3.5](https://huggingface.co/collections/Qwen/qwen35) is a hybrid architecture model series combining Gated DeltaNet linear attention with standard Transformer attention. All Qwen3.5 models are early-fusion vision-language models: dense variants use `Qwen3_5ForConditionalGeneration` and MoE variants use `Qwen3_5MoeForConditionalGeneration`.
 
-Vision and text tokens are processed through the same transformer stack. The configs below train on text-only data unless noted otherwise. See `9b-lora-vision.yaml` for a multimodal example.
-
-Available configs:
-
-| Config | Model | Type | Peak VRAM |
-|---|---|---|---|
-| `27b-qlora.yaml` | Qwen3.5-27B | Dense VLM, text-only QLoRA | ~47 GiB |
-| `27b-fft.yaml` | Qwen3.5-27B | Dense VLM, text-only FFT (vision frozen) | ~53 GiB |
-| `35b-a3b-moe-qlora.yaml` | Qwen3.5-35B-A3B | MoE, text-only QLoRA | — |
-| `122b-a10b-moe-qlora.yaml` | Qwen3.5-122B-A10B | MoE, text-only QLoRA | — |
-| `9b-lora-vision.yaml` | Qwen3.5-9B | Vision+text LoRA, single GPU | — |
-| `9b-fft-vision.yaml` | Qwen3.5-9B | Vision+text FFT, single GPU | ~61 GiB |
-
-
 ## Getting started
 
 1. Install Axolotl following the [installation guide](https://docs.axolotl.ai/docs/installation.html).
@@ -23,43 +9,69 @@ Available configs:
 2. Install [Cut Cross Entropy](https://docs.axolotl.ai/docs/custom_integrations.html#cut-cross-entropy) to reduce training VRAM usage.
 
 3. Install FLA for sample packing support with the Gated DeltaNet linear attention layers:
-```bash
-pip3 uninstall -y causal-conv1d && pip3 install flash-linear-attention==0.4.1
+  ```bash
+  pip3 uninstall -y causal-conv1d && pip3 install flash-linear-attention==0.4.1
+  ```
+  > FLA is required when `sample_packing: true`. Without it, training raises a `RuntimeError` on packed sequences. Vision configs use `sample_packing: false` so FLA is optional there.
+
+4. Pick any config from the table below and run:
+
+    ```bash
+    axolotl train examples/qwen3.5/<config>.yaml
+    ```
+
+Available configs:
+
+| Config | Model | Type | Peak VRAM |
+|---|---|---|---|
+| `9b-lora-vision.yaml` | Qwen3.5-9B | Vision+text LoRA, single GPU | — |
+| `9b-fft-vision.yaml` | Qwen3.5-9B | Vision+text FFT, single GPU | ~61 GiB |
+| `27b-qlora.yaml` | Qwen3.5-27B | Dense, text-only QLoRA | ~47 GiB |
+| `27b-fft.yaml` | Qwen3.5-27B | Dense, text-only FFT (vision frozen) | ~53 GiB |
+| `27b-qlora-fsdp.yaml` | Qwen3.5-27B | Dense, text-only QLoRA + FSDP2 | — |
+| `35b-a3b-moe-qlora.yaml` | Qwen3.5-35B-A3B | MoE, text-only QLoRA | — |
+| `35b-a3b-moe-qlora-fsdp.yaml` | Qwen3.5-35B-A3B | MoE, text-only QLoRA + FSDP2 | — |
+| `122b-a10b-moe-qlora.yaml` | Qwen3.5-122B-A10B | MoE, text-only QLoRA | — |
+| `122b-a10b-moe-qlora-fsdp.yaml` | Qwen3.5-122B-A10B | MoE, text-only QLoRA + FSDP2 | — |
+
+### Gated DeltaNet Linear Attention
+
+Qwen3.5 interleaves standard attention with Gated DeltaNet linear attention layers. To apply LoRA to them, add to `lora_target_modules`:
+
+```yaml
+lora_target_modules:
+  # ... standard projections ...
+  - linear_attn.in_proj_qkv
+  - linear_attn.in_proj_z
+  - linear_attn.out_proj
 ```
-> FLA is required when `sample_packing: true`. Without it, training raises a `RuntimeError` on packed sequences. Vision configs use `sample_packing: false` so FLA is optional there.
 
-4. Run a finetuning example:
+### Routed Experts (MoE)
 
-```bash
-# Dense 27B text-only (QLoRA, ~47 GiB VRAM with sample packing)
-axolotl train examples/qwen3.5/27b-qlora.yaml
+To apply LoRA to routed expert parameters, add `lora_target_parameters`:
 
-# Dense 27B text-only FFT with vision encoder frozen (~53 GiB, single 80 GiB GPU)
-axolotl train examples/qwen3.5/27b-fft.yaml
+```yaml
+lora_target_parameters:
+  - mlp.experts.gate_up_proj
+  - mlp.experts.down_proj
+#  - mlp.gate.weight  # router
+```
 
-# MoE 35B-A3B text-only (QLoRA)
-axolotl train examples/qwen3.5/35b-a3b-moe-qlora.yaml
+### Shared Experts (MoE)
 
-# MoE 122B-A10B text-only (QLoRA)
-axolotl train examples/qwen3.5/122b-a10b-moe-qlora.yaml
+Routed experts and shared experts both have `gate_up_proj`/`down_proj`, so a plain module name in `lora_target_modules` would match both. Use a regex to target only attention and shared expert projections, while `lora_target_parameters` above handles routed experts separately:
 
-# 9B vision+text (LoRA, multimodal dataset)
-axolotl train examples/qwen3.5/9b-lora-vision.yaml
-
-# 9B vision+text FFT, single 80 GiB GPU (~61 GiB peak)
-axolotl train examples/qwen3.5/9b-fft-vision.yaml
-
+```yaml
+lora_target_modules: 'model\.(language_model\.)?layers\.[\d]+\.(mlp|self_attn)\.(shared_expert\.)?(up|down|gate|gate_up|q|k|v|o)_proj'
 ```
 
 ### TIPS
 
-- For inference, you can experiment with `temperature: 0.7`, `top_p: 0.8`, `top_k: 20`, and `min_p: 0`.
-- For **text-only FFT** on 27B, use `27b-fft.yaml` which sets `unfrozen_parameters` to freeze the vision encoder (`model.visual.*`) — this avoids wasting optimizer state on parameters that receive no gradient from text-only data.
+- For inference hyp, please see the respective model card details.
 - You can run a full finetuning of smaller configs by removing `adapter: qlora` and `load_in_4bit: true`. See [Multi-GPU](#optimization-guides) below.
 - Read more on loading your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
 - The dataset format follows the OpenAI Messages format as seen [here](https://docs.axolotl.ai/docs/dataset-formats/conversation.html#chat_template).
 - For **multimodal** finetuning, set `processor_type: AutoProcessor`, `skip_prepare_dataset: true`, and `remove_unused_columns: false` as shown in `9b-lora-vision.yaml`.
-- The Gated DeltaNet linear attention layers (`linear_attn.*`) can optionally be added to `lora_target_modules` — they are commented out by default.
 
 ## Optimization Guides
 


### PR DESCRIPTION
# Description

using the lora_target_modules parameters as-is like in the examples will result in not correctly targeting all the modules in Qwen3.5 MoE models and result in extremely small LoRA adapters. Targeting manually using regex is required.

## How has this been tested?

Using lora_target_modules as-is originally in the example will result in very small LoRA adapters, 16-rank on Qwen3.5-35B-A3B results in a 13.5mb adapter.

Using the regex will target more modules and correctly result in larger and more normally expected adapter size. With 16-rank on Qwen3.5-35B-A3B resulting in a 3.7GB adapter.

## Types of changes

Example configs

## Social Handles (Optional)
@OwenArli on ArliAI discord


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new example configurations for Qwen3.5 MoE model fine-tuning with QLoRA and FSDP support, including 122B A10B and 35B A3B variants configured with optimized hyperparameters and 4-bit quantization.
  * Enhanced existing configurations with detailed guidance, explanatory comments, and optional parameter targeting approaches for improved training workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->