### PR TITLE
Fix Ray train crashing after succeeding

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -84,8 +84,11 @@ def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs):
                 storage_path=Path(parsed_cfg.output_dir).absolute().as_posix(),
             ),
         )
-        return trainer.fit()
-    return do_train(parsed_cfg, parsed_cli_args)
+
+        trainer.fit()
+        return
+
+    do_train(parsed_cfg, parsed_cli_args)
 
 
 def ray_train_func(kwargs: dict):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Makes it so trainers no longer returns to `fire.Fire()` causing Ray to `raise DeprecationError`.

<!--- Describe your changes in detail -->

## Motivation and Context

#3541 

## How has this been tested?

Change affects no other areas of code. Testing was done on Linux with A100x40g. Testing was done on a qlora finetune of Qwen3-0.6b and Alpaca for quick iteration.

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

No

## Screenshots (if appropriate)

Before:

```
(RayTrainWorker pid=1190) [2026-03-23 12:40:43,142] [INFO] [axolotl.train] Training completed! Saving trained model to /data/outputs/run-1.
100%|██████████| 593/593 [12:17<00:00,  1.24s/it]
(RayTrainWorker pid=1190) [2026-03-23 12:40:50,460] [INFO] [axolotl.train] Model successfully saved to /data/outputs/run-1
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib/python3.12/dist-packages/axolotl/cli/train.py", line 121, in <module>
    fire.Fire(do_cli)
  File "/usr/local/lib/python3.12/dist-packages/fire/core.py", line 161, in Fire
    _PrintResult(
  File "/usr/local/lib/python3.12/dist-packages/fire/core.py", line 272, in _PrintResult
    help_text = helptext.HelpText(
                ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fire/helptext.py", line 64, in HelpText
    actions_grouped_by_kind = _GetActionsGroupedByKind(component, verbose=verbose)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fire/helptext.py", line 385, in _GetActionsGroupedByKind
    members = completion.VisibleMembers(component, verbose=verbose)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fire/completion.py", line 362, in VisibleMembers
    members = inspect.getmembers(component)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 614, in getmembers
    return _getmembers(object, predicate, getattr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 592, in _getmembers
    value = getter(object, key)
            ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/train/v2/api/result.py", line 133, in config
    raise DeprecationWarning(
DeprecationWarning: The `config` property for a `ray.train.Result` is deprecated, since it is only relevant in the context of Ray Tune.
(PlacementGroupCleaner pid=1188) Failed to query Ray Train Controller actor state. State API may be temporarily unavailable. Continuing to monitor.
Traceback (most recent call last):
  File "/usr/local/bin/accelerate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/accelerate/commands/accelerate_cli.py", line 50, in main
    args.func(args)
  File "/usr/local/lib/python3.12/dist-packages/accelerate/commands/launch.py", line 1405, in launch_command
    simple_launcher(args)
  File "/usr/local/lib/python3.12/dist-packages/accelerate/commands/launch.py", line 993, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
```

After:
```
(RayTrainWorker pid=11914) [2026-03-24 18:59:34,157] [INFO] [axolotl.train] Starting trainer...
(RayTrainWorker pid=11914) The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The m
odel config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'bos_token
_id': None, 'pad_token_id': 151669}.
(RayTrainWorker pid=11914) [2026-03-24 18:59:39,071] [INFO] [axolotl.utils.samplers.multipack] gather_len_batches: [296]
  0%|          | 0/1 [00:00<?, ?it/s]                                                                                             
100%|██████████| 1/1 [00:04<00:00,  4.79s/it]
(RayTrainWorker pid=11914) {'loss': '2.222', 'grad_norm': '1.7', 'learning_rate': '0', 'ppl': '9.223', 'memory/max_active (GiB)': 
'30.63', 'memory/max_allocated (GiB)': '30.63', 'memory/device_reserved (GiB)': '35.4', 'tokens/train_per_sec_per_gpu': '2653', 't
okens/total': 32768, 'tokens/trainable': 18514, 'epoch': '0.006757'}  
(RayTrainWorker pid=11914) [2026-03-24 18:59:44,143] [INFO] [axolotl.core.trainers.base] Saving model checkpoint to /data/outputs/
run-1/checkpoint-1
100%|██████████| 1/1 [00:04<00:00,  4.79s/it]
(RayTrainWorker pid=11914) {'train_runtime': '52.77', 'train_samples_per_second': '0.152', 'train_steps_per_second': '0.019', 'tra
in_loss': '2.222', 'memory/max_active (GiB)': '1.22', 'memory/max_allocated (GiB)': '1.22', 'memory/device_reserved (GiB)': '35.4'
, 'epoch': '0.006757', 'tokens/train_per_sec_per_gpu': '0'}
(RayTrainWorker pid=11914) [2026-03-24 19:00:31,943] [INFO] [axolotl.train] Training completed! Saving trained model to /data/outp
uts/run-1.
100%|██████████| 1/1 [00:52<00:00, 52.77s/it]
(RayTrainWorker pid=11914) [2026-03-24 19:00:46,680] [INFO] [axolotl.train] Model successfully saved to /data/outputs/run-1
```

## Types of changes

Bug fix

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to training control flow with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->