### PR TITLE
fix: processor_kwargs for mm_chat regression

### DIFF
--- a/src/axolotl/utils/collators/mm_chat.py
+++ b/src/axolotl/utils/collators/mm_chat.py
@@ -43,16 +43,14 @@ class MultiModalChatDataCollator(DataCollatorMixin):
         # Initialize batch
         messages = [ex["messages"] for ex in examples]
 
-        batch = dict(
-            self.processing_strategy.processor.apply_chat_template(
-                messages,
-                add_generation_prompt=False,
-                tokenize=True,
-                return_tensors="pt",
-                padding=True,
-                return_dict=True,
-                chat_template=self.processing_strategy.chat_template,
-            )
+        batch = self.processing_strategy.processor.apply_chat_template(
+            messages,
+            add_generation_prompt=False,
+            tokenize=True,
+            return_tensors="pt",
+            return_dict=True,
+            chat_template=self.processing_strategy.chat_template,
+            processor_kwargs={"padding": True},
         )
 
         # Process the labels

--- a/tests/test_mm_chat_collator.py
+++ b/tests/test_mm_chat_collator.py
@@ -8,6 +8,7 @@ input_ids tensor instead of the full BatchFeature dict, leading to
 when downstream code did batch["input_ids"] on the resulting tensor.
 """
 
+from collections.abc import Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -97,10 +98,10 @@ class TestMultiModalChatDataCollatorShapeContract:
         ):
             batch = collator.process_rows(examples)
 
-        assert isinstance(batch, dict), (
-            "process_rows must return a dict (BatchFeature), not a raw tensor. "
-            "If it returns a tensor, apply_chat_template was called without "
-            "return_dict=True at the top level."
+        assert isinstance(batch, Mapping), (
+            "process_rows must return a Mapping (BatchFeature or dict), not a "
+            "raw tensor. If it returns a tensor, apply_chat_template was called "
+            "without return_dict=True at the top level."
         )
 
     def test_process_rows_input_ids_shape(self, mock_processing_strategy):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Removes redundant dict call and pass the padding through processor_kwargs to suppress errors

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal optimization in multi-modal chat data processing with no functional changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->