### PR TITLE
fix: [gemma4] fix VRAM leak in hybrid FA2+SDPA (hybrid attentiuon) path under activation check…

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -395,7 +395,16 @@ class PatchManager:
                     patch_gemma4_fused_attn,
                 )
 
-                patch_gemma4_fused_attn()
+                # Shared-KV side channel when activation checkpointing (PR #3611).
+                fsdp_cfg = self.cfg.fsdp_config
+                needs_shared_kv_workaround = (not self.inference) and bool(
+                    self.cfg.gradient_checkpointing
+                    or self.cfg.activation_offloading
+                    or (fsdp_cfg is not None and fsdp_cfg.activation_checkpointing)
+                )
+                patch_gemma4_fused_attn(
+                    install_shared_kv_workaround=needs_shared_kv_workaround
+                )
 
     @staticmethod
     def _fix_nemotron_h_conversion_mapping():

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import logging
-import threading
 from typing import Callable
 
 import torch
@@ -18,7 +17,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-# Thread-local side channel for the shared-KV dict. We route the dict through
+# Module-level side channel for the shared-KV dict. We route the dict through
 # this instead of a kwarg on the decoder-layer forward so that when HF's
 # GradientCheckpointingLayer forms `partial(super().__call__, **kwargs)` and
 # axolotl's CPU_Offloaded_Gradient_Checkpointer captures that partial in
@@ -27,15 +26,28 @@ logger = logging.getLogger(__name__)
 # pinned across the full backward pass (and, via Python ref-cycle delays in
 # torch's caching allocator, bleed across training steps), causing VRAM to
 # climb ~0.47 GiB/step under the hybrid FA2+SDPA path.
-_GEMMA4_SHARED_KV_TLS = threading.local()
+#
+# NOTE: originally `threading.local()`, but PyTorch's C++ autograd engine
+# (`_engine_run_backward`) spawns per-device worker threads to dispatch
+# backward. When HF-Trainer gradient_checkpointing (`torch.utils.checkpoint`,
+# non-reentrant / saved-tensor-hooks) fires `unpack_hook` -> `recompute_fn`
+# during backward, it runs on the autograd worker thread -- whose
+# `threading.local()` is empty, so the dict set on the main thread during
+# forward is invisible and `_get_shared_kv_states()` returns None, crashing
+# the consumer-layer lookup (`shared_kv_states[self.kv_shared_layer_index]`)
+# with `'NoneType' object is not subscriptable`. A plain module-level dict is
+# shared across all threads and works for both paths. The container is
+# overwritten each forward, so the previous step's dict is released promptly
+# -- same lifecycle guarantee the TLS variant gave.
+_GEMMA4_SHARED_KV_STORE: dict = {"store": None}
 
 
 def _set_shared_kv_states(store):
-    _GEMMA4_SHARED_KV_TLS.store = store
+    _GEMMA4_SHARED_KV_STORE["store"] = store
 
 
 def _get_shared_kv_states():
-    return getattr(_GEMMA4_SHARED_KV_TLS, "store", None)
+    return _GEMMA4_SHARED_KV_STORE["store"]
 
 
 def _make_fused_forward(original_forward):
@@ -170,7 +182,7 @@ def _patch_decoder_layer_call():
     """
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextDecoderLayer
 
-    if getattr(Gemma4TextDecoderLayer, "_axolotl_shared_kv_tls_patched", False):
+    if getattr(Gemma4TextDecoderLayer, "_axolotl_shared_kv_patched", False):
         return
 
     original_call = Gemma4TextDecoderLayer.__call__
@@ -185,7 +197,7 @@ def _patch_decoder_layer_call():
         return original_call(self, *args, **kwargs)
 
     Gemma4TextDecoderLayer.__call__ = patched_call
-    Gemma4TextDecoderLayer._axolotl_shared_kv_tls_patched = True
+    Gemma4TextDecoderLayer._axolotl_shared_kv_patched = True
 
 
 def patch_gemma4_fused_attn():

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -10,11 +10,32 @@ Usage:
 """
 
 import logging
+import threading
 from typing import Callable
 
 import torch
 
 logger = logging.getLogger(__name__)
+
+
+# Thread-local side channel for the shared-KV dict. We route the dict through
+# this instead of a kwarg on the decoder-layer forward so that when HF's
+# GradientCheckpointingLayer forms `partial(super().__call__, **kwargs)` and
+# axolotl's CPU_Offloaded_Gradient_Checkpointer captures that partial in
+# `ctx.forward_function`, the ctx does not hold a reference to the dict --
+# otherwise the K/V tensors stored in the dict for the producer layers stay
+# pinned across the full backward pass (and, via Python ref-cycle delays in
+# torch's caching allocator, bleed across training steps), causing VRAM to
+# climb ~0.47 GiB/step under the hybrid FA2+SDPA path.
+_GEMMA4_SHARED_KV_TLS = threading.local()
+
+
+def _set_shared_kv_states(store):
+    _GEMMA4_SHARED_KV_TLS.store = store
+
+
+def _get_shared_kv_states():
+    return getattr(_GEMMA4_SHARED_KV_TLS, "store", None)
 
 
 def _make_fused_forward(original_forward):
@@ -30,7 +51,7 @@ def _make_fused_forward(original_forward):
         hidden_states: torch.Tensor,
         position_embeddings: torch.Tensor,
         attention_mask: torch.Tensor | None,
-        shared_kv_states: dict[int, tuple[torch.Tensor, torch.Tensor]],
+        shared_kv_states: dict[int, tuple[torch.Tensor, torch.Tensor]] | None = None,
         past_key_values=None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -38,6 +59,12 @@ def _make_fused_forward(original_forward):
         from transformers.models.gemma4.modeling_gemma4 import (
             eager_attention_forward,
         )
+
+        # Prefer the thread-local store (populated by the patched decoder-layer
+        # __call__) so the dict is not captured by the checkpoint partial.
+        tls_store = _get_shared_kv_states()
+        if tls_store is not None:
+            shared_kv_states = tls_store
 
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
@@ -133,14 +160,43 @@ def _make_fused_forward(original_forward):
     return fused_forward
 
 
+def _patch_decoder_layer_call():
+    """Strip `shared_kv_states` from the decoder-layer kwargs and route it via
+    thread-local storage instead. This breaks the capture chain
+    `ctx.forward_function -> partial -> kwargs -> shared_kv_states dict` inside
+    the CPU-offload activation checkpointer, so the dict (and the K/V tensors
+    it holds for the producer layers) is not pinned for the duration of the
+    backward pass.
+    """
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4TextDecoderLayer
+
+    if getattr(Gemma4TextDecoderLayer, "_axolotl_shared_kv_tls_patched", False):
+        return
+
+    original_call = Gemma4TextDecoderLayer.__call__
+
+    def patched_call(self, *args, **kwargs):
+        shared_kv = kwargs.pop("shared_kv_states", None)
+        if shared_kv is not None:
+            _set_shared_kv_states(shared_kv)
+        return original_call(self, *args, **kwargs)
+
+    Gemma4TextDecoderLayer.__call__ = patched_call
+    Gemma4TextDecoderLayer._axolotl_shared_kv_tls_patched = True
+
+
 def patch_gemma4_fused_attn():
     """
-    Monkeypatch Gemma4TextAttention.forward to use fused RMSNorm+RoPE kernels.
+    Monkeypatch Gemma4TextAttention.forward to use fused RMSNorm+RoPE kernels,
+    and route `shared_kv_states` via thread-local storage to avoid a VRAM leak
+    under activation checkpointing.
     """
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
 
     original_forward = Gemma4TextAttention.forward
     Gemma4TextAttention.forward = _make_fused_forward(original_forward)
+
+    _patch_decoder_layer_call()
 
     logger.info(
         "Patched Gemma4TextAttention.forward with fused RMSNorm+RoPE Triton kernels"

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -6,7 +6,8 @@ kernels, eliminating intermediate tensor allocations from rotate_half / apply_ro
 
 Usage:
     from axolotl.monkeypatch.models.gemma4.fused_attn import patch_gemma4_fused_attn
-    patch_gemma4_fused_attn()
+    # Pass install_shared_kv_workaround=True when activation checkpointing is enabled.
+    patch_gemma4_fused_attn(install_shared_kv_workaround=True)
 """
 
 import logging
@@ -16,29 +17,8 @@ import torch
 
 logger = logging.getLogger(__name__)
 
-
-# Module-level side channel for the shared-KV dict. We route the dict through
-# this instead of a kwarg on the decoder-layer forward so that when HF's
-# GradientCheckpointingLayer forms `partial(super().__call__, **kwargs)` and
-# axolotl's CPU_Offloaded_Gradient_Checkpointer captures that partial in
-# `ctx.forward_function`, the ctx does not hold a reference to the dict --
-# otherwise the K/V tensors stored in the dict for the producer layers stay
-# pinned across the full backward pass (and, via Python ref-cycle delays in
-# torch's caching allocator, bleed across training steps), causing VRAM to
-# climb ~0.47 GiB/step under the hybrid FA2+SDPA path.
-#
-# NOTE: originally `threading.local()`, but PyTorch's C++ autograd engine
-# (`_engine_run_backward`) spawns per-device worker threads to dispatch
-# backward. When HF-Trainer gradient_checkpointing (`torch.utils.checkpoint`,
-# non-reentrant / saved-tensor-hooks) fires `unpack_hook` -> `recompute_fn`
-# during backward, it runs on the autograd worker thread -- whose
-# `threading.local()` is empty, so the dict set on the main thread during
-# forward is invisible and `_get_shared_kv_states()` returns None, crashing
-# the consumer-layer lookup (`shared_kv_states[self.kv_shared_layer_index]`)
-# with `'NoneType' object is not subscriptable`. A plain module-level dict is
-# shared across all threads and works for both paths. The container is
-# overwritten each forward, so the previous step's dict is released promptly
-# -- same lifecycle guarantee the TLS variant gave.
+# Module-level dict used as a side channel for shared KV states avoiding kwarg and TLS
+# to prevent memory leak on gradient checkpoint enabled training (PR #3611)
 _GEMMA4_SHARED_KV_STORE: dict = {"store": None}
 
 
@@ -72,11 +52,9 @@ def _make_fused_forward(original_forward):
             eager_attention_forward,
         )
 
-        # Prefer the thread-local store (populated by the patched decoder-layer
-        # __call__) so the dict is not captured by the checkpoint partial.
-        tls_store = _get_shared_kv_states()
-        if tls_store is not None:
-            shared_kv_states = tls_store
+        store = _get_shared_kv_states()
+        if store is not None:
+            shared_kv_states = store
 
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
@@ -173,12 +151,8 @@ def _make_fused_forward(original_forward):
 
 
 def _patch_decoder_layer_call():
-    """Strip `shared_kv_states` from the decoder-layer kwargs and route it via
-    thread-local storage instead. This breaks the capture chain
-    `ctx.forward_function -> partial -> kwargs -> shared_kv_states dict` inside
-    the CPU-offload activation checkpointer, so the dict (and the K/V tensors
-    it holds for the producer layers) is not pinned for the duration of the
-    backward pass.
+    """Strip `shared_kv_states` from decoder-layer kwargs and route via the
+    module-level side channel so the checkpoint partial cannot pin it (PR #3611).
     """
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextDecoderLayer
 
@@ -189,10 +163,8 @@ def _patch_decoder_layer_call():
 
     def patched_call(self, *args, **kwargs):
         shared_kv = kwargs.pop("shared_kv_states", None)
-        # Overwrite TLS unconditionally (including with None) so a previous
-        # step's dict cannot leak into a later call that doesn't pass
-        # `shared_kv_states`. The fallback branch in fused_forward relies on
-        # TLS being None to defer to the kwarg path.
+        # Overwrite unconditionally (including with None) so a previous step's
+        # dict cannot leak into a later call without shared_kv_states (PR #3611).
         _set_shared_kv_states(shared_kv)
         return original_call(self, *args, **kwargs)
 
@@ -200,19 +172,22 @@ def _patch_decoder_layer_call():
     Gemma4TextDecoderLayer._axolotl_shared_kv_patched = True
 
 
-def patch_gemma4_fused_attn():
+def patch_gemma4_fused_attn(install_shared_kv_workaround: bool = False):
     """
     Monkeypatch Gemma4TextAttention.forward to use fused RMSNorm+RoPE kernels,
-    and route `shared_kv_states` via thread-local storage to avoid a VRAM leak
-    under activation checkpointing.
+    and optionally route `shared_kv_states` via a module-level side channel to
+    avoid a VRAM leak under activation checkpointing (PR #3611).
     """
     from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
 
     original_forward = Gemma4TextAttention.forward
     Gemma4TextAttention.forward = _make_fused_forward(original_forward)
 
-    _patch_decoder_layer_call()
+    if install_shared_kv_workaround:
+        _patch_decoder_layer_call()
 
     logger.info(
         "Patched Gemma4TextAttention.forward with fused RMSNorm+RoPE Triton kernels"
     )
+    if install_shared_kv_workaround:
+        logger.info("Installed Gemma4 shared_kv_states side channel (PR #3611)")

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -177,8 +177,11 @@ def _patch_decoder_layer_call():
 
     def patched_call(self, *args, **kwargs):
         shared_kv = kwargs.pop("shared_kv_states", None)
-        if shared_kv is not None:
-            _set_shared_kv_states(shared_kv)
+        # Overwrite TLS unconditionally (including with None) so a previous
+        # step's dict cannot leak into a later call that doesn't pass
+        # `shared_kv_states`. The fallback branch in fused_forward relies on
+        # TLS being None to defer to the kwarg path.
+        _set_shared_kv_states(shared_kv)
         return original_call(self, *args, **kwargs)
 
     Gemma4TextDecoderLayer.__call__ = patched_call

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -10,12 +10,13 @@ Usage:
     patch_gemma4_fused_attn(install_shared_kv_workaround=True)
 """
 
-import logging
 from typing import Callable
 
 import torch
 
-logger = logging.getLogger(__name__)
+from axolotl.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Module-level dict used as a side channel for shared KV states avoiding kwarg and TLS
 # to prevent memory leak on gradient checkpoint enabled training (PR #3611)

--- a/tests/monkeypatch/test_gemma4_fused_attn_patch.py
+++ b/tests/monkeypatch/test_gemma4_fused_attn_patch.py
@@ -1,0 +1,144 @@
+"""Unit tests for the Gemma4 fused-attention shared_kv_states routing patch."""
+
+import pytest
+
+gemma4_modeling = pytest.importorskip("transformers.models.gemma4.modeling_gemma4")
+
+
+@pytest.fixture
+def clean_decoder_layer_patch_slate():
+    """Save and restore Gemma4TextDecoderLayer.__call__ and the sentinel."""
+    from axolotl.monkeypatch.models.gemma4 import fused_attn
+
+    cls = gemma4_modeling.Gemma4TextDecoderLayer
+    original_call = cls.__call__
+    had_sentinel = getattr(cls, "_axolotl_shared_kv_patched", False)
+
+    if had_sentinel:
+        del cls._axolotl_shared_kv_patched
+
+    try:
+        yield cls, fused_attn
+    finally:
+        cls.__call__ = original_call
+        if had_sentinel:
+            cls._axolotl_shared_kv_patched = True
+        elif hasattr(cls, "_axolotl_shared_kv_patched"):
+            del cls._axolotl_shared_kv_patched
+        fused_attn._set_shared_kv_states(None)
+
+
+class TestPatchedDecoderLayerCall:
+    def test_pops_shared_kv_states_and_populates_store(
+        self, clean_decoder_layer_patch_slate
+    ):
+        cls, fused_attn = clean_decoder_layer_patch_slate
+
+        captured = {}
+
+        def spy(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = dict(kwargs)
+            return "spy_return"
+
+        cls.__call__ = spy
+        fused_attn._patch_decoder_layer_call()
+
+        assert getattr(cls, "_axolotl_shared_kv_patched", False) is True
+        assert cls.__call__ is not spy
+
+        shared_kv = {"layer_0": ("k", "v")}
+        result = cls.__call__(
+            object(),
+            "positional_arg",
+            shared_kv_states=shared_kv,
+            other_kwarg="keep_me",
+        )
+
+        assert result == "spy_return"
+        assert captured["args"] == ("positional_arg",)
+        assert "shared_kv_states" not in captured["kwargs"]
+        assert captured["kwargs"] == {"other_kwarg": "keep_me"}
+        assert fused_attn._get_shared_kv_states() is shared_kv
+
+    def test_clears_store_when_kwarg_absent(self, clean_decoder_layer_patch_slate):
+        """Regression for commit 251021e1: a prior step's dict must not leak
+        into a later call that omits `shared_kv_states`."""
+        cls, fused_attn = clean_decoder_layer_patch_slate
+
+        def spy(self, *args, **kwargs):
+            return None
+
+        cls.__call__ = spy
+        fused_attn._patch_decoder_layer_call()
+
+        stale = {"stale_step": True}
+        fused_attn._set_shared_kv_states(stale)
+        assert fused_attn._get_shared_kv_states() is stale
+
+        cls.__call__(object())
+
+        assert fused_attn._get_shared_kv_states() is None
+
+
+@pytest.fixture
+def clean_entry_point_patch_slate():
+    """Save and restore Gemma4TextAttention.forward and Gemma4TextDecoderLayer.__call__."""
+    from axolotl.monkeypatch.models.gemma4 import fused_attn
+
+    decoder_cls = gemma4_modeling.Gemma4TextDecoderLayer
+    attn_cls = gemma4_modeling.Gemma4TextAttention
+
+    original_call = decoder_cls.__call__
+    original_forward = attn_cls.forward
+    had_sentinel = getattr(decoder_cls, "_axolotl_shared_kv_patched", False)
+
+    if had_sentinel:
+        del decoder_cls._axolotl_shared_kv_patched
+
+    try:
+        yield decoder_cls, attn_cls, original_call, original_forward, fused_attn
+    finally:
+        decoder_cls.__call__ = original_call
+        attn_cls.forward = original_forward
+        if had_sentinel:
+            decoder_cls._axolotl_shared_kv_patched = True
+        elif hasattr(decoder_cls, "_axolotl_shared_kv_patched"):
+            del decoder_cls._axolotl_shared_kv_patched
+        fused_attn._set_shared_kv_states(None)
+
+
+class TestPatchGemma4FusedAttnEntryPoint:
+    def test_default_flag_swaps_only_attention_forward(
+        self, clean_entry_point_patch_slate
+    ):
+        (
+            decoder_cls,
+            attn_cls,
+            original_call,
+            original_forward,
+            fused_attn,
+        ) = clean_entry_point_patch_slate
+
+        fused_attn.patch_gemma4_fused_attn()
+
+        assert attn_cls.forward is not original_forward
+        assert decoder_cls.__call__ is original_call
+        assert not getattr(decoder_cls, "_axolotl_shared_kv_patched", False)
+
+    def test_workaround_flag_installs_decoder_layer_patch(
+        self, clean_entry_point_patch_slate
+    ):
+        (
+            decoder_cls,
+            attn_cls,
+            original_call,
+            original_forward,
+            fused_attn,
+        ) = clean_entry_point_patch_slate
+
+        fused_attn.patch_gemma4_fused_attn(install_shared_kv_workaround=True)
+
+        assert attn_cls.forward is not original_forward
+        assert decoder_cls.__call__ is not original_call
+        assert getattr(decoder_cls, "_axolotl_shared_kv_patched", False) is True

--- a/tests/monkeypatch/test_gemma4_fused_attn_patch.py
+++ b/tests/monkeypatch/test_gemma4_fused_attn_patch.py
@@ -80,6 +80,33 @@ class TestPatchedDecoderLayerCall:
 
         assert fused_attn._get_shared_kv_states() is None
 
+    def test_store_visible_across_threads(self):
+        """Regression for commit e3669b2c: the store must be readable from
+        threads other than the one that set it. `threading.local()` failed
+        this invariant, crashing with 'NoneType' object is not subscriptable'
+        on MoE Gemma4 variants when autograd worker threads ran backward
+        recompute under HF-Trainer gradient_checkpointing."""
+        import threading
+
+        from axolotl.monkeypatch.models.gemma4 import fused_attn
+
+        sentinel = {"layer_0": ("k", "v")}
+        try:
+            fused_attn._set_shared_kv_states(sentinel)
+
+            seen = {}
+
+            def worker():
+                seen["value"] = fused_attn._get_shared_kv_states()
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+            assert seen["value"] is sentinel
+        finally:
+            fused_attn._set_shared_kv_states(None)
+
 
 @pytest.fixture
 def clean_entry_point_patch_slate():


### PR DESCRIPTION
# [gemma4] fix VRAM leak in hybrid FA2+SDPA path under activation checkpointing

Route `shared_kv_states` through a thread-local side channel instead of the decoder-layer kwargs so the checkpoint partial never references the dict.

# Description

HF's `Gemma4TextModel.forward` passes `shared_kv_states` (a mutable dict used for cross-layer K/V sharing) as a kwarg to every `decoder_layer(...)` call. `GradientCheckpointingLayer.__call__` then forms `partial(super().__call__, **kwargs)`, and whichever checkpoint implementation runs — axolotl's `CPU_Offloaded_Gradient_Checkpointer` (via `ctx.forward_function = forward_function` at `src/axolotl/monkeypatch/gradient_checkpointing/offload_cpu.py:51`) or torch's stock `torch.utils.checkpoint.checkpoint` — captures that partial. The partial holds a reference to the dict, which holds the K/V tensors produced by `store_full_length_kv` layers. Those tensors stay pinned for the full duration of backward, and delayed ref-cycle cleanup in torch's caching allocator under FSDP2 + activation checkpointing bleeds the residual across training steps.

**Violated invariant:** anything crossing an activation-checkpoint boundary must be a tensor (refcounted by autograd) or plain Python data — never a mutable container holding tensor references.

**All changes live in `src/axolotl/monkeypatch/models/gemma4/fused_attn.py` (+58 / −2):**

- `threading.local()` store with `_get_shared_kv_states()` / `_set_shared_kv_states()` helpers.
- `_patch_decoder_layer_call()` — monkeypatches `Gemma4TextDecoderLayer.__call__` to pop `shared_kv_states` from kwargs and stash it in TLS before delegating to `GradientCheckpointingLayer.__call__`. The partial formed downstream no longer references the dict.
- `fused_forward` reads TLS first and falls back to the kwarg for callers that bypass the patched `__call__` (e.g. direct attention invocation during eval hooks).
- Wired into `patch_gemma4_fused_attn()`; idempotent via an `_axolotl_shared_kv_tls_patched` sentinel.

TLS is overwritten on each new step's first decoder-layer call, so the previous step's dict is released promptly. No changes to the hybrid dispatch, FSDP wrap policy, config schema, or any public behavior. The patch is unconditional — it works correctly for hybrid, flex, and eager paths, because the TLS rerouting is semantically equivalent to the kwarg path (it is purely a capture-avoidance change).

## Motivation and Context

Fixes #3610.

Introduced by PR #3598 (commit `b8358aa5`, _"[gemma4] use mixed Flash Attention and SDPA and add fused RMSNorm+RoPE Triton kernels"_), which added the hybrid flag, the unconditional `patch_gemma4_fused_attn()` monkeypatch, and the fused RMSNorm+RoPE kernels together.

**Observed symptom (pre-patch):**

| Path                                   | VRAM behavior                                           | Throughput (steady-state) |
| -------------------------------------- | ------------------------------------------------------- | ------------------------- |
| `gemma4_hybrid_attn_impl: true`        | Climbs ~0.47 GiB/step from 42 GiB baseline; OOMs at step 73 (~94 GiB peak) | ~13–14 s/step             |
| `flex_attention: true` (all 60 layers) | Flat at 64 GiB                                          | ~30 s/step (~2× slower)  |

The climb is independent of actual sequence length or image size — confirmed by the reporter, which rules out shape variability, `torch.compile` recompiles, and head_dim=512 SDPA peak allocations (which would scale with T²). The flex path is flat but ~2× slower and not a practical workaround for a multi-day training run.

**Hypotheses considered and rejected during diagnosis:**

- **Per-layer shallow-copied config breaks FSDP/dynamo equivalence** — contributes to path divergence but is not the leak source.
- **Silent `cfg.flash_attention = True` activates downstream per-step allocations** — audited all `cfg.flash_attention` consumers; none allocate per-step state under the reported config (`sample_packing: false`, SM120 skips the FA4 auto-patch).
- **FA2 workspace retention under mixed dispatch** — FA2 workspace is stateless per-call; no accumulation.

The violated-invariant analysis also cleanly explains why the all-flex path doesn't leak: flex compiles all 60 layers identically into a single graph context where saved tensors are managed by the compiled graph rather than by Python refcounting, so the dict's refs don't pin anything.

## How has this been tested?

**Static / structural validation (performed):**

- `ast.parse` on the modified module — clean.
- Patch installation smoke test — both `Gemma4TextDecoderLayer.__call__` and `Gemma4TextAttention.forward` are replaced after `patch_gemma4_fused_attn()`.
- Sentinel (`_axolotl_shared_kv_tls_patched`) prevents double-wrapping on repeated invocations.
- TLS `_get_shared_kv_states()` / `_set_shared_kv_states()` round-trip correctly.
- Byte-identical to the editable install being used on the reporter's hardware.
- Ran `pre-commit run --files src/axolotl/monkeypatch/models/gemma4/fused_attn.py` on the modified file:       
   
  | Hook                     | Result     |                                                                    
  | ------------------------ | ---------- |                       
  | ruff (legacy alias)      | ✅ Passed  |                                                                    
  | ruff format              | ✅ Passed  |                                                                    
  | mypy                     | ✅ Passed  |
  | bandit                   | ✅ Passed  |                                                                    
  | fix end of files         | ✅ Passed  |                       
  | trim trailing whitespace | ✅ Passed  |          

**End-to-end VRAM-flatness validation (confirmed on reporter's hardware):**

Reran the failing config — Gemma-4 31B multimodal, LoRA r=256 on language layers, vision tower + `embed_vision` trained full, `sample_packing: false`, `pad_to_sequence_len: false`, `sequence_len: 5248`, FSDP2 with `reshard_after_forward: true`, `activation_checkpointing: true` under `fsdp_config` (HF Trainer-level `gradient_checkpointing: false`), on 2× RTX PRO 6000 Blackwell 96 GB. Ran 200+ steps past the previous OOM point (step 73) including a full eval + checkpoint-save cycle at step 200. VRAM is flat; throughput matches pre-patch hybrid.

| step               | was (pre-patch)    | is (post-patch)   |
| ------------------:| ------------------:| -----------------:|
| eval (pre-train)   | 42.5 GiB           | 42.6 GiB          |
| 9                  | 57.2 GiB           | 55.3 GiB          |
| 19                 | 64.8 GiB           | 56.3 GiB          |
| 29                 | 62.0 GiB           | 48.7 GiB          |
| 39                 | 72.5 GiB           | 55.0 GiB          |
| 49                 | 74.7 GiB           | 52.1 GiB          |
| 59                 | 79.2 GiB           | 49.0 GiB          |
| 69                 | 85.6 GiB           | 52.9 GiB          |
| 73                 | **OOM (~94 GiB)**  | —                 |
| 79                 | —                  | 57.1 GiB          |
| 89                 | —                  | 52.7 GiB          |
| 99                 | —                  | 57.5 GiB          |
| 109                | —                  | 48.5 GiB          |
| 119                | —                  | 53.4 GiB          |
| 129                | —                  | 52.3 GiB          |
| 139                | —                  | 58.5 GiB          |
| 149                | —                  | 49.9 GiB          |
| 159                | —                  | 57.9 GiB          |
| 169                | —                  | 53.7 GiB          |
| 179                | —                  | 54.3 GiB          |
| 189                | —                  | 66.2 GiB          |
| 199                | —                  | 49.3 GiB          |
| eval @ 200         | —                  | 44.6 GiB          |
| save @ 200         | —                  | ✅ checkpoint saved |

Post-patch VRAM oscillates in a ~48–58 GiB band with one excursion to 66.2 GiB at step 189; no upward trend. Step time is ~13–14 s/it (steady-state), identical to pre-patch hybrid. Eval loss dropped 5.43 → 0.69 over the first 200 steps; the first `save_strategy: steps` checkpoint wrote cleanly under `SHARDED_STATE_DICT` FSDP2.

**Testing environment of record:**

- `transformers` 5.5.4
- Hardware: 2× RTX PRO 6000 Blackwell 96 GB (SM120); FSDP2; activation checkpointing enabled.
- Model: Gemma-4 31B (shimmed to enforce max image tokens in training)
- `torch` 2.11.0+cu130
- main/323da791 served as basis for fork with these changes 

**What reviewers may want to sanity-check:**

- The `Gemma4TextDecoderLayer.__call__` intercept sits _above_ `GradientCheckpointingLayer.__call__`, so the partial formed downstream does not re-capture the popped kwarg.
- The kwarg fallback in `fused_forward` preserves behavior for any caller that invokes attention without going through the patched decoder-layer `__call__` (e.g. custom eval hooks that reach into `self_attn` directly).
- The unconditional application to the flex and eager paths is intentional and benign: the TLS rerouting is a capture-avoidance change, not a behavior change.

## AI Usage Disclaimer

Claude  Code (Opus 4.7) was used in the following scopes:

- **Root-cause investigation** — reading the axolotl + HF transformers source for the Gemma-4 hybrid attention path, `CPU_Offloaded_Gradient_Checkpointer`, `GradientCheckpointingLayer`, and the `shared_kv_states` dataflow through the decoder loop; validating four hypotheses against the code; producing the "violated invariant" analysis.
- **Patch design** — proposing the thread-local side channel as the minimal diff shape that preserves the hybrid dispatch and FSDP wrap policy.
- **Patch implementation** — writing the TLS helpers, the `_patch_decoder_layer_call()` intercept, and the `fused_forward` fallback; wiring into `patch_gemma4_fused_attn()`; adding the idempotency sentinel.
- **Static validation** — the AST parse, patch-installation smoke test, TLS round-trip, and idempotency verification.

Supplied by the human author: the training config, observed VRAM numbers (0.47 GiB/step, step-73 OOM, 42 GiB baseline, 94 GiB peak, 13–14 vs 30 s/step steady-state throughput), hardware details, confirmation that the climb is independent of sequence length / image size, and the end-to-end 200+ step VRAM-flatness rerun on the reporter's 2× RTX PRO 6000 Blackwell hardware including a full eval + checkpoint-save cycle.

## Screenshots (if appropriate)

N/A — the change is a structural fix with no user-visible surface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Performance / memory optimization (eliminates per-step VRAM accumulation on the hybrid path)
- [ ] Documentation update

## Social Handles (Optional)

_(fill in if desired)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management and state handling for Gemma4 model attention processing, enhancing overall efficiency and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->