### PR TITLE
allow bf16 flag but warn

### DIFF
--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1359,7 +1359,7 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 and not self.is_preprocess
                 and (self.bf16 is True or self.bfloat16 is True)
             ):
-                LOG.warn(
+                LOG.warning(
                     "bf16 requested, but AMP is not supported on this GPU. Requires Ampere series or above. Training will fail, but other operations (such as merging) are still functional."
                 )
         return self

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1359,8 +1359,8 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 and not self.is_preprocess
                 and (self.bf16 is True or self.bfloat16 is True)
             ):
-                raise ValueError(
-                    "bf16 requested, but AMP is not supported on this GPU. Requires Ampere series or above."
+                LOG.warn(
+                    "bf16 requested, but AMP is not supported on this GPU. Requires Ampere series or above. Training will fail, but other operations (such as merging) are still functional."
                 )
         return self
 

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -726,8 +726,12 @@ class TestValidation(BaseValidation):
             | minimal_cfg
         )
 
-        with pytest.raises(ValueError, match=r".*AMP is not supported on this GPU*"):
+        with self._caplog.at_level("WARNING"):
             AxolotlConfigWCapabilities(**cfg.to_dict())
+            assert any(
+                "AMP is not supported" in record.message
+                for record in self._caplog.records
+            )
 
         cfg = (
             DictDefault(


### PR DESCRIPTION
Reason: when doing e.g. LoRA merges with CUDA_VISIBLE_DEVICES=, this will unnecessarily crash, even though the LoRA merge operation would have finished successfully. This seems to warrant changing it to a warning instead, as the code will most likely crash later if bf16 is unavailable and training begins anyway.

## Types of changes

- [x] validation tweak


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bfloat16 configuration validation to issue informative warnings instead of blocking execution when GPU AMP support is unavailable. Users can now proceed with operations like model merging while being clearly notified that training may fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->