### PR TITLE
feat: add processor_kwargs YAML field forwarded to from_pretrained

### DIFF
--- a/src/axolotl/loaders/processor.py
+++ b/src/axolotl/loaders/processor.py
@@ -23,6 +23,8 @@ def load_processor(cfg: DictDefault, tokenizer: PreTrainedTokenizerBase):
     processor_kwargs = {}
     if cfg.revision_of_model:
         processor_kwargs["revision"] = cfg.revision_of_model
+    if cfg.processor_kwargs:
+        processor_kwargs.update(cfg.processor_kwargs)
 
     if cfg.tokenizer_use_mistral_common:
 

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -67,21 +67,7 @@ class ModelInputConfig(BaseModel):
     processor_kwargs: dict[str, Any] | None = Field(
         default=None,
         json_schema_extra={
-            "description": (
-                "Extra kwargs forwarded to the processor's from_pretrained(), overriding "
-                "fields in the processor's on-disk config (e.g. image_seq_length, "
-                "max_soft_tokens for image processors; min_pixels, max_pixels for "
-                "Qwen-VL). Useful when you want to tune per-processor-field values "
-                "without editing processor_config.json on disk.\n\n"
-                "Note: despite the name, this is distinct from transformers' own "
-                "`processor_kwargs` dict argument to ProcessorMixin.__call__ (which "
-                "controls per-sub-processor call-time kwargs). This field only "
-                "affects from_pretrained load-time kwargs.\n\n"
-                "Do not set `revision` or `trust_remote_code` here -- use the "
-                "top-level `revision_of_model` / `trust_remote_code` keys instead. "
-                "Setting either inside `processor_kwargs` will be rejected by the "
-                "schema validator with a ValueError at config parse time."
-            )
+            "description": "kwargs forwarded to the processor's from_pretrained(), overriding processor config (e.g. image_seq_length, min_pixels, etc.)."
         },
     )
     tokenizer_save_jinja_files: bool | None = Field(

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -64,6 +64,26 @@ class ModelInputConfig(BaseModel):
     processor_type: str | None = Field(
         default=None, json_schema_extra={"description": "transformers processor class"}
     )
+    processor_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Extra kwargs forwarded to the processor's from_pretrained(), overriding "
+                "fields in the processor's on-disk config (e.g. image_seq_length, "
+                "max_soft_tokens for image processors; min_pixels, max_pixels for "
+                "Qwen-VL). Useful when you want to tune per-processor-field values "
+                "without editing processor_config.json on disk.\n\n"
+                "Note: despite the name, this is distinct from transformers' own "
+                "`processor_kwargs` dict argument to ProcessorMixin.__call__ (which "
+                "controls per-sub-processor call-time kwargs). This field only "
+                "affects from_pretrained load-time kwargs.\n\n"
+                "Do not set `revision` or `trust_remote_code` here -- use the "
+                "top-level `revision_of_model` / `trust_remote_code` keys instead. "
+                "Setting them inside `processor_kwargs` has inconsistent precedence "
+                "across axolotl's loader branches."
+            )
+        },
+    )
     tokenizer_save_jinja_files: bool | None = Field(
         default=True,  # match the default behavior from transformers
         json_schema_extra={

--- a/src/axolotl/utils/schemas/model.py
+++ b/src/axolotl/utils/schemas/model.py
@@ -79,8 +79,8 @@ class ModelInputConfig(BaseModel):
                 "affects from_pretrained load-time kwargs.\n\n"
                 "Do not set `revision` or `trust_remote_code` here -- use the "
                 "top-level `revision_of_model` / `trust_remote_code` keys instead. "
-                "Setting them inside `processor_kwargs` has inconsistent precedence "
-                "across axolotl's loader branches."
+                "Setting either inside `processor_kwargs` will be rejected by the "
+                "schema validator with a ValueError at config parse time."
             )
         },
     )
@@ -126,6 +126,22 @@ class ModelInputConfig(BaseModel):
                 "`trust_remote_code` is set to true. Please make sure that you reviewed the remote code/model."
             )
         return trust_remote_code
+
+    @field_validator("processor_kwargs")
+    @classmethod
+    def reject_reserved_processor_kwargs(cls, processor_kwargs):
+        if not processor_kwargs:
+            return processor_kwargs
+        reserved = {"revision", "trust_remote_code"}
+        conflicts = reserved.intersection(processor_kwargs)
+        if conflicts:
+            raise ValueError(
+                "Do not set reserved keys "
+                f"{sorted(conflicts)} inside `processor_kwargs`; "
+                "use the top-level `revision_of_model` / `trust_remote_code` "
+                "config keys instead."
+            )
+        return processor_kwargs
 
 
 class ModelOutputConfig(BaseModel):

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -558,6 +558,11 @@ class TrainingValidationMixin:
                 "Setting chat_template is not supported with mistral-common tokenizer"
             )
 
+        if data.get("processor_kwargs"):
+            raise ValueError(
+                "processor_kwargs is not supported with mistral-common tokenizer"
+            )
+
         return data
 
     @model_validator(mode="before")

--- a/tests/test_revision_parameter.py
+++ b/tests/test_revision_parameter.py
@@ -186,6 +186,7 @@ class TestRevisionParameter:
 
     def test_processor_kwargs_schema_rejects_revision(self):
         import pytest
+
         from axolotl.utils.schemas.model import ModelInputConfig
 
         with pytest.raises(ValueError, match="revision"):
@@ -196,6 +197,7 @@ class TestRevisionParameter:
 
     def test_processor_kwargs_schema_rejects_trust_remote_code(self):
         import pytest
+
         from axolotl.utils.schemas.model import ModelInputConfig
 
         with pytest.raises(ValueError, match="trust_remote_code"):
@@ -220,4 +222,6 @@ class TestRevisionParameter:
         from axolotl.utils.schemas.model import ModelInputConfig
 
         assert ModelInputConfig(base_model="x").processor_kwargs is None
-        assert ModelInputConfig(base_model="x", processor_kwargs={}).processor_kwargs == {}
+        assert (
+            ModelInputConfig(base_model="x", processor_kwargs={}).processor_kwargs == {}
+        )

--- a/tests/test_revision_parameter.py
+++ b/tests/test_revision_parameter.py
@@ -225,3 +225,16 @@ class TestRevisionParameter:
         assert (
             ModelInputConfig(base_model="x", processor_kwargs={}).processor_kwargs == {}
         )
+
+    def test_processor_kwargs_incompatible_with_mistral_common(self, min_base_cfg):
+        import pytest
+
+        from axolotl.utils.config import validate_config
+        from axolotl.utils.dict import DictDefault
+
+        cfg = min_base_cfg | DictDefault(
+            tokenizer_use_mistral_common=True,
+            processor_kwargs={"image_seq_length": 1120},
+        )
+        with pytest.raises(ValueError, match="processor_kwargs"):
+            validate_config(cfg)

--- a/tests/test_revision_parameter.py
+++ b/tests/test_revision_parameter.py
@@ -133,3 +133,53 @@ class TestRevisionParameter:
 
         call_kwargs = mock_auto_processor.from_pretrained.call_args
         assert "revision" not in call_kwargs.kwargs
+
+    @patch("axolotl.loaders.processor.AutoProcessor")
+    def test_load_processor_forwards_processor_kwargs(self, mock_auto_processor):
+        mock_processor = MagicMock()
+        mock_processor.size = {}
+        mock_auto_processor.from_pretrained.return_value = mock_processor
+
+        cfg = DictDefault(
+            {
+                "processor_config": "some-model",
+                "trust_remote_code": False,
+                "processor_kwargs": {
+                    "image_seq_length": 1120,
+                    "max_soft_tokens": 1120,
+                },
+            }
+        )
+        tokenizer = MagicMock(spec=PreTrainedTokenizerBase)
+
+        from axolotl.loaders.processor import load_processor
+
+        load_processor(cfg, tokenizer)
+
+        call_kwargs = mock_auto_processor.from_pretrained.call_args
+        assert call_kwargs.kwargs.get("image_seq_length") == 1120
+        assert call_kwargs.kwargs.get("max_soft_tokens") == 1120
+
+    @patch("axolotl.loaders.processor.AutoProcessor")
+    def test_load_processor_omits_processor_kwargs_when_unset(
+        self, mock_auto_processor
+    ):
+        mock_processor = MagicMock()
+        mock_processor.size = {}
+        mock_auto_processor.from_pretrained.return_value = mock_processor
+
+        cfg = DictDefault(
+            {
+                "processor_config": "some-model",
+                "trust_remote_code": False,
+            }
+        )
+        tokenizer = MagicMock(spec=PreTrainedTokenizerBase)
+
+        from axolotl.loaders.processor import load_processor
+
+        load_processor(cfg, tokenizer)
+
+        call_kwargs = mock_auto_processor.from_pretrained.call_args
+        assert "image_seq_length" not in call_kwargs.kwargs
+        assert "max_soft_tokens" not in call_kwargs.kwargs

--- a/tests/test_revision_parameter.py
+++ b/tests/test_revision_parameter.py
@@ -183,3 +183,41 @@ class TestRevisionParameter:
         call_kwargs = mock_auto_processor.from_pretrained.call_args
         assert "image_seq_length" not in call_kwargs.kwargs
         assert "max_soft_tokens" not in call_kwargs.kwargs
+
+    def test_processor_kwargs_schema_rejects_revision(self):
+        import pytest
+        from axolotl.utils.schemas.model import ModelInputConfig
+
+        with pytest.raises(ValueError, match="revision"):
+            ModelInputConfig(
+                base_model="some-model",
+                processor_kwargs={"revision": "abc123"},
+            )
+
+    def test_processor_kwargs_schema_rejects_trust_remote_code(self):
+        import pytest
+        from axolotl.utils.schemas.model import ModelInputConfig
+
+        with pytest.raises(ValueError, match="trust_remote_code"):
+            ModelInputConfig(
+                base_model="some-model",
+                processor_kwargs={"trust_remote_code": True},
+            )
+
+    def test_processor_kwargs_schema_accepts_valid_keys(self):
+        from axolotl.utils.schemas.model import ModelInputConfig
+
+        cfg = ModelInputConfig(
+            base_model="some-model",
+            processor_kwargs={"image_seq_length": 1120, "max_soft_tokens": 1120},
+        )
+        assert cfg.processor_kwargs == {
+            "image_seq_length": 1120,
+            "max_soft_tokens": 1120,
+        }
+
+    def test_processor_kwargs_schema_accepts_none_and_empty(self):
+        from axolotl.utils.schemas.model import ModelInputConfig
+
+        assert ModelInputConfig(base_model="x").processor_kwargs is None
+        assert ModelInputConfig(base_model="x", processor_kwargs={}).processor_kwargs == {}


### PR DESCRIPTION
## Description

Adds a new `processor_kwargs: dict[str, Any] | None` field on `ModelInputConfig`. Its contents are forwarded as `**kwargs` to the processor class's `from_pretrained()` call inside `load_processor`, giving users a YAML hook for overriding fields that live in a model's on-disk `processor_config.json` without having to maintain a local directory that shadows the real weights just to swap one file or update the file directly.

**Scope:** applies to any model whose load path goes through `load_processor` (i.e. `cfg.processor_type` is set). HF's `ProcessorMixin.from_pretrained` propagates top-level kwargs to sub-processors (image / video / feature-extractor / tokenizer), so the same field works across image, video, and audio processors with no model-specific wiring.

**Changes:**
- `src/axolotl/utils/schemas/model.py`: new `processor_kwargs` field on `ModelInputConfig`, placed next to `processor_type` and mirroring the existing `model_quantization_config` / `model_quantization_config_kwargs` pairing. Docstring notes (a) the name overlap with transformers' own call-time `processor_kwargs` argument and (b) that `revision` / `trust_remote_code` should stay on the top-level keys to avoid inconsistent precedence across loader branches.
- `src/axolotl/loaders/processor.py`: forwards `cfg.processor_kwargs` into the shared kwargs dict before the Voxtral and main `from_pretrained()` calls. The `Mistral3Processor` path does not call `from_pretrained` and is intentionally untouched.
- `tests/test_revision_parameter.py`: two new tests covering the forward path and the no-op default.

**Example (Gemma-4):**

```yaml
processor_kwargs:
  image_seq_length: 1120
  max_soft_tokens: 1120
```

Default behavior is preserved when the field is unset (`None`): the guard in `load_processor` skips the update and nothing new reaches `from_pretrained`.

## Motivation and Context

There is currently no YAML hook for per-processor-field overrides. Users who want to change defaults like Gemma-4's `image_seq_length` / `max_soft_tokens` or Qwen-VL's `min_pixels` / `max_pixels` have to maintain a local model directory that symlinks every real file except `processor_config.json`, which they override on disk or edit the model files directly.

## How has this been tested?

1. **Unit tests** (mocked `AutoProcessor`, added in `tests/test_revision_parameter.py`):
   - `test_load_processor_forwards_processor_kwargs` asserts `image_seq_length` and `max_soft_tokens` reach `AutoProcessor.from_pretrained` call kwargs.
   - `test_load_processor_omits_processor_kwargs_when_unset` asserts no-op default.
   - All 8 tests in the file pass (6 pre-existing + 2 new).

2. **Schema round-trip** against the real Gemma-4 YAML config: `AxolotlInputConfig(**yaml.safe_load(...))` with `processor_kwargs` populated preserves the value intact through Pydantic validation.

3. **End-to-end image tokenization** against `google/gemma-4-31B-it`: same 896×896 test image fed through two processors loaded via `load_processor`.

   | metric | baseline | with override `image_seq_length=1120, max_soft_tokens=1120` | ratio |
   |---|---:|---:|---:|
   | `image_seq_length` attr | 280 | 1120 | 4× |
   | `pixel_values` patches | 2520 | 10080 | 4× |
   | `image_position_ids` entries | 2520 | 10080 | 4× |

   The patch-count scaling exactly matches the configured token budget, confirming the override reaches the live image processor's encode path.

**Environment:** Python 3.12, torch 2.9 / transformers 5.5.4, tested on CPU (no GPU-specific paths touched).

## AI Usage Disclaimer

Yes — Claude (Anthropic) was used to assist with tracing the config-loading plumbing, drafting the schema field and forwarder, and authoring the tests.

## Screenshots (if appropriate)

N/A.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Social Handles (Optional)

N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to customize processor initialization, allowing you to override default processor settings at load time.
  * Processor loading now properly forwards and applies custom configuration values for enhanced control over processor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->