### PR TITLE
fix AssertionError: Original QKV code not found

### DIFF
--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -76,85 +76,11 @@ QKV_PATCHES = [
     value_states = value_states.view(hidden_shape).transpose(1, 2)
 """.lstrip("\n"),
     ),
-    # Gemma4: norm between proj and transpose, RoPE between norm and transpose,
-    # conditional KV sharing (is_kv_shared_layer), v_proj may be None (attention_k_eq_v).
-    # We only fuse the projection calls; norms, RoPE, and KV sharing stay as-is.
-    (
-        """
-    query_states = self.q_proj(hidden_states).view(hidden_shape)
-    query_states = self.q_norm(query_states)
-    query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
-    query_states = query_states.transpose(1, 2)
-
-    # For layers with shared KV (from kv sharing point onwards), we reuse the same keys/values states as the last non-sharing layer
-    if self.is_kv_shared_layer and past_key_values is not None:
-        key_states, value_states = past_key_values.shared_layers[self.kv_shared_layer_index]
-        # Device of past layer may be different from current one
-        key_states = key_states.to(query_states.device)
-        value_states = value_states.to(query_states.device)
-    else:
-        key_states = self.k_proj(hidden_states).view(hidden_shape)
-        value_states = self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
-""".lstrip("\n"),
-        """
-    query_states, key_states, value_states = self.apply_qkv(hidden_states)
-    query_states = query_states.view(hidden_shape)
-    query_states = self.q_norm(query_states)
-    query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
-    query_states = query_states.transpose(1, 2)
-
-    # For layers with shared KV (from kv sharing point onwards), we reuse the same keys/values states as the last non-sharing layer
-    if self.is_kv_shared_layer and past_key_values is not None:
-        key_states, value_states = past_key_values.shared_layers[self.kv_shared_layer_index]
-        # Device of past layer may be different from current one
-        key_states = key_states.to(query_states.device)
-        value_states = value_states.to(query_states.device)
-    else:
-        key_states = key_states.view(hidden_shape)
-        value_states = value_states.view(hidden_shape) if self.v_proj is not None else key_states
-""".lstrip("\n"),
-    ),
-    # Gemma4 (transformers >= 5.6): shared_kv_states parameter replaces
-    # past_key_values.shared_layers, and v_norm added after k_norm.
-    (
-        """
-    query_states = self.q_proj(hidden_states).view(hidden_shape)
-    query_states = self.q_norm(query_states)
-    query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
-    query_states = query_states.transpose(1, 2)
-
-    # For layers with shared KV (from kv sharing point onwards), we reuse the same keys/values states as the last non-sharing layer.
-    # We cannot simply reuse the cached state if we have a Cache, as sliding layers will not remember the full states in their Cache
-    # once we are past the sliding window - so we always use `shared_kv_states` instead, even when past_key_values is not None
-    if self.is_kv_shared_layer:
-        key_states, value_states = shared_kv_states[self.kv_shared_layer_index]
-        # Device of past layer may be different from current one
-        key_states = key_states.to(query_states.device)
-        value_states = value_states.to(query_states.device)
-    else:
-        key_states = self.k_proj(hidden_states).view(hidden_shape)
-        value_states = self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
-""".lstrip("\n"),
-        """
-    query_states, key_states, value_states = self.apply_qkv(hidden_states)
-    query_states = query_states.view(hidden_shape)
-    query_states = self.q_norm(query_states)
-    query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
-    query_states = query_states.transpose(1, 2)
-
-    # For layers with shared KV (from kv sharing point onwards), we reuse the same keys/values states as the last non-sharing layer.
-    # We cannot simply reuse the cached state if we have a Cache, as sliding layers will not remember the full states in their Cache
-    # once we are past the sliding window - so we always use `shared_kv_states` instead, even when past_key_values is not None
-    if self.is_kv_shared_layer:
-        key_states, value_states = shared_kv_states[self.kv_shared_layer_index]
-        # Device of past layer may be different from current one
-        key_states = key_states.to(query_states.device)
-        value_states = value_states.to(query_states.device)
-    else:
-        key_states = key_states.view(hidden_shape)
-        value_states = value_states.view(hidden_shape) if self.v_proj is not None else key_states
-""".lstrip("\n"),
-    ),
+    # NOTE: Gemma4 intentionally has no QKV_PATCHES entry. It always runs
+    # through the fused attention monkeypatch (patch_gemma4_fused_attn),
+    # whose hand-written forward already calls self.apply_qkv/self.apply_o.
+    # patch_self_attn_lora skips Gemma4 by class, so a source-rewrite pattern
+    # here would be permanently dead. See that skip for the rationale.
 ]
 
 ORIGINAL_O_CODE = """
@@ -323,18 +249,26 @@ def patch_self_attn_lora(cfg: DictDefault):
         LOG.info(f"{attention_cls.__name__} already patched")
         return
 
-    # Some model-specific monkeypatches (e.g. Gemma4 fused RMSNorm+RoPE) replace
-    # ``forward`` wholesale with an implementation that already routes through
-    # ``self.apply_qkv``/``self.apply_o`` when present. In that case the
-    # source-rewrite below would fail to find the original QKV pattern, and is
-    # also unnecessary — the instance-level method swaps in
-    # ``apply_lora_kernel_patches`` are sufficient.
-    if getattr(attention_cls, "_axolotl_supports_lora_kernels", False):
-        LOG.info(
-            f"{attention_cls.__name__} already supports apply_qkv/apply_o via "
-            "model-specific patch - skipping source rewrite"
+    # Gemma4 always runs through the fused RMSNorm+RoPE monkeypatch
+    # (``patch_gemma4_fused_attn``, applied unconditionally for gemma4 models
+    # in patch_manager). Its hand-written ``forward`` already routes through
+    # ``self.apply_qkv``/``self.apply_o`` when present, so the source-rewrite
+    # below is both impossible (the original QKV source is gone) and
+    # unnecessary. Gemma4 therefore has exactly one LoRA-kernel path — the
+    # fused one — and intentionally no QKV_PATCHES entry.
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import (
+            Gemma4TextAttention,
         )
-        return
+
+        if attention_cls is Gemma4TextAttention:
+            LOG.info(
+                "Gemma4TextAttention uses the fused attention path "
+                "(apply_qkv/apply_o) - skipping LoRA source rewrite"
+            )
+            return
+    except ImportError:
+        pass
 
     self_attn_forward = inspect.getsource(attention_cls.forward)
     attention_cls._original_forward = self_attn_forward

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -76,11 +76,8 @@ QKV_PATCHES = [
     value_states = value_states.view(hidden_shape).transpose(1, 2)
 """.lstrip("\n"),
     ),
-    # NOTE: Gemma4 intentionally has no QKV_PATCHES entry. It always runs
-    # through the fused attention monkeypatch (patch_gemma4_fused_attn),
-    # whose hand-written forward already calls self.apply_qkv/self.apply_o.
-    # patch_self_attn_lora skips Gemma4 by class, so a source-rewrite pattern
-    # here would be permanently dead. See that skip for the rationale.
+    # Gemma4 has no entry: its fused forward already calls apply_qkv/apply_o,
+    # and patch_self_attn_lora skips it (see the skip there).
 ]
 
 ORIGINAL_O_CODE = """
@@ -249,13 +246,9 @@ def patch_self_attn_lora(cfg: DictDefault):
         LOG.info(f"{attention_cls.__name__} already patched")
         return
 
-    # Gemma4 always runs through the fused RMSNorm+RoPE monkeypatch
-    # (``patch_gemma4_fused_attn``, applied unconditionally for gemma4 models
-    # in patch_manager). Its hand-written ``forward`` already routes through
-    # ``self.apply_qkv``/``self.apply_o`` when present, so the source-rewrite
-    # below is both impossible (the original QKV source is gone) and
-    # unnecessary. Gemma4 therefore has exactly one LoRA-kernel path — the
-    # fused one — and intentionally no QKV_PATCHES entry.
+    # Skip Gemma4: patch_manager applies patch_gemma4_fused_attn
+    # unconditionally for gemma4 before this runs, and that fused forward
+    # already calls apply_qkv/apply_o, so the source rewrite is dead.
     try:
         from transformers.models.gemma4.modeling_gemma4 import (
             Gemma4TextAttention,

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -323,6 +323,19 @@ def patch_self_attn_lora(cfg: DictDefault):
         LOG.info(f"{attention_cls.__name__} already patched")
         return
 
+    # Some model-specific monkeypatches (e.g. Gemma4 fused RMSNorm+RoPE) replace
+    # ``forward`` wholesale with an implementation that already routes through
+    # ``self.apply_qkv``/``self.apply_o`` when present. In that case the
+    # source-rewrite below would fail to find the original QKV pattern, and is
+    # also unnecessary — the instance-level method swaps in
+    # ``apply_lora_kernel_patches`` are sufficient.
+    if getattr(attention_cls, "_axolotl_supports_lora_kernels", False):
+        LOG.info(
+            f"{attention_cls.__name__} already supports apply_qkv/apply_o via "
+            "model-specific patch - skipping source rewrite"
+        )
+        return
+
     self_attn_forward = inspect.getsource(attention_cls.forward)
     attention_cls._original_forward = self_attn_forward
     self_attn_forward, _ = detab_code(self_attn_forward)

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -187,10 +187,6 @@ def patch_gemma4_fused_attn(install_shared_kv_workaround: bool = False):
 
     original_forward = Gemma4TextAttention.forward
     Gemma4TextAttention.forward = _make_fused_forward(original_forward)
-    # Signal to lora_kernels.patch_self_attn_lora that the source-rewrite for
-    # apply_qkv/apply_o is unnecessary: fused_forward already routes through
-    # them when present on the attention instance.
-    Gemma4TextAttention._axolotl_supports_lora_kernels = True
 
     if install_shared_kv_workaround:
         _patch_decoder_layer_call()

--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -145,7 +145,11 @@ def _make_fused_forward(original_forward):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        attn_output = self.o_proj(attn_output)
+        # Use apply_o if present (LoRA O kernel patch), otherwise direct proj
+        if hasattr(self, "apply_o"):
+            attn_output = self.apply_o(attn_output)
+        else:
+            attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 
     return fused_forward
@@ -183,6 +187,10 @@ def patch_gemma4_fused_attn(install_shared_kv_workaround: bool = False):
 
     original_forward = Gemma4TextAttention.forward
     Gemma4TextAttention.forward = _make_fused_forward(original_forward)
+    # Signal to lora_kernels.patch_self_attn_lora that the source-rewrite for
+    # apply_qkv/apply_o is unnecessary: fused_forward already routes through
+    # them when present on the attention instance.
+    Gemma4TextAttention._axolotl_supports_lora_kernels = True
 
     if install_shared_kv_workaround:
         _patch_decoder_layer_call()


### PR DESCRIPTION

# Description
when training Gemma 4 with LoRA. The Gemma 4 fused RMSNorm+RoPE monkeypatch replaces Gemma4TextAttention.forward wholesale before the LoRA QKV/O source-rewrite patch runs, so the rewrite can no longer find its expected pattern and asserts.




## Motivation and Context

#3655

## How has this been tested?

config runs without  AssertionError: Original QKV code not found

## AI Usage Disclaimer

claude dignose 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA compatibility with optimized/fused attention paths to avoid incorrect patching.
  * Gemma4 models now bypass incompatible forward-rewrite logic and use the LoRA output hook when available, preventing misapplied patches and ensuring safer fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->