### PR TITLE
fix un supported tensor for pTq

### DIFF
--- a/src/axolotl/cli/quantize.py
+++ b/src/axolotl/cli/quantize.py
@@ -93,10 +93,19 @@ def do_quantize(
         weight_dtype, activation_dtype, group_size
     )
 
-    LOG.info(f"Saving quantized model to: {str(Path(output_dir) / 'quantized')}.")
+    save_path = str(Path(output_dir) / "quantized")
+    is_mx = getattr(model, "_is_mx_quantized", False)
+    if is_mx:
+        LOG.info(
+            f"Saving MX-quantized model to: {save_path} "
+            "(using torch.save — MXTensor does not support safetensors yet)."
+        )
+    else:
+        LOG.info(f"Saving quantized model to: {save_path}.")
     model.save_pretrained(
-        str(Path(output_dir) / "quantized"),
+        save_path,
         progressbar=True,
+        safe_serialization=not is_mx,
     )
     tokenizer.save_pretrained(
         str(Path(output_dir) / "quantized"),

--- a/src/axolotl/cli/quantize.py
+++ b/src/axolotl/cli/quantize.py
@@ -94,21 +94,10 @@ def do_quantize(
     )
 
     LOG.info(f"Saving quantized model to: {str(Path(output_dir) / 'quantized')}.")
-    try:
-        model.save_pretrained(
-            str(Path(output_dir) / "quantized"),
-            progressbar=True,
-        )
-    except (NotImplementedError, ValueError):
-        LOG.warning(
-            "Standard save failed (likely MX format tensor subclass), "
-            "retrying with save_original_format=False"
-        )
-        model.save_pretrained(
-            str(Path(output_dir) / "quantized"),
-            progressbar=True,
-            save_original_format=False,
-        )
+    model.save_pretrained(
+        str(Path(output_dir) / "quantized"),
+        progressbar=True,
+    )
     tokenizer.save_pretrained(
         str(Path(output_dir) / "quantized"),
         progressbar=True,

--- a/src/axolotl/cli/quantize.py
+++ b/src/axolotl/cli/quantize.py
@@ -15,6 +15,7 @@ from axolotl.utils.quantization import (
     get_quantization_config,
     quantization_config_to_str,
     quantize_model,
+    save_quantized_model,
 )
 
 LOG = get_logger(__name__)
@@ -102,11 +103,7 @@ def do_quantize(
         )
     else:
         LOG.info(f"Saving quantized model to: {save_path}.")
-    model.save_pretrained(
-        save_path,
-        progressbar=True,
-        safe_serialization=not is_mx,
-    )
+    save_quantized_model(model, save_path, progressbar=True)
     tokenizer.save_pretrained(
         str(Path(output_dir) / "quantized"),
         progressbar=True,

--- a/src/axolotl/cli/quantize.py
+++ b/src/axolotl/cli/quantize.py
@@ -99,10 +99,10 @@ def do_quantize(
             str(Path(output_dir) / "quantized"),
             progressbar=True,
         )
-    except NotImplementedError:
+    except (NotImplementedError, ValueError):
         LOG.warning(
-            "Model weight conversions do not support reverse_op, "
-            "retrying save with save_original_format=False"
+            "Standard save failed (likely MX format tensor subclass), "
+            "retrying with save_original_format=False"
         )
         model.save_pretrained(
             str(Path(output_dir) / "quantized"),

--- a/src/axolotl/utils/quantization.py
+++ b/src/axolotl/utils/quantization.py
@@ -202,8 +202,13 @@ def quantize_model(
             filter_fn=lambda m, _: isinstance(m, torch.nn.Embedding),
         )
 
-    if weight_dtype == TorchAOQuantDType.mxfp4:
-        _register_mx_state_dict_hook(model)
+    try:
+        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
+
+        if isinstance(linear_ptq_config, MXDynamicActivationMXWeightConfig):
+            _register_mx_state_dict_hook(model)
+    except ImportError:
+        pass
 
 
 def _make_qat_config(

--- a/src/axolotl/utils/quantization.py
+++ b/src/axolotl/utils/quantization.py
@@ -141,28 +141,27 @@ def get_quantization_config(
     )
 
 
-def _register_mx_state_dict_hook(model):
-    """Register a state_dict hook that dequantizes MXTensor subclasses for safe
-    serialization.
+def _attach_torchao_quantizer(
+    model, quantization_config, include_input_output_embeddings=False
+):
+    """Attach a TorchAoHfQuantizer to the model so save_pretrained uses
+    torchao's flatten_tensor_state_dict path, preserving quantized weights
+    in the safetensors file.
 
-    MXTensor (from torchao MX/MXFP4 quantization) doesn't expose a valid Python
-    storage, causing safetensors' storage_ptr() to fail during save_pretrained.
-    This hook converts MXTensor values to plain tensors via dequantize() so the
-    model can be saved normally and re-quantized at load time.
+    Note: This does NOT work for MX formats (MXTensor) because MXTensor
+    lacks the ``tensor_data_names`` attribute that flatten_tensor_state_dict
+    requires.  MX formats use ``safe_serialization=False`` instead.
     """
+    from transformers import TorchAoConfig
+    from transformers.quantizers.quantizer_torchao import TorchAoHfQuantizer
 
-    def _dequantize_mx_tensors(module, state_dict, prefix, local_metadata):
-        try:
-            from torchao.prototype.mx_formats.mx_tensor import MXTensor
-        except ImportError:
-            return state_dict
-
-        for key in list(state_dict.keys()):
-            if isinstance(state_dict[key], MXTensor):
-                state_dict[key] = state_dict[key].dequantize()
-        return state_dict
-
-    model._register_state_dict_hook(_dequantize_mx_tensors)
+    ao_config = TorchAoConfig(
+        quant_type=quantization_config,
+        include_input_output_embeddings=include_input_output_embeddings,
+    )
+    model.config.quantization_config = ao_config
+    quantizer = TorchAoHfQuantizer(ao_config)
+    model.hf_quantizer = quantizer
 
 
 def quantize_model(
@@ -202,13 +201,25 @@ def quantize_model(
             filter_fn=lambda m, _: isinstance(m, torch.nn.Embedding),
         )
 
+    is_mx = False
     try:
         from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
 
-        if isinstance(linear_ptq_config, MXDynamicActivationMXWeightConfig):
-            _register_mx_state_dict_hook(model)
+        is_mx = isinstance(linear_ptq_config, MXDynamicActivationMXWeightConfig)
     except ImportError:
         pass
+
+    if is_mx:
+        # MXTensor lacks tensor_data_names so flatten_tensor_state_dict (safetensors)
+        # cannot serialize it.  Mark the model so the caller can use
+        # safe_serialization=False (torch.save) which supports __tensor_flatten__.
+        model._is_mx_quantized = True
+    else:
+        _attach_torchao_quantizer(
+            model,
+            linear_ptq_config,
+            include_input_output_embeddings=bool(quantize_embedding),
+        )
 
 
 def _make_qat_config(

--- a/src/axolotl/utils/quantization.py
+++ b/src/axolotl/utils/quantization.py
@@ -222,6 +222,36 @@ def quantize_model(
         )
 
 
+def save_quantized_model(model, save_dir, **kwargs):
+    """Save a quantized model, handling MXTensor serialization.
+
+    MXTensor does not have a valid storage pointer, which causes
+    ``save_pretrained`` to crash (both in ``remove_tied_weights_from_state_dict``
+    via ``id_tensor_storage``, and in safetensors serialization).
+    Transformers >=5.5 removed the ``safe_serialization`` parameter entirely.
+
+    For MX-quantized models we save the config/generation_config via
+    ``save_pretrained`` machinery and the weights via ``torch.save``.
+    """
+    import os
+
+    is_mx = getattr(model, "_is_mx_quantized", False)
+    if not is_mx:
+        model.save_pretrained(save_dir, **kwargs)
+        return
+
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Save config, generation_config, etc.
+    model.config.save_pretrained(save_dir)
+    if hasattr(model, "generation_config") and model.generation_config is not None:
+        model.generation_config.save_pretrained(save_dir)
+
+    # Save weights via torch.save (supports __tensor_flatten__)
+    weights_path = os.path.join(save_dir, "pytorch_model.bin")
+    torch.save(model.state_dict(), weights_path)
+
+
 def _make_qat_config(
     base_config: AOBaseConfig,
     weight_dtype: TorchAOQuantDType,

--- a/src/axolotl/utils/quantization.py
+++ b/src/axolotl/utils/quantization.py
@@ -34,8 +34,6 @@ if version.parse(torch.__version__) >= version.parse("2.8.0"):
     except (ImportError, RuntimeError):
         pass
 
-    # int4 weight config imports will fail on machines with fbgemm-gpu installed
-    # without a CUDA runtime available so we do this safely
     try:
         from torchao.quantization.quant_api import Int4WeightOnlyConfig
 
@@ -123,14 +121,14 @@ def get_quantization_config(
         return NVFP4WeightOnlyConfig()
 
     if weight_dtype == TorchAOQuantDType.mxfp4:
+        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
+
         # MXFP4 uses block_size=32 by default (vs NVFP4's 16)
         block_size = group_size if group_size is not None else 32
         if block_size != 32:
             raise ValueError(
                 "MXFP4 quantization must use a block_size (group_size) of 32"
             )
-
-        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
 
         return MXDynamicActivationMXWeightConfig(
             activation_dtype=torch.float4_e2m1fn_x2,
@@ -143,26 +141,28 @@ def get_quantization_config(
     )
 
 
-def _attach_torchao_quantizer(
-    model, quantization_config, include_input_output_embeddings=False
-):
-    """Attach a TorchAoHfQuantizer to the model so save_pretrained uses
-    torchao's flatten_tensor_state_dict path, preserving quantized weights
-    (e.g. MXTensor qdata+scale) in the safetensors file.
+def _register_mx_state_dict_hook(model):
+    """Register a state_dict hook that dequantizes MXTensor subclasses for safe
+    serialization.
 
-    Without this, save_pretrained falls through to the default path which
-    calls safetensors storage_ptr() on tensor subclasses and crashes.
+    MXTensor (from torchao MX/MXFP4 quantization) doesn't expose a valid Python
+    storage, causing safetensors' storage_ptr() to fail during save_pretrained.
+    This hook converts MXTensor values to plain tensors via dequantize() so the
+    model can be saved normally and re-quantized at load time.
     """
-    from transformers import TorchAoConfig
-    from transformers.quantizers.quantizer_torchao import TorchAoHfQuantizer
 
-    ao_config = TorchAoConfig(
-        quant_type=quantization_config,
-        include_input_output_embeddings=include_input_output_embeddings,
-    )
-    model.config.quantization_config = ao_config
-    quantizer = TorchAoHfQuantizer(ao_config)
-    model.hf_quantizer = quantizer
+    def _dequantize_mx_tensors(module, state_dict, prefix, local_metadata):
+        try:
+            from torchao.prototype.mx_formats.mx_tensor import MXTensor
+        except ImportError:
+            return state_dict
+
+        for key in list(state_dict.keys()):
+            if isinstance(state_dict[key], MXTensor):
+                state_dict[key] = state_dict[key].dequantize()
+        return state_dict
+
+    model._register_state_dict_hook(_dequantize_mx_tensors)
 
 
 def quantize_model(
@@ -202,11 +202,8 @@ def quantize_model(
             filter_fn=lambda m, _: isinstance(m, torch.nn.Embedding),
         )
 
-    _attach_torchao_quantizer(
-        model,
-        linear_ptq_config,
-        include_input_output_embeddings=bool(quantize_embedding),
-    )
+    if weight_dtype == TorchAOQuantDType.mxfp4:
+        _register_mx_state_dict_hook(model)
 
 
 def _make_qat_config(

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -389,7 +389,7 @@ class TestMXQuantizeSaveLoad:
             assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
             assert v.dtype == torch.bfloat16
 
-        from safetensors.torch import save_file, load_file
+        from safetensors.torch import load_file, save_file
 
         save_path = str(tmp_path / "model.safetensors")
         save_file(sd, save_path)
@@ -431,7 +431,7 @@ class TestMXQuantizeSaveLoad:
         for k, v in sd.items():
             assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
 
-        from safetensors.torch import save_file, load_file
+        from safetensors.torch import load_file, save_file
 
         save_path = str(tmp_path / "model.safetensors")
         save_file(sd, save_path)
@@ -469,7 +469,7 @@ class TestMXQuantizeSaveLoad:
         for v in sd.values():
             assert not isinstance(v, MXTensor)
 
-        from safetensors.torch import save_file, load_file
+        from safetensors.torch import load_file, save_file
 
         save_path = str(tmp_path / "model.safetensors")
         save_file(sd, save_path)

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -362,6 +362,126 @@ class TestQuantization:
         assert isinstance(model.lm_head.weight, nn.Parameter)
 
 
+class TestMXQuantizeSaveLoad:
+    """Tests for MX format (mxfp4/mxfp8) quantize-save-load round-trip.
+
+    Uses small randomly initialized models on CPU so no specific GPU is required.
+    """
+
+    @require_torch_2_8_0
+    def test_mxfp4_quantize_save_load(self, tmp_path):
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+        from axolotl.utils.quantization import _register_mx_state_dict_hook
+
+        model = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.Linear(64, 32),
+        ).to(torch.bfloat16)
+        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
+
+        quantize_model(model, TorchAOQuantDType.mxfp4, 32)
+
+        for child in model.children():
+            if isinstance(child, nn.Linear):
+                assert isinstance(child.weight, MXTensor)
+
+        sd = model.state_dict()
+        for k, v in sd.items():
+            assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
+            assert v.dtype == torch.bfloat16
+
+        from safetensors.torch import save_file, load_file
+
+        save_path = str(tmp_path / "model.safetensors")
+        save_file(sd, save_path)
+
+        loaded = load_file(save_path)
+        for k, expected_shape in original_shapes.items():
+            assert k in loaded, f"Missing key {k}"
+            assert loaded[k].shape == expected_shape, (
+                f"{k}: shape mismatch {loaded[k].shape} vs {expected_shape}"
+            )
+
+    @require_torch_2_8_0
+    def test_mxfp8_quantize_save_load(self, tmp_path):
+        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+        from torchao.quantization import quantize_
+
+        from axolotl.utils.quantization import _register_mx_state_dict_hook
+
+        model = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.Linear(64, 32),
+        ).to(torch.bfloat16)
+        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
+
+        cfg = MXDynamicActivationMXWeightConfig(
+            activation_dtype=torch.float8_e4m3fn,
+            weight_dtype=torch.float8_e4m3fn,
+            block_size=32,
+        )
+        quantize_(model, cfg)
+
+        for child in model.children():
+            if isinstance(child, nn.Linear):
+                assert isinstance(child.weight, MXTensor)
+
+        _register_mx_state_dict_hook(model)
+        sd = model.state_dict()
+        for k, v in sd.items():
+            assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
+
+        from safetensors.torch import save_file, load_file
+
+        save_path = str(tmp_path / "model.safetensors")
+        save_file(sd, save_path)
+
+        loaded = load_file(save_path)
+        for k, expected_shape in original_shapes.items():
+            assert k in loaded, f"Missing key {k}"
+            assert loaded[k].shape == expected_shape, (
+                f"{k}: shape mismatch {loaded[k].shape} vs {expected_shape}"
+            )
+
+    @require_torch_2_8_0
+    def test_mxfp4_qat_then_ptq_save_load(self, tmp_path):
+        """Full QAT -> PTQ -> save -> load round-trip for mxfp4."""
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+        from torchao.prototype.qat import MXFakeQuantizedLinear
+
+        model = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.Linear(64, 32),
+        ).to(torch.bfloat16)
+        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
+
+        prepare_model_for_qat(model, TorchAOQuantDType.mxfp4, 32)
+        for child in model.children():
+            if isinstance(child, nn.Linear):
+                assert isinstance(child, MXFakeQuantizedLinear)
+
+        quantize_model(model, TorchAOQuantDType.mxfp4, 32)
+        for child in model.children():
+            if isinstance(child, nn.Linear):
+                assert isinstance(child.weight, MXTensor)
+
+        sd = model.state_dict()
+        for v in sd.values():
+            assert not isinstance(v, MXTensor)
+
+        from safetensors.torch import save_file, load_file
+
+        save_path = str(tmp_path / "model.safetensors")
+        save_file(sd, save_path)
+
+        loaded = load_file(save_path)
+        for k, expected_shape in original_shapes.items():
+            assert k in loaded, f"Missing key {k}"
+            assert loaded[k].shape == expected_shape
+
+
 class TestQuantizationCallback:
     """
     Test QATCallback

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -363,111 +363,117 @@ class TestQuantization:
 
 
 class TestMXQuantizeSaveLoad:
-    """Tests for MX format (mxfp4/mxfp8) quantize-save-load round-trip.
+    """Tests for MX format (mxfp4) quantize-save-load round-trip via save_pretrained.
 
-    Uses small randomly initialized models on CPU so no specific GPU is required.
+    Uses a tiny HF model built from config (no download) so tests exercise the
+    real save_pretrained / from_pretrained code path — the same one the CLI uses.
+    MX format models are saved with safe_serialization=False (torch.save) because
+    MXTensor does not yet support safetensors serialization.
     """
 
+    @staticmethod
+    def _make_tiny_model():
+        """Build a minimal HF causal-LM that can be quantized on CPU."""
+        from transformers import Qwen2Config
+
+        config = Qwen2Config(
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=256,
+            max_position_embeddings=64,
+            torch_dtype="bfloat16",
+        )
+        model = AutoModelForCausalLM.from_config(config).to(torch.bfloat16)
+        return model
+
     @require_torch_2_8_0
-    def test_mxfp4_quantize_save_load(self, tmp_path):
+    def test_mxfp4_quantize_save_pretrained(self, tmp_path):
+        """quantize_model(mxfp4) -> save_pretrained -> from_pretrained round-trip."""
         from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
-        model = nn.Sequential(
-            nn.Linear(64, 64),
-            nn.Linear(64, 32),
-        ).to(torch.bfloat16)
-        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
+        model = self._make_tiny_model()
+        original_keys = set(model.state_dict().keys())
 
         quantize_model(model, TorchAOQuantDType.mxfp4, 32)
 
-        for child in model.children():
-            if isinstance(child, nn.Linear):
-                assert isinstance(child.weight, MXTensor)
+        # Weights should be MXTensor after quantization
+        for module in model.modules():
+            if isinstance(module, nn.Linear):
+                assert isinstance(module.weight, MXTensor)
 
-        for v in model.state_dict().values():
-            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
+        # Model should be flagged for MX-style save
+        assert getattr(model, "_is_mx_quantized", False)
 
-        from safetensors.torch import load_file, save_model
+        # save_pretrained with safe_serialization=False (torch.save path)
+        save_dir = str(tmp_path / "mxfp4_model")
+        model.save_pretrained(save_dir, safe_serialization=False)
 
-        save_path = str(tmp_path / "model.safetensors")
-        save_model(model, save_path)
+        # Verify checkpoint files were written
+        import glob
 
-        loaded = load_file(save_path)
-        for k, expected_shape in original_shapes.items():
-            assert loaded[k].shape == expected_shape
+        assert glob.glob(f"{save_dir}/*.bin") or glob.glob(f"{save_dir}/**/*.bin")
 
-    @require_torch_2_8_0
-    def test_mxfp8_quantize_save_load(self, tmp_path):
-        from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
-        from torchao.prototype.mx_formats.mx_tensor import MXTensor
-        from torchao.quantization import quantize_
-
-        from axolotl.utils.quantization import _register_mx_state_dict_hook
-
-        model = nn.Sequential(
-            nn.Linear(64, 64),
-            nn.Linear(64, 32),
-        ).to(torch.bfloat16)
-        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
-
-        cfg = MXDynamicActivationMXWeightConfig(
-            activation_dtype=torch.float8_e4m3fn,
-            weight_dtype=torch.float8_e4m3fn,
-            block_size=32,
+        # from_pretrained should load without error
+        loaded = AutoModelForCausalLM.from_pretrained(
+            save_dir, torch_dtype=torch.bfloat16
         )
-        quantize_(model, cfg)
-
-        for child in model.children():
-            if isinstance(child, nn.Linear):
-                assert isinstance(child.weight, MXTensor)
-
-        _register_mx_state_dict_hook(model)
-        for v in model.state_dict().values():
-            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
-
-        from safetensors.torch import load_file, save_model
-
-        save_path = str(tmp_path / "model.safetensors")
-        save_model(model, save_path)
-
-        loaded = load_file(save_path)
-        for k, expected_shape in original_shapes.items():
-            assert loaded[k].shape == expected_shape
+        loaded_keys = set(loaded.state_dict().keys())
+        assert original_keys == loaded_keys, (
+            f"Key mismatch: missing={original_keys - loaded_keys}, "
+            f"extra={loaded_keys - original_keys}"
+        )
 
     @require_torch_2_8_0
-    def test_mxfp4_qat_then_ptq_save_load(self, tmp_path):
-        """Full QAT -> PTQ -> save -> load round-trip for mxfp4."""
+    def test_mxfp4_is_mx_flag_set(self):
+        """quantize_model sets _is_mx_quantized for MX configs."""
+        model = self._make_tiny_model()
+        quantize_model(model, TorchAOQuantDType.mxfp4, 32)
+        assert getattr(model, "_is_mx_quantized", False)
+
+    @require_torch_2_8_0
+    def test_non_mx_uses_torchao_quantizer(self):
+        """Non-MX quantization attaches TorchAoHfQuantizer, not _is_mx_quantized."""
+        model = self._make_tiny_model()
+        quantize_model(model, TorchAOQuantDType.int4, group_size=32)
+        assert not getattr(model, "_is_mx_quantized", False)
+        assert hasattr(model, "hf_quantizer")
+
+    @require_torch_2_8_0
+    def test_mxfp4_qat_then_ptq_save_pretrained(self, tmp_path):
+        """Full QAT -> convert -> PTQ -> save_pretrained -> from_pretrained."""
         from torchao.prototype.mx_formats.mx_tensor import MXTensor
         from torchao.prototype.qat import MXFakeQuantizedLinear
 
-        model = nn.Sequential(
-            nn.Linear(64, 64),
-            nn.Linear(64, 32),
-        ).to(torch.bfloat16)
-        original_shapes = {k: v.shape for k, v in model.state_dict().items()}
+        model = self._make_tiny_model()
+        original_keys = set(model.state_dict().keys())
 
+        # QAT preparation
         prepare_model_for_qat(model, TorchAOQuantDType.mxfp4, 32)
-        for child in model.children():
-            if isinstance(child, nn.Linear):
-                assert isinstance(child, MXFakeQuantizedLinear)
+        for module in model.modules():
+            if isinstance(module, nn.Linear):
+                assert isinstance(module, MXFakeQuantizedLinear)
 
+        # Convert QAT back to normal linear
         convert_qat_model(model)
+
+        # PTQ quantize
         quantize_model(model, TorchAOQuantDType.mxfp4, 32)
-        for child in model.children():
-            if isinstance(child, nn.Linear):
-                assert isinstance(child.weight, MXTensor)
+        for module in model.modules():
+            if isinstance(module, nn.Linear):
+                assert isinstance(module.weight, MXTensor)
 
-        for v in model.state_dict().values():
-            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
+        # save_pretrained round-trip
+        save_dir = str(tmp_path / "mxfp4_qat_model")
+        model.save_pretrained(save_dir, safe_serialization=False)
 
-        from safetensors.torch import load_file, save_model
-
-        save_path = str(tmp_path / "model.safetensors")
-        save_model(model, save_path)
-
-        loaded = load_file(save_path)
-        for k, expected_shape in original_shapes.items():
-            assert loaded[k].shape == expected_shape
+        loaded = AutoModelForCausalLM.from_pretrained(
+            save_dir, torch_dtype=torch.bfloat16
+        )
+        loaded_keys = set(loaded.state_dict().keys())
+        assert original_keys == loaded_keys
 
 
 class TestQuantizationCallback:

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -372,8 +372,6 @@ class TestMXQuantizeSaveLoad:
     def test_mxfp4_quantize_save_load(self, tmp_path):
         from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
-        from axolotl.utils.quantization import _register_mx_state_dict_hook
-
         model = nn.Sequential(
             nn.Linear(64, 64),
             nn.Linear(64, 32),

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -384,22 +384,17 @@ class TestMXQuantizeSaveLoad:
             if isinstance(child, nn.Linear):
                 assert isinstance(child.weight, MXTensor)
 
-        sd = model.state_dict()
-        for k, v in sd.items():
-            assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
-            assert v.dtype == torch.bfloat16
+        for v in model.state_dict().values():
+            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
 
-        from safetensors.torch import load_file, save_file
+        from safetensors.torch import load_file, save_model
 
         save_path = str(tmp_path / "model.safetensors")
-        save_file(sd, save_path)
+        save_model(model, save_path)
 
         loaded = load_file(save_path)
         for k, expected_shape in original_shapes.items():
-            assert k in loaded, f"Missing key {k}"
-            assert loaded[k].shape == expected_shape, (
-                f"{k}: shape mismatch {loaded[k].shape} vs {expected_shape}"
-            )
+            assert loaded[k].shape == expected_shape
 
     @require_torch_2_8_0
     def test_mxfp8_quantize_save_load(self, tmp_path):
@@ -427,21 +422,17 @@ class TestMXQuantizeSaveLoad:
                 assert isinstance(child.weight, MXTensor)
 
         _register_mx_state_dict_hook(model)
-        sd = model.state_dict()
-        for k, v in sd.items():
-            assert not isinstance(v, MXTensor), f"{k} should be dequantized by hook"
+        for v in model.state_dict().values():
+            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
 
-        from safetensors.torch import load_file, save_file
+        from safetensors.torch import load_file, save_model
 
         save_path = str(tmp_path / "model.safetensors")
-        save_file(sd, save_path)
+        save_model(model, save_path)
 
         loaded = load_file(save_path)
         for k, expected_shape in original_shapes.items():
-            assert k in loaded, f"Missing key {k}"
-            assert loaded[k].shape == expected_shape, (
-                f"{k}: shape mismatch {loaded[k].shape} vs {expected_shape}"
-            )
+            assert loaded[k].shape == expected_shape
 
     @require_torch_2_8_0
     def test_mxfp4_qat_then_ptq_save_load(self, tmp_path):
@@ -460,23 +451,22 @@ class TestMXQuantizeSaveLoad:
             if isinstance(child, nn.Linear):
                 assert isinstance(child, MXFakeQuantizedLinear)
 
+        convert_qat_model(model)
         quantize_model(model, TorchAOQuantDType.mxfp4, 32)
         for child in model.children():
             if isinstance(child, nn.Linear):
                 assert isinstance(child.weight, MXTensor)
 
-        sd = model.state_dict()
-        for v in sd.values():
-            assert not isinstance(v, MXTensor)
+        for v in model.state_dict().values():
+            assert not isinstance(v, MXTensor), "hook should dequantize all MXTensors"
 
-        from safetensors.torch import load_file, save_file
+        from safetensors.torch import load_file, save_model
 
         save_path = str(tmp_path / "model.safetensors")
-        save_file(sd, save_path)
+        save_model(model, save_path)
 
         loaded = load_file(save_path)
         for k, expected_shape in original_shapes.items():
-            assert k in loaded, f"Missing key {k}"
             assert loaded[k].shape == expected_shape
 
 

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -23,6 +23,7 @@ from axolotl.utils.quantization import (
     get_quantization_config,
     prepare_model_for_qat,
     quantize_model,
+    save_quantized_model,
 )
 from axolotl.utils.schemas.enums import TorchAOQuantDType
 from axolotl.utils.schemas.quantization import QATConfig
@@ -409,7 +410,7 @@ class TestMXQuantizeSaveLoad:
 
         # save_pretrained with safe_serialization=False (torch.save path)
         save_dir = str(tmp_path / "mxfp4_model")
-        model.save_pretrained(save_dir, safe_serialization=False)
+        save_quantized_model(model, save_dir)
 
         # Verify checkpoint files were written
         import glob
@@ -434,10 +435,14 @@ class TestMXQuantizeSaveLoad:
         assert getattr(model, "_is_mx_quantized", False)
 
     @require_torch_2_8_0
+    @requires_cuda_ge_8_9
     def test_non_mx_uses_torchao_quantizer(self):
         """Non-MX quantization attaches TorchAoHfQuantizer, not _is_mx_quantized."""
         model = self._make_tiny_model()
-        quantize_model(model, TorchAOQuantDType.int4, group_size=32)
+        try:
+            quantize_model(model, TorchAOQuantDType.int4, group_size=32)
+        except ImportError:
+            pytest.skip("int4 quantization requires mslk >= 1.0.0")
         assert not getattr(model, "_is_mx_quantized", False)
         assert hasattr(model, "hf_quantizer")
 
@@ -467,7 +472,7 @@ class TestMXQuantizeSaveLoad:
 
         # save_pretrained round-trip
         save_dir = str(tmp_path / "mxfp4_qat_model")
-        model.save_pretrained(save_dir, safe_serialization=False)
+        save_quantized_model(model, save_dir)
 
         loaded = AutoModelForCausalLM.from_pretrained(
             save_dir, torch_dtype=torch.bfloat16


### PR DESCRIPTION
#3539 

PR #3553  switched to MXDynamicActivationMXWeightConfig for PTQ added _attach_torchao_quantizer() for saving. 

However, _attach_torchao_quantizer sets up TorchAoHfQuantizer, which calls flatten_tensor_state_dict() during save — and that function doesn't support MXTensor, giving `ValueError: Unsupported tensor type: <class 'torchao.prototype.mx_formats.mx_tensor.MXTensor'>.`

tested with scripts present in issue 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when saving quantized models with automatic fallback recovery.

* **Improvements**
  * Improved MX format quantization configuration and serialization support.
  * Updated quantization-aware training configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->