### PR TITLE
DPO support loss types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ axolotl config-schema                  # Dump config JSON schema
 | Method | Config Key | When to Use |
 |--------|-----------|-------------|
 | SFT | *(default)* | Input-output pairs, instruction tuning |
-| DPO/IPO | `rl: dpo` / `rl: ipo` | Paired preference data (chosen vs rejected) |
+| DPO/IPO | `rl: dpo` / `rl: dpo, dpo_loss_type: ["ipo"]` | Paired preference data (chosen vs rejected) |
 | KTO | `rl: kto` | Unpaired binary preference labels |
 | ORPO | `rl: orpo` | Single-stage alignment, no ref model |
 | GRPO | `rl: grpo` | RL with verifiable reward functions (math, code) |

--- a/docs/agents/preference_tuning.md
+++ b/docs/agents/preference_tuning.md
@@ -38,7 +38,7 @@ No vLLM server needed (unlike GRPO). Offline RL with pre-collected preference da
 
 1. Paired preference data (chosen + rejected)?
    - Default → `rl: dpo`
-   - Overfitting → `rl: ipo`
+   - Overfitting → `rl: dpo, dpo_loss_type: ["ipo"]`
    - VRAM-limited → `rl: orpo` (no ref model)
    - Length-sensitive → `rl: simpo` (no ref model)
 2. Only binary labels (good/bad)? → `rl: kto`

--- a/docs/rlhf.qmd
+++ b/docs/rlhf.qmd
@@ -320,8 +320,10 @@ The input format is a simple JSON input with customizable fields based on the ab
 As IPO is just DPO with a different loss function, all supported dataset formats for [DPO](#dpo) are also supported for IPO.
 
 ```yaml
-rl: ipo
+rl: dpo
+dpo_loss_type: ["ipo"]
 ```
+*Note:* Passing `rl: ipo` directly is still supported, but will soon be deprecated.
 
 ### ORPO
 

--- a/src/axolotl/core/trainers/dpo/__init__.py
+++ b/src/axolotl/core/trainers/dpo/__init__.py
@@ -20,14 +20,15 @@ class DPOStrategy:
     @classmethod
     def set_training_args_kwargs(cls, cfg):
         training_args_kwargs = {}
-        if cfg.rl is RLType.IPO:
-            training_args_kwargs["loss_type"] = ["ipo"]
-        else:
+        if cfg.rl is RLType.DPO:
             if cfg.dpo_loss_type is not None:
                 training_args_kwargs["loss_type"] = cfg.dpo_loss_type
 
             if cfg.dpo_loss_weights is not None:
                 training_args_kwargs["loss_weights"] = cfg.dpo_loss_weights
+
+        if cfg.rl is RLType.IPO:
+            training_args_kwargs["loss_type"] = ["ipo"]
 
         # Label smoothing is not compatible with IPO
         if cfg.rl is RLType.DPO and cfg.dpo_label_smoothing:

--- a/src/axolotl/core/trainers/dpo/__init__.py
+++ b/src/axolotl/core/trainers/dpo/__init__.py
@@ -22,6 +22,13 @@ class DPOStrategy:
         training_args_kwargs = {}
         if cfg.rl is RLType.IPO:
             training_args_kwargs["loss_type"] = ["ipo"]
+        else:
+            if cfg.dpo_loss_type is not None:
+                training_args_kwargs["loss_type"] = cfg.dpo_loss_type
+
+            if cfg.dpo_loss_weights is not None:
+                training_args_kwargs["loss_weights"] = cfg.dpo_loss_weights
+
         # Label smoothing is not compatible with IPO
         if cfg.rl is RLType.DPO and cfg.dpo_label_smoothing:
             training_args_kwargs["label_smoothing"] = cfg.dpo_label_smoothing

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -309,12 +309,12 @@ class AxolotlInputConfig(
 
     dpo_padding_free: bool | None = None
 
-    dpo_loss_type: list[str] | None = Field(
+    dpo_loss_type: Annotated[list[str], MinLen(1)] | None = Field(
         default=None,
         json_schema_extra={"description": "List of DPO losses to use."},
     )
 
-    dpo_loss_weights: list[float] | None = Field(
+    dpo_loss_weights: Annotated[list[float], MinLen(1)] | None = Field(
         default=None,
         json_schema_extra={"description": "Weights for each DPO loss."},
     )

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -309,6 +309,16 @@ class AxolotlInputConfig(
 
     dpo_padding_free: bool | None = None
 
+    dpo_loss_type: list[str] | None = Field(
+        default=None,
+        json_schema_extra={"description": "List of DPO losses to use."},
+    )
+
+    dpo_loss_weights: list[float] | None = Field(
+        default=None,
+        json_schema_extra={"description": "Weights for each DPO loss."},
+    )
+
     datasets: (
         Annotated[
             list[

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -776,16 +776,20 @@ class RLValidationMixin:
             )
 
         if rl == "dpo":
+            if dpo_loss_weights is not None and dpo_loss_type is None:
+                raise ValueError(
+                    "`dpo_loss_weights` requires `dpo_loss_type` to be set"
+                )
             if (
-                dpo_loss_type
-                and dpo_loss_weights
+                dpo_loss_type is not None
+                and dpo_loss_weights is not None
                 and len(dpo_loss_type) != len(dpo_loss_weights)
             ):
                 raise ValueError(
-                    f"`dpo_loss_type` and `dpo_dpo_loss_weights` must be the same length, "
+                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
                     f"but got {len(dpo_loss_type)} losses and {len(dpo_loss_weights)} weights"
                 )
-        elif dpo_loss_type or dpo_loss_weights:
+        elif dpo_loss_type is not None or dpo_loss_weights is not None:
             raise ValueError(
                 f"`dpo_loss_type` and `dpo_loss_weights` are for DPO only,"
                 f"but got {rl=}, {dpo_loss_type=} and {dpo_loss_weights=}"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -763,15 +763,26 @@ class RLValidationMixin:
     @model_validator(mode="before")
     @classmethod
     def check_dpo(cls, data):
-        if data.get("rl") == "dpo":
-            loss_types = data.get("dpo_loss_type")
-            loss_weights = data.get("dpo_loss_weights")
+        dpo_loss_type = data.get("dpo_loss_type")
+        dpo_loss_weights = data.get("dpo_loss_weights")
+        rl = data.get("rl")
 
-            if loss_types and loss_weights and len(loss_types) != len(loss_weights):
+        if rl == "dpo":
+            if (
+                dpo_loss_type
+                and dpo_loss_weights
+                and len(dpo_loss_type) != len(dpo_loss_weights)
+            ):
                 raise ValueError(
-                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
-                    f"but got {len(loss_types)} losses and {len(loss_weights)} weights"
+                    f"`dpo_loss_type` and `dpo_dpo_loss_weights` must be the same length, "
+                    f"but got {len(dpo_loss_type)} losses and {len(dpo_loss_weights)} weights"
                 )
+        elif dpo_loss_type or dpo_loss_weights:
+            raise ValueError(
+                f"`dpo_loss_type` and `dpo_loss_weights` are for DPO only,"
+                f"but got {rl=}, {dpo_loss_type=} and {dpo_loss_weights=}"
+            )
+
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 
 from pydantic import (
@@ -766,6 +767,13 @@ class RLValidationMixin:
         dpo_loss_type = data.get("dpo_loss_type")
         dpo_loss_weights = data.get("dpo_loss_weights")
         rl = data.get("rl")
+
+        if rl == "ipo":
+            warnings.warn(
+                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if rl == "dpo":
             if (

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -762,6 +762,20 @@ class RLValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
+    def check_dpo(cls, data):
+        if data.get("rl") == "dpo":
+            loss_types = data.get("dpo_loss_type")
+            loss_weights = data.get("dpo_loss_weights")
+
+            if loss_types and loss_weights and len(loss_types) != len(loss_weights):
+                raise ValueError(
+                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
+                    f"but got {len(loss_types)} losses and {len(loss_weights)} weights"
+                )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_grpo_batch_size_divisibility(cls, data):
         """Surface GRPO batch-shape mismatches at config-parse time.
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -769,9 +769,7 @@ class RLValidationMixin:
 
         if rl == "ipo":
             LOG.warning(
-                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead."
             )
 
         if rl == "dpo":

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -3,7 +3,6 @@
 import json
 import sys
 import tempfile
-import warnings
 from pathlib import Path
 
 from pydantic import (
@@ -769,7 +768,7 @@ class RLValidationMixin:
         rl = data.get("rl")
 
         if rl == "ipo":
-            warnings.warn(
+            LOG.warning(
                 "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -3,7 +3,6 @@
 import json
 import sys
 import tempfile
-import warnings
 from pathlib import Path
 
 from pydantic import (
@@ -779,7 +778,7 @@ class RLValidationMixin:
         rl = data.get("rl")
 
         if rl == "ipo":
-            warnings.warn(
+            LOG.warning(
                 "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -770,6 +770,20 @@ class RLValidationMixin:
             )
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_dpo(cls, data):
+        if data.get("rl") == "dpo":
+            loss_types = data.get("dpo_loss_type")
+            loss_weights = data.get("dpo_loss_weights")
+
+            if loss_types and loss_weights and len(loss_types) != len(loss_weights):
+                raise ValueError(
+                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
+                    f"but got {len(loss_types)} losses and {len(loss_weights)} weights"
+                )
+        return data
+
 
 class OptimizationValidationMixin:
     """Validation methods related to optimization and performance."""

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -779,9 +779,7 @@ class RLValidationMixin:
 
         if rl == "ipo":
             LOG.warning(
-                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
-                DeprecationWarning,
-                stacklevel=2,
+                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead."
             )
 
         if rl == "dpo":

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -773,15 +773,26 @@ class RLValidationMixin:
     @model_validator(mode="before")
     @classmethod
     def check_dpo(cls, data):
-        if data.get("rl") == "dpo":
-            loss_types = data.get("dpo_loss_type")
-            loss_weights = data.get("dpo_loss_weights")
+        dpo_loss_type = data.get("dpo_loss_type")
+        dpo_loss_weights = data.get("dpo_loss_weights")
+        rl = data.get("rl")
 
-            if loss_types and loss_weights and len(loss_types) != len(loss_weights):
+        if rl == "dpo":
+            if (
+                dpo_loss_type
+                and dpo_loss_weights
+                and len(dpo_loss_type) != len(dpo_loss_weights)
+            ):
                 raise ValueError(
-                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
-                    f"but got {len(loss_types)} losses and {len(loss_weights)} weights"
+                    f"`dpo_loss_type` and `dpo_dpo_loss_weights` must be the same length, "
+                    f"but got {len(dpo_loss_type)} losses and {len(dpo_loss_weights)} weights"
                 )
+        elif dpo_loss_type or dpo_loss_weights:
+            raise ValueError(
+                f"`dpo_loss_type` and `dpo_loss_weights` are for DPO only,"
+                f"but got {rl=}, {dpo_loss_type=} and {dpo_loss_weights=}"
+            )
+
         return data
 
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -786,16 +786,20 @@ class RLValidationMixin:
             )
 
         if rl == "dpo":
+            if dpo_loss_weights is not None and dpo_loss_type is None:
+                raise ValueError(
+                    "`dpo_loss_weights` requires `dpo_loss_type` to be set"
+                )
             if (
-                dpo_loss_type
-                and dpo_loss_weights
+                dpo_loss_type is not None
+                and dpo_loss_weights is not None
                 and len(dpo_loss_type) != len(dpo_loss_weights)
             ):
                 raise ValueError(
-                    f"`dpo_loss_type` and `dpo_dpo_loss_weights` must be the same length, "
+                    f"`dpo_loss_type` and `dpo_loss_weights` must be the same length, "
                     f"but got {len(dpo_loss_type)} losses and {len(dpo_loss_weights)} weights"
                 )
-        elif dpo_loss_type or dpo_loss_weights:
+        elif dpo_loss_type is not None or dpo_loss_weights is not None:
             raise ValueError(
                 f"`dpo_loss_type` and `dpo_loss_weights` are for DPO only,"
                 f"but got {rl=}, {dpo_loss_type=} and {dpo_loss_weights=}"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 
 from pydantic import (
@@ -776,6 +777,13 @@ class RLValidationMixin:
         dpo_loss_type = data.get("dpo_loss_type")
         dpo_loss_weights = data.get("dpo_loss_weights")
         rl = data.get("rl")
+
+        if rl == "ipo":
+            warnings.warn(
+                "rl: ipo will soon be deprecated. Use `rl: dpo` with `dpo_loss_type: ['ipo']` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if rl == "dpo":
             if (

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -96,6 +96,8 @@ def fixture_dpo_cfg(base_cfg):
             "dpo_use_weighting": True,
             "dpo_label_smoothing": 0.1,
             "beta": 0.1,  # DPO beta
+            "dpo_loss_type": ["sigmoid", "sft"],
+            "dpo_loss_weights": [1.0, 0.5],
         }
     )
     return cfg
@@ -300,6 +302,8 @@ class TestHFRLTrainerBuilder:
         assert training_arguments.use_weighting is True
         assert training_arguments.label_smoothing == 0.1
         assert training_arguments.precompute_ref_log_probs is True
+        assert training_arguments.loss_type == ["sigmoid", "sft"]
+        assert training_arguments.loss_weights == [1.0, 0.5]
 
     def test_orpo_training_arguments(self, orpo_cfg, model, tokenizer):
         builder = HFRLTrainerBuilder(orpo_cfg, model, tokenizer)

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -166,7 +166,8 @@ def fixture_ipo_cfg(base_cfg):
     cfg = base_cfg.copy()
     cfg.update(
         {
-            "rl": RLType.IPO,
+            "rl": RLType.DPO,
+            "dpo_loss_type": ["ipo"],
             "dpo_label_smoothing": 0,
             "beta": 0.1,
         }

--- a/tests/e2e/test_dpo.py
+++ b/tests/e2e/test_dpo.py
@@ -116,6 +116,58 @@ class TestDPOLlamaLora(unittest.TestCase):
         train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(Path(temp_dir) / "checkpoint-20", cfg)
 
+    @with_temp_dir
+    def test_rpo(self, temp_dir):
+        # For TRL >= 0.29, loss_type=["sigmoid", "sft"], loss_weights=[1, alpha]
+        # replaces loss_type="rpo", rpo_alpha=alpha.
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 64,
+                "lora_alpha": 32,
+                "lora_dropout": 0.1,
+                "lora_target_linear": True,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "rl": "dpo",
+                "dpo_loss_type": ["sigmoid", "sft"],
+                "dpo_loss_weights": [1.0, 1.0],
+                "datasets": [
+                    {
+                        "path": "arcee-ai/distilabel-intel-orca-dpo-pairs-binarized",
+                        "type": "chatml.ultra",
+                        "split": "train",
+                    },
+                ],
+                "num_epochs": 1,
+                "micro_batch_size": 4,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "paged_adamw_8bit",
+                "lr_scheduler": "cosine",
+                "max_steps": 20,
+                "save_steps": 10,
+                "warmup_steps": 5,
+                "gradient_checkpointing": True,
+                "gradient_checkpointing_kwargs": {"use_reentrant": True},
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        cli_args = TrainerCliArgs()
+        dataset_meta = load_preference_datasets(cfg=cfg, cli_args=cli_args)
+
+        train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(Path(temp_dir) / "checkpoint-20", cfg)
+
     @pytest.mark.skip("kto_pair no longer supported in trl")
     @with_temp_dir
     def test_kto_pair_lora(self, temp_dir):

--- a/tests/e2e/test_dpo.py
+++ b/tests/e2e/test_dpo.py
@@ -233,7 +233,8 @@ class TestDPOLlamaLora(unittest.TestCase):
                 "special_tokens": {
                     "pad_token": "<|endoftext|>",
                 },
-                "rl": "ipo",
+                "rl": "dpo",
+                "dpo_loss_type": ["ipo"],
                 "datasets": [
                     {
                         "path": "arcee-ai/distilabel-intel-orca-dpo-pairs-binarized",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Support multiple loss types and weights as part of TRL >= v0.29.0 updates. #3565 

**Key changes:**
1. Adds two new config parameters `dpo_loss_type` and `dpo_loss_weights` which are passed to Axolotl's DPO Trainer via `DPOStrategy`. Note that `dpo_loss_type` expects a list of strings.
2. Partially deprecates `RLType.IPO/rl: ipo` in favour of passing `rl: dpo, dpo_loss_type: ["ipo"]`. Warns users of upcoming deprecation.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR exposes the full list of loss functions available in TRL and the ability to combine multiple dpo losses with custom weightings. 

This will also restore losses previously available in axolotl such as RPO (and hopefully [length-normalised DPO](https://github.com/huggingface/trl/pull/5406) once TRL supports this), but are now broken on TRL >= 0.29 due to refactors/parameter deprecation [see #3548  #3560]. This PR aims to update Axolotl to work with the newer TRL version and restore this functionality. 

This PR also begins cleaning up `RLType.IPO`, which is no longer needed as a separate RL type.

## How has this been tested?
Unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer
Claude for light review, updates/fixes written by me.
<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Types of changes
Config additions, new losses for DPO, partial deprecation of `RLType.IPO`.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable DPO loss types and weights via `dpo_loss_type` and `dpo_loss_weights` parameters for flexible training customization.

* **Deprecation**
  * The `rl: ipo` configuration is now deprecated; use `rl: dpo` with `dpo_loss_type: ["ipo"]` instead.

* **Documentation**
  * Updated training method guidance to reflect the new DPO configuration approach and IPO deprecation notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->