### PR TITLE
fix: rename model to adapter_model for fsdp sharded final model

### DIFF
--- a/src/axolotl/cli/merge_sharded_fsdp_weights.py
+++ b/src/axolotl/cli/merge_sharded_fsdp_weights.py
@@ -38,7 +38,7 @@ class BFloat16CastPlanner(_EmptyStateDictLoadPlanner):
 def _distributed_checkpoint_to_merged_weights(
     checkpoint_dir: Union[str, Path],
     save_path: str,
-    max_shard_size: str = "50GB",
+    max_shard_size: str = "5GB",
 ) -> Path:
     """
     Passthrough to `torch.distributed.checkpoint.format_utils.dcp_to_torch_save`. Will

--- a/src/axolotl/cli/merge_sharded_fsdp_weights.py
+++ b/src/axolotl/cli/merge_sharded_fsdp_weights.py
@@ -38,7 +38,7 @@ class BFloat16CastPlanner(_EmptyStateDictLoadPlanner):
 def _distributed_checkpoint_to_merged_weights(
     checkpoint_dir: Union[str, Path],
     save_path: str,
-    max_shard_size: str = "5GB",
+    max_shard_size: str = "50GB",
 ) -> Path:
     """
     Passthrough to `torch.distributed.checkpoint.format_utils.dcp_to_torch_save`. Will

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -231,9 +231,7 @@ def _rename_fsdp_merged_to_adapter(merged_dir: Path):
     Also rewrites the index JSON weight_map if sharded output was produced.
     """
     for file in sorted(merged_dir.iterdir()):
-        if file.name.startswith("model") and file.name != file.name.replace(
-            "model", "adapter_model", 1
-        ):
+        if file.name.startswith("model") and ".safetensors" in file.name:
             file.rename(merged_dir / file.name.replace("model", "adapter_model", 1))
 
     index = merged_dir / "adapter_model.safetensors.index.json"

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -294,11 +294,17 @@ def save_trained_model(
                 )
                 trainer.accelerator.wait_for_everyone()
                 if trainer.accelerator.is_main_process:
-                    # move all files in merged_path to cfg.output_dir
+                    is_peft = cfg.adapter and not cfg.relora
                     for merged_file in Path(merged_path).iterdir():
-                        if (Path(cfg.output_dir) / merged_file.name).exists():
-                            (Path(cfg.output_dir) / merged_file.name).unlink()
-                        shutil.move(str(merged_file), cfg.output_dir)
+                        dest_name = merged_file.name
+                        if is_peft:
+                            # Rename merged adapter
+                            dest_name = dest_name.replace(
+                                "model.safetensors", "adapter_model.safetensors"
+                            )
+                        if (Path(cfg.output_dir) / dest_name).exists():
+                            (Path(cfg.output_dir) / dest_name).unlink()
+                        shutil.move(str(merged_file), Path(cfg.output_dir) / dest_name)
                     shutil.rmtree(merged_path)  # remove what should be an empty dir
         # TODO(wing):see https://github.com/huggingface/transformers/pull/40207
         # cleanup the FSDP prefix in the model config.json

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -225,6 +225,30 @@ def execute_training(
         PLUGIN_MANAGER.post_train(cfg, trainer.model)
 
 
+def _rename_fsdp_merged_to_adapter(merged_dir: Path):
+    """Rename model*.safetensors files to adapter_model* in place.
+
+    Also rewrites the index JSON weight_map if sharded output was produced.
+    """
+    for file in sorted(merged_dir.iterdir()):
+        if file.name.startswith("model") and file.name != file.name.replace(
+            "model", "adapter_model", 1
+        ):
+            file.rename(merged_dir / file.name.replace("model", "adapter_model", 1))
+
+    index = merged_dir / "adapter_model.safetensors.index.json"
+    if index.exists():
+        data = json.loads(index.read_text(encoding="utf-8"))
+        if "weight_map" in data:
+            data["weight_map"] = {
+                k: v.replace("model", "adapter_model", 1)
+                for k, v in data["weight_map"].items()
+            }
+        index.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+
 def save_trained_model(
     cfg: DictDefault,
     trainer: Any,
@@ -294,18 +318,17 @@ def save_trained_model(
                 )
                 trainer.accelerator.wait_for_everyone()
                 if trainer.accelerator.is_main_process:
+                    # FSDP checkpoints for PEFT only contain adapter weights;
+                    # rename model* → adapter_model* so it loads correctly.
                     is_peft = cfg.adapter and not cfg.relora
+                    if is_peft:
+                        _rename_fsdp_merged_to_adapter(Path(merged_path))
                     for merged_file in Path(merged_path).iterdir():
-                        dest_name = merged_file.name
-                        if is_peft:
-                            # Rename merged adapter
-                            dest_name = dest_name.replace(
-                                "model.safetensors", "adapter_model.safetensors"
-                            )
-                        if (Path(cfg.output_dir) / dest_name).exists():
-                            (Path(cfg.output_dir) / dest_name).unlink()
-                        shutil.move(str(merged_file), Path(cfg.output_dir) / dest_name)
-                    shutil.rmtree(merged_path)  # remove what should be an empty dir
+                        dest = Path(cfg.output_dir) / merged_file.name
+                        if dest.exists():
+                            dest.unlink()
+                        shutil.move(str(merged_file), dest)
+                    shutil.rmtree(merged_path)
         # TODO(wing):see https://github.com/huggingface/transformers/pull/40207
         # cleanup the FSDP prefix in the model config.json
         if trainer.accelerator.is_main_process:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

We have folks reporting final model when training adapter fsdp named as `model.safetensors`. They found that a simple rename is all that's needed to fix the naming inconsistency. This PR adds a simple check and rename if this occurs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model file naming during model saving. When using adapter-based training, output files are now properly renamed to accurately reflect their configuration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->