### PR TITLE
feat: add FineGrainedFP8Config support for model quantization

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -547,6 +547,16 @@ class ModelLoader:
                 mxfp4_kwargs = self.cfg.model_quantization_config_kwargs
             self.model_kwargs["quantization_config"] = Mxfp4Config(**mxfp4_kwargs)
 
+        if self.cfg.model_quantization_config == "FineGrainedFP8Config":
+            from transformers import FineGrainedFP8Config
+
+            fp8_kwargs = {}
+            if self.cfg.model_quantization_config_kwargs:
+                fp8_kwargs = self.cfg.model_quantization_config_kwargs
+            self.model_kwargs["quantization_config"] = FineGrainedFP8Config(
+                **fp8_kwargs
+            )
+
         if self.cfg.gptq:
             if not hasattr(self.model_config, "quantization_config"):
                 LOG.warning(

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -87,9 +87,11 @@ class ModelInputConfig(BaseModel):
         json_schema_extra={"description": "Use custom kernels, e.g. MegaBlocks."},
     )
 
-    model_quantization_config: Literal["Mxfp4Config"] | None = Field(
-        default=None,
-        json_schema_extra={"description": "Model loading quantization config"},
+    model_quantization_config: Literal["Mxfp4Config", "FineGrainedFP8Config"] | None = (
+        Field(
+            default=None,
+            json_schema_extra={"description": "Model loading quantization config"},
+        )
     )
     model_quantization_config_kwargs: dict[str, Any] | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

Adds `FineGrainedFP8Config` as a supported `model_quantization_config` option, enabling loading of FP8-quantized models (e.g., `Mistral-Small-4-119B-2603`) with optional kwargs like `dequantize=True` for full fine-tuning. Training might still not work even though loading does.

## Changes

- **`src/axolotl/utils/schemas/model.py`**: Added `"FineGrainedFP8Config"` to the `model_quantization_config` Literal type
- **`src/axolotl/loaders/model.py`**: Added handling for `FineGrainedFP8Config` in `_set_quantization_config()`, following the same pattern as `Mxfp4Config`

## Usage

```yaml
base_model: mistralai/Mistral-Small-4-119B-2603
model_quantization_config: FineGrainedFP8Config
model_quantization_config_kwargs:
  dequantize: true  # optional: dequantize to bf16 for FFT
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fine-Grained FP8 quantization as a model configuration option. Users can now leverage expanded quantization choices to optimize model performance for different workloads. The implementation includes support for customizable parameters, giving users fine-grained control over quantization settings and behavior for improved results across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->