### PR TITLE
Feat: add support for datasets with `str` saved `messages` field

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1004,6 +1004,11 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         if tools is None:
             return None
 
+
+        # Some datasets have tools set to str
+        if isinstance(tools, str):
+            tools = json.loads(tools)
+
         if isinstance(tools, list):
             # Process each tool to handle JSON string parameters
             for tool in tools:

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1004,7 +1004,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         if tools is None:
             return None
 
-
         # Some datasets have tools set to str
         if isinstance(tools, str):
             tools = json.loads(tools)
@@ -1041,11 +1040,15 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         if isinstance(messages, str):
             messages = json.loads(messages)
-            assert isinstance(messages, list), f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"
+            assert isinstance(messages, list), (
+                f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"
+            )
 
             # Extra check here to make sure decoded json is a list of dicts.
             for i, message in enumerate(messages):
-                assert isinstance(message, dict), f"For SFT datasets that are stored in `str` format, each turns must be saved in a dictionary, got {type(message)} for the turn {i}"
+                assert isinstance(message, dict), (
+                    f"For SFT datasets that are stored in `str` format, each turns must be saved in a dictionary, got {type(message)} for the turn {i}"
+                )
 
         if isinstance(messages, list):
             return messages

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1006,8 +1006,14 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         # Some datasets have tools set to str
         if isinstance(tools, str):
-            tools = json.loads(tools)
-
+            try:
+                tools = json.loads(tools)
+            except json.JSONDecodeError as e:
+                LOG.error(
+                    f"Error parsing tool parameters as JSON. "
+                    f"Error: {e}"
+                )
+                raise
         if isinstance(tools, list):
             # Process each tool to handle JSON string parameters
             for tool in tools:
@@ -1039,7 +1045,14 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             raise ValueError("Messages is null. Please check `field_messages`.")
 
         if isinstance(messages, str):
-            messages = json.loads(messages)
+            try:
+                messages = json.loads(messages)
+            except json.JSONDecodeError as e:
+                LOG.error(
+                    f"Error parsing messages as JSON. "
+                    f"Error: {e}"
+                )
+                raise
             assert isinstance(messages, list), (
                 f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"
             )

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1009,10 +1009,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             try:
                 tools = json.loads(tools)
             except json.JSONDecodeError as e:
-                LOG.error(
-                    f"Error parsing tool parameters as JSON. "
-                    f"Error: {e}"
-                )
+                LOG.error(f"Error parsing tool parameters as JSON. Error: {e}")
                 raise
         if isinstance(tools, list):
             # Process each tool to handle JSON string parameters
@@ -1048,10 +1045,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             try:
                 messages = json.loads(messages)
             except json.JSONDecodeError as e:
-                LOG.error(
-                    f"Error parsing messages as JSON. "
-                    f"Error: {e}"
-                )
+                LOG.error(f"Error parsing messages as JSON. Error: {e}")
                 raise
             assert isinstance(messages, list), (
                 f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -394,8 +394,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
     def is_prompt_batched(self, prompt: dict[str, Any]) -> bool:
         try:
-            return all(isinstance(v, list) for v in prompt.values()) and all(
-                isinstance(v, list) for v in prompt[self.prompter.field_messages]
+            return all(isinstance(v, (str, list)) for v in prompt.values()) and all(
+                isinstance(v, (str, list)) for v in prompt[self.prompter.field_messages]
             )
         except KeyError:
             return False
@@ -1033,6 +1033,14 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         messages = prompt.get(self.prompter.field_messages, None)
         if messages is None:
             raise ValueError("Messages is null. Please check `field_messages`.")
+
+        if isinstance(messages, str):
+            messages = json.loads(messages)
+            assert isinstance(messages, list), f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"
+
+            # Extra check here to make sure decoded json is a list of dicts.
+            for i, message in enumerate(messages):
+                assert isinstance(message, dict), f"For SFT datasets that are stored in `str` format, each turns must be saved in a dictionary, got {type(message)} for the turn {i}"
 
         if isinstance(messages, list):
             return messages

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -487,3 +487,63 @@ class TestDatasetPreparation:
             assert "attention_mask" in dataset.features
             assert "labels" in dataset.features
             shutil.rmtree(tmp_ds_path)
+
+    @enable_hf_offline
+    def test_load_dataset_with_str_json_data(self, tokenizer):
+        """
+        Test loading datasets where data is stored as str JSON instead of list of dicts.
+        see: https://github.com/axolotl-ai-cloud/axolotl/pull/3607 for more details.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            import json
+            
+            str_json_ds = Dataset.from_list(
+                [
+                    {
+                        "messages": json.dumps([
+                            {"role": "user", "content": "Hello how are you?"},
+                            {"role": "assistant", "content": "I am doing good thanks"}
+                        ])
+                    },
+                    {
+                        "messages": json.dumps([
+                            {"role": "user", "content": "What is 2+2?"},
+                            {"role": "assistant", "content": "2+2 equals 4."}
+                        ])
+                    }
+                ]
+            )
+            
+            tmp_ds_path = Path(tmp_dir) / "str_json_dataset.parquet"
+            str_json_ds.to_parquet(tmp_ds_path)
+            
+            prepared_path = Path(tmp_dir) / "prepared"
+            cfg = DictDefault(
+                {
+                    "tokenizer_config": "huggyllama/llama-7b",
+                    "sequence_len": 512,
+                    "datasets": [
+                        {
+                            "path": str(tmp_ds_path),
+                            "name": "test_str_json",
+                            "type": "chat_template",
+                            "field_messages": "messages",
+                            "message_field_role": "role",
+                            "message_field_content": "content",
+                        },
+                    ],
+                    "dataset_num_proc": 4,
+                }
+            )
+            
+            with patch(
+                "axolotl.common.const.DEFAULT_DATASET_PREPARED_PATH", str(prepared_path)
+            ):
+                dataset, _ = _load_tokenized_prepared_datasets(tokenizer, cfg)
+            
+            assert len(dataset) == 2
+            assert "input_ids" in dataset.features
+            assert "attention_mask" in dataset.features
+            assert "labels" in dataset.features
+            
+            assert len(dataset[0]["input_ids"]) > 0

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -496,27 +496,34 @@ class TestDatasetPreparation:
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
             import json
-            
+
             str_json_ds = Dataset.from_list(
                 [
                     {
-                        "messages": json.dumps([
-                            {"role": "user", "content": "Hello how are you?"},
-                            {"role": "assistant", "content": "I am doing good thanks"}
-                        ])
+                        "messages": json.dumps(
+                            [
+                                {"role": "user", "content": "Hello how are you?"},
+                                {
+                                    "role": "assistant",
+                                    "content": "I am doing good thanks",
+                                },
+                            ]
+                        )
                     },
                     {
-                        "messages": json.dumps([
-                            {"role": "user", "content": "What is 2+2?"},
-                            {"role": "assistant", "content": "2+2 equals 4."}
-                        ])
-                    }
+                        "messages": json.dumps(
+                            [
+                                {"role": "user", "content": "What is 2+2?"},
+                                {"role": "assistant", "content": "2+2 equals 4."},
+                            ]
+                        )
+                    },
                 ]
             )
-            
+
             tmp_ds_path = Path(tmp_dir) / "str_json_dataset.parquet"
             str_json_ds.to_parquet(tmp_ds_path)
-            
+
             prepared_path = Path(tmp_dir) / "prepared"
             cfg = DictDefault(
                 {
@@ -535,15 +542,15 @@ class TestDatasetPreparation:
                     "dataset_num_proc": 4,
                 }
             )
-            
+
             with patch(
                 "axolotl.common.const.DEFAULT_DATASET_PREPARED_PATH", str(prepared_path)
             ):
                 dataset, _ = _load_tokenized_prepared_datasets(tokenizer, cfg)
-            
+
             assert len(dataset) == 2
             assert "input_ids" in dataset.features
             assert "attention_mask" in dataset.features
             assert "labels" in dataset.features
-            
+
             assert len(dataset[0]["input_ids"]) > 0


### PR DESCRIPTION
This PR supports datasets that saves `messages` field in `str` format. This happens for agentic datasets with large traces such as https://huggingface.co/datasets/allenai/Sera-4.6-Lite-T2

To reproduce, simply run `axolotl preprocess config.yaml --debug` with the config below:

```yaml
base_model: Qwen/Qwen3.5-0.8B
# Automatically upload checkpoint and final model to HF
# hub_model_id: username/custom_model_name

datasets:
  - path: allenai/Sera-4.6-Lite-T2
    type: chat_template
    field_messages: messages
    split: "train[:1%]"
    train_on_eot: turn
    roles_to_train: ["assistant"]
    message_property_mappings:
      role: role
      content: content
    message_field_training: "train"
    roles:
      assistant:
        - gpt
        - model
        - assistant
      user:
        - human
        - tool
        - user

val_set_size: 0.1
output_dir: ./outputs/lora-out

adapter: lora
lora_model_dir:

sequence_len: 32768
sample_packing: true
eval_sample_packing: true


lora_r: 16
lora_alpha: 32
lora_dropout: 0.05
lora_target_modules:
  - gate_proj
  - down_proj
  - up_proj
  - q_proj
  - v_proj
  - k_proj
  - o_proj

wandb_project:
wandb_entity:
wandb_watch:
wandb_name:
wandb_log_model:

gradient_accumulation_steps: 2
micro_batch_size: 2
num_epochs: 1

optimizer: adamw_8bit
lr_scheduler: cosine
learning_rate: 0.0002

bf16: auto
tf32: false

gradient_checkpointing: true
resume_from_checkpoint:
logging_steps: 1
flash_attention: true

loss_watchdog_threshold: 5.0
loss_watchdog_patience: 3

warmup_ratio: 0.1
evals_per_epoch: 4
saves_per_epoch: 1
weight_decay: 0.0
special_tokens:
  pad_token: "<|end_of_text|>"

# save_first_step: true  # uncomment this to validate checkpoint saving works with your config
```

With the fixes proposed in this PR, datasets such as Sera are properly loaded and tokenized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded input format support to accept JSON-encoded strings for tool and message specifications.
  * Enhanced batch detection to recognize both string and list-formatted prompt values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->