### PR TITLE
Add precompute_ref_log_probs to config schema

### DIFF
--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -242,10 +242,6 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
             and self.cfg.rl not in (RLType.GRPO, RLType.ORPO, RLType.EBFT)
         ):
             trainer_kwargs["peft_config"] = self.peft_config
-        if self.cfg.precompute_ref_log_probs is not None:
-            trainer_kwargs["precompute_ref_log_probs"] = (
-                self.cfg.precompute_ref_log_probs
-            )
 
         trainer_cls, trainer_cls_args = self._get_trainer_cls(trainer_kwargs)
 

--- a/src/axolotl/core/trainers/dpo/__init__.py
+++ b/src/axolotl/core/trainers/dpo/__init__.py
@@ -34,4 +34,8 @@ class DPOStrategy:
             training_args_kwargs["dpo_norm_loss"] = cfg.dpo_norm_loss
         if cfg.dpo_use_liger_kernel is not None:
             training_args_kwargs["use_liger_kernel"] = cfg.dpo_use_liger_kernel
+        if cfg.precompute_ref_log_probs is not None:
+            training_args_kwargs["precompute_ref_log_probs"] = (
+                cfg.precompute_ref_log_probs
+            )
         return training_args_kwargs

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -295,6 +295,7 @@ class AxolotlInputConfig(
     )
     dpo_label_smoothing: float | None = None
     dpo_norm_loss: bool | None = None
+    precompute_ref_log_probs: bool | None = None
 
     dpo_use_liger_kernel: bool | None = Field(
         default=None,

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -295,7 +295,12 @@ class AxolotlInputConfig(
     )
     dpo_label_smoothing: float | None = None
     dpo_norm_loss: bool | None = None
-    precompute_ref_log_probs: bool | None = None
+    precompute_ref_log_probs: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Precompute reference model log probabilities for DPO"
+        },
+    )
 
     dpo_use_liger_kernel: bool | None = Field(
         default=None,

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -96,6 +96,7 @@ def fixture_dpo_cfg(base_cfg):
             "dpo_use_weighting": True,
             "dpo_label_smoothing": 0.1,
             "beta": 0.1,  # DPO beta
+            "precompute_ref_log_probs": True,
         }
     )
     return cfg
@@ -298,6 +299,7 @@ class TestHFRLTrainerBuilder:
         assert hasattr(training_arguments, "use_weighting")
         assert training_arguments.use_weighting is True
         assert training_arguments.label_smoothing == 0.1
+        assert training_arguments.precompute_ref_log_probs is True
 
     def test_orpo_training_arguments(self, orpo_cfg, model, tokenizer):
         builder = HFRLTrainerBuilder(orpo_cfg, model, tokenizer)

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -96,7 +96,6 @@ def fixture_dpo_cfg(base_cfg):
             "dpo_use_weighting": True,
             "dpo_label_smoothing": 0.1,
             "beta": 0.1,  # DPO beta
-            "precompute_ref_log_probs": True,
         }
     )
     return cfg
@@ -290,6 +289,7 @@ class TestHFRLTrainerBuilder:
         # assert training_arguments.gradient_checkpointing is True
 
     def test_dpo_training_arguments(self, dpo_cfg, model, tokenizer):
+        dpo_cfg["precompute_ref_log_probs"] = True
         builder = HFRLTrainerBuilder(dpo_cfg, model, tokenizer)
         training_arguments, _ = builder._build_training_arguments(100)
 


### PR DESCRIPTION
Fixes #3546

The RL builder reads `cfg.precompute_ref_log_probs` to configure DPO training, but the field is missing from `AxolotlInputConfig`. Since the schema uses Pydantic validation, setting this field in a config file has no effect — it gets silently dropped.

Added `precompute_ref_log_probs: bool | None = None` alongside the existing DPO fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration parameter for precomputing reference log probabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->