### PR TITLE
fix: preserve split slices for local file datasets

### DIFF
--- a/src/axolotl/utils/data/shared.py
+++ b/src/axolotl/utils/data/shared.py
@@ -240,8 +240,10 @@ def _load_from_local_path(
     elif local_path.is_file():
         dataset_type = get_dataset_type(dataset_config)
 
-        # For single file datasets, HF always creates only a "train" split
-        if dataset_type in ("json", "csv", "text"):
+        # Single-file paths always expose only a "train" split regardless of format.
+        # Preserve any user-provided slice syntax (e.g. "train[:500]"); only
+        # fall back to "train" when no split was specified.
+        if not load_dataset_kwargs.get("split"):
             load_dataset_kwargs["split"] = "train"
 
         return load_dataset(

--- a/tests/utils/data/test_utils.py
+++ b/tests/utils/data/test_utils.py
@@ -2,11 +2,14 @@
 Unit tests for data utility functions
 """
 
+import tempfile
 import unittest
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from datasets import Dataset
 
+from axolotl.utils.data.shared import _load_from_local_path
 from axolotl.utils.data.utils import handle_long_seq_in_dataset, remove_double_bos_token
 from axolotl.utils.dict import DictDefault
 
@@ -539,6 +542,58 @@ class TestHandleLongSeqInDataset(unittest.TestCase):
         # Should behave like 'drop'
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0]["input_ids"]), 3)
+
+
+class TestLocalFileSplitHandling(unittest.TestCase):
+    """Regression tests for local-file dataset split handling."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.gettempdir())
+
+    @patch("axolotl.utils.data.shared.load_dataset")
+    def test_local_jsonl_preserves_split_slice(self, mock_load_dataset):
+        path = str(self.tmpdir / "sample.jsonl")
+        dataset_config = DictDefault(
+            {"path": path, "ds_type": "json", "split": "train[:500]"}
+        )
+        load_dataset_kwargs = {"split": dataset_config.split}
+
+        with patch("pathlib.Path.is_file", return_value=True):
+            _load_from_local_path(dataset_config, load_dataset_kwargs)
+
+        mock_load_dataset.assert_called_once()
+        _, kwargs = mock_load_dataset.call_args
+        self.assertEqual(kwargs["split"], "train[:500]")
+        self.assertEqual(kwargs["data_files"], path)
+
+    @patch("axolotl.utils.data.shared.load_dataset")
+    def test_local_csv_preserves_split_slice(self, mock_load_dataset):
+        path = str(self.tmpdir / "sample.csv")
+        dataset_config = DictDefault(
+            {"path": path, "ds_type": "csv", "split": "train[:200]"}
+        )
+        load_dataset_kwargs = {"split": dataset_config.split}
+
+        with patch("pathlib.Path.is_file", return_value=True):
+            _load_from_local_path(dataset_config, load_dataset_kwargs)
+
+        mock_load_dataset.assert_called_once()
+        _, kwargs = mock_load_dataset.call_args
+        self.assertEqual(kwargs["split"], "train[:200]")
+        self.assertEqual(kwargs["data_files"], path)
+
+    @patch("axolotl.utils.data.shared.load_dataset")
+    def test_local_file_no_split_defaults_to_train(self, mock_load_dataset):
+        path = str(self.tmpdir / "sample.parquet")
+        dataset_config = DictDefault({"path": path, "split": None})
+        load_dataset_kwargs = {"split": None}
+
+        with patch("pathlib.Path.is_file", return_value=True):
+            _load_from_local_path(dataset_config, load_dataset_kwargs)
+
+        mock_load_dataset.assert_called_once()
+        _, kwargs = mock_load_dataset.call_args
+        self.assertEqual(kwargs["split"], "train")
 
 
 class TestRemoveDoubleBOSToken(unittest.TestCase):


### PR DESCRIPTION
  # Description                                                                                                                                         
                                                                                                                                                        
  `_load_from_local_path` in `src/axolotl/utils/data/shared.py` was unconditionally                                                                     
  overwriting `split` with `"train"` for single-file `json`/`csv`/`text` datasets,                                                                      
  while leaving other formats (parquet, arrow) without any default. This caused                                                                         
  two bugs:                                                                                                                                             
                                                                                                                                                        
     like `split: "train[:500]"` was silently replaced with `"train"`, loading                                                                          
     the entire file instead of the requested slice.                                                                                                    
  2. **Single-file `parquet`/`arrow` with no `split:` returned `DatasetDict`**                                                                          
     instead of `Dataset`, breaking downstream code that expects a `Dataset`.                                                                         
                                                                                                                                                        
  The fix flips the condition from "what file format is it?" to "did the user                                                                         
  already set a split?". A default `"train"` is only filled in when no split was                                                                        
  specified, regardless of format.                                                                                                                    
                                                                                                                                                        
  ## Verified behavior (actual `load_dataset` calls)                                                                                                  
                                                                                                                                                        
  Tested with a 30-row sample written to both `.jsonl` and `.parquet`:                                                                                
                                                                                                                                                        
  | YAML config (single local file) | Before (`main`) | After (this PR) |                                                                               
  |---|---|---|                                                          
  | `path: a.jsonl`, `split: "train[:5]"` | ❌ `Dataset(len=30)` — slice ignored | ✅ `Dataset(len=5)` |                                                  
  | `path: a.jsonl`, no split | ✅ `Dataset(len=30)` | ✅ `Dataset(len=30)` |                           
  | `path: a.parquet`, `split: "train[:5]"` | ✅ `Dataset(len=5)` | ✅ `Dataset(len=5)` |                                                                 
  | `path: a.parquet`, no split | ❌ `DatasetDict({"train": ...})` | ✅ `Dataset(len=30)` |                                                               
                                                                                                                                                        
  ## Motivation and Context                                                                                                                             
                                                                                                                                                        
  A single-file dataset always exposes only a `train` split regardless of format,                                                                       
  so the safe behavior is: only fall back to `"train"` when the user has not set 
  a split — never overwrite a user-provided value. Removing the format                                                                                  
  allowlist also fixes the parquet/arrow `DatasetDict` regression for free.                                                                             
                                                                                                                                                        
  ## How has this been tested?                                                                                                                          
                                                                                                                                                        
  Added regression tests in `tests/utils/data/test_utils.py::TestLocalFileSplitHandling`:                                                               
                                                                                         
  - `test_local_jsonl_preserves_split_slice` — `train[:500]` on jsonl is preserved                                                                      
  - `test_local_csv_preserves_split_slice` — `train[:200]` on csv is preserved                                                                          
  - `test_local_file_no_split_defaults_to_train` — parquet with no split defaults to `"train"`                                                          
                                                                                                                                                        
  pytest tests/utils/data/test_utils.py::TestLocalFileSplitHandling -v                                                                                  
  3 passed                                                                                                                                              
                                                                                                                                                        
                                                                                                                                                        
  Manually verified the `Before` / `After` table above by invoking `load_dataset`                                                                       
  directly with the old and new conditions on real `.jsonl` and `.parquet`                                                                              
  fixtures.                                                                                                                                             
                                                                                                                                                        
  ## AI Usage Disclaimer
                                                                                                                                                        
  Yes — Claude Code was used to draft the regression tests and PR description.
  The fix and design decisions were authored/reviewed manually.                                                                                         
                                                                                                                                                        
  ## Types of changes                                                                                                                                   
                                                                                                                                                        
  - [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset loading to properly respect user-specified split configurations, including slice syntax. Default behavior preserved—the system automatically uses 'train' split when no split is explicitly specified.

* **Tests**
  * Added regression tests to ensure split handling behavior is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->