### PR TITLE
fix: allow kwargs-only forward on PEFT ModulesToSaveWrapper

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -313,6 +313,13 @@ class PatchManager:
 
             patch_peft_prep_code()
 
+        if self.cfg.adapter:
+            from axolotl.monkeypatch.peft_modules_to_save import (
+                patch_peft_modules_to_save_kwargs,
+            )
+
+            patch_peft_modules_to_save_kwargs()
+
     def _apply_flex_attention_patches(self):
         """Apply patches for flexible attention."""
         if self.cfg.flex_attention:

--- a/src/axolotl/monkeypatch/peft_modules_to_save.py
+++ b/src/axolotl/monkeypatch/peft_modules_to_save.py
@@ -1,0 +1,57 @@
+"""Patch PEFT's AuxiliaryTrainingWrapper / ModulesToSaveWrapper so kwargs-only
+forward calls work (e.g. Gemma 4 vision_tower / embed_vision in lora_modules_to_save)."""
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+_PATCHED_ATTR = "_axolotl_modules_to_save_kwargs_patched"
+
+
+def _patched_forward(self, *args, **kwargs):
+    # _check_forward_args only validates len(x) vs len(adapter_names); skip when no positional x.
+    if args:
+        self._check_forward_args(*args, **kwargs)
+
+    adapter_names = kwargs.pop("adapter_names", None)
+
+    if self.disable_adapters or any(
+        adapter not in self._adapters for adapter in self.active_adapters
+    ):
+        return self._forward_wrapped_passthrough(*args, **kwargs)
+
+    if adapter_names is None:
+        return self._forward_wrapped(*args, **kwargs)
+    # Mixed-batch path needs positional input for sub-batch indexing; leave unchanged.
+    return self._mixed_batch_forward(*args, adapter_names=adapter_names, **kwargs)
+
+
+def _patched_forward_wrapped(self, *args, **kwargs):
+    if not self.active_adapters:
+        return self._forward_wrapped_passthrough(*args, **kwargs)
+    return self.modules_to_save[self.active_adapters[0]](*args, **kwargs)
+
+
+def _patched_forward_wrapped_passthrough(self, *args, **kwargs):
+    return self.original_module(*args, **kwargs)
+
+
+def patch_peft_modules_to_save_kwargs() -> None:
+    """Apply the kwargs-compatible forward patch to PEFT. Idempotent."""
+    from peft.utils.other import AuxiliaryTrainingWrapper, ModulesToSaveWrapper
+
+    if getattr(AuxiliaryTrainingWrapper, _PATCHED_ATTR, False):
+        return
+
+    AuxiliaryTrainingWrapper.forward = _patched_forward
+    ModulesToSaveWrapper._forward_wrapped = _patched_forward_wrapped
+    ModulesToSaveWrapper._forward_wrapped_passthrough = (
+        _patched_forward_wrapped_passthrough
+    )
+
+    setattr(AuxiliaryTrainingWrapper, _PATCHED_ATTR, True)
+    LOG.debug(
+        "Patched peft.AuxiliaryTrainingWrapper / ModulesToSaveWrapper to accept "
+        "kwargs-only forward calls (enables full-FT of modules called with "
+        "keyword args, e.g. Gemma 4 vision_tower/embed_vision)"
+    )

--- a/tests/monkeypatch/test_peft_modules_to_save.py
+++ b/tests/monkeypatch/test_peft_modules_to_save.py
@@ -1,0 +1,148 @@
+"""Tests for axolotl.monkeypatch.peft_modules_to_save."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("peft")
+
+
+@pytest.fixture(scope="module")
+def patched():
+    from axolotl.monkeypatch.peft_modules_to_save import (
+        patch_peft_modules_to_save_kwargs,
+    )
+
+    patch_peft_modules_to_save_kwargs()
+    yield
+
+
+@pytest.fixture
+def wrap_module(patched):
+    """Wrap ``module`` like PEFT wraps a ``modules_to_save`` entry."""
+    from peft.utils.other import ModulesToSaveWrapper
+
+    def _wrap(module: nn.Module) -> ModulesToSaveWrapper:
+        w = ModulesToSaveWrapper(module, "default")
+        w.set_adapter("default")
+        return w
+
+    return _wrap
+
+
+def test_kwargs_only_forward(wrap_module):
+    """Gemma 4 vision_tower shape: self.vision_tower(pixel_values=...)."""
+
+    class KwargsOnly(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, *, pixel_values):
+            return self.lin(pixel_values)
+
+    w = wrap_module(KwargsOnly())
+    out = w(pixel_values=torch.randn(2, 8))
+    assert out.shape == (2, 8)
+
+
+def test_positional_only_forward(wrap_module):
+    """embed_tokens shape: self.embed_tokens(input_ids)."""
+
+    class PosOnly(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.emb = nn.Embedding(100, 8)
+
+        def forward(self, x):
+            return self.emb(x)
+
+    w = wrap_module(PosOnly())
+    out = w(torch.tensor([1, 2, 3]))
+    assert out.shape == (3, 8)
+
+
+def test_mixed_args_kwargs_forward(wrap_module):
+    """Module taking both positional and keyword args."""
+
+    class Mixed(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, x, scale=1.0):
+            return self.lin(x) * scale
+
+    w = wrap_module(Mixed())
+    out = w(torch.randn(2, 8), scale=2.0)
+    assert out.shape == (2, 8)
+
+
+def test_kwargs_only_disabled_adapter(wrap_module):
+    """Passthrough branch (enable_adapters(False)) must also accept kwargs-only."""
+
+    class KwargsOnly(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, *, pixel_values):
+            return self.lin(pixel_values)
+
+    w = wrap_module(KwargsOnly())
+    w.enable_adapters(False)
+
+    out = w(pixel_values=torch.randn(2, 8))
+    assert out.shape == (2, 8)
+
+
+def test_trainable_tokens_wrapper_not_broken(patched):
+    """Base-class forward replacement must not break TrainableTokensWrapper
+    (positional embed_tokens path must still work)."""
+    try:
+        from peft.utils.other import TrainableTokensWrapper
+    except ImportError:
+        pytest.skip("TrainableTokensWrapper not available in installed PEFT")
+
+    try:
+        w = TrainableTokensWrapper(
+            nn.Embedding(100, 8), "default", token_indices=[0, 1, 2]
+        )
+    except TypeError as exc:
+        pytest.skip(f"TrainableTokensWrapper init signature changed: {exc}")
+    w.set_adapter("default")
+
+    out = w(torch.tensor([0, 1, 2, 5]))
+    assert out.shape == (4, 8)
+
+
+def test_mixed_batch_kwargs_only_raises(wrap_module):
+    """Document current behavior: adapter_names without positional input is
+    unsupported (mixed-batch path is deliberately not kwargs-patched)."""
+
+    class KwargsOnly(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+
+        def forward(self, *, pixel_values):
+            return self.lin(pixel_values)
+
+    w = wrap_module(KwargsOnly())
+    with pytest.raises(TypeError):
+        w(pixel_values=torch.randn(2, 8), adapter_names=["default", "default"])
+
+
+def test_patch_is_idempotent():
+    """Applying the patch twice is a no-op."""
+    from peft.utils.other import AuxiliaryTrainingWrapper
+
+    from axolotl.monkeypatch.peft_modules_to_save import (
+        patch_peft_modules_to_save_kwargs,
+    )
+
+    patch_peft_modules_to_save_kwargs()
+    first = AuxiliaryTrainingWrapper.forward
+    patch_peft_modules_to_save_kwargs()
+    second = AuxiliaryTrainingWrapper.forward
+    assert first is second, "patch must be idempotent"


### PR DESCRIPTION
# Description

Patch PEFT's `ModulesToSaveWrapper` / `AuxiliaryTrainingWrapper.forward` so it accepts kwargs-only calls. The vanilla PEFT signature requires a positional `x` tensor, which works for modules called positionally (e.g. `embed_tokens(input_ids)`) but crashes when a module in `lora_modules_to_save` is invoked with keyword arguments only — as Gemma 4's VLM forward does for both `vision_tower(pixel_values=...)` and `embed_vision(inputs_embeds=...)`.

The monkeypatch rewrites `forward`, `_forward_wrapped`, and `_forward_wrapped_passthrough` on `AuxiliaryTrainingWrapper` / `ModulesToSaveWrapper` to accept `*args, **kwargs` — backward-compatible with every existing positional caller. `_mixed_batch_forward` is intentionally left untouched because it needs a positional input for sub-batch indexing and only runs under multi-adapter `adapter_names=...` inference, which does not occur in single-adapter training. `_check_forward_args` is short-circuited when no positional input is provided (its only real work validates `len(x) == len(adapter_names)`, which itself requires `adapter_names`).

The patch is installed from `PatchManager._apply_adapter_patches()` gated on `cfg.adapter`, so it is in place before `get_peft_model` wires up any wrappers, and it is completely inert when no adapter is configured. The patch is idempotent.

## Motivation and Context

When experimenting with training the vision tower on Gemma 4 with `lora_modules_to_save` including `vision_tower` / `embed_vision`, PEFT raises:

```
TypeError: AuxiliaryTrainingWrapper.forward() missing 1 required positional argument: 'x'
```

at the first forward pass (typically eval step 0), forcing users to drop those modules from `lora_modules_to_save` and exclude vision tower from trainable parameters.

Minimum reproducer with Gemma4 (tested with 31B and E2B):

```yaml
adapter: lora
lora_modules_to_save:
  - vision_tower   # or any module whose forward is called with keyword args
```

## How has this been tested?

### Unit tests

`tests/monkeypatch/test_peft_modules_to_save.py` — **7/7 passing** - added as unit tests to commit

- Kwargs-only forward (Gemma 4 `vision_tower` shape: `self.vision_tower(pixel_values=...)`)
- Positional forward still works (`embed_tokens(input_ids)` shape — regression guard)
- Mixed positional + keyword args forward
- Passthrough branch (`enable_adapters(False)`) also accepts kwargs-only
- `TrainableTokensWrapper` (sibling subclass of `AuxiliaryTrainingWrapper`) end-to-end still works — defensive regression for subclass safety
- `adapter_names=...` with kwargs-only raises `TypeError` — locks the deliberately-unsupported mixed-batch shape so a future patch change cannot silently flip behavior
- Patch is idempotent (applying twice is a no-op)

### Lint

`ruff check` and `ruff format --check` clean on all touched files.

### End-to-end training run

Gemma 4 E2B → E4B adaptation on a single RTX 5090 32 GB, using `axolotl_gemma4_E4B_5090_config.yml`:

- Base model: `gemma-4-E2B-it`
- `adapter: lora`, `lora_r: 256`, `lora_alpha: 256` (rsLoRA, α/√r = 16 effective scale)
- `lora_modules_to_save: [vision_tower, embed_vision]` ← **the shape this fix unblocks**
- `sequence_len: 5048`, `micro_batch_size: 1`, `gradient_accumulation_steps: 4`, `bf16: true`

I am also currently testing with the same Lora config + FSDP2 on Gemma 4 31B across 2x RTX 6000, loss is nominal vs. vanilla as you would expect with expanding trainable parameters. 

**Trainable-parameter increase vs. the prior run (before the fix, with vision modules excluded):**

| | Old run (vision modules omitted) | New run (this PR) | Δ |
|---|---:|---:|---:|
| Trainable params | 789,184,512 | **957,728,768** | **+168,544,256 (+21.4%)** |
| All params | 5,893,482,016 | 6,062,026,272 | +168,543,712 |
| Trainable % | 13.39 % | **15.80 %** | **+2.41 pp** |

The +168M delta accounts for `vision_tower` + `embed_vision` being made trainable.

**Per-epoch loss / grad comparison (OLD vs NEW):**

| Epoch    | OLD eval | NEW eval | OLD train | NEW train | OLD grad | NEW grad |
|----------|---------:|---------:|----------:|----------:|---------:|---------:|
| 0 (pre)  | 3.86     | 3.525    | —         | —         | —        | —        |
| 0.01385  | 1.12     | 1.551    | 1.53      | 2.262     | 39.75    | 112      |
| 0.0277   | 0.7508   | 1.385    | 1.143     | 2.06      | 27.88    | 117      |
| 0.04155  | 0.6873   | 1.401    | 1.02      | 1.869     | 14.94    | 51.5     |
| 0.0554   | 0.6495   | 1.299    | 1.13      | 1.774     | 23.62    | 30.12    |
| 0.06925  | 0.6088   | 1.261    | 0.8163    | 1.429     | 22.75    | 48.25    |
| 0.0831   | 0.5777   | 1.312    | 1.071     | 1.468     | 20.38    | 57.25    |
| 0.09695  | 0.5542   | 1.208    | 0.757     | 1.289     | 16.0     | 30.12    |

The higher early-epoch train/eval losses and larger grad norms are expected — vision_tower + embed_vision are now in the active gradient path and carry ~168M additional trainable parameters, so early-warmup signal is noisier as expected. Both curves are trending down cleanly.

Please note, the loss and gradient numbers are likely also impacted by a local branch to mask all but assistant prompts from loss calculation on Gemma 4.  

**Current training progress (ongoing at time of PR):**

- Multimodal dataset (image, system, user, assistant prompt pairs)
- Step **1,850 / 43,320** (~4.3 %), epoch ~0.13
- Checkpoints written successfully: `checkpoint-200`, `-400`, `-600`, `-800`, `-1000`, `-1200`, `-1400`, `-1600`, `-1800`
- Loss: ~1.13–1.47 (expected range for early steps under rsLoRA warmup)
- Learning rate: 1.07e-5 (mid-warmup, target 2e-5)
- VRAM: 17–21 GiB active / 27.97 GiB reserved (well under 32 GiB — fits on 5090)
- Throughput: ~6 s/it, ~1.8 trainable tok/s/GPU
- No PEFT-related errors; `vision_tower` and `embed_vision` forwards are producing gradients correctly

## AI Usage Disclaimer

Opus 4.7, was used for diagnosing the original `TypeError`, assisted with authoring the monkeypatch, writing the test suite, routing the patch through `PatchManager`. All code was reviewed by me before commit with significant testing .

## Screenshots (if appropriate)

N/A — backend patch, no UI surface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed adapter support for models using keyword-only arguments in forward passes.

* **Tests**
  * Added comprehensive test coverage for adapter configuration handling across various function signatures and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->