### PR TITLE
feat: migrate gc_steps to native torch_empty_cache_steps

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -122,8 +122,11 @@ class TrainerBuilderBase(abc.ABC):
         if self.cfg.resume_from_checkpoint:
             callbacks.append(SkipEvalOnResumeCallback())
 
-        if self.cfg.gc_steps:
-            callbacks.append(GCCallback(gc_steps=self.cfg.gc_steps))
+        gc_collect_steps = getattr(self.cfg, "gc_collect_steps", None) or getattr(
+            self.cfg, "gc_steps", None
+        )
+        if gc_collect_steps:
+            callbacks.append(GCCallback(gc_collect_steps=gc_collect_steps))
 
         if self.cfg.dynamic_checkpoint and self.cfg.dynamic_checkpoint.enabled:
             from axolotl.utils.callbacks.dynamic_checkpoint import (
@@ -573,6 +576,8 @@ class TrainerBuilderBase(abc.ABC):
             "dion_rank_fraction",
             "dion_rank_multiple_of",
             "dataset_num_proc",
+            # memory management
+            "torch_empty_cache_steps",
         ]:
             if hasattr(self.cfg, arg) and getattr(self.cfg, arg) is not None:
                 training_args_kwargs[arg] = getattr(self.cfg, arg)

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -930,8 +930,7 @@ class GCCallback(TrainerCallback):
             # also GC on the start of the next step after the eval
             self.next_gc_on_begin_step = state.global_step + 1
         elif (
-            self.gc_collect_steps > 0
-            and state.global_step % self.gc_collect_steps == 0
+            self.gc_collect_steps > 0 and state.global_step % self.gc_collect_steps == 0
         ):
             self._gc()
         elif (

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -878,15 +878,25 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
 
 
 class GCCallback(TrainerCallback):
-    """Callback to garbage collect torch cache"""
+    """Callback to run Python garbage collection during training.
 
-    def __init__(self, gc_steps: int | None = -1):
-        self.gc_steps: int = gc_steps or -1
+    This handles gc.collect() calls which reclaim Python-level memory. CUDA cache
+    clearing is handled natively by the Trainer via torch_empty_cache_steps in
+    TrainingArguments, so this callback focuses solely on Python GC.
+
+    Note: gc.collect() is still valuable because it can free Python objects that
+    hold references to GPU tensors, allowing those tensors to be reclaimed.
+    """
+
+    def __init__(self, gc_collect_steps: int | None = -1, gc_steps: int | None = None):
+        if gc_steps is not None and gc_collect_steps in (-1, None):
+            gc_collect_steps = gc_steps
+        self.gc_collect_steps: int = gc_collect_steps or -1
         self.next_gc_on_begin_step: int = -1
 
     def _gc(self):
-        torch.cuda.empty_cache()
         gc.collect()
+        torch.cuda.empty_cache()
 
     def on_train_begin(
         self,
@@ -919,7 +929,10 @@ class GCCallback(TrainerCallback):
             self._gc()
             # also GC on the start of the next step after the eval
             self.next_gc_on_begin_step = state.global_step + 1
-        elif self.gc_steps > 0 and state.global_step % self.gc_steps == 0:
+        elif (
+            self.gc_collect_steps > 0
+            and state.global_step % self.gc_collect_steps == 0
+        ):
             self._gc()
         elif (
             args.save_strategy == SaveStrategy.STEPS

--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -878,14 +878,10 @@ class SaveAxolotlConfigtoWandBCallback(TrainerCallback):
 
 
 class GCCallback(TrainerCallback):
-    """Callback to run Python garbage collection during training.
-
-    This handles gc.collect() calls which reclaim Python-level memory. CUDA cache
-    clearing is handled natively by the Trainer via torch_empty_cache_steps in
-    TrainingArguments, so this callback focuses solely on Python GC.
-
-    Note: gc.collect() is still valuable because it can free Python objects that
-    hold references to GPU tensors, allowing those tensors to be reclaimed.
+    """Runs ``gc.collect()`` + ``torch.cuda.empty_cache()`` on
+    ``gc_collect_steps`` intervals and on eval/save/epoch boundaries that
+    the Trainer's native ``torch_empty_cache_steps`` doesn't cover. The two
+    settings are complementary; overlapping intervals just double-clear.
     """
 
     def __init__(self, gc_collect_steps: int | None = -1, gc_steps: int | None = None):

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -507,8 +507,35 @@ class AxolotlInputConfig(
 
     gc_steps: int | None = Field(
         default=None,
+        deprecated=(
+            "Use `torch_empty_cache_steps` to control CUDA cache clearing and "
+            "`gc_collect_steps` for Python garbage collection. "
+            "`gc_steps` will be removed in a future version."
+        ),
         json_schema_extra={
-            "description": "Run garbage collection every `gc_steps` steps. -1 will run on epoch end and before evaluations. Default is 0 (disabled)."
+            "description": "Deprecated. Run garbage collection every `gc_steps` steps. Use `torch_empty_cache_steps` and `gc_collect_steps` instead."
+        },
+    )
+    torch_empty_cache_steps: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Number of steps between calls to `torch.cuda.empty_cache()`, "
+                "handled natively by the HuggingFace Trainer. "
+                "This helps manage GPU memory fragmentation during training."
+            )
+        },
+    )
+    gc_collect_steps: int | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Number of steps between Python `gc.collect()` calls. "
+                "-1 will run on epoch end and before evaluations only. "
+                "Default is 0 (disabled). "
+                "This is separate from `torch_empty_cache_steps` as `gc.collect()` "
+                "reclaims Python-level memory which the native Trainer cache clearing does not do."
+            )
         },
     )
 
@@ -1774,6 +1801,34 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
             del data["dataset_processes"]
         elif data.get("dataset_num_proc") is None:
             data["dataset_num_proc"] = get_default_process_count()
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_gc_steps(cls, data):
+        gc_steps = data.get("gc_steps")
+        if gc_steps is not None:
+            if (
+                data.get("torch_empty_cache_steps") is None
+                and data.get("gc_collect_steps") is None
+            ):
+                # Map gc_steps to both new options to preserve original behavior
+                if gc_steps > 0:
+                    data["torch_empty_cache_steps"] = gc_steps
+                data["gc_collect_steps"] = gc_steps
+                LOG.warning(
+                    "`gc_steps` is deprecated. Use `torch_empty_cache_steps` for "
+                    "CUDA cache clearing (handled natively by Trainer) and "
+                    "`gc_collect_steps` for Python garbage collection. "
+                    "Automatically mapping gc_steps=%d to both options.",
+                    gc_steps,
+                )
+            else:
+                LOG.warning(
+                    "`gc_steps` is set alongside `torch_empty_cache_steps` or "
+                    "`gc_collect_steps`. The new options take precedence; "
+                    "`gc_steps` is ignored."
+                )
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -532,7 +532,7 @@ class AxolotlInputConfig(
             "description": (
                 "Number of steps between Python `gc.collect()` calls. "
                 "-1 will run on epoch end and before evaluations only. "
-                "Default is 0 (disabled). "
+                "None means disabled (no periodic Python GC). "
                 "This is separate from `torch_empty_cache_steps` as `gc.collect()` "
                 "reclaims Python-level memory which the native Trainer cache clearing does not do."
             )

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -519,23 +519,13 @@ class AxolotlInputConfig(
     torch_empty_cache_steps: int | None = Field(
         default=None,
         json_schema_extra={
-            "description": (
-                "Number of steps between calls to `torch.cuda.empty_cache()`, "
-                "handled natively by the HuggingFace Trainer. "
-                "This helps manage GPU memory fragmentation during training."
-            )
+            "description": "Steps between native HF Trainer `torch.cuda.empty_cache()` calls."
         },
     )
     gc_collect_steps: int | None = Field(
         default=None,
         json_schema_extra={
-            "description": (
-                "Number of steps between Python `gc.collect()` calls. "
-                "-1 will run on epoch end and before evaluations only. "
-                "None means disabled (no periodic Python GC). "
-                "This is separate from `torch_empty_cache_steps` as `gc.collect()` "
-                "reclaims Python-level memory which the native Trainer cache clearing does not do."
-            )
+            "description": "Steps between Python `gc.collect()` calls. -1 runs on epoch end and before evals only; None disables."
         },
     )
 
@@ -1817,17 +1807,14 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                     data["torch_empty_cache_steps"] = gc_steps
                 data["gc_collect_steps"] = gc_steps
                 LOG.warning(
-                    "`gc_steps` is deprecated. Use `torch_empty_cache_steps` for "
-                    "CUDA cache clearing (handled natively by Trainer) and "
-                    "`gc_collect_steps` for Python garbage collection. "
-                    "Automatically mapping gc_steps=%d to both options.",
+                    "`gc_steps` is deprecated; mapping gc_steps=%d to "
+                    "`torch_empty_cache_steps` and `gc_collect_steps`.",
                     gc_steps,
                 )
             else:
                 LOG.warning(
-                    "`gc_steps` is set alongside `torch_empty_cache_steps` or "
-                    "`gc_collect_steps`. The new options take precedence; "
-                    "`gc_steps` is ignored."
+                    "`gc_steps` ignored; `torch_empty_cache_steps` / "
+                    "`gc_collect_steps` take precedence."
                 )
         return data
 

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -1762,9 +1762,7 @@ class TestGCStepsMigration(BaseValidation):
         assert new_cfg.gc_collect_steps == -1
 
     def test_new_options_take_precedence(self, minimal_cfg):
-        cfg = DictDefault(
-            {**minimal_cfg, "gc_steps": 10, "torch_empty_cache_steps": 5}
-        )
+        cfg = DictDefault({**minimal_cfg, "gc_steps": 10, "torch_empty_cache_steps": 5})
 
         new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
 

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -1768,7 +1768,9 @@ class TestGCStepsMigration(BaseValidation):
 
         new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
 
+        # New options take precedence; gc_steps migration is skipped
         assert new_cfg.torch_empty_cache_steps == 5
+        assert new_cfg.gc_collect_steps is None
 
     def test_torch_empty_cache_steps_standalone(self, minimal_cfg):
         cfg = DictDefault({**minimal_cfg, "torch_empty_cache_steps": 8})

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -1738,6 +1738,55 @@ class TestDataloaderValidation(BaseValidation):
         assert new_cfg.dataloader_prefetch_factor == 256
 
 
+class TestGCStepsMigration(BaseValidation):
+    """
+    Tests for gc_steps -> torch_empty_cache_steps / gc_collect_steps migration
+    """
+
+    def test_gc_steps_maps_to_new_options(self, minimal_cfg):
+        cfg = DictDefault({**minimal_cfg, "gc_steps": 10})
+
+        new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
+
+        assert new_cfg.torch_empty_cache_steps == 10
+        assert new_cfg.gc_collect_steps == 10
+
+    def test_gc_steps_negative_maps_gc_collect_only(self, minimal_cfg):
+        cfg = DictDefault({**minimal_cfg, "gc_steps": -1})
+
+        new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
+
+        # -1 means only epoch end/eval GC, not periodic; torch_empty_cache_steps
+        # should not be set for negative values
+        assert new_cfg.torch_empty_cache_steps is None
+        assert new_cfg.gc_collect_steps == -1
+
+    def test_new_options_take_precedence(self, minimal_cfg):
+        cfg = DictDefault(
+            {**minimal_cfg, "gc_steps": 10, "torch_empty_cache_steps": 5}
+        )
+
+        new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
+
+        assert new_cfg.torch_empty_cache_steps == 5
+
+    def test_torch_empty_cache_steps_standalone(self, minimal_cfg):
+        cfg = DictDefault({**minimal_cfg, "torch_empty_cache_steps": 8})
+
+        new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
+
+        assert new_cfg.torch_empty_cache_steps == 8
+        assert new_cfg.gc_collect_steps is None
+
+    def test_gc_collect_steps_standalone(self, minimal_cfg):
+        cfg = DictDefault({**minimal_cfg, "gc_collect_steps": 5})
+
+        new_cfg = validate_config(cfg, {"n_gpu": 1}, {"torch_version": "2.6.0"})
+
+        assert new_cfg.gc_collect_steps == 5
+        assert new_cfg.torch_empty_cache_steps is None
+
+
 class TestSyntheticDatasetValidation(BaseValidation):
     """
     Tests for synthetic dataset config validation

--- a/tests/utils/callbacks/test_gc_callback.py
+++ b/tests/utils/callbacks/test_gc_callback.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from axolotl.utils.callbacks import GCCallback
 
 

--- a/tests/utils/callbacks/test_gc_callback.py
+++ b/tests/utils/callbacks/test_gc_callback.py
@@ -1,0 +1,92 @@
+"""Tests for the GCCallback"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from axolotl.utils.callbacks import GCCallback
+
+
+class TestGCCallback:
+    """Tests for GCCallback which handles Python gc.collect() during training."""
+
+    def test_init_with_gc_collect_steps(self):
+        cb = GCCallback(gc_collect_steps=10)
+        assert cb.gc_collect_steps == 10
+
+    def test_init_with_negative_gc_collect_steps(self):
+        cb = GCCallback(gc_collect_steps=-1)
+        assert cb.gc_collect_steps == -1
+
+    def test_init_with_legacy_gc_steps(self):
+        cb = GCCallback(gc_steps=5)
+        assert cb.gc_collect_steps == 5
+
+    def test_init_gc_collect_steps_overrides_gc_steps(self):
+        cb = GCCallback(gc_collect_steps=10, gc_steps=5)
+        assert cb.gc_collect_steps == 10
+
+    def test_init_default(self):
+        cb = GCCallback()
+        assert cb.gc_collect_steps == -1
+
+    @patch("axolotl.utils.callbacks.gc.collect")
+    @patch("axolotl.utils.callbacks.torch.cuda.empty_cache")
+    def test_gc_calls_collect_and_empty_cache(self, mock_empty_cache, mock_gc_collect):
+        cb = GCCallback(gc_collect_steps=1)
+        cb._gc()
+        mock_gc_collect.assert_called_once()
+        mock_empty_cache.assert_called_once()
+
+    @patch("axolotl.utils.callbacks.gc.collect")
+    @patch("axolotl.utils.callbacks.torch.cuda.empty_cache")
+    def test_on_step_end_periodic_gc(self, mock_empty_cache, mock_gc_collect):
+        cb = GCCallback(gc_collect_steps=5)
+        args = MagicMock()
+        args.save_strategy = "no"
+        state = MagicMock()
+        state.global_step = 10
+        state.save_steps = 0
+        state.max_steps = 100
+        control = MagicMock()
+        control.should_evaluate = False
+
+        cb.on_step_end(args, state, control)
+
+        # Step 10 % 5 == 0, so GC should have been called
+        mock_gc_collect.assert_called_once()
+
+    @patch("axolotl.utils.callbacks.gc.collect")
+    @patch("axolotl.utils.callbacks.torch.cuda.empty_cache")
+    def test_on_step_end_no_gc_when_not_on_interval(
+        self, mock_empty_cache, mock_gc_collect
+    ):
+        cb = GCCallback(gc_collect_steps=5)
+        args = MagicMock()
+        args.save_strategy = "no"
+        state = MagicMock()
+        state.global_step = 7
+        state.save_steps = 0
+        state.max_steps = 100
+        control = MagicMock()
+        control.should_evaluate = False
+
+        cb.on_step_end(args, state, control)
+
+        # Step 7 % 5 != 0, so GC should not have been called
+        mock_gc_collect.assert_not_called()
+
+    @patch("axolotl.utils.callbacks.gc.collect")
+    @patch("axolotl.utils.callbacks.torch.cuda.empty_cache")
+    def test_on_step_end_gc_before_eval(self, mock_empty_cache, mock_gc_collect):
+        cb = GCCallback(gc_collect_steps=-1)
+        args = MagicMock()
+        state = MagicMock()
+        state.global_step = 3
+        control = MagicMock()
+        control.should_evaluate = True
+
+        cb.on_step_end(args, state, control)
+
+        mock_gc_collect.assert_called_once()
+        assert cb.next_gc_on_begin_step == 4


### PR DESCRIPTION
# Description

Migrate the custom `gc_steps` implementation to leverage the native `torch_empty_cache_steps` parameter from HuggingFace `TrainingArguments`, as proposed in #2689.

**Summary of changes:**

1. **New `torch_empty_cache_steps` config option** — passed directly to `TrainingArguments`, letting the Trainer handle CUDA cache clearing natively. This is the standard mechanism in `transformers` for periodic `torch.cuda.empty_cache()` calls.

2. **New `gc_collect_steps` config option** — explicit control over Python `gc.collect()` frequency. This is kept separate because `transformers` Trainer does **not** call `gc.collect()`, which is still valuable for freeing Python objects that hold GPU tensor references.

3. **Deprecate `gc_steps`** with automatic backward-compatible migration:
   - Positive `gc_steps` values map to **both** `torch_empty_cache_steps` and `gc_collect_steps`
   - Negative values (`-1`) map only to `gc_collect_steps` (epoch-end/eval GC behavior)
   - When new options are explicitly set alongside `gc_steps`, the new options take precedence

4. **Refactor `GCCallback`** to use the `gc_collect_steps` parameter name and reorder operations (`gc.collect()` before `empty_cache()` for better memory reclamation — collecting Python garbage first makes the subsequent cache clear more effective).

## Motivation and Context

As noted in #2689, `transformers` added `torch_empty_cache_steps` as a native `TrainingArguments` parameter. Axolotl's `gc_steps` predates this and bundles two distinct concerns: CUDA cache clearing and Python garbage collection. This PR separates the concerns, letting the native Trainer handle CUDA cache management while keeping Python GC as an Axolotl-specific feature.

Users who currently use `gc_steps` will see a deprecation warning but their config will continue to work without changes.

## How has this been tested?

- Added unit tests for config migration (`TestGCStepsMigration` in `tests/patched/test_validation.py`)
- Added unit tests for `GCCallback` refactoring (`tests/utils/callbacks/test_gc_callback.py`)
- Verified syntax correctness of all modified files

## Breaking Changes

None. `gc_steps` continues to work via automatic migration. The deprecation warning guides users to the new config options.

Closes #2689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added granular garbage collection configuration options: `gc_collect_steps` for Python garbage collection and `torch_empty_cache_steps` for CUDA memory management, enabling more precise control over memory optimization.

* **Chores**
  * Deprecated legacy garbage collection setting; existing configurations automatically migrate to new options while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->