### PR TITLE
fix fsdp shard dict saving and reload 

### DIFF
--- a/src/axolotl/core/trainers/mixins/checkpoints.py
+++ b/src/axolotl/core/trainers/mixins/checkpoints.py
@@ -1,5 +1,7 @@
 """Custom handling to not fail training if fsdp optimizer is not savable"""
 
+import os
+
 from transformers import Trainer
 
 from axolotl.utils.logging import get_logger
@@ -14,9 +16,65 @@ class CheckpointSaveMixin(Trainer):
         try:
             super()._save_optimizer_and_scheduler(output_dir)
         except (NotImplementedError, KeyError) as exc:
-            # TODO: fix fsdp2 optimizer saving
             LOG.warning_once(
                 f"Trainer does not support saving optimizer and scheduler:  {exc}\n"
                 "Optimizer and scheduler states were not saved - resuming from checkpoints "
                 "for this training run will not be possible.",
+            )
+
+    def _load_from_checkpoint(self, resume_from_checkpoint, model=None):
+        if (
+            resume_from_checkpoint is not None
+            and self.is_fsdp_enabled
+            and getattr(self.accelerator.state.fsdp_plugin, "fsdp_version", 1) == 2
+        ):
+            self._align_fsdp2_state_dict_type(resume_from_checkpoint)
+        super()._load_from_checkpoint(resume_from_checkpoint, model)
+
+    def _align_fsdp2_state_dict_type(self, checkpoint):
+        """Set fsdp_plugin.state_dict_type to match the format actually saved in checkpoint.
+
+        FSDP2 defaults to SHARDED_STATE_DICT, but users can change the setting between
+        runs, causing load_fsdp_model/load_fsdp_optimizer to look for the wrong files.
+        Auto-detecting from the checkpoint dir fixes the mismatch. The state_dict_config
+        objects must also be replaced to stay consistent with the new type.
+        """
+        from torch.distributed.fsdp import (
+            FullOptimStateDictConfig,
+            FullStateDictConfig,
+            ShardedOptimStateDictConfig,
+            ShardedStateDictConfig,
+        )
+        from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+
+        fsdp_plugin = self.accelerator.state.fsdp_plugin
+        sharded_exists = os.path.isdir(os.path.join(checkpoint, "pytorch_model_fsdp_0"))
+        full_exists = os.path.isfile(os.path.join(checkpoint, "pytorch_model_fsdp.bin"))
+
+        if (
+            sharded_exists
+            and fsdp_plugin.state_dict_type != StateDictType.SHARDED_STATE_DICT
+        ):
+            LOG.warning(
+                f"Checkpoint at {checkpoint} was saved with SHARDED_STATE_DICT but current "
+                f"state_dict_type is {fsdp_plugin.state_dict_type}. Overriding to SHARDED_STATE_DICT."
+            )
+            fsdp_plugin.state_dict_type = StateDictType.SHARDED_STATE_DICT
+            fsdp_plugin.state_dict_config = ShardedStateDictConfig(offload_to_cpu=True)
+            fsdp_plugin.optim_state_dict_config = ShardedOptimStateDictConfig(
+                offload_to_cpu=True
+            )
+        elif (
+            full_exists and fsdp_plugin.state_dict_type != StateDictType.FULL_STATE_DICT
+        ):
+            LOG.warning(
+                f"Checkpoint at {checkpoint} was saved with FULL_STATE_DICT but current "
+                f"state_dict_type is {fsdp_plugin.state_dict_type}. Overriding to FULL_STATE_DICT."
+            )
+            fsdp_plugin.state_dict_type = StateDictType.FULL_STATE_DICT
+            fsdp_plugin.state_dict_config = FullStateDictConfig(
+                offload_to_cpu=True, rank0_only=True
+            )
+            fsdp_plugin.optim_state_dict_config = FullOptimStateDictConfig(
+                offload_to_cpu=True, rank0_only=True
             )


### PR DESCRIPTION
# Description
fix fsdp shard dict saving and reload 


## Motivation and Context
towards exteramly parallel training  

## How has this been tested?
saving/checkpointing with shard dict and reloading with full state dict works now
```
fsdp_version: 2
fsdp_config:
  offload_params: false
  cpu_ram_efficient_loading: true
  transformer_layer_cls_to_wrap: Qwen2DecoderLayer
  auto_wrap_policy: TRANSFORMER_BASED_WRAP
  reshard_after_forward: true
 
```

## AI Usage Disclaimer
claude for troubleshooting T_T'



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint resumption for distributed training with FSDP2, including automatic detection of checkpoint formats and configuration adjustment for seamless restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->