### PR TITLE
FIX:ValueError:You passed a PeftModel instance with peft_config

### DIFF
--- a/src/axolotl/core/builders/rl.py
+++ b/src/axolotl/core/builders/rl.py
@@ -274,7 +274,7 @@ class HFRLTrainerBuilder(TrainerBuilderBase):
         if (
             self.cfg.adapter
             and self.peft_config
-            and self.cfg.rl not in (RLType.GRPO, RLType.ORPO, RLType.EBFT)
+            and self.cfg.rl not in (RLType.GRPO, RLType.ORPO, RLType.EBFT, RLType.SIMPO)
         ):
             trainer_kwargs["peft_config"] = self.peft_config
 


### PR DESCRIPTION

# Description
ValueError: You passed a PeftModel instance together with a peft_config to the trainer.
for SIMPO 
just pass simpo in rl type 


## Motivation and Context
https://discord.com/channels/1104757954588196865/1502375546409975939/1504310571196219442

## test
 config runs fine 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reinforcement learning trainer configuration handling for improved compatibility with additional model types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->