### PR TITLE
Add troubleshooting note for GLM4 GGUF MTP mismatch

### DIFF
--- a/examples/glm45/README.md
+++ b/examples/glm45/README.md
@@ -58,42 +58,13 @@ datasets:
 - **LoRA kernels**: Incompatible with this model. Must be explicitly disabled (`lora_*_kernel: false`).
 - Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
 
-### ⚠️ GGUF / llama.cpp loading error (missing tensors)
+### GGUF / llama.cpp loading error (missing tensors)
 
-If you encounter an error like:
+If you see `missing tensor 'blk.X.attn_norm.weight'` when loading a GLM-4 / GLM4-MoE model in llama.cpp, this is likely
+caused by `num_nextn_predict_layers` being set to `1` in `config.json` while the MTP weights were not exported (possible
+after PEFT/QLoRA training).
 
-```
-llama_model_load: error loading model: missing tensor 'blk.X.attn_norm.weight'
-```
-
-when converting or loading a GLM-4 / GLM4-MoE model in `llama.cpp`, this is likely caused by a mismatch between the model config and exported weights.
-
-Some GLM-4 configs include:
-
-```json
-"num_nextn_predict_layers": 1
-```
-
-This enables MTP (multi-token prediction) layers, but these layers are not always included during PEFT/QLoRA training or GGUF conversion.
-
-#### ✅ Fix
-
-Before converting to GGUF, set:
-
-```json
-"num_nextn_predict_layers": 0
-```
-
-in your `config.json`, then reconvert the model.
-
-#### Why this happens
-
-* The config enables MTP layers
-* The actual weights do not include them
-* This causes tensor misalignment during loading in `llama.cpp`
-
-This is an upstream configuration mismatch rather than an Axolotl-specific issue.
-
+**Fix:** Set `"num_nextn_predict_layers": 0` in your `config.json` before converting to GGUF.
 
 ## Optimization Guides
 

--- a/examples/glm45/README.md
+++ b/examples/glm45/README.md
@@ -71,7 +71,7 @@ when converting or loading a GLM-4 / GLM4-MoE model in `llama.cpp`, this is like
 Some GLM-4 configs include:
 
 ```json
-"num_nextn_predict_layers": = 1
+"num_nextn_predict_layers": 1
 ```
 
 This enables MTP (multi-token prediction) layers, but these layers are not always included during PEFT/QLoRA training or GGUF conversion.

--- a/examples/glm45/README.md
+++ b/examples/glm45/README.md
@@ -58,6 +58,43 @@ datasets:
 - **LoRA kernels**: Incompatible with this model. Must be explicitly disabled (`lora_*_kernel: false`).
 - Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
 
+### ⚠️ GGUF / llama.cpp loading error (missing tensors)
+
+If you encounter an error like:
+
+```
+llama_model_load: error loading model: missing tensor 'blk.X.attn_norm.weight'
+```
+
+when converting or loading a GLM-4 / GLM4-MoE model in `llama.cpp`, this is likely caused by a mismatch between the model config and exported weights.
+
+Some GLM-4 configs include:
+
+```json
+"num_nextn_predict_layers": = 1
+```
+
+This enables MTP (multi-token prediction) layers, but these layers are not always included during PEFT/QLoRA training or GGUF conversion.
+
+#### ✅ Fix
+
+Before converting to GGUF, set:
+
+```json
+"num_nextn_predict_layers": 0
+```
+
+in your `config.json`, then reconvert the model.
+
+#### Why this happens
+
+* The config enables MTP layers
+* The actual weights do not include them
+* This causes tensor misalignment during loading in `llama.cpp`
+
+This is an upstream configuration mismatch rather than an Axolotl-specific issue.
+
+
 ## Optimization Guides
 
 Please check the [Optimizations doc](https://docs.axolotl.ai/docs/optimizations.html).


### PR DESCRIPTION
Adds a troubleshooting note for a common issue when converting GLM-4 / GLM4-MoE models to GGUF.

If `num_nextn_predict_layers > 0` is present in config but MTP weights are not included (e.g. after PEFT/QLoRA), llama.cpp fails to load with missing tensor errors.

Solution: set `num_nextn_predict_layers = 0` before conversion.

This helps users avoid a non-obvious failure during llama.cpp loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for GGUF model-loading failures reporting missing tensor errors. Provides configuration solutions to resolve tensor alignment mismatches in GLM-4 and GLM4-MoE models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->