### PR TITLE
fix: respect has_aux contract in KD liger chunked loss

### DIFF
--- a/src/axolotl/integrations/kd/kernels/liger.py
+++ b/src/axolotl/integrations/kd/kernels/liger.py
@@ -225,7 +225,7 @@ class LigerFusedLinearKLTopKLogprobFunction(LigerFusedLinearDistillationBase):
             _target_mask_chunk,
             _true_labels_chunk,
         ):
-            return cls._compute_loss_kl_topk(
+            soft_loss, ce_loss = cls._compute_loss_kl_topk(
                 student_input_chunk=_student_input_chunk,
                 student_weight=_student_lm_head_weight,
                 target_token_ids_chunk=_target_token_ids_chunk,
@@ -242,6 +242,11 @@ class LigerFusedLinearKLTopKLogprobFunction(LigerFusedLinearDistillationBase):
                 beta=beta,
                 normalize_topk=normalize_topk,
             )
+            # has_aux=True: first return is the differentiated scalar, rest is aux.
+            # Combine here so both terms contribute to backward; aux carries the
+            # unweighted soft/ce values for reporting.
+            combined = weight_soft_loss * soft_loss + weight_hard_loss * ce_loss
+            return combined, (soft_loss, ce_loss)
 
         def accumulate_chunk_grads(
             student_input_chunk_ac,
@@ -254,7 +259,9 @@ class LigerFusedLinearKLTopKLogprobFunction(LigerFusedLinearDistillationBase):
             if student_lm_head_bias is not None:
                 (
                     (chunk_grad_input, chunk_grad_weight, chunk_grad_bias),
-                    (chunk_kd_loss, chunk_ce_loss),
+                    # grad_and_value(has_aux=True) returns (grads, (value, aux));
+                    # value = combined scalar, aux = (soft_loss, ce_loss) from loss_fn_for_grad.
+                    (_, (chunk_kd_loss, chunk_ce_loss)),
                 ) = torch.func.grad_and_value(
                     loss_fn_for_grad, argnums=(0, 1, 2), has_aux=True
                 )(
@@ -271,7 +278,9 @@ class LigerFusedLinearKLTopKLogprobFunction(LigerFusedLinearDistillationBase):
                 argnums_for_grad = (0, 1)  # Differentiate wrt input_chunk, weight
                 (
                     (chunk_grad_input, chunk_grad_weight),  # No grad for bias
-                    (chunk_kd_loss, chunk_ce_loss),
+                    # grad_and_value(has_aux=True) returns (grads, (value, aux));
+                    # value = combined scalar, aux = (soft_loss, ce_loss) from loss_fn_for_grad.
+                    (_, (chunk_kd_loss, chunk_ce_loss)),
                 ) = torch.func.grad_and_value(
                     loss_fn_for_grad, argnums=argnums_for_grad, has_aux=True
                 )(

--- a/tests/integrations/test_kd_liger.py
+++ b/tests/integrations/test_kd_liger.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for LigerFusedLinearKLTopKLogprobFunction autograd contract.
+
+Regression tests for the has_aux=True contract violation in
+LigerFusedLinearKLTopKLogprobFunction: CE loss must contribute to the
+backward graph, not be silently dropped as aux.
+"""
+
+import torch
+
+from axolotl.integrations.kd.kernels.liger import LigerFusedLinearKLTopKLogprobLoss
+
+BATCH_SIZE = 1
+SEQ_LEN = 4
+VOCAB_SIZE = 16
+HIDDEN_DIM = 8
+TOP_K = 4
+
+
+def make_inputs(seed: int):
+    torch.manual_seed(seed)
+    student_hidden_states = torch.randn(
+        BATCH_SIZE, SEQ_LEN, HIDDEN_DIM, dtype=torch.float32, requires_grad=True
+    )
+    lm_head_weight = torch.randn(
+        VOCAB_SIZE, HIDDEN_DIM, dtype=torch.float32, requires_grad=True
+    )
+    target_token_ids = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN, TOP_K))
+    target_logprobs = torch.log_softmax(torch.randn(BATCH_SIZE, SEQ_LEN, TOP_K), dim=-1)
+    target_mask = torch.ones(BATCH_SIZE, SEQ_LEN, TOP_K, dtype=torch.bool)
+    true_labels = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN))
+    # Set an interior position to ignore_index. After the left-shift inside the
+    # kernel (true_labels = pad(...); true_labels[:, 1:]), index [0, 2] in the
+    # input becomes index 1 in the flattened CE labels, so this exercises
+    # ignore_index handling in F.cross_entropy.
+    true_labels[0, 2] = -100
+    return {
+        "student_hidden_states": student_hidden_states,
+        "lm_head_weight": lm_head_weight,
+        "target_token_ids": target_token_ids,
+        "target_logprobs": target_logprobs,
+        "target_mask": target_mask,
+        "true_labels": true_labels,
+    }
+
+
+def test_ce_only_gradient_flows_to_student_hidden_states():
+    """Regression: with weight_soft_loss=0, weight_hard_loss=1 the CE gradient must reach inputs.
+
+    Pre-fix, has_aux=True dropped CE from the backward graph and student_input.grad was all zero.
+    """
+    inputs = make_inputs(seed=0)
+    loss_fn = LigerFusedLinearKLTopKLogprobLoss(
+        weight_hard_loss=1.0,
+        weight_soft_loss=0.0,
+        temperature=1.0,
+        beta=0.0,
+        compiled=False,
+        chunk_size=2,
+        compute_ce_loss=True,
+    )
+    loss = loss_fn(
+        inputs["lm_head_weight"],
+        inputs["student_hidden_states"],
+        inputs["target_token_ids"],
+        inputs["target_logprobs"],
+        inputs["target_mask"],
+        inputs["true_labels"],
+    )
+    loss.backward()
+
+    assert inputs["student_hidden_states"].grad is not None
+    assert torch.isfinite(inputs["student_hidden_states"].grad).all()
+    assert inputs["student_hidden_states"].grad.abs().sum().item() > 0
+
+    assert inputs["lm_head_weight"].grad is not None
+    assert torch.isfinite(inputs["lm_head_weight"].grad).all()
+    assert inputs["lm_head_weight"].grad.abs().sum().item() > 0
+
+
+def test_kd_mix_gradient_changes_when_ce_weight_changes():
+    """Regression: in KD-mix mode, increasing weight_hard_loss must change the gradient.
+
+    Two runs with identical RNG, differing only in weight_hard_loss (0.0 vs 0.5). Pre-fix
+    both runs produced identical grads because CE was silently dropped from backward.
+    """
+    inputs_a = make_inputs(seed=42)
+    loss_fn_a = LigerFusedLinearKLTopKLogprobLoss(
+        weight_soft_loss=0.5,
+        weight_hard_loss=0.0,
+        temperature=1.0,
+        beta=0.0,
+        compiled=False,
+        chunk_size=2,
+        compute_ce_loss=True,
+    )
+    loss_a = loss_fn_a(
+        inputs_a["lm_head_weight"],
+        inputs_a["student_hidden_states"],
+        inputs_a["target_token_ids"],
+        inputs_a["target_logprobs"],
+        inputs_a["target_mask"],
+        inputs_a["true_labels"],
+    )
+    loss_a.backward()
+    grad_a_h = inputs_a["student_hidden_states"].grad.detach().clone()
+    grad_a_w = inputs_a["lm_head_weight"].grad.detach().clone()
+
+    inputs_b = make_inputs(seed=42)
+    loss_fn_b = LigerFusedLinearKLTopKLogprobLoss(
+        weight_soft_loss=0.5,
+        weight_hard_loss=0.5,
+        temperature=1.0,
+        beta=0.0,
+        compiled=False,
+        chunk_size=2,
+        compute_ce_loss=True,
+    )
+    loss_b = loss_fn_b(
+        inputs_b["lm_head_weight"],
+        inputs_b["student_hidden_states"],
+        inputs_b["target_token_ids"],
+        inputs_b["target_logprobs"],
+        inputs_b["target_mask"],
+        inputs_b["true_labels"],
+    )
+    loss_b.backward()
+    grad_b_h = inputs_b["student_hidden_states"].grad.detach().clone()
+    grad_b_w = inputs_b["lm_head_weight"].grad.detach().clone()
+
+    assert grad_a_h is not None
+    assert torch.isfinite(grad_a_h).all()
+    assert grad_b_h is not None
+    assert torch.isfinite(grad_b_h).all()
+
+    assert grad_a_w is not None
+    assert torch.isfinite(grad_a_w).all()
+    assert grad_b_w is not None
+    assert torch.isfinite(grad_b_w).all()
+
+    diff = (grad_b_h - grad_a_h).abs().sum().item()
+    assert not torch.allclose(grad_a_h, grad_b_h, atol=1e-6, rtol=1e-5)
+    assert diff > 1e-4, f"CE gradient contribution suspiciously small: {diff}"
+
+    diff_w = (grad_b_w - grad_a_w).abs().sum().item()
+    assert not torch.allclose(grad_a_w, grad_b_w, atol=1e-6, rtol=1e-5)
+    assert diff_w > 1e-4, (
+        f"CE weight-gradient contribution suspiciously small: {diff_w}"
+    )


### PR DESCRIPTION
# Description

The KD liger chunked loss was dropping the CE term from the backward pass. The inner loss function returned `(soft_loss, ce_loss)` to `torch.func.grad_and_value(has_aux=True)`, which only computes gradients for the first element. CE was getting treated as aux and got no gradient flow.

## Motivation and Context

When training with `weight_hard_loss > 0`:
- CE-only setup (`weight_soft_loss=0, weight_hard_loss=1`): grad_norm was 0 every step, model did not learn.
- KD-mix setup (e.g. 0.5 / 0.5): the reported loss showed both terms, but only the KD gradient reached the optimizer.

The printed loss values looked fine, so this is easy to miss during a training run. The fix combines both losses inside the differentiated function so both reach backward, and returns `(soft_loss, ce_loss)` as aux for reporting. Reported loss values stay the same as before.

## How has this been tested?

Two new tests in `tests/integrations/test_kd_liger.py`:

1. `test_ce_only_gradient_flows_to_student_hidden_states`: with `weight_soft_loss=0, weight_hard_loss=1`, runs forward and backward and checks gradients on `student_hidden_states` and `lm_head_weight` are non-zero and finite.
2. `test_kd_mix_gradient_changes_when_ce_weight_changes`: runs the same inputs twice, changing only `weight_hard_loss` from 0.0 to 0.5, and checks the gradients differ. Before the fix both runs gave the same grads because CE was dropped.

Both tests fail on the unfixed source and pass with the fix. Ran locally on torch 2.11, Python 3.12, CPU, finishes in about 2 seconds.

## AI Usage Disclaimer

Opus was used to write the regression tests and review the diff.

## Types of changes

- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Knowledge Distillation loss computation structure for correct gradient handling

* **Tests**
  * Added regression tests for gradient flow with mixed Knowledge Distillation and Cross Entropy loss
  * Verified gradient correctness across different loss weight configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->