### PR TITLE
fix: probe GPU capabilities on Ray worker, not driver (#3179)

### DIFF
--- a/src/axolotl/cli/config.py
+++ b/src/axolotl/cli/config.py
@@ -299,7 +299,7 @@ def load_cfg(
 
     prepare_plugins(cfg)
 
-    if cfg.get("use_ray"):
+    if cfg.use_ray:
         # Ray drivers typically have no GPU; defer capability checks to the worker.
         capabilities, env_capabilities = None, None
     else:

--- a/src/axolotl/cli/config.py
+++ b/src/axolotl/cli/config.py
@@ -297,26 +297,18 @@ def load_cfg(
             existing_child = cfg[parent].get(child_key)
             cfg[parent][child_key] = _coerce_value(child_value, existing_child)
 
-    try:
-        device_props = torch.cuda.get_device_properties("cuda")
-        gpu_version = "sm_" + str(device_props.major) + str(device_props.minor)
-    except (RuntimeError, AssertionError):
-        gpu_version = None
-
     prepare_plugins(cfg)
+
+    if cfg.get("use_ray"):
+        # Ray drivers typically have no GPU; defer capability checks to the worker.
+        capabilities, env_capabilities = None, None
+    else:
+        capabilities, env_capabilities = gpu_capabilities()
 
     cfg = validate_config(
         cfg,
-        capabilities={
-            "bf16": is_torch_bf16_gpu_available(),
-            "fp8": compute_supports_fp8(),
-            "tf32": is_torch_tf32_available(),
-            "n_gpu": int(os.environ.get("WORLD_SIZE", 1)),
-            "compute_capability": gpu_version,
-        },
-        env_capabilities={
-            "torch_version": str(torch.__version__).split("+", maxsplit=1)[0]
-        },
+        capabilities=capabilities,
+        env_capabilities=env_capabilities,
     )
 
     # NOTE(djsaunde): We start outputting to output_dir/debug.log at this point since we
@@ -352,3 +344,29 @@ def compute_supports_fp8() -> bool:
         return compute_capability >= (9, 0)
     except RuntimeError:
         return False
+
+
+def gpu_capabilities() -> tuple[dict, dict]:
+    """Probe the local GPU and return ``(capabilities, env_capabilities)`` dicts
+    suitable for :func:`axolotl.utils.config.validate_config`.
+
+    Must be called on a GPU-enabled host (e.g. a Ray worker), otherwise the
+    detected values reflect the driver/CPU node and not the training device.
+    """
+    try:
+        device_props = torch.cuda.get_device_properties("cuda")
+        gpu_version = "sm_" + str(device_props.major) + str(device_props.minor)
+    except (RuntimeError, AssertionError):
+        gpu_version = None
+
+    capabilities = {
+        "bf16": is_torch_bf16_gpu_available(),
+        "fp8": compute_supports_fp8(),
+        "tf32": is_torch_tf32_available(),
+        "n_gpu": int(os.environ.get("WORLD_SIZE", 1)),
+        "compute_capability": gpu_version,
+    }
+    env_capabilities = {
+        "torch_version": str(torch.__version__).split("+", maxsplit=1)[0]
+    }
+    return capabilities, env_capabilities

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -92,6 +92,11 @@ def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs):
 
 
 def ray_train_func(kwargs: dict):
+    """Ray Train entrypoint executed on each GPU worker.
+
+    Re-validates the config against worker-local GPU capabilities (deferred from
+    the driver), then runs the standard training pipeline.
+    """
     # cast `cfg` back to DictDefault (ray tune deepcopy has issues with DictDefault so needed it to be dict)
     # also renormalize the config now that TorchTrainer has spawned distributed workers
     cfg = DictDefault(kwargs["cfg"])

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -11,11 +11,11 @@ from transformers.hf_argparser import HfArgumentParser
 
 from axolotl.cli.args import TrainerCliArgs
 from axolotl.cli.checks import check_accelerate_default_config, check_user_token
-from axolotl.cli.config import load_cfg
+from axolotl.cli.config import gpu_capabilities, load_cfg
 from axolotl.common.datasets import load_datasets, load_preference_datasets
 from axolotl.integrations.base import PluginManager
 from axolotl.train import train
-from axolotl.utils.config import normalize_config, resolve_dtype
+from axolotl.utils.config import normalize_config, resolve_dtype, validate_config
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.trainer import prepare_optim_env
 
@@ -95,10 +95,18 @@ def ray_train_func(kwargs: dict):
     # cast `cfg` back to DictDefault (ray tune deepcopy has issues with DictDefault so needed it to be dict)
     # also renormalize the config now that TorchTrainer has spawned distributed workers
     cfg = DictDefault(kwargs["cfg"])
+
+    # GPU capability detection was deferred from the driver; run the checks now
+    # that we are on a worker that actually has the training device attached.
+    capabilities, env_capabilities = gpu_capabilities()
+    cfg = validate_config(
+        cfg,
+        capabilities=capabilities,
+        env_capabilities=env_capabilities,
+    )
+
     prepare_optim_env(cfg)
     normalize_config(cfg)
-
-    # now that we are on the worker node, we can check `is_torch_bf16_gpu_available` to resolve dtype
     resolve_dtype(cfg)
 
     # ray serializing objects gets rid of frozen attribute - HF expects dict not DefaultDict

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -11,7 +11,12 @@ from transformers.hf_argparser import HfArgumentParser
 
 from axolotl.cli.args import TrainerCliArgs
 from axolotl.cli.checks import check_accelerate_default_config, check_user_token
-from axolotl.cli.config import gpu_capabilities, load_cfg
+from axolotl.cli.config import (
+    gpu_capabilities,
+    load_cfg,
+    plugin_set_cfg,
+    prepare_plugins,
+)
 from axolotl.common.datasets import load_datasets, load_preference_datasets
 from axolotl.integrations.base import PluginManager
 from axolotl.train import train
@@ -101,6 +106,12 @@ def ray_train_func(kwargs: dict):
     # also renormalize the config now that TorchTrainer has spawned distributed workers
     cfg = DictDefault(kwargs["cfg"])
 
+    # Plugins must be registered before `validate_config` so the plugin-extended
+    # pydantic schema is in scope on this worker; otherwise plugin-specific cfg
+    # fields are silently dropped by `model_dump(exclude_none=True)`.
+    if cfg.get("plugins"):
+        prepare_plugins(cfg)
+
     # GPU capability detection was deferred from the driver; run the checks now
     # that we are on a worker that actually has the training device attached.
     capabilities, env_capabilities = gpu_capabilities()
@@ -121,11 +132,8 @@ def ray_train_func(kwargs: dict):
     # initialize accelerator before model instantiation
     Accelerator(gradient_accumulation_steps=cfg.gradient_accumulation_steps)
 
-    # Register plugins in Ray workers
+    # Bind the post-validation cfg to the plugin manager.
     if cfg.get("plugins"):
-        from axolotl.cli.config import plugin_set_cfg, prepare_plugins
-
-        prepare_plugins(cfg)
         plugin_set_cfg(cfg)
 
     kwargs["cfg"] = cfg

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from axolotl.cli.config import load_cfg
 
-
 _BASE_CONFIG = """
 base_model: HuggingFaceTB/SmolLM2-135M
 datasets:

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -1,0 +1,65 @@
+"""Tests for GPU capability detection in `load_cfg`."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from axolotl.cli.config import load_cfg
+
+
+_BASE_CONFIG = """
+base_model: HuggingFaceTB/SmolLM2-135M
+datasets:
+  - path: mhenrichsen/alpaca_2k_test
+    type: alpaca
+sequence_len: 2048
+max_steps: 1
+micro_batch_size: 1
+gradient_accumulation_steps: 1
+learning_rate: 1e-3
+special_tokens:
+  pad_token: <|endoftext|>
+"""
+
+
+def _write_cfg(tmp_path: Path, extra: str = "") -> Path:
+    path = tmp_path / "config.yml"
+    path.write_text(_BASE_CONFIG + extra)
+    return path
+
+
+def _patch_load_cfg_dependencies(monkeypatch):
+    """Stub everything `load_cfg` does after validation so the test can focus
+    on whether GPU capabilities were probed on the driver."""
+    monkeypatch.setattr("axolotl.cli.config.validate_config", lambda cfg, **_: cfg)
+    monkeypatch.setattr("axolotl.cli.config.normalize_config", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.normalize_cfg_datasets", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.prepare_debug_log", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.prepare_optim_env", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.setup_wandb_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.setup_mlflow_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.setup_comet_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.setup_trackio_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.config.plugin_set_cfg", lambda *_: None)
+
+
+def test_load_cfg_probes_capabilities_by_default(tmp_path, monkeypatch):
+    """Without `use_ray`, `load_cfg` probes GPU capabilities on the local host."""
+    _patch_load_cfg_dependencies(monkeypatch)
+    config_path = _write_cfg(tmp_path)
+
+    with patch("axolotl.cli.config.gpu_capabilities") as mock_caps:
+        mock_caps.return_value = ({"bf16": False}, {"torch_version": "2.6.0"})
+        load_cfg(str(config_path))
+
+    mock_caps.assert_called_once()
+
+
+def test_load_cfg_skips_capabilities_under_ray(tmp_path, monkeypatch):
+    """With `use_ray: true`, capability detection is deferred to the worker."""
+    _patch_load_cfg_dependencies(monkeypatch)
+    config_path = _write_cfg(tmp_path, "use_ray: true\nray_num_workers: 1\n")
+
+    with patch("axolotl.cli.config.gpu_capabilities") as mock_caps:
+        load_cfg(str(config_path))
+
+    mock_caps.assert_not_called()

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -22,6 +22,7 @@ special_tokens:
 
 
 def _write_cfg(tmp_path: Path, extra: str = "") -> Path:
+    """Write the base test config (plus any extra YAML lines) to a temp file."""
     path = tmp_path / "config.yml"
     path.write_text(_BASE_CONFIG + extra)
     return path

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -1,9 +1,10 @@
-"""Tests for GPU capability detection in `load_cfg`."""
+"""Tests for GPU capability detection in `load_cfg` and `ray_train_func`."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from axolotl.cli.config import load_cfg
+from axolotl.cli.train import ray_train_func
 
 _BASE_CONFIG = """
 base_model: HuggingFaceTB/SmolLM2-135M
@@ -27,10 +28,18 @@ def _write_cfg(tmp_path: Path, extra: str = "") -> Path:
     return path
 
 
-def _patch_load_cfg_dependencies(monkeypatch):
+def _patch_load_cfg_dependencies(monkeypatch, validate_mock=None):
     """Stub everything `load_cfg` does after validation so the test can focus
-    on whether GPU capabilities were probed on the driver."""
-    monkeypatch.setattr("axolotl.cli.config.validate_config", lambda cfg, **_: cfg)
+    on whether GPU capabilities were probed on the driver.
+
+    If ``validate_mock`` is given, it is installed as ``validate_config`` so the
+    test can inspect the arguments it was called with; otherwise a simple
+    identity stub is used.
+    """
+    monkeypatch.setattr(
+        "axolotl.cli.config.validate_config",
+        validate_mock if validate_mock is not None else (lambda cfg, **_: cfg),
+    )
     monkeypatch.setattr("axolotl.cli.config.normalize_config", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.config.normalize_cfg_datasets", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.config.prepare_debug_log", lambda *_: None)
@@ -40,11 +49,16 @@ def _patch_load_cfg_dependencies(monkeypatch):
     monkeypatch.setattr("axolotl.cli.config.setup_comet_env_vars", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.config.setup_trackio_env_vars", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.config.plugin_set_cfg", lambda *_: None)
+    monkeypatch.setattr(
+        "axolotl.cli.config.TELEMETRY_MANAGER.send_event", lambda *_, **__: None
+    )
 
 
 def test_load_cfg_probes_capabilities_by_default(tmp_path, monkeypatch):
-    """Without `use_ray`, `load_cfg` probes GPU capabilities on the local host."""
-    _patch_load_cfg_dependencies(monkeypatch)
+    """Without `use_ray`, `load_cfg` probes GPU capabilities on the local host
+    and passes the results into `validate_config`."""
+    validate_mock = MagicMock(side_effect=lambda cfg, **_: cfg)
+    _patch_load_cfg_dependencies(monkeypatch, validate_mock=validate_mock)
     config_path = _write_cfg(tmp_path)
 
     with patch("axolotl.cli.config.gpu_capabilities") as mock_caps:
@@ -52,14 +66,61 @@ def test_load_cfg_probes_capabilities_by_default(tmp_path, monkeypatch):
         load_cfg(str(config_path))
 
     mock_caps.assert_called_once()
+    _, kwargs = validate_mock.call_args
+    assert kwargs["capabilities"] == {"bf16": False}
+    assert kwargs["env_capabilities"] == {"torch_version": "2.6.0"}
 
 
 def test_load_cfg_skips_capabilities_under_ray(tmp_path, monkeypatch):
-    """With `use_ray: true`, capability detection is deferred to the worker."""
-    _patch_load_cfg_dependencies(monkeypatch)
+    """With `use_ray: true`, capability detection is deferred to the worker
+    and `validate_config` receives `None` for both capability dicts."""
+    validate_mock = MagicMock(side_effect=lambda cfg, **_: cfg)
+    _patch_load_cfg_dependencies(monkeypatch, validate_mock=validate_mock)
     config_path = _write_cfg(tmp_path, "use_ray: true\nray_num_workers: 1\n")
 
     with patch("axolotl.cli.config.gpu_capabilities") as mock_caps:
         load_cfg(str(config_path))
 
     mock_caps.assert_not_called()
+    _, kwargs = validate_mock.call_args
+    assert kwargs["capabilities"] is None
+    assert kwargs["env_capabilities"] is None
+
+
+def test_ray_train_func_validates_with_worker_capabilities(monkeypatch):
+    """`ray_train_func` must probe `gpu_capabilities()` on the worker and feed
+    the result into `validate_config` before training runs."""
+    cfg_dict = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "gradient_accumulation_steps": 1,
+    }
+
+    validate_mock = MagicMock(side_effect=lambda cfg, **_: cfg)
+    do_train_mock = MagicMock()
+    accelerator_mock = MagicMock()
+
+    monkeypatch.setattr("axolotl.cli.train.validate_config", validate_mock)
+    monkeypatch.setattr("axolotl.cli.train.do_train", do_train_mock)
+    monkeypatch.setattr("axolotl.cli.train.prepare_optim_env", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.Accelerator", accelerator_mock)
+
+    with patch("axolotl.cli.train.gpu_capabilities") as mock_caps:
+        mock_caps.return_value = (
+            {"bf16": True, "fp8": False, "tf32": True, "compute_capability": "sm_90"},
+            {"torch_version": "2.6.0"},
+        )
+        ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
+
+    mock_caps.assert_called_once()
+    validate_mock.assert_called_once()
+    _, kwargs = validate_mock.call_args
+    assert kwargs["capabilities"] == {
+        "bf16": True,
+        "fp8": False,
+        "tf32": True,
+        "compute_capability": "sm_90",
+    }
+    assert kwargs["env_capabilities"] == {"torch_version": "2.6.0"}
+    do_train_mock.assert_called_once()

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -124,3 +124,79 @@ def test_ray_train_func_validates_with_worker_capabilities(monkeypatch):
     }
     assert kwargs["env_capabilities"] == {"torch_version": "2.6.0"}
     do_train_mock.assert_called_once()
+
+
+def test_ray_train_func_registers_plugins_before_validate_config(monkeypatch):
+    """Regression: plugins must be registered before `validate_config` so the
+    plugin-extended pydantic schema is in scope. Otherwise `merge_input_args`
+    sees an empty PluginManager on the worker and `model_dump(exclude_none=True)`
+    silently drops plugin-specific cfg fields.
+    """
+    cfg_dict = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "gradient_accumulation_steps": 1,
+        "plugins": ["axolotl.integrations.liger.LigerPlugin"],
+    }
+
+    parent = MagicMock()
+    parent.validate_config.side_effect = lambda cfg, **_: cfg
+
+    # Patch at the source module so a local `from axolotl.cli.config import ...`
+    # inside the function also resolves to the mock; also patch the train module
+    # for top-level imports (raising=False keeps it tolerant of either style).
+    monkeypatch.setattr("axolotl.cli.config.prepare_plugins", parent.prepare_plugins)
+    monkeypatch.setattr("axolotl.cli.config.plugin_set_cfg", parent.plugin_set_cfg)
+    monkeypatch.setattr(
+        "axolotl.cli.train.prepare_plugins", parent.prepare_plugins, raising=False
+    )
+    monkeypatch.setattr(
+        "axolotl.cli.train.plugin_set_cfg", parent.plugin_set_cfg, raising=False
+    )
+    monkeypatch.setattr("axolotl.cli.train.validate_config", parent.validate_config)
+    monkeypatch.setattr("axolotl.cli.train.gpu_capabilities", lambda: ({}, {}))
+    monkeypatch.setattr("axolotl.cli.train.do_train", MagicMock())
+    monkeypatch.setattr("axolotl.cli.train.prepare_optim_env", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.Accelerator", MagicMock())
+
+    ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
+
+    # Filter to the calls we care about, in the order they happened.
+    ordered = [
+        call[0]
+        for call in parent.mock_calls
+        if call[0] in ("prepare_plugins", "validate_config", "plugin_set_cfg")
+    ]
+    assert ordered == ["prepare_plugins", "validate_config", "plugin_set_cfg"], (
+        f"Expected prepare_plugins -> validate_config -> plugin_set_cfg; got {ordered}"
+    )
+
+
+def test_ray_train_func_skips_plugin_registration_when_no_plugins(monkeypatch):
+    """When no plugins are configured, neither `prepare_plugins` nor
+    `plugin_set_cfg` should be invoked on the worker."""
+    cfg_dict = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "gradient_accumulation_steps": 1,
+    }
+
+    prepare_plugins_mock = MagicMock()
+    plugin_set_cfg_mock = MagicMock()
+
+    monkeypatch.setattr("axolotl.cli.train.prepare_plugins", prepare_plugins_mock)
+    monkeypatch.setattr("axolotl.cli.train.plugin_set_cfg", plugin_set_cfg_mock)
+    monkeypatch.setattr(
+        "axolotl.cli.train.validate_config", MagicMock(side_effect=lambda cfg, **_: cfg)
+    )
+    monkeypatch.setattr("axolotl.cli.train.gpu_capabilities", lambda: ({}, {}))
+    monkeypatch.setattr("axolotl.cli.train.do_train", MagicMock())
+    monkeypatch.setattr("axolotl.cli.train.prepare_optim_env", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.Accelerator", MagicMock())
+
+    ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
+
+    prepare_plugins_mock.assert_not_called()
+    plugin_set_cfg_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- Skip GPU capability detection in `load_cfg` when `use_ray: true` so the
  CPU-only Ray driver no longer reports false `bf16=False` / `fp8=False` /
  `tf32=False` / unknown `compute_capability` values.
- Re-run `validate_config` inside `ray_train_func` with capabilities probed on
  the actual GPU worker, so capability-dependent validators (`check_bf16`,
  `check_tf32`, `check_fp8`, `check_sample_packing_w_sdpa_bf16`,
  `check_compute_capability_w_sageattn`, `check_multigpu_lora_kernels`,
  `check_auto_enable_lora_kernels`) see the right values.
- Extract a `gpu_capabilities()` helper to share the probe between driver and
  worker.

Fixes #3179.

## Test plan

- [x] `pytest tests/cli/test_load_cfg_capabilities.py` — passes locally (2/2)
- [ ] Existing Ray e2e (`tests/e2e/multigpu/test_ray.py`) — requires multi-GPU; needs CI