### PR TITLE
provide early warning to users when dependencies are missing for a feature they may be using

### DIFF
--- a/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
@@ -19,6 +19,9 @@ except ImportError:
         from fla.modules.conv import causal_conv1d as fla_causal_conv1d  # FLA < 0.4.1
     except ImportError:
         fla_causal_conv1d = None
+        LOG.warning(
+            "fla.modules.convolution.causal_conv1d (cu_seqlens support) not available. You must install flash-linear-attention or disable packing. Axolotl will crash if packing is enabled."
+        )
 
 
 def get_cu_seqlens(position_ids):


### PR DESCRIPTION
This attempts to at least warn users attempting to use packing when they haven't installed the flash-linear-attention package, to eliminate time waste.

# Description

Adds a simple warning log message when the import fails for `causal_conv1d`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for model configurations. The application now displays a warning message instead of crashing when required dependencies are missing, allowing users to identify and resolve configuration issues more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->