### PR TITLE
qwen3_5.jinja: handle list content on system messages

### DIFF
--- a/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
+++ b/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
@@ -1,7 +1,14 @@
 {%- if tools %}
     {{- '<|im_start|>system\n' }}
     {%- if messages[0].role == 'system' %}
-        {{- messages[0].content + '\n\n' }}
+        {%- if messages[0].content is string %}
+            {{- messages[0].content + '\n\n' }}
+        {%- else %}
+            {%- for part in messages[0].content %}
+                {%- if 'text' in part %}{{- part['text'] }}{%- endif %}
+            {%- endfor %}
+            {{- '\n\n' }}
+        {%- endif %}
     {%- endif %}
     {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
     {%- for tool in tools %}
@@ -11,7 +18,15 @@
     {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
 {%- else %}
     {%- if messages[0].role == 'system' %}
-        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+        {%- if messages[0].content is string %}
+            {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+        {%- else %}
+            {{- '<|im_start|>system\n' }}
+            {%- for part in messages[0].content %}
+                {%- if 'text' in part %}{{- part['text'] }}{%- endif %}
+            {%- endfor %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
     {%- endif %}
 {%- endif %}
 {%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}

--- a/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
+++ b/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
@@ -5,7 +5,12 @@
             {{- messages[0].content + '\n\n' }}
         {%- else %}
             {%- for part in messages[0].content %}
-                {%- if 'text' in part %}{{- part['text'] }}{%- endif %}
+                {%- if part is mapping %}
+                    {%- set system_text = part.get('text') or part.get('content') or part.get('value') %}
+                    {%- if system_text %}{{- system_text }}{%- endif %}
+                {%- elif part is string %}
+                    {{- part }}
+                {%- endif %}
             {%- endfor %}
             {{- '\n\n' }}
         {%- endif %}
@@ -23,7 +28,12 @@
         {%- else %}
             {{- '<|im_start|>system\n' }}
             {%- for part in messages[0].content %}
-                {%- if 'text' in part %}{{- part['text'] }}{%- endif %}
+                {%- if part is mapping %}
+                    {%- set system_text = part.get('text') or part.get('content') or part.get('value') %}
+                    {%- if system_text %}{{- system_text }}{%- endif %}
+                {%- elif part is string %}
+                    {{- part }}
+                {%- endif %}
             {%- endfor %}
             {{- '<|im_end|>\n' }}
         {%- endif %}


### PR DESCRIPTION
The system message branch in `qwen3_5.jinja` used string concatenation on `messages[0].content`, which breaks when the first system message uses the OpenAI-style list-of-parts format that multimodal datasets produce. The user and assistant branches already handle both string and list content, but the system branch did not.

This patch adds the same `is string` / iterate-parts pattern to both system message paths (tool and no-tool branches).

Fixes #3590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system message handling in chat templates to support both plain text and structured message formats, ensuring more robust message processing across different input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->