### PR TITLE
feat: support field_messages in multimodal collator

### DIFF
--- a/docs/multimodal.qmd
+++ b/docs/multimodal.qmd
@@ -285,6 +285,10 @@ For multi-modal datasets, we adopt an extended `chat_template` format similar to
 - `role` can be `system`, `user`, `assistant`, etc.
 - `content` is a list of `type` and (`text`, `image`, `path`, `url`, `base64`, or `audio`).
 
+::: {.callout-note}
+The recommended column name is `messages` with the OpenAI-style `role`/`content` schema shown above. If your upstream data already lives under a different column name (e.g., `conversations`, `dialogue`), set `field_messages: <your_column>` in the dataset config; this is a rename-only escape hatch — the inner schema must still match one of the two formats above (`role`/`content` or ShareGPT's `from`/`value`).
+:::
+
 ### Image
 
 ::: {.callout-note}

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -545,6 +545,14 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 if self.cfg.role_boundaries:
                     role_boundaries_override = list(self.cfg.role_boundaries)
 
+                # Deduped union of per-dataset `field_messages` so custom
+                # conversation column names are honored by the MM collator.
+                field_messages = []
+                for dataset_cfg in ds_entries:
+                    field_message = _ds_get(dataset_cfg, "field_messages")
+                    if field_message and field_message not in field_messages:
+                        field_messages.append(field_message)
+
                 # build() calls build_collator twice (eval + train); log once.
                 if not is_eval:
                     LOG.info(
@@ -566,6 +574,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                     roles_to_train=roles_to_train,
                     train_on_eos=train_on_eos,
                     role_boundaries_override=role_boundaries_override,
+                    field_messages=field_messages or None,
                 )
             elif self.cfg.batch_flattening:
                 collator = DataCollatorWithFlattening

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -545,8 +545,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                 if self.cfg.role_boundaries:
                     role_boundaries_override = list(self.cfg.role_boundaries)
 
-                # Deduped union of per-dataset `field_messages` so custom
-                # conversation column names are honored by the MM collator.
+                # Deduped union of per-dataset `field_messages` for the MM collator.
                 field_messages = []
                 for dataset_cfg in ds_entries:
                     field_message = _ds_get(dataset_cfg, "field_messages")

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -58,11 +58,13 @@ class ProcessingStrategy:
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         self.processor = processor
         self.chat_template = chat_template
         self.image_token = None
         self.image_token_id = None
+        self.field_messages = self._normalize_field_messages(field_messages)
 
         self.image_size = image_size
         self.image_resize_algorithm = (
@@ -139,6 +141,34 @@ class ProcessingStrategy:
         """Subclasses declare role boundaries here; [] opts out of role masking."""
         return []
 
+    @staticmethod
+    def _normalize_field_messages(
+        field_messages: str | list[str] | tuple[str, ...] | None,
+    ) -> tuple[str, ...]:
+        if field_messages is None:
+            return ("messages",)
+        if isinstance(field_messages, str):
+            return (field_messages,)
+        return tuple(field for field in field_messages if field)
+
+    def _get_messages_field(self, example: dict) -> str | None:
+        if "messages" in example and example["messages"] is not None:
+            return "messages"
+        for field in self.field_messages:
+            if field in example and example[field] is not None:
+                return field
+        return None
+
+    @staticmethod
+    def _is_legacy_schema(messages) -> bool:
+        """Detect ShareGPT-style schema by inspecting the first message."""
+        return (
+            isinstance(messages, list)
+            and bool(messages)
+            and isinstance(messages[0], dict)
+            and "from" in messages[0]
+        )
+
     def __call__(self, examples: list[dict]) -> list[dict]:
         """Normalize examples to OpenAI ``messages`` format (accepts legacy ``conversations``)."""
         role_mapping = {
@@ -188,9 +218,26 @@ class ProcessingStrategy:
 
         processed_examples = []
         for example in examples:
+            messages_field = self._get_messages_field(example)
+            # Only re-route when the user supplied a custom `field_messages`
+            # that is neither of the two canonical keys; for "messages" and
+            # "conversations" we defer entirely to the existing branches
+            # below so their behavior is unchanged.
+            if messages_field and messages_field not in {"messages", "conversations"}:
+                msgs = example[messages_field]
+                # Auto-detect ShareGPT vs OpenAI schema from the first
+                # message and route to the matching canonical key so the
+                # existing branches do the right schema conversion.
+                target = "conversations" if self._is_legacy_schema(msgs) else "messages"
+                example = dict(example)
+                example[target] = msgs
+                example.pop(messages_field, None)
+                if target == "conversations":
+                    example.pop("messages", None)
+
             if not ("messages" in example or "conversations" in example):
                 raise ValueError(
-                    "Only `messages` and `conversations` message keys are currently supported."
+                    "Only configured `field_messages`, `messages`, and `conversations` message keys are currently supported."
                 )
 
             if "messages" in example and example["messages"] is not None:
@@ -519,6 +566,7 @@ class Qwen2VLProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -529,6 +577,7 @@ class Qwen2VLProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         self.image_token = "<|image_pad|>"  # nosec
         self.image_token_id = processor.tokenizer.convert_tokens_to_ids(
@@ -564,6 +613,7 @@ class Qwen3_5ProcessingStrategy(Qwen2VLProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -574,6 +624,7 @@ class Qwen3_5ProcessingStrategy(Qwen2VLProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         self.video_token = "<|video_pad|>"  # nosec
         self.video_token_id = processor.tokenizer.convert_tokens_to_ids(
@@ -631,6 +682,7 @@ class Gemma3ProcessingStrategy(_GemmaTurnStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -641,6 +693,7 @@ class Gemma3ProcessingStrategy(_GemmaTurnStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         # Real Gemma3 tokenizers expose boi_token as a direct attribute, not
         # via special_tokens_map (which only holds HF's standard slots).
@@ -879,6 +932,7 @@ class VoxtralProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -889,6 +943,7 @@ class VoxtralProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         special_ids = (
             processor.tokenizer.tokenizer.instruct_tokenizer.audio_encoder.special_ids
@@ -929,6 +984,7 @@ class SmolVLM2ProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -939,6 +995,7 @@ class SmolVLM2ProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         self.image_token = "<image>"  # nosec
 
@@ -964,6 +1021,7 @@ class Mistral3ProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -974,6 +1032,7 @@ class Mistral3ProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
         special_ids = (
             processor.tokenizer.tokenizer.instruct_tokenizer.image_encoder.special_ids
@@ -1014,6 +1073,7 @@ class InternVLProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -1024,6 +1084,7 @@ class InternVLProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
 
         if not hasattr(processor, "image_ids"):
@@ -1064,6 +1125,7 @@ class Glm4vProcessingStrategy(ProcessingStrategy):
         roles_to_train: Optional[list[str]] = None,
         train_on_eos: Optional[str] = None,
         role_boundaries_override: Optional[list[dict]] = None,
+        field_messages: str | list[str] | tuple[str, ...] | None = None,
     ):
         super().__init__(
             processor,
@@ -1074,6 +1136,7 @@ class Glm4vProcessingStrategy(ProcessingStrategy):
             roles_to_train=roles_to_train,
             train_on_eos=train_on_eos,
             role_boundaries_override=role_boundaries_override,
+            field_messages=field_messages,
         )
 
         self.tokenizer = getattr(processor, "tokenizer", processor)
@@ -1132,6 +1195,7 @@ def get_processing_strategy(
     roles_to_train: Optional[list[str]] = None,
     train_on_eos: Optional[str] = None,
     role_boundaries_override: Optional[list[dict]] = None,
+    field_messages: str | list[str] | tuple[str, ...] | None = None,
 ):
     processing_kwargs = {
         "processor": processor,
@@ -1142,6 +1206,7 @@ def get_processing_strategy(
         "roles_to_train": roles_to_train,
         "train_on_eos": train_on_eos,
         "role_boundaries_override": role_boundaries_override,
+        "field_messages": field_messages,
     }
 
     if chat_template_type in [None, "tokenizer_default"]:

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -149,28 +149,20 @@ class ProcessingStrategy:
             return ("messages",)
         if isinstance(field_messages, str):
             return (field_messages,)
-        return tuple(field for field in field_messages if field)
+        return tuple(name for name in field_messages if name)
 
     def _get_messages_field(self, example: dict) -> str | None:
-        # Honor an explicitly configured `field_messages` first so a stale
-        # "messages" column on the row cannot silently override the user's
-        # intent. When `field_messages` is left at its default of
-        # ("messages",) this collapses back to the previous behavior.
-        for field in self.field_messages:
-            if field in example and example[field] is not None:
-                return field
+        # Configured field wins so a stale `messages` column can't override it.
+        for name in self.field_messages:
+            if name in example and example[name] is not None:
+                return name
         if "messages" in example and example["messages"] is not None:
             return "messages"
         return None
 
     @staticmethod
     def _is_legacy_schema(messages) -> bool:
-        """Detect ShareGPT-style schema by inspecting the first message.
-
-        Both `from` and `value` must be present so that rows whose first
-        message merely happens to carry a `from` key (e.g., custom metadata)
-        are not misrouted into the legacy conversion branch.
-        """
+        """Detect ShareGPT schema: first message has both ``from`` and ``value``."""
         return (
             isinstance(messages, list)
             and bool(messages)
@@ -229,15 +221,10 @@ class ProcessingStrategy:
         processed_examples = []
         for example in examples:
             messages_field = self._get_messages_field(example)
-            # Only re-route when the user supplied a custom `field_messages`
-            # that is neither of the two canonical keys; for "messages" and
-            # "conversations" we defer entirely to the existing branches
-            # below so their behavior is unchanged.
+            # Re-route a custom field into the canonical key whose schema it matches;
+            # the canonical "messages"/"conversations" branches below are unchanged.
             if messages_field and messages_field not in {"messages", "conversations"}:
                 msgs = example[messages_field]
-                # Auto-detect ShareGPT vs OpenAI schema from the first
-                # message and route to the matching canonical key so the
-                # existing branches do the right schema conversion.
                 target = "conversations" if self._is_legacy_schema(msgs) else "messages"
                 example = dict(example)
                 example[target] = msgs

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -152,25 +152,35 @@ class ProcessingStrategy:
         return tuple(field for field in field_messages if field)
 
     def _get_messages_field(self, example: dict) -> str | None:
-        if "messages" in example and example["messages"] is not None:
-            return "messages"
+        # Honor an explicitly configured `field_messages` first so a stale
+        # "messages" column on the row cannot silently override the user's
+        # intent. When `field_messages` is left at its default of
+        # ("messages",) this collapses back to the previous behavior.
         for field in self.field_messages:
             if field in example and example[field] is not None:
                 return field
+        if "messages" in example and example["messages"] is not None:
+            return "messages"
         return None
 
     @staticmethod
     def _is_legacy_schema(messages) -> bool:
-        """Detect ShareGPT-style schema by inspecting the first message."""
+        """Detect ShareGPT-style schema by inspecting the first message.
+
+        Both `from` and `value` must be present so that rows whose first
+        message merely happens to carry a `from` key (e.g., custom metadata)
+        are not misrouted into the legacy conversion branch.
+        """
         return (
             isinstance(messages, list)
             and bool(messages)
             and isinstance(messages[0], dict)
             and "from" in messages[0]
+            and "value" in messages[0]
         )
 
     def __call__(self, examples: list[dict]) -> list[dict]:
-        """Normalize examples to OpenAI ``messages`` format (accepts legacy ``conversations``)."""
+        """Normalize examples to OpenAI ``messages`` (accepts legacy ``conversations`` or custom ``field_messages``)."""
         role_mapping = {
             "human": "user",
             "gpt": "assistant",

--- a/tests/test_processing_strategies.py
+++ b/tests/test_processing_strategies.py
@@ -1,6 +1,7 @@
 """Tests for ``axolotl.processing_strategies`` using fake tokenizers (offline/CI-safe)."""
 
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -1162,3 +1163,157 @@ def test_multimodal_config_parses_dict_role_boundaries_to_specs():
     seq = [51, 7, 60, 50, 8, 60]
     out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
     assert out == [-100, -100, -100, -100, 8, 60]
+# --------------------------------------------------------------------------- #
+# field_messages plumbing: helpers and __call__ re-routing
+# --------------------------------------------------------------------------- #
+
+
+def _mock_processor() -> MagicMock:
+    """Processor mock with no ``image_token`` attr so __init__ skips that branch."""
+    processor = MagicMock()
+    del processor.image_token
+    return processor
+
+
+def _openai_messages() -> list[dict]:
+    return [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+
+
+def _sharegpt_messages() -> list[dict]:
+    return [
+        {"from": "human", "value": "hello"},
+        {"from": "gpt", "value": "hi"},
+    ]
+
+
+def test_normalize_field_messages_none_defaults_to_messages():
+    assert ProcessingStrategy._normalize_field_messages(None) == ("messages",)
+
+
+def test_normalize_field_messages_string_wrapped_in_tuple():
+    assert ProcessingStrategy._normalize_field_messages("dialogue") == ("dialogue",)
+
+
+def test_normalize_field_messages_list_preserved():
+    assert ProcessingStrategy._normalize_field_messages(["foo", "bar"]) == ("foo", "bar")
+
+
+def test_normalize_field_messages_falsy_entries_dropped():
+    assert ProcessingStrategy._normalize_field_messages(
+        ["foo", "", None, "bar"]
+    ) == ("foo", "bar")
+
+
+def test_is_legacy_schema_sharegpt_pair_detected():
+    assert ProcessingStrategy._is_legacy_schema([{"from": "human", "value": "hi"}])
+
+
+def test_is_legacy_schema_only_from_is_not_enough():
+    # `from` without `value` (e.g., custom metadata) must not be misrouted.
+    assert not ProcessingStrategy._is_legacy_schema([{"from": "human", "extra": "x"}])
+
+
+def test_is_legacy_schema_openai_schema_returns_false():
+    assert not ProcessingStrategy._is_legacy_schema([{"role": "user", "content": "hi"}])
+
+
+def test_is_legacy_schema_empty_list_returns_false():
+    assert not ProcessingStrategy._is_legacy_schema([])
+
+
+def test_is_legacy_schema_non_list_returns_false():
+    assert not ProcessingStrategy._is_legacy_schema(None)
+    assert not ProcessingStrategy._is_legacy_schema("not a list")
+
+
+def test_get_messages_field_default_returns_messages():
+    strategy = ProcessingStrategy(processor=_mock_processor())
+    assert strategy._get_messages_field({"messages": _openai_messages()}) == "messages"
+
+
+def test_get_messages_field_custom_field_returns_custom():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    assert strategy._get_messages_field({"my_col": _openai_messages()}) == "my_col"
+
+
+def test_get_messages_field_custom_takes_priority_over_stale_messages():
+    # Configured custom field must beat a leftover `messages` column.
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    example = {
+        "messages": [{"role": "user", "content": "stale"}],
+        "my_col": _openai_messages(),
+    }
+    assert strategy._get_messages_field(example) == "my_col"
+
+
+def test_get_messages_field_falls_back_to_messages_when_custom_absent():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    assert strategy._get_messages_field({"messages": _openai_messages()}) == "messages"
+
+
+def test_get_messages_field_returns_none_when_no_match():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    assert strategy._get_messages_field({"random_col": "x"}) is None
+
+
+def test_call_canonical_messages_openai():
+    strategy = ProcessingStrategy(processor=_mock_processor())
+    out = strategy([{"messages": _openai_messages()}])
+
+    assert len(out) == 1
+    assert out[0]["messages"][0]["role"] == "user"
+    # String content is wrapped to multimedia content list.
+    assert out[0]["messages"][0]["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_call_canonical_conversations_sharegpt():
+    strategy = ProcessingStrategy(processor=_mock_processor())
+    out = strategy([{"conversations": _sharegpt_messages()}])
+
+    # Roles get normalized: human -> user, gpt -> assistant.
+    assert out[0]["messages"][0]["role"] == "user"
+    assert out[0]["messages"][1]["role"] == "assistant"
+    assert "conversations" not in out[0]
+
+
+def test_call_custom_field_with_openai_schema():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    out = strategy([{"my_col": _openai_messages()}])
+
+    assert out[0]["messages"][0]["role"] == "user"
+    assert "my_col" not in out[0]
+
+
+def test_call_custom_field_with_sharegpt_schema():
+    # A custom column whose first message looks like ShareGPT is routed to the legacy branch.
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    out = strategy([{"my_col": _sharegpt_messages()}])
+
+    assert out[0]["messages"][0]["role"] == "user"
+    assert out[0]["messages"][1]["role"] == "assistant"
+    assert "my_col" not in out[0]
+    assert "conversations" not in out[0]
+
+
+def test_call_custom_field_overrides_stale_messages_column():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+    out = strategy(
+        [
+            {
+                "messages": [{"role": "user", "content": "stale"}],
+                "my_col": [{"role": "user", "content": "fresh"}],
+            }
+        ]
+    )
+
+    assert out[0]["messages"][0]["content"] == [{"type": "text", "text": "fresh"}]
+
+
+def test_call_unknown_key_raises_value_error():
+    strategy = ProcessingStrategy(processor=_mock_processor(), field_messages="my_col")
+
+    with pytest.raises(ValueError):
+        strategy([{"random_col": _openai_messages()}])

--- a/tests/test_processing_strategies.py
+++ b/tests/test_processing_strategies.py
@@ -1163,6 +1163,8 @@ def test_multimodal_config_parses_dict_role_boundaries_to_specs():
     seq = [51, 7, 60, 50, 8, 60]
     out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
     assert out == [-100, -100, -100, -100, 8, 60]
+
+
 # --------------------------------------------------------------------------- #
 # field_messages plumbing: helpers and __call__ re-routing
 # --------------------------------------------------------------------------- #
@@ -1198,13 +1200,17 @@ def test_normalize_field_messages_string_wrapped_in_tuple():
 
 
 def test_normalize_field_messages_list_preserved():
-    assert ProcessingStrategy._normalize_field_messages(["foo", "bar"]) == ("foo", "bar")
+    assert ProcessingStrategy._normalize_field_messages(["foo", "bar"]) == (
+        "foo",
+        "bar",
+    )
 
 
 def test_normalize_field_messages_falsy_entries_dropped():
-    assert ProcessingStrategy._normalize_field_messages(
-        ["foo", "", None, "bar"]
-    ) == ("foo", "bar")
+    assert ProcessingStrategy._normalize_field_messages(["foo", "", None, "bar"]) == (
+        "foo",
+        "bar",
+    )
 
 
 def test_is_legacy_schema_sharegpt_pair_detected():


### PR DESCRIPTION
  # Description                                                                                                                                     
                  
  `ProcessingStrategy.__call__` (used by `MultiModalChatDataCollator`) currently                                                                    
  hard-codes the message column lookup to `"messages"` or `"conversations"` —
  any other column name silently raises:                                                                                                            
  
  > `ValueError: Only "messages" and "conversations" message keys are currently supported.`                                                         
                  
  The `field_messages` option in the dataset config is honored by the text-only                                                                     
  prompt strategy (`prompt_strategies/chat_template.py`) but was completely
  ignored by the multimodal collator, so users with multimodal datasets stored                                                                      
  under a custom column name had no way to train.
                                                                                                                                                    
  This PR threads `field_messages` from the dataset config through to the
  multimodal `ProcessingStrategy`. When the configured field name is not one of                                                                     
  the two canonical keys, the strategy:
                                                                                                                                                    
  1. inspects the first message to decide whether the data uses the OpenAI
     (`role`/`content`) or ShareGPT (`from`/`value`) schema, and                                                                                    
  2. routes it to the matching canonical key so the existing OpenAI / legacy
     branches do the right schema conversion.                                                                                                       
  
  The behavior of the canonical `messages` and `conversations` keys is left                                                                         
  untouched so existing configs are not affected.
                                                                                                                                                    
  ## Behavior comparison
                                                                                                                                                    
  | Dataset config | Before (`main`) | After (this PR) |
  |---|---|---|
  | `messages` column, OpenAI content | ✅ | ✅ (unchanged) |
  | `conversations` column, ShareGPT content | ✅ | ✅ (unchanged) |                                                                                ──
  | `field_messages: my_col`, OpenAI content | ❌ `ValueError` | ✅ routed to OpenAI branch |
  | `field_messages: my_col`, ShareGPT content | ❌ `ValueError` | ✅ routed to legacy branch |                                                       
  | `messages` column, ShareGPT content (mismatched) | ❌ `KeyError` | ❌ `KeyError` (out of scope) |                                                 
  | `conversations` column, OpenAI content (mismatched) | ❌ `KeyError` | ❌ `KeyError` (out of scope) |                                            ──
                                                                                                                                                    
  ## Motivation and Context                                                                                                                         
                  
  Encountered while training a Gemma 4 vision LoRA on a multimodal parquet                                                                          
  dataset whose conversation column was named something other than `messages`
  (OpenAI schema, multimedia content). Minimal config shape:                                                                                        
                                                                                                                                                    
  ```yaml                                                                                                                                           
  datasets:                                                                                                                                         
    - path: <local parquet>
      ds_type: parquet
      type: chat_template
      field_messages: <custom_column_name>
      train_on_eot: turn                                                                                                                            
      split: train
  chat_template: gemma4                                                                                                                             
  processor_type: AutoProcessor
  skip_prepare_dataset: true
                                                                                                                                                    
  On main the run fails immediately at the first batch because
  MultiModalChatDataCollator calls ProcessingStrategy.__call__, which raises                                                                        
  the hard-coded error above.                                                                                                                       
  
  This is multimodal-only — the text prompt-strategy framework has its own                                                                          
  field_messages plumbing in chat_template.py:1207 and was never affected.
                                                                                                                                                    
  How has this been tested?
                                                                                                                                                    
  Verified end-to-end against a real Gemma 4 vision setup with an actual
  Gemma4Processor (loaded via AutoProcessor) and a small batch of
  multimodal samples whose conversation column is renamed away from                                                                                 
  messages:                                                                                                                                         
                                                                                                                                                    
  - main:                                                                                                                                           
    - Calling get_processing_strategy(..., field_messages=<custom>) →
  TypeError: got an unexpected keyword argument 'field_messages'                                                                                    
    - Bypassing that and feeding the samples to the unparameterized strategy →
  ValueError: Only 'messages' and 'conversations' message keys are currently supported.                                                             
  - This PR:      
    - Samples processed successfully; the custom column is rerouted to                                                                              
  messages, content is upgraded to the multimedia format                                                                                            
  ({"type": "text", "text": ...}), and the original key is dropped.                                                                                 
    - Schema auto-detection covered manually for both OpenAI and ShareGPT                                                                           
  inputs under a custom field name.                                                                                                                 
  
  axolotl preprocess is not applicable here because the config sets                                                                                 
  skip_prepare_dataset: true (multimodal datasets are processed at collate
  time), so verification was done at the collator entry point directly.                                                                             
  
  Existing canonical-key behavior was confirmed unchanged (messages + OpenAI                                                                        
  and conversations + ShareGPT both still work as before).
                                                                                                                                                    
  AI Usage Disclaimer

  Yes — Claude Code was used to draft the schema-detection helper and PR                                                                            
  description. The bug investigation, the choice to keep the canonical-key
  behavior untouched (rather than auto-detect across the board), and the                                                                            
  end-to-end verification approach were directed manually.
                                                                                                                                                    
  Screenshots (if appropriate)
                                                                                                                                                    
  N/A             

  Types of changes

  - Bug fix (non-breaking change which fixes an issue)
  - Improvement (small extension to existing functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable support for custom field names when specifying conversation data in datasets, enabling greater flexibility with diverse data sources.
  * Implemented automatic detection and normalization of message formats to ensure consistent processing across different conversation schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->