### PR TITLE
fix: FSDP FULL_STATE_DICT oom from memory leak 

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import json
 import math
 import os
@@ -800,7 +801,14 @@ class AxolotlTrainer(
             with open(tokens_state_path, "w", encoding="utf-8") as f:
                 json.dump(tokens_state, f)
 
-        return super()._save_checkpoint(model, trial, **kwargs)
+        result = super()._save_checkpoint(model, trial, **kwargs)
+
+        # Reclaim VRAM held by the FSDP full-state-dict gather.
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        return result
 
     # TODO(wing): remove once https://github.com/huggingface/transformers/pull/39866/files is merged
     def _save(self, output_dir: Optional[str] = None, state_dict=None):

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -4,6 +4,7 @@ monkeypatch for accelerate fsdp2 fix when modifying ordereddict during interatio
 
 import copy
 import functools
+import gc
 import os
 import sys
 
@@ -161,6 +162,7 @@ def get_state_dict(self, model, unwrap=True):
 
         state_dict = {}
         sharded_state_dict = model.state_dict()
+        is_rank_zero = torch.distributed.get_rank() == 0
         for param_name, param in sharded_state_dict.items():
             if param.is_cpu:
                 param = param.to(torch.device("cuda"))
@@ -168,9 +170,21 @@ def get_state_dict(self, model, unwrap=True):
             if isinstance(param, DTensor):
                 param = param.full_tensor()
 
-            if torch.distributed.get_rank() == 0:
+            if is_rank_zero:
                 state_dict[param_name] = param.cpu()
+            # Drop the GPU-resident gathered tensor before the next iteration
+            # allocates the next one; otherwise the caching allocator holds
+            # both reservations and we accumulate ~model-size of VRAM.
+            del param
             torch.distributed.barrier()
+
+        # Release the sharded view and force the allocator to give back the
+        # gather buffers. Together with the empty_cache in
+        # AxolotlTrainer._save_checkpoint, this is the fix for #3596.
+        del sharded_state_dict
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
     elif self.distributed_type == DistributedType.FSDP:
         from torch.distributed.fsdp import (
             FullStateDictConfig,

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -179,8 +179,7 @@ def get_state_dict(self, model, unwrap=True):
             torch.distributed.barrier()
 
         # Release the sharded view and force the allocator to give back the
-        # gather buffers. Together with the empty_cache in
-        # AxolotlTrainer._save_checkpoint, this is the fix for #3596.
+        # gather buffers.
         del sharded_state_dict
         gc.collect()
         if torch.cuda.is_available():


### PR DESCRIPTION
memory clean up every step 

##TEST
fixes #3596 

modified config from 3596 for testing 9 steps save every 3 steps 

``` # Gemma 4 26B-A4B MoE QLoRA with ScatterMoE kernels
#
# Validated: 50 steps on FineTome-100k, loss 8.8 -> 1.8, single RTX 5090 (32GB)
# torch_compile=true: 21 GiB peak VRAM, ~230 tok/s, 336s total
#
# Key notes:
# - Max sequence length on 32GB GPU: 2048 (micro_batch_size=1, SDP attention).
#   4096 seq_len OOMs due to head_dim=512 math SDP materializing full score matrix.
#   Use 48GB+ GPUs for longer sequences or multi-GPU with FSDP.

base_model: google/gemma-4-E4B-it

plugins:
  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
  - axolotl.integrations.kernels.KernelsPlugin
  - axolotl.integrations.liger.LigerPlugin
use_kernels: true
use_scattermoe: true
experts_implementation: scattermoe
torch_compile: false #true
liger_layer_norm: false
liger_rope: true
liger_rms_norm: true
liger_glu_activation: true
liger_rms_norm_gated: true
strict: false

#from gemma 3 config
dataset_num_proc: 16
save_safetensors: true
auto_resume_from_checkpoints: false

# Write outputs and the HF datasets cache to the network mount instead of
# overlay (35 GB free). Overlay fills up after a couple of full-state-dict
# checkpoints, which surfaces as 'I/O operation on closed file' in worker
# processes during dataset prep. /workspace/data has 84 TB free.
output_dir: /workspace/data/axolotl-artifacts/gemaa-out
dataset_prepared_path: /workspace/data/axolotl-artifacts/gemaa-prepared

chat_template: gemma4
datasets:
  - path: mlabonne/FineTome-100k
    type: chat_template
    split: train[:1%]   # was 10% — short verify run only needs ~10 steps
    field_messages: conversations
    message_property_mappings:
      role: from
      content: value
# val_set_size: 0.0005


sequence_len: 2048
sample_packing: true
eval_sample_packing: true
remove_unused_columns: true
pad_to_sequence_len: true

# for flex attension
# torch_compile: true
flex_attention: false #true
sdp_attention: true 
# flex_attention: true
#lora
# load_in_4bit: true
# quantize_moe_experts: true
# adapter: qlora
# lora_r: 16
# lora_alpha: 32
# lora_dropout: 0

# Restrict LoRA to text backbone only (skip vision/audio encoders)
# using regex to match only the text decoder attention projections.
# lora_target_modules: 'model.language_model.layers.[\d]+.(_checkpoint_wrapped_module.)?(mlp|self_attn).(up|down|gate|q|k|v|o)_proj'

# # MoE expert LoRA (3D Parameter tensors, not nn.Linear)
# lora_target_parameters:
#   - experts.gate_up_proj
#   - experts.down_proj

# lora_mlp_kernel: false
# lora_qkv_kernel: false
# lora_o_kernel: false

#for lora
# bnb_config_kwargs:
#   bnb_4bit_use_double_quant: true

# Weights & Biases configuration
use_wandb: true
wandb_project: gemmafor 
wandb_entity: # Your wandb username or team name
wandb_name: 
wandb_watch: # "gradients", "all", or "false"
# wandb_log_model: "checkpoint"  # "checkpoint" to log model every save_steps, "end" to log only at end
wandb_mode: # "online", "offline", or "disabled" - leave empty for default (online)
wandb_log_model:

gradient_accumulation_steps: 16   # was 4 — keep effective batch at 16 (was 4*4=16)
micro_batch_size: 1               # was 4 — full-FT 26B-A4B with no CCE makes [B,T,V] logits cost ~4 GB per sample at vocab≈262K
num_epochs: 1                     # short verify run; max_steps caps it further
max_steps: 9                     # saves at 3,6,9 then exits memory budget, not the save path
optimizer: adamw_torch_8bit
lr_scheduler: cosine
learning_rate: 0.000001

bf16: auto
tf32: true

gradient_checkpointing: false   # was false — required for full-FT 26B on 80GB; halves activation memory
activation_offloading: false #true
# logging_steps: 1

# FA2 not supported
# sdp_attention: true

warmup_ratio: 0.1
# from gemma 4 example
# evals_per_epoch: 4
# saves_per_epoch: 1
# weight_decay: 0.0
special_tokens:
# from gemma 3


# Logging and saving
logging_steps: 5
# save_strategy: "epoch"
# save_steps: 250
# evals_per_epoch: 1
save_total_limit: 3       # keep all 3 verify-run checkpoints so we can compare VRAM across them
save_steps: 3             # save at steps 3, 6, 9 — three observations of the leak pattern
# saves_per_epoch: 100    # disabled in favor of save_steps for the short verify run
use_tensorboard: true
## less saves to save 
# save_strategy: "steps"
# save_steps: 4125  ## 2 nodes 5 epoch save        # 1650 / 2 = halfway
# save_total_limit: 2
# use_tensorboard: true

# Best model selection
load_best_model_at_end: false  # disabled for short verify run (also requires eval set, which isn't configured)
# metric_for_best_model: "eval_loss"  # Use validation loss to determine best model
greater_is_better: false  # Lower loss is better
# early_stopping_patience: 3  # Stop if no improvement for 3 evaluations (optional)
early_stopping_patience:


fsdp_config:
  enable_cpu_offload: false
  fsdp_activation_checkpointing: true
  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
  fsdp_cpu_ram_efficient_loading: true
  fsdp_limit_all_gathers: true
  fsdp_offload_params: false
  fsdp_reshard_after_forward: true
  fsdp_sharding_strategy: FULL_SHARD
  # FULL_STATE_DICT requires the get_state_dict + _save_checkpoint patches
  # (gc.collect + torch.cuda.empty_cache after the gather loop and after save).
  # Without them, save fails with `basic_ios::clear: iostream error` during
  # torch.save → write_end_of_file. With them, saves succeed and VRAM does
  # not creep across saves. This is the fix for axolotl-ai-cloud/axolotl#3596.
  fsdp_state_dict_type: FULL_STATE_DICT
  fsdp_sync_module_states: true
  fsdp_transformer_layer_cls_to_wrap: Gemma4TextDecoderLayer
  fsdp_version: 2

# fsdp_config:
#   enable_cpu_offload: false
#   fsdp_activation_checkpointing: true
#   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
#   fsdp_cpu_ram_efficient_loading: true
#   fsdp_limit_all_gathers: true
#   fsdp_offload_params: false
#   fsdp_reshard_after_forward: true
#   fsdp_sharding_strategy: FULL_SHARD
#   fsdp_state_dict_type: SHARDED_STATE_DICT
#   fsdp_final_state_dict_type: FULL_STATE_DICT
#   fsdp_sync_module_states: true
#   fsdp_transformer_layer_cls_to_wrap: Gemma4TextDecoderLayer
#   fsdp_version: 2

# Add DDP timeout for multi-node training
ddp_timeout: 7200  # 2 hours in seconds

# Additional settings for stability
dataloader_num_workers: 4   # was 64 — way too many; 2-8 per GPU is the norm
dataloader_pin_memory: false```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GPU memory management during distributed training checkpoints, reducing VRAM accumulation and fragmentation. This allows more stable training on memory-constrained GPUs and reduces out-of-memory errors during checkpoint saving operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->