### PR TITLE
Add uninstall command to cut_cross_entropy import message

### DIFF
--- a/src/axolotl/integrations/cut_cross_entropy/__init__.py
+++ b/src/axolotl/integrations/cut_cross_entropy/__init__.py
@@ -35,7 +35,7 @@ LOG = get_logger(__name__)
 
 _CCE_INSTALL_MESSAGE = (
     "Please install Axolotl's fork of cut_cross_entropy with transformers support using "
-    '`pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@fec1a88"`'
+    '`pip uninstall -y cut-cross-entropy && pip install "cut-cross-entropy[transformers] @ git+https://github.com/axolotl-ai-cloud/ml-cross-entropy.git@fec1a88"`'
 )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Adds the uninstall command to the `cut_cross_entropy` import/install message.

## Motivation and Context

I was following the error message's install instructions, and it was not installing a newer version. I think it would be helpful to update this message with the uninstall part. See https://github.com/axolotl-ai-cloud/axolotl/issues/3530#issuecomment-4183971476

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Has not been tested.

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation instructions to provide clearer guidance for dependency setup and reinstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->