### PR TITLE
use vllm 0.19.0 for torch 2.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def parse_requirements(extras_require_map):
                 ]
                 if not install_xformers:
                     _install_requires.pop(_install_requires.index(xformers_version))
-                extras_require_map["vllm"] = ["vllm>=0.17.1"]
+                extras_require_map["vllm"] = ["vllm>=0.19.0"]
             elif (major, minor) >= (2, 9):
                 extras_require_map.pop("fbgemm-gpu")
                 extras_require_map["fbgemm-gpu"] = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vllm dependency to require version 0.19.0 or later for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->