### PR TITLE
Fix lm-eval integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ zstandard==0.22.0
 fastcore
 
 # lm eval harness
-lm_eval==0.4.7
+lm_eval==0.4.11
 langdetect==1.0.9
 immutabledict==4.2.0
 antlr4-python3-runtime==4.13.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Update lm-eval to 0.4.11 to fix errors and support models trained on both transformers v4 and v5 (new tokenizers api).

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3570.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Ran `axolotl lm-eval config.yml` for both Qwen/Qwen3-0.6B (transformers v4) and LiquidAI/LFM2.5-350M (transformers v5) where config.yml is the minimal config below
```
lm_eval_model: LiquidAI/LFM2.5-350M 

plugins:
  - axolotl.integrations.lm_eval.LMEvalPlugin

lm_eval_tasks:
  - gsm8k

lm_eval_batch_size: 1
output_dir: ./outputs
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer
No AI
<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes
Update package version

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to improve stability and compatibility with the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->