### PR TITLE
train only on last assistant message

### DIFF
--- a/src/axolotl/core/datasets/transforms/chat_builder.py
+++ b/src/axolotl/core/datasets/transforms/chat_builder.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 
 def chat_message_transform_builder(
     train_on_inputs=False,
+    train_on_last_assistant_only=False,
     conversations_field: str = "messages",
     message_field_role: str | list[str] | None = None,  # commonly "role"
     message_field_content: str | list[str] | None = None,  # commonly "content"
@@ -145,6 +146,15 @@ def chat_message_transform_builder(
                         "weight": weight,
                     }
                 )
+
+        if train_on_last_assistant_only:
+            last_assistant_idx = -1
+            for i, message in enumerate(messages):
+                if message["role"] == "assistant":
+                    last_assistant_idx = i
+            for i, message in enumerate(messages):
+                if message["role"] == "assistant" and i != last_assistant_idx:
+                    message["weight"] = 0
 
         return {"conversation": messages}
 

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -280,9 +280,11 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         train_on_eot: str | None = None,
         eot_tokens: list[str] | None = None,
         split_thinking: bool | None = False,
+        train_on_last_assistant_only: bool = False,
     ):
         super().__init__(prompter, tokenizer, train_on_inputs, sequence_len)
         self.prompter: ChatTemplatePrompter = prompter
+        self.train_on_last_assistant_only = train_on_last_assistant_only
 
         self.roles_to_train = []
         if roles_to_train:
@@ -483,6 +485,15 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 should_train = bool(train_detail)
             else:
                 should_train = self.train_on_inputs or role in self.roles_to_train
+
+            if getattr(self, "train_on_last_assistant_only", False) and should_train and role == "assistant":
+                is_last_assistant = True
+                for t in turns[index+1:]:
+                    if t.get("role") == "assistant":
+                        is_last_assistant = False
+                        break
+                if not is_last_assistant:
+                    should_train = False
 
             LOG.debug(f"Should train: {should_train}")
 
@@ -965,6 +976,7 @@ class StrategyLoader:
     def _get_strategy_params(self, cfg, ds_cfg: Dict[str, Any]):
         return {
             "train_on_inputs": cfg.train_on_inputs,
+            "train_on_last_assistant_only": ds_cfg.get("train_on_last_assistant_only", getattr(cfg, "train_on_last_assistant_only", False)),
             "sequence_len": cfg.sequence_len,
             "roles_to_train": ds_cfg.get("roles_to_train", ["assistant"]),
             "train_on_eos": ds_cfg.get("train_on_eos", "turn"),

--- a/src/axolotl/prompt_strategies/messages/chat.py
+++ b/src/axolotl/prompt_strategies/messages/chat.py
@@ -78,10 +78,13 @@ def load(tokenizer, cfg, ds_cfg: Optional[Dict[str, Any]] = None):
 
     if chat_template == "chatml":
         from axolotl.core.chat.format.chatml import format_message  # noqa F811
-    if chat_template.startswith("llama3"):
+    if chat_template and chat_template.startswith("llama3"):
         from axolotl.core.chat.format.llama3x import format_message  # noqa F811
     message_transform: Callable = chat_message_transform_builder(
         train_on_inputs=ds_cfg.get("train_on_inputs", False),
+        train_on_last_assistant_only=ds_cfg.get(
+            "train_on_last_assistant_only", cfg.get("train_on_last_assistant_only", False)
+        ),
         **builder_kwargs,
     )
     strategy = ChatMessageDatasetWrappingStrategy(

--- a/src/axolotl/utils/schemas/training.py
+++ b/src/axolotl/utils/schemas/training.py
@@ -61,6 +61,12 @@ class HyperparametersConfig(BaseModel):
             "description": "Whether to mask out or include the human's prompt from the training labels"
         },
     )
+    train_on_last_assistant_only: bool | None = Field(
+        default=False,
+        json_schema_extra={
+            "description": "Whether to only train on the last assistant turn in a multi-turn conversation."
+        },
+    )
     group_by_length: bool | None = Field(
         default=None,
         json_schema_extra={

--- a/tests/prompt_strategies/test_chat_templates.py
+++ b/tests/prompt_strategies/test_chat_templates.py
@@ -227,6 +227,63 @@ class TestAssistantChatTemplateLlama3:
         )
 
 
+    def test_llama3_train_on_last_assistant_only(self, llama3_tokenizer, assistant_dataset):
+        LOG.info("Testing llama-3 with train_on_last_assistant_only=True")
+        strategy = ChatTemplateStrategy(
+            ChatTemplatePrompter(
+                llama3_tokenizer,
+                chat_template=get_chat_template("llama3"),
+                message_property_mappings={
+                    "role": "role",
+                    "content": "content",
+                },
+                roles={
+                    "user": ["user"],
+                    "assistant": ["assistant"],
+                    "system": ["system"],
+                },
+            ),
+            tokenizer=llama3_tokenizer,
+            train_on_inputs=False,
+            sequence_len=512,
+            roles_to_train=["assistant"],
+            train_on_last_assistant_only=True,
+        )
+
+        res = strategy.tokenize_prompt(assistant_dataset[0])
+        input_ids = res["input_ids"]
+        labels = res["labels"]
+        # fmt: off
+        expected_input_ids = [
+            128000,  # bos
+            128006, 882, 128007,  # user header
+            271, 15339, 128009,  # user prompt eot
+            128006, 78191, 128007,  # assistant header
+            271, 15339, 128009,   # assistant response eot
+            128006, 882, 128007,
+            271, 19045, 29474, 128009,
+            128006, 78191, 128007,
+            271, 19045, 29474, 128009,
+        ]
+        expected_labels = [
+            IGNORE_TOKEN_ID,  # bos
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,  # user header
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,  # user prompt eot
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,  # assistant header
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,   # assistant response eot NOT trained because of train_on_last_assistant_only
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,
+            IGNORE_TOKEN_ID, IGNORE_TOKEN_ID, IGNORE_TOKEN_ID,
+            IGNORE_TOKEN_ID, 19045, 29474, IGNORE_TOKEN_ID, # ONLY THIS ASSISTANT TRAINED
+        ]
+        # fmt: on
+        LOG.debug(f"Expected labels: {expected_labels}")
+        LOG.debug(f"Actual labels: {labels}")
+        assert labels == expected_labels, (
+            f"Labels mismatch: {labels} != {expected_labels}"
+        )
+
+
 class TestSharegptChatTemplateLlama3:
     """
     Test class for ShareGPT style datasets with llama-3 prompts using the chat_template strategy.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
A flag to enable loss computation and training only on the last assistant turn of a conversation. 

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- In vanilla multi-turn training, the loss over all the assistant tokens is calculated. But in case of some special cases (maybe in-context examples in a chat format), the only loss over the last assistant turn needs to be calculated, and the previous turns just demonstrate the pattern, and we want to take them as fixed inputs and not compute the loss. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- A basic test has been added to `tests/prompt_strategies/test_chat_templates.py`
<!--- Include details of your testing environment, tests ran to see how -->
- No special environment, no additional code changes.
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
- Yes, GitHub CoPilot assisted. I asked it to make the patch and manually tested it. 
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)
NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Added a `train_on_last_assistant_only` flag, and it goes along with `train_on_inputs: false`
- Once this flag is detected, we just loop through the messages, and set the weight of the assistant turns to 0 expect the last one. ([diff](https://github.com/axolotl-ai-cloud/axolotl/compare/main...VarunGumma:axolotl:main#diff-84365377db47760a349b310d6fb8e831fde45479ceaccb0beca877b2f2831872))

## Social Handles (Optional)
- GitHub: https://github.com/VarunGumma
- X: https://x.com/VarunGumma23

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `train_on_last_assistant_only` configuration parameter to enable selective training on only the final assistant message in multi-turn conversations, while disabling training on prior assistant messages.

* **Tests**
  * Added test coverage validating the new `train_on_last_assistant_only` feature behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->