### PR TITLE
scattermoe-lora: INT64_INDICES tl.constexpr in scatter2scatter family (supersedes chunking workaround)

### DIFF
--- a/src/axolotl/integrations/kernels/autotune_collector.py
+++ b/src/axolotl/integrations/kernels/autotune_collector.py
@@ -21,15 +21,17 @@ _KERNEL_REGISTRY: list[tuple[str, str]] = [
     ("group_bwd_lora_fused", "_group_bwd_lora_fused"),
 ]
 
-# The autotune key declared on every kernel: key=["M", "N", "K"]
-_KEY_NAMES: list[str] = ["M", "N", "K"]
+# The autotune key declared on every kernel: key=["M_BUCKET", "N", "K"].
+# M_BUCKET is the seqlen-bucketed M (see _bucket_m in lora_ops.py) so cache
+# entries don't churn with every distinct M.
+_KEY_NAMES: list[str] = ["M_BUCKET", "N", "K"]
 
 
 def _parse_key_tuple(key_tuple: tuple) -> dict[str, Any]:
     """Turn the autotune cache key tuple into a labelled dict.
 
     Triton builds the cache key from the values of the declared ``key``
-    args (``M``, ``N``, ``K``) followed by dtype signature elements.
+    args (``M_BUCKET``, ``N``, ``K``) followed by dtype signature elements.
     We label the first three and store the rest under ``_extra``.
     """
     result: dict[str, Any] = {}

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -54,6 +54,17 @@ def _next_power_of_2(n: int) -> int:
     return n + 1
 
 
+# Granularity for the autotune cache key on M. The kernel still runs on the
+# real M (loop bounds + masks); only the @triton.autotune key is bucketed so
+# that varying seqlens/routing don't keep invalidating the cache.
+_M_BUCKET_GRANULARITY = 1024
+
+
+def _bucket_m(m: int) -> int:
+    g = _M_BUCKET_GRANULARITY
+    return ((m + g - 1) // g) * g
+
+
 # Triton tl.dot requires minimum tile dimensions of 16 on modern GPUs.
 MIN_TRITON_DOT_SIZE = 16
 
@@ -450,7 +461,7 @@ def _prune_fwd_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_scatter2scatter_lora_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_fwd_configs},
 )
 @triton.heuristics(
@@ -489,6 +500,7 @@ def _scatter2scatter_lora(
     # Dimensions
     FAN_OUT: tl.constexpr,
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     E: tl.constexpr,
@@ -795,6 +807,7 @@ def scatter2scatter_lora(
         sorted_expert_idxs,
         FAN_OUT=k,
         M=X.size(0),
+        M_BUCKET=_bucket_m(X.size(0)),
         K=K,
         N=N,
         E=E,
@@ -1043,7 +1056,7 @@ def _prune_dX_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_scatter2scatter_lora_dX_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_dX_configs},
 )
 @triton.heuristics(
@@ -1080,6 +1093,7 @@ def _scatter2scatter_lora_dX(
     # Dimensions
     FAN_OUT: tl.constexpr,
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     E: tl.constexpr,
@@ -1270,6 +1284,7 @@ def scatter2scatter_lora_dX(
         sorted_expert_idxs,
         FAN_OUT=fan_out,
         M=M,
+        M_BUCKET=_bucket_m(M),
         K=K,
         N=N,
         E=E,
@@ -1384,7 +1399,7 @@ def _prune_bwd_lora_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_group_bwd_lora_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_bwd_lora_configs},
     reset_to_zero=["DLA_ptr", "DLB_ptr"],
 )
@@ -1421,6 +1436,7 @@ def _group_bwd_lora(
     expert_offsets_ptr,
     # Dimensions
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     ACTUAL_R: tl.constexpr,  # True LoRA rank (for weight indexing)
@@ -1632,7 +1648,7 @@ def _prune_split_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_group_bwd_split_configs(),
-    key=["M", "K", "N"],
+    key=["M_BUCKET", "K", "N"],
     prune_configs_by={"early_config_prune": _prune_split_configs},
 )
 @triton.heuristics(
@@ -1665,6 +1681,7 @@ def _group_bwd_lora_split(
     expert_offsets_ptr,
     # Dimensions
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     ACTUAL_R: tl.constexpr,
@@ -1917,6 +1934,7 @@ def group_bwd_lora(
         dA.stride(1),
         expert_offsets,
         M=DY.size(0),
+        M_BUCKET=_bucket_m(DY.size(0)),
         K=K,
         N=N,
         ACTUAL_R=R,
@@ -1947,6 +1965,7 @@ def group_bwd_lora(
         dB.stride(1),
         expert_offsets,
         M=DY.size(0),
+        M_BUCKET=_bucket_m(DY.size(0)),
         K=K,
         N=N,
         ACTUAL_R=R,
@@ -1969,7 +1988,7 @@ def group_bwd_lora(
 
 @triton.autotune(
     configs=_group_bwd_lora_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_bwd_lora_configs},
     reset_to_zero=["DLA_ptr", "DLB_ptr"],
 )
@@ -2011,6 +2030,7 @@ def _group_bwd_lora_fused(
     real_expert_offsets_ptr,
     # Dimensions
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     ACTUAL_R: tl.constexpr,
@@ -2293,6 +2313,7 @@ def group_bwd_lora_fused(
         expert_offsets_ptr=expert_offsets,
         real_expert_offsets_ptr=real_expert_offsets,
         M=sorted_scattered_idxs.size(0),
+        M_BUCKET=_bucket_m(sorted_scattered_idxs.size(0)),
         K=K,
         N=N,
         ACTUAL_R=R,
@@ -2565,7 +2586,7 @@ def _prune_fwd_mx_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_scatter2scatter_lora_mx_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_fwd_mx_configs},
 )
 @triton.heuristics(
@@ -2613,6 +2634,7 @@ def _scatter2scatter_lora_mx(
     # Dimensions
     FAN_OUT: tl.constexpr,
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     E: tl.constexpr,
@@ -2801,6 +2823,7 @@ def scatter2scatter_lora_mx(
         sorted_expert_idxs,
         FAN_OUT=k,
         M=X.size(0),
+        M_BUCKET=_bucket_m(X.size(0)),
         K=K,
         N=N,
         E=E,
@@ -3037,7 +3060,7 @@ def _prune_dX_mx_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=_scatter2scatter_lora_dX_mx_configs(),
-    key=["M", "N", "K"],
+    key=["M_BUCKET", "N", "K"],
     prune_configs_by={"early_config_prune": _prune_dX_mx_configs},
 )
 @triton.heuristics(
@@ -3074,6 +3097,7 @@ def _scatter2scatter_lora_dX_mx(
     expert_idxs_ptr,
     FAN_OUT: tl.constexpr,
     M,
+    M_BUCKET,
     K: tl.constexpr,
     N: tl.constexpr,
     E: tl.constexpr,
@@ -3255,6 +3279,7 @@ def scatter2scatter_lora_dX_mx(
         sorted_expert_idxs,
         FAN_OUT=fan_out,
         M=M,
+        M_BUCKET=_bucket_m(M),
         K=K,
         N=N,
         E=E,

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -1434,6 +1434,7 @@ def _group_bwd_lora(
     allow_tf32: tl.constexpr,
     NO_K_MASK: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """
     Compute LoRA gradients for each expert on grouped data.
@@ -1458,12 +1459,20 @@ def _group_bwd_lora(
     if E_idx == 0:
         start_idx = 0
     else:
-        start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
-    end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
+        if INT64_INDICES:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
+    if INT64_INDICES:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
+    else:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx
 
     if num_tokens > 0:
         M_block = tl.arange(0, BLOCK_M)
+        if INT64_INDICES:
+            M_block = M_block.to(tl.int64)
         K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
         K_mask = K_block < K
         N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -1669,6 +1678,7 @@ def _group_bwd_lora_split(
     ACC_TYPE: tl.constexpr,
     allow_tf32: tl.constexpr,
     NO_DIM_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """
     Unified split kernel for LoRA gradient computation.
@@ -1695,8 +1705,14 @@ def _group_bwd_lora_split(
     if E_idx == 0:
         start_idx = 0
     else:
-        start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
-    end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
+        if INT64_INDICES:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
+    if INT64_INDICES:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
+    else:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx
 
     # Output dimension tile (K for dA, N for dB)
@@ -1728,6 +1744,8 @@ def _group_bwd_lora_split(
 
     if num_tokens > 0:
         M_block = tl.arange(0, BLOCK_M)
+        if INT64_INDICES:
+            M_block = M_block.to(tl.int64)
         INPUT_DTYPE = X_ptr.dtype.element_ty
         BLOCK_INNER: tl.constexpr = 64
         inner_iters = tl.cdiv(INNER_DIM, BLOCK_INNER)
@@ -1847,6 +1865,7 @@ def group_bwd_lora(
     scaling: float,
     sorted_scattered_idxs: Optional[torch.Tensor] = None,
     k: int = 1,
+    int64_indices: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Compute LoRA gradients for A and B on expert-grouped data.
@@ -1905,6 +1924,7 @@ def group_bwd_lora(
         COMPUTE_DA=True,
         ACC_TYPE=tl.float32,
         allow_tf32=ALLOW_TF32,
+        INT64_INDICES=int64_indices,
     )
 
     def grid_dB(META):
@@ -1934,6 +1954,7 @@ def group_bwd_lora(
         COMPUTE_DA=False,
         ACC_TYPE=tl.float32,
         allow_tf32=ALLOW_TF32,
+        INT64_INDICES=int64_indices,
     )
 
     return dA, dB
@@ -2003,6 +2024,7 @@ def _group_bwd_lora_fused(
     NO_N_MASK: tl.constexpr,
     # Whether DY is already in grouped (expert-sorted) order
     dy_grouped: tl.constexpr = False,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """
     Fused gather + LoRA gradient computation. Same as _group_bwd_lora but
@@ -2043,14 +2065,24 @@ def _group_bwd_lora_fused(
         start_idx = 0
         real_start_idx = 0
     else:
-        start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
-        real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int32)
-    end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
-    real_end_idx = tl.load(real_expert_offsets_ptr + E_idx).to(tl.int32)
+        if INT64_INDICES:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
+            real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int64)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
+            real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int32)
+    if INT64_INDICES:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
+        real_end_idx = tl.load(real_expert_offsets_ptr + E_idx).to(tl.int64)
+    else:
+        end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
+        real_end_idx = tl.load(real_expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx
 
     if num_tokens > 0:
         M_block = tl.arange(0, BLOCK_M)
+        if INT64_INDICES:
+            M_block = M_block.to(tl.int64)
         K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
         K_mask = K_block < K
         N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -2095,9 +2127,14 @@ def _group_bwd_lora_fused(
             M_mask = M_local < real_num_tokens
 
             # Fused gather: load scatter indices for indirect X access
-            scatter_idx = tl.load(
-                sorted_scattered_idxs_ptr + M_idx, mask=M_mask, other=0
-            ).to(tl.int32)
+            if INT64_INDICES:
+                scatter_idx = tl.load(
+                    sorted_scattered_idxs_ptr + M_idx, mask=M_mask, other=0
+                ).to(tl.int64)
+            else:
+                scatter_idx = tl.load(
+                    sorted_scattered_idxs_ptr + M_idx, mask=M_mask, other=0
+                ).to(tl.int32)
             X_token_idx = scatter_idx // FAN_OUT  # X is [M, K], not expanded by k
 
             # Load X via indirect index: [BLOCK_M, BLOCK_K]
@@ -2175,6 +2212,7 @@ def group_bwd_lora_fused(
     scaling: float,
     real_expert_offsets: Optional[torch.Tensor] = None,
     dy_grouped: bool = False,
+    int64_indices: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Fused gather + LoRA gradient computation. Same result as
@@ -2259,6 +2297,7 @@ def group_bwd_lora_fused(
         ACC_TYPE=tl.float32,
         allow_tf32=ALLOW_TF32,
         dy_grouped=dy_grouped,
+        INT64_INDICES=int64_indices,
     )
 
     return dA, dB

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -1456,16 +1456,17 @@ def _group_bwd_lora(
     N_block_id = pid1
 
     # Get expert's token range from cumulative offsets
-    if E_idx == 0:
-        start_idx = 0
-    else:
-        if INT64_INDICES:
-            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
-        else:
-            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
     if INT64_INDICES:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int64)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
     else:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int32)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx
 
@@ -1702,16 +1703,17 @@ def _group_bwd_lora_split(
     E_idx = tl.program_id(0)
     dim_block_id = tl.program_id(1)
 
-    if E_idx == 0:
-        start_idx = 0
-    else:
-        if INT64_INDICES:
-            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
-        else:
-            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
     if INT64_INDICES:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int64)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
     else:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int32)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx
 
@@ -2061,20 +2063,22 @@ def _group_bwd_lora_fused(
     # Get expert's token range from cumulative offsets
     # start_idx/end_idx from expert_offsets_ptr: iteration range (possibly padded)
     # real_end_idx from real_expert_offsets_ptr: for M_mask (real token count)
-    if E_idx == 0:
-        start_idx = 0
-        real_start_idx = 0
-    else:
-        if INT64_INDICES:
+    if INT64_INDICES:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int64)
+            real_start_idx = tl.zeros([], dtype=tl.int64)
+        else:
             start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int64)
             real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int64)
-        else:
-            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
-            real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int32)
-    if INT64_INDICES:
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int64)
         real_end_idx = tl.load(real_expert_offsets_ptr + E_idx).to(tl.int64)
     else:
+        if E_idx == 0:
+            start_idx = tl.zeros([], dtype=tl.int32)
+            real_start_idx = tl.zeros([], dtype=tl.int32)
+        else:
+            start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
+            real_start_idx = tl.load(real_expert_offsets_ptr + E_idx - 1).to(tl.int32)
         end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
         real_end_idx = tl.load(real_expert_offsets_ptr + E_idx).to(tl.int32)
     num_tokens = end_idx - start_idx

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -506,6 +506,7 @@ def _scatter2scatter_lora(
     y_grouped: tl.constexpr,
     NO_K_MASK: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """
     Fused scatter2scatter with LoRA: Y = X @ W + scaling * (X @ A^T) @ B^T + bias
@@ -517,6 +518,8 @@ def _scatter2scatter_lora(
     N_block_id = pid % N_BLOCK_COUNT
 
     M_block = M_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    if INT64_INDICES:
+        M_block = M_block.to(tl.int64)
     N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
     N_mask = N_block < N
     M_boundary_mask = M_block < (FAN_OUT * M)
@@ -529,7 +532,10 @@ def _scatter2scatter_lora(
 
     E_first_idx = tl.min(E_idxs)
     E_last_idx = tl.minimum(tl.max(E_idxs), E - 1)
-    M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
+    if INT64_INDICES:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int64)
+    else:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
 
     for E_idx in range(E_first_idx, E_last_idx + 1):
         E_mask = E_idxs == E_idx
@@ -600,6 +606,7 @@ def _scatter2scatter_lora_split(
     x_grouped: bool = False,
     y_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """Split base+LoRA forward: 3 scatter2scatter calls, no fused LoRA kernel.
 
@@ -629,6 +636,7 @@ def _scatter2scatter_lora_split(
         x_grouped=x_grouped,
         y_grouped=y_grouped,
         out=out,
+        int64_indices=int64_indices,
     )
 
     # 2. XA = X @ A^T  (tiny: output is [M*k, R])
@@ -642,6 +650,7 @@ def _scatter2scatter_lora_split(
         k=k,
         x_grouped=x_grouped,
         y_grouped=True,
+        int64_indices=int64_indices,
     )
 
     # 3. Y_lora = XA @ B^T  (R is tiny, so this is very fast)
@@ -655,6 +664,7 @@ def _scatter2scatter_lora_split(
         k=1,
         x_grouped=True,
         y_grouped=y_grouped,
+        int64_indices=int64_indices,
     )
 
     # 4. Y = Y_base + scaling * Y_lora
@@ -683,6 +693,7 @@ def scatter2scatter_lora(
     x_grouped: bool = False,
     y_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """
     Scatter2scatter with LoRA: Y[i] = X[i] @ W[e] + scaling * (X[i] @ A[e]^T) @ B[e]^T + b[e]
@@ -729,6 +740,7 @@ def scatter2scatter_lora(
             x_grouped,
             y_grouped,
             out,
+            int64_indices=int64_indices,
         )
 
     assert sorted_scattered_idxs.size(0) == sorted_expert_idxs.size(0)
@@ -793,6 +805,7 @@ def scatter2scatter_lora(
         allow_tf32=ALLOW_TF32,
         x_grouped=x_grouped,
         y_grouped=y_grouped,
+        INT64_INDICES=int64_indices,
     )
 
     return output
@@ -1084,6 +1097,7 @@ def _scatter2scatter_lora_dX(
     dx_grouped: tl.constexpr,
     NO_K_MASK: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """
     Fused backward dX = DY @ W^T + scaling * (DY @ B) @ A
@@ -1100,6 +1114,8 @@ def _scatter2scatter_lora_dX(
     K_block_id = pid % K_BLOCK_COUNT
 
     M_block = M_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    if INT64_INDICES:
+        M_block = M_block.to(tl.int64)
     K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
     K_mask = K_block < K
     M_boundary_mask = M_block < (FAN_OUT * M)
@@ -1112,7 +1128,10 @@ def _scatter2scatter_lora_dX(
 
     E_first_idx = tl.min(E_idxs)
     E_last_idx = tl.minimum(tl.max(E_idxs), E - 1)
-    M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
+    if INT64_INDICES:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int64)
+    else:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
 
     for E_idx in range(E_first_idx, E_last_idx + 1):
         E_mask = E_idxs == E_idx
@@ -1175,6 +1194,7 @@ def scatter2scatter_lora_dX(
     dy_grouped: bool = True,
     dx_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """
     Fused backward dX = DY @ W^T + scaling * (DY @ B) @ A
@@ -1261,6 +1281,7 @@ def scatter2scatter_lora_dX(
         allow_tf32=ALLOW_TF32,
         dy_grouped=dy_grouped,
         dx_grouped=dx_grouped,
+        INT64_INDICES=int64_indices,
     )
 
     return output
@@ -2565,6 +2586,7 @@ def _scatter2scatter_lora_mx(
     y_grouped: tl.constexpr,
     NO_K_MASK: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """Fused scatter2scatter forward with MXFP4 base weights + LoRA."""
     pid = tl.program_id(axis=0)
@@ -2573,6 +2595,8 @@ def _scatter2scatter_lora_mx(
     N_block_id = pid % N_BLOCK_COUNT
 
     M_block = M_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    if INT64_INDICES:
+        M_block = M_block.to(tl.int64)
     N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
     N_mask = N_block < N
     M_boundary_mask = M_block < (FAN_OUT * M)
@@ -2583,7 +2607,10 @@ def _scatter2scatter_lora_mx(
 
     E_first_idx = tl.min(E_idxs)
     E_last_idx = tl.minimum(tl.max(E_idxs), E - 1)
-    M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
+    if INT64_INDICES:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int64)
+    else:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
 
     for E_idx in range(E_first_idx, E_last_idx + 1):
         E_mask = E_idxs == E_idx
@@ -2658,6 +2685,7 @@ def scatter2scatter_lora_mx(
     x_grouped: bool = False,
     y_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """Forward dispatcher for the fused MXFP4 + LoRA kernel.
 
@@ -2741,6 +2769,7 @@ def scatter2scatter_lora_mx(
         allow_tf32=ALLOW_TF32,
         x_grouped=x_grouped,
         y_grouped=y_grouped,
+        INT64_INDICES=int64_indices,
     )
     return output
 
@@ -3017,6 +3046,7 @@ def _scatter2scatter_lora_dX_mx(
     dy_grouped: tl.constexpr,
     dx_grouped: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     """Fused MXFP4 dX kernel."""
     pid = tl.program_id(axis=0)
@@ -3025,6 +3055,8 @@ def _scatter2scatter_lora_dX_mx(
     K_block_id = pid % K_BLOCK_COUNT
 
     M_block = M_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    if INT64_INDICES:
+        M_block = M_block.to(tl.int64)
     K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
     K_mask = K_block < K
     M_boundary_mask = M_block < (FAN_OUT * M)
@@ -3035,7 +3067,10 @@ def _scatter2scatter_lora_dX_mx(
 
     E_first_idx = tl.min(E_idxs)
     E_last_idx = tl.minimum(tl.max(E_idxs), E - 1)
-    M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
+    if INT64_INDICES:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int64)
+    else:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
 
     for E_idx in range(E_first_idx, E_last_idx + 1):
         E_mask = E_idxs == E_idx
@@ -3103,6 +3138,7 @@ def scatter2scatter_lora_dX_mx(
     dy_grouped: bool = True,
     dx_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """Backward-dX dispatcher for the fused MXFP4 kernel.
 
@@ -3187,5 +3223,6 @@ def scatter2scatter_lora_dX_mx(
         allow_tf32=ALLOW_TF32,
         dy_grouped=dy_grouped,
         dx_grouped=dx_grouped,
+        INT64_INDICES=int64_indices,
     )
     return output

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
@@ -108,6 +108,7 @@ def _scatter2scatter(
     y_grouped: tl.constexpr,
     NO_K_MASK: tl.constexpr,
     NO_N_MASK: tl.constexpr,
+    INT64_INDICES: tl.constexpr = False,
 ):
     pid = tl.program_id(axis=0)
 
@@ -116,6 +117,8 @@ def _scatter2scatter(
     N_block_id = pid % N_BLOCK_COUNT
 
     M_block = M_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    if INT64_INDICES:
+        M_block = M_block.to(tl.int64)
     N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
     N_mask = N_block < N
     M_boundary_mask = M_block < (FAN_OUT * M)
@@ -126,7 +129,10 @@ def _scatter2scatter(
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
     E_first_idx = tl.min(E_idxs)
     E_last_idx = tl.minimum(tl.max(E_idxs), E - 1)
-    M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
+    if INT64_INDICES:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int64)
+    else:
+        M_idx = tl.load(grouped_idx_ptr + M_block, mask=M_boundary_mask).to(tl.int32)
     for E_idx in range(E_first_idx, E_last_idx + 1):
         E_mask = E_idxs == E_idx
         E_M_idx = M_idx
@@ -176,6 +182,7 @@ def scatter2scatter(
     x_grouped=False,
     y_grouped=False,
     out=None,
+    int64_indices=False,
 ):
     assert sorted_scattered_idxs.size(0) == sorted_expert_idxs.size(0)
     assert sorted_scattered_idxs.size(0) == X.size(0) * k
@@ -198,6 +205,7 @@ def scatter2scatter(
         b,
         x_grouped,
         y_grouped,
+        int64_indices,
     )
     return output
 
@@ -213,6 +221,7 @@ def scatter2scatter_compileable(
     b: Optional[torch.Tensor],
     x_grouped: bool,
     y_grouped: bool,
+    int64_indices: bool = False,
 ) -> None:
     def grid(META):
         grid_num = (
@@ -258,6 +267,7 @@ def scatter2scatter_compileable(
         allow_tf32=ALLOW_TF32,
         x_grouped=x_grouped,
         y_grouped=y_grouped,
+        INT64_INDICES=int64_indices,
     )
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
@@ -10,6 +10,177 @@ import torch
 import torch.nn as nn
 
 from . import kernels
+from .kernels.ops import BLOCK_M as _SCATTER2SCATTER_BLOCK_M
+
+# Int32-overflow guard for the scatter2scatter Triton kernel.
+#
+# The kernel computes output-pointer offsets as
+#   Y_ptr + M_block * stride_ym + N_block * stride_yn
+# where M_block / N_block / stride_ym are int32. When the output buffer
+# has L_scattered * y_dim >= 2**31 elements, the M_block * stride_ym
+# product overflows int32 for the trailing rows. The masked stores then
+# either silently drop (rows come back as zeros) or write to bogus
+# addresses, which can also trip a delayed CUDA illegal-memory-access
+# / CUBLAS_STATUS_EXECUTION_FAILED in a downstream kernel.
+#
+# This is reachable in production at seq=512K with coarse shards
+# (tokens_per_shard * top_k * 2*INTERMEDIATE >= 2**31 elements). The
+# fix is to chunk the call along the L_scattered axis when the kernel
+# is in the only mode where chunking is safe — y_grouped=True, where
+# the kernel uses M_block (a 0-based per-launch program_id) as the
+# output row index. With a sliced sei/ssi and out=output[start:end],
+# each sub-call's M_block * stride_ym fits in int32.
+#
+# Threshold is conservative (< 2**31 elements per call, not bytes) so
+# the safety margin holds for fp32 / bf16 / fp16 alike. The check is
+# guarded behind `if L_scattered * y_dim >= _SCATTER2SCATTER_INT32_LIMIT`
+# so the common path (anything below ~2 GiB of bf16 output) goes
+# straight to a single kernel launch with no extra overhead.
+_SCATTER2SCATTER_INT32_LIMIT = 2**31
+# Triton kernel's BLOCK_M tile is imported above as
+# ``_SCATTER2SCATTER_BLOCK_M`` so the chunk boundaries stay in sync if
+# ``kernels/ops.py`` ever retunes BLOCK_M.
+
+
+def _scatter2scatter_int32_safe(
+    *,
+    X: torch.Tensor,
+    W: torch.Tensor,
+    sorted_expert_idxs: torch.Tensor,
+    sorted_scattered_idxs: torch.Tensor,
+    k: int,
+    b: Optional[torch.Tensor] = None,
+    x_grouped: bool = False,
+    y_grouped: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Wrapper around ``kernels.ops.scatter2scatter`` that splits the call
+    when its output would overflow the Triton kernel's int32 pointer
+    arithmetic.
+
+    Fast path (common case): if the output is below
+    ``_SCATTER2SCATTER_INT32_LIMIT`` elements, dispatch one kernel call.
+    Slow path (long-seq + coarse shards): for ``y_grouped=True``, allocate
+    the full output and call the kernel on chunks of the sorted-index
+    arrays, each writing to a sub-view of the output. ``y_grouped=False``
+    is left unchunked because the kernel addresses output rows via the
+    per-position scattered index ``M_idx`` (not a 0-based ``M_block``),
+    so the row range can't be tiled safely from the wrapper; the only
+    overflow-affected production call sites are ``y_grouped=True``.
+    """
+    L_scattered = sorted_expert_idxs.size(0)
+    y_dim = W.size(-1)
+
+    if L_scattered * y_dim < _SCATTER2SCATTER_INT32_LIMIT:
+        return kernels.ops.scatter2scatter(
+            X=X,
+            W=W,
+            sorted_expert_idxs=sorted_expert_idxs,
+            sorted_scattered_idxs=sorted_scattered_idxs,
+            k=k,
+            b=b,
+            x_grouped=x_grouped,
+            y_grouped=y_grouped,
+            out=out,
+        )
+
+    if not y_grouped:
+        # ``y_grouped=False`` uses per-position scattered indices for
+        # the output rows, so the wrapper can't tile the row range
+        # safely from the outside. Production overflow paths today
+        # are all ``y_grouped=True`` so this branch is unreachable in
+        # the bench; hard-raise here rather than fall through —
+        # silently letting the raw kernel run would corrupt the
+        # trailing rows. The kernel itself needs an int64
+        # pointer-arithmetic fix before y_grouped=False at this scale
+        # is safe.
+        raise RuntimeError(
+            f"scatter2scatter call with y_grouped=False has output "
+            f"L_scattered ({L_scattered}) * y_dim ({y_dim}) = "
+            f"{L_scattered * y_dim} elements >= the int32 overflow "
+            f"threshold ({_SCATTER2SCATTER_INT32_LIMIT}). The Triton "
+            f"kernel's pointer arithmetic would silently corrupt "
+            f"output rows whose M_idx * stride_ym overflows int32. "
+            f"The int32-safe wrapper cannot tile this case (it would "
+            f"require per-position output-row tiling); the kernel "
+            f"itself needs an int64 pointer-arithmetic fix."
+        )
+
+    if out is None:
+        out = torch.empty((L_scattered, y_dim), device=X.device, dtype=X.dtype)
+    else:
+        # Mirror scatter2scatter's contract on out.
+        assert out.size(0) == L_scattered and out.size(1) == y_dim
+
+    # Chunk size — largest BLOCK_M-aligned row count whose
+    # ``rows * y_dim`` product fits int32. The aligned floor cannot
+    # be zero because y_dim must itself be below the int32 limit for
+    # a single output row to fit (asserted below).
+    max_rows = _SCATTER2SCATTER_INT32_LIMIT // y_dim
+    chunk_rows = (max_rows // _SCATTER2SCATTER_BLOCK_M) * _SCATTER2SCATTER_BLOCK_M
+    assert chunk_rows > 0, (
+        f"scatter2scatter int32-safe chunking: y_dim={y_dim} is too large "
+        f"to fit even one BLOCK_M-aligned chunk under the int32 limit"
+    )
+    # OOB-guard for x_grouped=False with a non-aligned last chunk: the
+    # kernel's M_boundary_mask is ``M_block < FAN_OUT * X.size(0)``,
+    # which equals the FULL L_scattered (X is not chunked in this
+    # mode). A partial last chunk would let the kernel's final tile
+    # tl.load past the end of sei_chunk / ssi_chunk and tl.store past
+    # the end of out_chunk. The x_grouped=True path is naturally
+    # bounded because X is chunked too (mask becomes
+    # ``M_block < FAN_OUT * chunk_size``).
+    #
+    # For all realistic production callers (power-of-2 token counts
+    # ✕ power-of-2 top_k, y_dim a clean power-of-2) ``L_scattered``
+    # is a multiple of ``chunk_rows`` and the assertion holds. If a
+    # future caller hits a non-aligned shape this assertion fires
+    # rather than silently corrupting — the right fix at that point
+    # is to teach the kernel to take a per-launch M override.
+    if not x_grouped:
+        assert L_scattered % chunk_rows == 0, (
+            f"scatter2scatter int32-safe chunking with x_grouped=False "
+            f"requires L_scattered ({L_scattered}) to be a multiple of "
+            f"chunk_rows ({chunk_rows}); a partial last chunk would "
+            f"trigger an out-of-bounds tl.load against sei_chunk because "
+            f"the kernel's M_boundary_mask bounds against the full X "
+            f"(unchunked) size, not the chunk size"
+        )
+
+    # When the X buffer is itself grouped (x_grouped=True), the kernel
+    # uses the per-launch program_id (M_block) as the X row index, so
+    # we must slice X in lockstep with the sei/ssi chunk so the kernel
+    # reads X[chunk_start + M_block]. When x_grouped=False the kernel
+    # indexes X via ``M_idx // FAN_OUT`` where M_idx is a global
+    # (un-chunked) position from sorted_scattered_idxs, so X stays
+    # full.
+    #
+    # The high-level scatter2scatter() wrapper asserts
+    # ``sorted_scattered_idxs.size(0) == X.size(0) * k`` — true for the
+    # full call but not for our chunks — so we drop into
+    # ``scatter2scatter_compileable`` directly (the registered Triton
+    # custom op, which carries no such precondition).
+    for chunk_start in range(0, L_scattered, chunk_rows):
+        chunk_end = min(chunk_start + chunk_rows, L_scattered)
+        sei_chunk = sorted_expert_idxs[chunk_start:chunk_end]
+        ssi_chunk = sorted_scattered_idxs[chunk_start:chunk_end]
+        out_chunk = out[chunk_start:chunk_end]
+        if x_grouped:
+            X_chunk = X[chunk_start:chunk_end]
+        else:
+            X_chunk = X
+        kernels.ops.scatter2scatter_compileable(
+            out_chunk,
+            W,
+            X_chunk,
+            k,
+            sei_chunk,
+            ssi_chunk,
+            b,
+            x_grouped,
+            y_grouped,
+        )
+    return out
 
 
 @torch.library.custom_op("scattermoe::bincount", mutates_args={})
@@ -55,7 +226,7 @@ class ParallelLinear(torch.autograd.Function):
         if expert_biases is not None and expert_biases.dtype != x.dtype:
             expert_biases = expert_biases.to(x.dtype)
         with torch.device(x.device):
-            output = kernels.ops.scatter2scatter(
+            output = _scatter2scatter_int32_safe(
                 X=x,
                 W=expert_weights,
                 b=expert_biases,
@@ -145,7 +316,7 @@ class ParallelLinear(torch.autograd.Function):
                 has_bias=expert_biases is not None,
             )
 
-            d_expanded_input = kernels.ops.scatter2scatter(
+            d_expanded_input = _scatter2scatter_int32_safe(
                 X=grouped_grad_out,
                 x_grouped=True,
                 W=expert_weights.permute(0, 2, 1),

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
@@ -87,9 +87,7 @@ class ParallelLinear(torch.autograd.Function):
         # Cheap probe: the kernel's overflow risk is the M_block * stride_ym
         # product, dominated by the output buffer L_scattered * y_dim. We also
         # check x because the X_ptr arithmetic uses similar indices.
-        needs_int64_fwd = (L_scattered * y_dim) >= _INT_MAX or _needs_int64_indices(
-            x
-        )
+        needs_int64_fwd = (L_scattered * y_dim) >= _INT_MAX or _needs_int64_indices(x)
         with torch.device(x.device):
             output = kernels.ops.scatter2scatter(
                 X=x,

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
@@ -10,7 +10,6 @@ import torch
 import torch.nn as nn
 
 from . import kernels
-from .kernels.ops import BLOCK_M as _SCATTER2SCATTER_BLOCK_M
 
 # When the maximum addressable element offset across any input/output buffer
 # exceeds INT_MAX, the Triton kernel's int32 pointer-offset arithmetic
@@ -21,6 +20,13 @@ from .kernels.ops import BLOCK_M as _SCATTER2SCATTER_BLOCK_M
 # is cast to int64 before it enters the multiplication. Strides themselves
 # are already int64 at the Python level (from ``tensor.stride()``); only
 # the *index* type needs the bump.
+#
+# The threshold here matches the kernel's correctness boundary: as soon as
+# any indexed buffer has 2**31 - 1 or more elements, the int32 multiply at
+# the end of the buffer can overflow. The wrapper used to chunk the call to
+# keep ``rows * y_dim`` below 2**31; with INT64_INDICES the kernel itself
+# handles overflow, so the auto-dispatch routes directly to a single
+# kernel launch in either mode.
 _INT_MAX = 2**31 - 1
 
 
@@ -32,199 +38,6 @@ def _needs_int64_indices(*tensors) -> bool:
         if t.numel() >= _INT_MAX:
             return True
     return False
-
-# Int32-overflow guard for the scatter2scatter Triton kernel.
-#
-# The kernel computes output-pointer offsets as
-#   Y_ptr + M_block * stride_ym + N_block * stride_yn
-# where M_block / N_block / stride_ym are int32. When the output buffer
-# has L_scattered * y_dim >= 2**31 elements, the M_block * stride_ym
-# product overflows int32 for the trailing rows. The masked stores then
-# either silently drop (rows come back as zeros) or write to bogus
-# addresses, which can also trip a delayed CUDA illegal-memory-access
-# / CUBLAS_STATUS_EXECUTION_FAILED in a downstream kernel.
-#
-# This is reachable in production at seq=512K with coarse shards
-# (tokens_per_shard * top_k * 2*INTERMEDIATE >= 2**31 elements). The
-# fix is to chunk the call along the L_scattered axis when the kernel
-# is in the only mode where chunking is safe — y_grouped=True, where
-# the kernel uses M_block (a 0-based per-launch program_id) as the
-# output row index. With a sliced sei/ssi and out=output[start:end],
-# each sub-call's M_block * stride_ym fits in int32.
-#
-# Threshold is conservative (< 2**31 elements per call, not bytes) so
-# the safety margin holds for fp32 / bf16 / fp16 alike. The check is
-# guarded behind `if L_scattered * y_dim >= _SCATTER2SCATTER_INT32_LIMIT`
-# so the common path (anything below ~2 GiB of bf16 output) goes
-# straight to a single kernel launch with no extra overhead.
-_SCATTER2SCATTER_INT32_LIMIT = 2**31
-# Triton kernel's BLOCK_M tile is imported above as
-# ``_SCATTER2SCATTER_BLOCK_M`` so the chunk boundaries stay in sync if
-# ``kernels/ops.py`` ever retunes BLOCK_M.
-
-
-def _scatter2scatter_int32_safe(
-    *,
-    X: torch.Tensor,
-    W: torch.Tensor,
-    sorted_expert_idxs: torch.Tensor,
-    sorted_scattered_idxs: torch.Tensor,
-    k: int,
-    b: Optional[torch.Tensor] = None,
-    x_grouped: bool = False,
-    y_grouped: bool = False,
-    out: Optional[torch.Tensor] = None,
-    int64_indices: bool = False,
-) -> torch.Tensor:
-    """Wrapper around ``kernels.ops.scatter2scatter`` that splits the call
-    when its output would overflow the Triton kernel's int32 pointer
-    arithmetic.
-
-    Fast path (common case): if the output is below
-    ``_SCATTER2SCATTER_INT32_LIMIT`` elements, dispatch one kernel call.
-    Slow path (long-seq + coarse shards): for ``y_grouped=True``, allocate
-    the full output and call the kernel on chunks of the sorted-index
-    arrays, each writing to a sub-view of the output. ``y_grouped=False``
-    is left unchunked because the kernel addresses output rows via the
-    per-position scattered index ``M_idx`` (not a 0-based ``M_block``),
-    so the row range can't be tiled safely from the wrapper; the only
-    overflow-affected production call sites are ``y_grouped=True``.
-    """
-    L_scattered = sorted_expert_idxs.size(0)
-    y_dim = W.size(-1)
-
-    if L_scattered * y_dim < _SCATTER2SCATTER_INT32_LIMIT:
-        return kernels.ops.scatter2scatter(
-            X=X,
-            W=W,
-            sorted_expert_idxs=sorted_expert_idxs,
-            sorted_scattered_idxs=sorted_scattered_idxs,
-            k=k,
-            b=b,
-            x_grouped=x_grouped,
-            y_grouped=y_grouped,
-            out=out,
-            int64_indices=int64_indices,
-        )
-
-    # Above the int32 limit, route through the int64 kernel path directly:
-    # the kernel-level fix (INT64_INDICES=True) handles both y_grouped=True
-    # and y_grouped=False, where the chunking workaround below cannot tile
-    # y_grouped=False safely. Chunking is retained for now as a fallback for
-    # extremely large outputs where the int64 kernel hasn't been validated,
-    # but the primary correctness path at overflow scale is now int64.
-    if int64_indices:
-        return kernels.ops.scatter2scatter(
-            X=X,
-            W=W,
-            sorted_expert_idxs=sorted_expert_idxs,
-            sorted_scattered_idxs=sorted_scattered_idxs,
-            k=k,
-            b=b,
-            x_grouped=x_grouped,
-            y_grouped=y_grouped,
-            out=out,
-            int64_indices=True,
-        )
-
-    if not y_grouped:
-        # ``y_grouped=False`` uses per-position scattered indices for
-        # the output rows, so the wrapper can't tile the row range
-        # safely from the outside. Production overflow paths today
-        # are all ``y_grouped=True`` so this branch is unreachable in
-        # the bench; hard-raise here rather than fall through —
-        # silently letting the raw kernel run would corrupt the
-        # trailing rows. The kernel itself needs an int64
-        # pointer-arithmetic fix before y_grouped=False at this scale
-        # is safe.
-        raise RuntimeError(
-            f"scatter2scatter call with y_grouped=False has output "
-            f"L_scattered ({L_scattered}) * y_dim ({y_dim}) = "
-            f"{L_scattered * y_dim} elements >= the int32 overflow "
-            f"threshold ({_SCATTER2SCATTER_INT32_LIMIT}). The Triton "
-            f"kernel's pointer arithmetic would silently corrupt "
-            f"output rows whose M_idx * stride_ym overflows int32. "
-            f"The int32-safe wrapper cannot tile this case (it would "
-            f"require per-position output-row tiling); the kernel "
-            f"itself needs an int64 pointer-arithmetic fix."
-        )
-
-    if out is None:
-        out = torch.empty((L_scattered, y_dim), device=X.device, dtype=X.dtype)
-    else:
-        # Mirror scatter2scatter's contract on out.
-        assert out.size(0) == L_scattered and out.size(1) == y_dim
-
-    # Chunk size — largest BLOCK_M-aligned row count whose
-    # ``rows * y_dim`` product fits int32. The aligned floor cannot
-    # be zero because y_dim must itself be below the int32 limit for
-    # a single output row to fit (asserted below).
-    max_rows = _SCATTER2SCATTER_INT32_LIMIT // y_dim
-    chunk_rows = (max_rows // _SCATTER2SCATTER_BLOCK_M) * _SCATTER2SCATTER_BLOCK_M
-    assert chunk_rows > 0, (
-        f"scatter2scatter int32-safe chunking: y_dim={y_dim} is too large "
-        f"to fit even one BLOCK_M-aligned chunk under the int32 limit"
-    )
-    # OOB-guard for x_grouped=False with a non-aligned last chunk: the
-    # kernel's M_boundary_mask is ``M_block < FAN_OUT * X.size(0)``,
-    # which equals the FULL L_scattered (X is not chunked in this
-    # mode). A partial last chunk would let the kernel's final tile
-    # tl.load past the end of sei_chunk / ssi_chunk and tl.store past
-    # the end of out_chunk. The x_grouped=True path is naturally
-    # bounded because X is chunked too (mask becomes
-    # ``M_block < FAN_OUT * chunk_size``).
-    #
-    # For all realistic production callers (power-of-2 token counts
-    # ✕ power-of-2 top_k, y_dim a clean power-of-2) ``L_scattered``
-    # is a multiple of ``chunk_rows`` and the assertion holds. If a
-    # future caller hits a non-aligned shape this assertion fires
-    # rather than silently corrupting — the right fix at that point
-    # is to teach the kernel to take a per-launch M override.
-    if not x_grouped:
-        assert L_scattered % chunk_rows == 0, (
-            f"scatter2scatter int32-safe chunking with x_grouped=False "
-            f"requires L_scattered ({L_scattered}) to be a multiple of "
-            f"chunk_rows ({chunk_rows}); a partial last chunk would "
-            f"trigger an out-of-bounds tl.load against sei_chunk because "
-            f"the kernel's M_boundary_mask bounds against the full X "
-            f"(unchunked) size, not the chunk size"
-        )
-
-    # When the X buffer is itself grouped (x_grouped=True), the kernel
-    # uses the per-launch program_id (M_block) as the X row index, so
-    # we must slice X in lockstep with the sei/ssi chunk so the kernel
-    # reads X[chunk_start + M_block]. When x_grouped=False the kernel
-    # indexes X via ``M_idx // FAN_OUT`` where M_idx is a global
-    # (un-chunked) position from sorted_scattered_idxs, so X stays
-    # full.
-    #
-    # The high-level scatter2scatter() wrapper asserts
-    # ``sorted_scattered_idxs.size(0) == X.size(0) * k`` — true for the
-    # full call but not for our chunks — so we drop into
-    # ``scatter2scatter_compileable`` directly (the registered Triton
-    # custom op, which carries no such precondition).
-    for chunk_start in range(0, L_scattered, chunk_rows):
-        chunk_end = min(chunk_start + chunk_rows, L_scattered)
-        sei_chunk = sorted_expert_idxs[chunk_start:chunk_end]
-        ssi_chunk = sorted_scattered_idxs[chunk_start:chunk_end]
-        out_chunk = out[chunk_start:chunk_end]
-        if x_grouped:
-            X_chunk = X[chunk_start:chunk_end]
-        else:
-            X_chunk = X
-        kernels.ops.scatter2scatter_compileable(
-            out_chunk,
-            W,
-            X_chunk,
-            k,
-            sei_chunk,
-            ssi_chunk,
-            b,
-            x_grouped,
-            y_grouped,
-            False,
-        )
-    return out
 
 
 @torch.library.custom_op("scattermoe::bincount", mutates_args={})
@@ -278,7 +91,7 @@ class ParallelLinear(torch.autograd.Function):
             x
         )
         with torch.device(x.device):
-            output = _scatter2scatter_int32_safe(
+            output = kernels.ops.scatter2scatter(
                 X=x,
                 W=expert_weights,
                 b=expert_biases,
@@ -374,7 +187,7 @@ class ParallelLinear(torch.autograd.Function):
             needs_int64_bwd = (
                 L_scattered * dx_dim
             ) >= _INT_MAX or _needs_int64_indices(grouped_grad_out)
-            d_expanded_input = _scatter2scatter_int32_safe(
+            d_expanded_input = kernels.ops.scatter2scatter(
                 X=grouped_grad_out,
                 x_grouped=True,
                 W=expert_weights.permute(0, 2, 1),

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
@@ -12,6 +12,27 @@ import torch.nn as nn
 from . import kernels
 from .kernels.ops import BLOCK_M as _SCATTER2SCATTER_BLOCK_M
 
+# When the maximum addressable element offset across any input/output buffer
+# exceeds INT_MAX, the Triton kernel's int32 pointer-offset arithmetic
+# overflows. ``_needs_int64_indices`` returns True iff any tensor has
+# ``numel() >= INT_MAX``, which is a sufficient condition for the
+# ``M_idx * stride_*m`` product to overflow somewhere in the kernel. When
+# True, callers pass ``INT64_INDICES=True`` to the kernel so the index range
+# is cast to int64 before it enters the multiplication. Strides themselves
+# are already int64 at the Python level (from ``tensor.stride()``); only
+# the *index* type needs the bump.
+_INT_MAX = 2**31 - 1
+
+
+def _needs_int64_indices(*tensors) -> bool:
+    """True iff any input/output tensor's element count exceeds INT_MAX."""
+    for t in tensors:
+        if t is None or not isinstance(t, torch.Tensor):
+            continue
+        if t.numel() >= _INT_MAX:
+            return True
+    return False
+
 # Int32-overflow guard for the scatter2scatter Triton kernel.
 #
 # The kernel computes output-pointer offsets as
@@ -53,6 +74,7 @@ def _scatter2scatter_int32_safe(
     x_grouped: bool = False,
     y_grouped: bool = False,
     out: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
 ) -> torch.Tensor:
     """Wrapper around ``kernels.ops.scatter2scatter`` that splits the call
     when its output would overflow the Triton kernel's int32 pointer
@@ -82,6 +104,27 @@ def _scatter2scatter_int32_safe(
             x_grouped=x_grouped,
             y_grouped=y_grouped,
             out=out,
+            int64_indices=int64_indices,
+        )
+
+    # Above the int32 limit, route through the int64 kernel path directly:
+    # the kernel-level fix (INT64_INDICES=True) handles both y_grouped=True
+    # and y_grouped=False, where the chunking workaround below cannot tile
+    # y_grouped=False safely. Chunking is retained for now as a fallback for
+    # extremely large outputs where the int64 kernel hasn't been validated,
+    # but the primary correctness path at overflow scale is now int64.
+    if int64_indices:
+        return kernels.ops.scatter2scatter(
+            X=X,
+            W=W,
+            sorted_expert_idxs=sorted_expert_idxs,
+            sorted_scattered_idxs=sorted_scattered_idxs,
+            k=k,
+            b=b,
+            x_grouped=x_grouped,
+            y_grouped=y_grouped,
+            out=out,
+            int64_indices=True,
         )
 
     if not y_grouped:
@@ -226,6 +269,14 @@ class ParallelLinear(torch.autograd.Function):
             expert_weights = expert_weights.to(x.dtype)
         if expert_biases is not None and expert_biases.dtype != x.dtype:
             expert_biases = expert_biases.to(x.dtype)
+        L_scattered = sorted_expert_idxs.size(0)
+        y_dim = expert_weights.size(-1)
+        # Cheap probe: the kernel's overflow risk is the M_block * stride_ym
+        # product, dominated by the output buffer L_scattered * y_dim. We also
+        # check x because the X_ptr arithmetic uses similar indices.
+        needs_int64_fwd = (L_scattered * y_dim) >= _INT_MAX or _needs_int64_indices(
+            x
+        )
         with torch.device(x.device):
             output = _scatter2scatter_int32_safe(
                 X=x,
@@ -236,6 +287,7 @@ class ParallelLinear(torch.autograd.Function):
                 sorted_scattered_idxs=sorted_scattered_idxs,
                 x_grouped=grouped_in,
                 y_grouped=grouped_out,
+                int64_indices=needs_int64_fwd,
             )
             if gates is not None:
                 output_expanded = output.view(
@@ -317,6 +369,11 @@ class ParallelLinear(torch.autograd.Function):
                 has_bias=expert_biases is not None,
             )
 
+            L_scattered = sorted_expert_idxs.size(0)
+            dx_dim = expert_weights.size(1)  # K dim of W = output dim for dX
+            needs_int64_bwd = (
+                L_scattered * dx_dim
+            ) >= _INT_MAX or _needs_int64_indices(grouped_grad_out)
             d_expanded_input = _scatter2scatter_int32_safe(
                 X=grouped_grad_out,
                 x_grouped=True,
@@ -326,6 +383,7 @@ class ParallelLinear(torch.autograd.Function):
                 k=1,
                 y_grouped=grouped_in,
                 out=d_expanded_input,  # Reuse grouped_x buffer
+                int64_indices=needs_int64_bwd,
             )
 
             if k == 1:

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_experts.py
@@ -179,6 +179,7 @@ def _scatter2scatter_int32_safe(
             b,
             x_grouped,
             y_grouped,
+            False,
         )
     return out
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
@@ -37,6 +37,7 @@ from .kernels.lora_ops import (
     scatter2scatter_lora_mx,
 )
 from .mx_weights import MXLayout, MXWeights
+from .parallel_experts import _INT_MAX, _needs_int64_indices
 
 
 class ScatterMoELoRA(torch.autograd.Function):
@@ -80,6 +81,14 @@ class ScatterMoELoRA(torch.autograd.Function):
             is_mx = False
         if expert_biases is not None and expert_biases.dtype != x.dtype:
             expert_biases = expert_biases.to(x.dtype)
+        L_scattered = sorted_expert_idxs.size(0)
+        N_dim = expert_weights.N if is_mx else expert_weights.size(-1)
+        # Forward output is [L_scattered, N]. Overflow risk is dominated by
+        # that buffer; also probe X for the unusual case where it alone is
+        # huge (e.g. very wide hidden with modest seq).
+        needs_int64_fwd = (L_scattered * N_dim) >= _INT_MAX or _needs_int64_indices(
+            x
+        )
         with torch.device(x.device):
             if is_mx:
                 # Fused MXFP4 forward: dequant happens inside the K-loop
@@ -95,6 +104,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                     b=expert_biases,
                     x_grouped=grouped_in,
                     y_grouped=grouped_out,
+                    int64_indices=needs_int64_fwd,
                 )
             else:
                 # Fused forward: Y = X @ W + scaling * (X @ A^T) @ B^T
@@ -110,6 +120,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                     b=expert_biases,
                     x_grouped=grouped_in,
                     y_grouped=grouped_out,
+                    int64_indices=needs_int64_fwd,
                 )
 
             # Handle gating (weighted combination of top-k expert outputs)
@@ -216,6 +227,15 @@ class ScatterMoELoRA(torch.autograd.Function):
                 and fuse_gather_workload < _FUSE_GATHER_THRESHOLD
             )
 
+            # The backward path indexes into grad_out [M_total, N] and x [M, K]
+            # using either M_idx (grouped) or scatter_idx (ungrouped). Overflow
+            # risk is dominated by the largest indexed buffer along the M axis.
+            needs_int64_bwd = (
+                (M_total * N_dim) >= _INT_MAX
+                or (M_total * K_dim) >= _INT_MAX
+                or _needs_int64_indices(grad_out, x)
+            )
+
             if can_fuse_gather:
                 # ------------------------------------------------------------------
                 # Fused path: skip group(x) entirely
@@ -233,6 +253,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                     k=k,
                     scaling=scaling,
                     dy_grouped=grouped_out,
+                    int64_indices=needs_int64_bwd,
                 )
 
                 # Prepare grouped_grad_out for the dX path (needed by both
@@ -277,6 +298,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                     expert_offsets=expert_offsets,
                     E=E,
                     scaling=scaling,
+                    int64_indices=needs_int64_bwd,
                 )
 
             # ------------------------------------------------------------------
@@ -298,6 +320,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                         dy_grouped=False,
                         dx_grouped=grouped_in,
                         out=d_expanded_input,
+                        int64_indices=needs_int64_bwd,
                     )
                 else:
                     d_expanded_input = scatter2scatter_lora_dX_mx(
@@ -312,6 +335,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                         dy_grouped=True,
                         dx_grouped=grouped_in,
                         out=d_expanded_input,
+                        int64_indices=needs_int64_bwd,
                     )
             elif ctx.use_fused_dX:
                 if can_fuse_gather and not grouped_out:
@@ -328,6 +352,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                         dy_grouped=False,
                         dx_grouped=grouped_in,
                         out=d_expanded_input,
+                        int64_indices=needs_int64_bwd,
                     )
                 else:
                     # Fused dX only: read from pre-grouped DY
@@ -343,6 +368,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                         dy_grouped=True,
                         dx_grouped=grouped_in,
                         out=d_expanded_input,
+                        int64_indices=needs_int64_bwd,
                     )
             else:
                 # Original path: separate base scatter2scatter + LoRA Python loop
@@ -355,6 +381,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                     k=1,
                     y_grouped=grouped_in,
                     out=d_expanded_input,
+                    int64_indices=needs_int64_bwd,
                 )
 
                 # LoRA part: dX_lora = scaling * (dY @ B) @ A

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
@@ -82,13 +82,14 @@ class ScatterMoELoRA(torch.autograd.Function):
         if expert_biases is not None and expert_biases.dtype != x.dtype:
             expert_biases = expert_biases.to(x.dtype)
         L_scattered = sorted_expert_idxs.size(0)
-        N_dim = expert_weights.N if is_mx else expert_weights.size(-1)
+        if is_mx:
+            N_dim = expert_weights.N  # type: ignore[union-attr]
+        else:
+            N_dim = expert_weights.size(-1)  # type: ignore[union-attr]
         # Forward output is [L_scattered, N]. Overflow risk is dominated by
         # that buffer; also probe X for the unusual case where it alone is
         # huge (e.g. very wide hidden with modest seq).
-        needs_int64_fwd = (L_scattered * N_dim) >= _INT_MAX or _needs_int64_indices(
-            x
-        )
+        needs_int64_fwd = (L_scattered * N_dim) >= _INT_MAX or _needs_int64_indices(x)
         with torch.device(x.device):
             if is_mx:
                 # Fused MXFP4 forward: dequant happens inside the K-loop

--- a/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel.py
+++ b/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel.py
@@ -37,10 +37,12 @@ from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
     scatter2scatter,
 )
 from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
-    _SCATTER2SCATTER_INT32_LIMIT,
-    _scatter2scatter_int32_safe,
     flatten_sort_count,
 )
+
+# Sufficient condition for int32 pointer arithmetic to overflow in the
+# scatter2scatter Triton kernel: ``L_scattered * y_dim >= 2**31``.
+_SCATTER2SCATTER_INT32_LIMIT = 2**31
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
@@ -74,7 +76,9 @@ def _time_ms(fn: Callable[[], torch.Tensor], iters: int = 10, warmup: int = 3) -
     return statistics.median(samples)
 
 
-def _build_inputs(*, T: int, hidden: int, top_k: int, n: int, num_experts: int, seed: int):
+def _build_inputs(
+    *, T: int, hidden: int, top_k: int, n: int, num_experts: int, seed: int
+):
     torch.manual_seed(seed)
     x = torch.randn(T, hidden, device=DEVICE, dtype=DTYPE)
     W = torch.randn(num_experts, hidden, n, device=DEVICE, dtype=DTYPE) * 0.02
@@ -106,31 +110,12 @@ def _run_shape(name: str, *, T: int, hidden: int, top_k: int, n: int, num_expert
         )
 
     # Warm both Triton variants (separate JITs per constexpr).
-    _ = call(False) if not overflow else None
     if overflow:
         # int32 path is unsafe at overflow shapes (silent corruption); skip.
         ms_i32 = None
     else:
         ms_i32 = _time_ms(lambda: call(False))
     ms_i64 = _time_ms(lambda: call(True))
-
-    # Chunked workaround timing (only meaningful at overflow shapes; below
-    # threshold the wrapper short-circuits to the same kernel call).
-    if overflow:
-        ms_chunk = _time_ms(
-            lambda: _scatter2scatter_int32_safe(
-                X=x,
-                W=W,
-                sorted_expert_idxs=sei,
-                sorted_scattered_idxs=ssi,
-                k=top_k,
-                x_grouped=False,
-                y_grouped=True,
-                int64_indices=False,
-            )
-        )
-    else:
-        ms_chunk = None
 
     return {
         "name": name,
@@ -145,7 +130,6 @@ def _run_shape(name: str, *, T: int, hidden: int, top_k: int, n: int, num_expert
         "auto_int64": auto_int64,
         "ms_i32": ms_i32,
         "ms_i64": ms_i64,
-        "ms_chunk": ms_chunk,
     }
 
 
@@ -163,52 +147,64 @@ def _markdown(rows, gpu_label: str) -> str:
     lines.append("")
     lines.append("Median of 10 iters, 3 warmup. `top_k=8`, dtype=bf16, 128 experts.")
     lines.append("")
-    lines.append("`auto_int64` is the wrapper's auto-dispatch verdict from "
-                 "`_needs_int64_indices`. At overflow shapes the int32 path "
-                 "is silently incorrect, so the int32 column shows the "
-                 "chunked workaround's wall-clock from PR #3667 as the "
-                 "apples-to-apples baseline.")
+    lines.append(
+        "`auto_int64` is the wrapper's auto-dispatch verdict from "
+        "`_needs_int64_indices`. At overflow shapes the int32 path "
+        "is silently incorrect (the multiplication wraps mid-buffer), "
+        "so only the int64 timing is reported."
+    )
     lines.append("")
-    lines.append("| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | chunked ms | int64 vs fast (%) |")
-    lines.append("|---|---|---|---|---|---|---|---|---|")
+    lines.append(
+        "| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | int64 vs int32 (%) |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
     for r in rows:
-        # Penalty: int64 vs the fastest legal int32 path
-        # (raw int32 when below overflow, chunked workaround otherwise).
-        baseline = r["ms_i32"] if r["ms_i32"] is not None else r["ms_chunk"]
-        if baseline is not None and r["ms_i64"] is not None:
-            pen = 100.0 * (r["ms_i64"] - baseline) / baseline
+        if r["ms_i32"] is not None and r["ms_i64"] is not None:
+            pen = 100.0 * (r["ms_i64"] - r["ms_i32"]) / r["ms_i32"]
             pen_s = f"{pen:+.1f}"
         else:
             pen_s = "—"
         lines.append(
             f"| {r['name']} | {r['T']} | {r['L_scattered']} | "
             f"{r['out_elements']:.2e} | {str(r['auto_int64'])} | "
-            f"{_fmt(r['ms_i32'])} | {_fmt(r['ms_i64'])} | "
-            f"{_fmt(r['ms_chunk'])} | {pen_s} |"
+            f"{_fmt(r['ms_i32'])} | {_fmt(r['ms_i64'])} | {pen_s} |"
         )
     lines.append("")
-    lines.append("Acceptance: ≤5% regression on the int32 fast path at "
-                 "small/medium shapes, ≤25% regression on the int64 path "
-                 "vs the chunked workaround at overflow shapes.")
+    lines.append(
+        "Acceptance: ≤5% regression on the int32 fast path at "
+        "small/medium shapes (the auto-dispatch picks int32 there, so "
+        "this row characterises the JIT overhead of having an int64 "
+        "variant available)."
+    )
     lines.append("")
     return "\n".join(lines)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--out", type=str, default=None,
-                        help="Output markdown path (default: alongside script)")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Output markdown path (default: alongside script)",
+    )
     args = parser.parse_args()
 
     # Three representative shapes per the task spec.
     shapes = [
         # name              T (tokens before top_k expansion), hidden, top_k, N (out), num_experts
-        dict(name="small",  T=8_192,   hidden=2048, top_k=8, n=2048, num_experts=128),
+        dict(name="small", T=8_192, hidden=2048, top_k=8, n=2048, num_experts=128),
         dict(name="medium", T=128_000, hidden=2048, top_k=8, n=2048, num_experts=128),
         # Overflow shape: 524288 / 16 shards = 32768 tokens, top_k=8 -> L=262144,
         # N=16384 (= 2*intermediate at the bench config) -> 2**32 elements.
-        dict(name="overflow_524k_s16",
-             T=32_768, hidden=2048, top_k=8, n=16_384, num_experts=128),
+        dict(
+            name="overflow_524k_s16",
+            T=32_768,
+            hidden=2048,
+            top_k=8,
+            n=16_384,
+            num_experts=128,
+        ),
     ]
 
     rows = []

--- a/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel.py
+++ b/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""
+ScatterMoE — INT64_INDICES vs INT32 dense scatter2scatter benchmark.
+
+Times the dense ``kernels.ops.scatter2scatter`` at three representative
+shapes and reports ms/iter for both ``INT64_INDICES=False`` (int32 fast
+path) and ``INT64_INDICES=True`` (int64 safe path). The third shape is
+the previously-failing seq=512K / 16-shard config; at that scale the
+int32 path is incorrect (silent overflow corruption) so the int32 row
+is gated by the ``_SCATTER2SCATTER_INT32_LIMIT`` and reported as the
+chunked workaround's wall-clock instead (also for comparison against
+the chunking baseline that PR #3667 shipped).
+
+Run from the repo root:
+
+  python tests/integrations/kernels/scattermoe_lora/bench_int64_kernel.py
+
+A markdown summary is printed to stdout and written to
+``bench_int64_kernel_results.md`` next to this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
+    scatter2scatter,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+    _SCATTER2SCATTER_INT32_LIMIT,
+    _scatter2scatter_int32_safe,
+    flatten_sort_count,
+)
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+def gpu_name() -> str:
+    try:
+        out = subprocess.check_output(["nvidia-smi", "-L"], text=True).strip()
+        first = out.splitlines()[0]
+        if ":" in first:
+            after_colon = first.split(":", 1)[1].strip()
+            return after_colon.split("(", 1)[0].strip()
+        return first
+    except Exception:
+        return torch.cuda.get_device_name(0)
+
+
+def _time_ms(fn: Callable[[], torch.Tensor], iters: int = 10, warmup: int = 3) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end))
+    return statistics.median(samples)
+
+
+def _build_inputs(*, T: int, hidden: int, top_k: int, n: int, num_experts: int, seed: int):
+    torch.manual_seed(seed)
+    x = torch.randn(T, hidden, device=DEVICE, dtype=DTYPE)
+    W = torch.randn(num_experts, hidden, n, device=DEVICE, dtype=DTYPE) * 0.02
+    logits = torch.randn(T, num_experts, device=DEVICE)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), top_k, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, num_experts)
+    return x, W, sei, ssi
+
+
+def _run_shape(name: str, *, T: int, hidden: int, top_k: int, n: int, num_experts: int):
+    x, W, sei, ssi = _build_inputs(
+        T=T, hidden=hidden, top_k=top_k, n=n, num_experts=num_experts, seed=42
+    )
+    L_scattered = sei.size(0)
+    out_elements = L_scattered * n
+    overflow = out_elements >= _SCATTER2SCATTER_INT32_LIMIT
+    auto_int64 = overflow  # the wrapper's auto-dispatch verdict
+
+    def call(int64_indices: bool):
+        return scatter2scatter(
+            X=x,
+            W=W,
+            sorted_expert_idxs=sei,
+            sorted_scattered_idxs=ssi,
+            k=top_k,
+            x_grouped=False,
+            y_grouped=True,
+            int64_indices=int64_indices,
+        )
+
+    # Warm both Triton variants (separate JITs per constexpr).
+    _ = call(False) if not overflow else None
+    if overflow:
+        # int32 path is unsafe at overflow shapes (silent corruption); skip.
+        ms_i32 = None
+    else:
+        ms_i32 = _time_ms(lambda: call(False))
+    ms_i64 = _time_ms(lambda: call(True))
+
+    # Chunked workaround timing (only meaningful at overflow shapes; below
+    # threshold the wrapper short-circuits to the same kernel call).
+    if overflow:
+        ms_chunk = _time_ms(
+            lambda: _scatter2scatter_int32_safe(
+                X=x,
+                W=W,
+                sorted_expert_idxs=sei,
+                sorted_scattered_idxs=ssi,
+                k=top_k,
+                x_grouped=False,
+                y_grouped=True,
+                int64_indices=False,
+            )
+        )
+    else:
+        ms_chunk = None
+
+    return {
+        "name": name,
+        "T": T,
+        "hidden": hidden,
+        "top_k": top_k,
+        "n": n,
+        "num_experts": num_experts,
+        "L_scattered": L_scattered,
+        "out_elements": out_elements,
+        "overflow": overflow,
+        "auto_int64": auto_int64,
+        "ms_i32": ms_i32,
+        "ms_i64": ms_i64,
+        "ms_chunk": ms_chunk,
+    }
+
+
+def _fmt(v):
+    if v is None:
+        return "—"
+    return f"{v:.3f}"
+
+
+def _markdown(rows, gpu_label: str) -> str:
+    lines = []
+    lines.append("# scatter2scatter INT64_INDICES bench")
+    lines.append("")
+    lines.append(f"GPU: **{gpu_label}**")
+    lines.append("")
+    lines.append("Median of 10 iters, 3 warmup. `top_k=8`, dtype=bf16, 128 experts.")
+    lines.append("")
+    lines.append("`auto_int64` is the wrapper's auto-dispatch verdict from "
+                 "`_needs_int64_indices`. At overflow shapes the int32 path "
+                 "is silently incorrect, so the int32 column shows the "
+                 "chunked workaround's wall-clock from PR #3667 as the "
+                 "apples-to-apples baseline.")
+    lines.append("")
+    lines.append("| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | chunked ms | int64 vs fast (%) |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        # Penalty: int64 vs the fastest legal int32 path
+        # (raw int32 when below overflow, chunked workaround otherwise).
+        baseline = r["ms_i32"] if r["ms_i32"] is not None else r["ms_chunk"]
+        if baseline is not None and r["ms_i64"] is not None:
+            pen = 100.0 * (r["ms_i64"] - baseline) / baseline
+            pen_s = f"{pen:+.1f}"
+        else:
+            pen_s = "—"
+        lines.append(
+            f"| {r['name']} | {r['T']} | {r['L_scattered']} | "
+            f"{r['out_elements']:.2e} | {str(r['auto_int64'])} | "
+            f"{_fmt(r['ms_i32'])} | {_fmt(r['ms_i64'])} | "
+            f"{_fmt(r['ms_chunk'])} | {pen_s} |"
+        )
+    lines.append("")
+    lines.append("Acceptance: ≤5% regression on the int32 fast path at "
+                 "small/medium shapes, ≤25% regression on the int64 path "
+                 "vs the chunked workaround at overflow shapes.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=str, default=None,
+                        help="Output markdown path (default: alongside script)")
+    args = parser.parse_args()
+
+    # Three representative shapes per the task spec.
+    shapes = [
+        # name              T (tokens before top_k expansion), hidden, top_k, N (out), num_experts
+        dict(name="small",  T=8_192,   hidden=2048, top_k=8, n=2048, num_experts=128),
+        dict(name="medium", T=128_000, hidden=2048, top_k=8, n=2048, num_experts=128),
+        # Overflow shape: 524288 / 16 shards = 32768 tokens, top_k=8 -> L=262144,
+        # N=16384 (= 2*intermediate at the bench config) -> 2**32 elements.
+        dict(name="overflow_524k_s16",
+             T=32_768, hidden=2048, top_k=8, n=16_384, num_experts=128),
+    ]
+
+    rows = []
+    for s in shapes:
+        print(f"running {s['name']} ...", flush=True)
+        rows.append(_run_shape(**s))
+        torch.cuda.empty_cache()
+
+    label = gpu_name()
+    md = _markdown(rows, label)
+    print(md)
+
+    if args.out:
+        out_path = Path(args.out)
+    else:
+        out_path = Path(__file__).with_name("bench_int64_kernel_results.md")
+    out_path.write_text(md)
+    print(f"\nwrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel_results.md
+++ b/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel_results.md
@@ -4,12 +4,12 @@ GPU: **NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition**
 
 Median of 10 iters, 3 warmup. `top_k=8`, dtype=bf16, 128 experts.
 
-`auto_int64` is the wrapper's auto-dispatch verdict from `_needs_int64_indices`. At overflow shapes the int32 path is silently incorrect, so the int32 column shows the chunked workaround's wall-clock from PR #3667 as the apples-to-apples baseline.
+`auto_int64` is the wrapper's auto-dispatch verdict from `_needs_int64_indices`. At overflow shapes the int32 path is silently incorrect (the multiplication wraps mid-buffer), so only the int64 timing is reported.
 
-| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | chunked ms | int64 vs fast (%) |
-|---|---|---|---|---|---|---|---|---|
-| small | 8192 | 65536 | 1.34e+08 | False | 2.687 | 2.689 | — | +0.0 |
-| medium | 128000 | 1024000 | 2.10e+09 | False | 40.220 | 40.581 | — | +0.9 |
-| overflow_524k_s16 | 32768 | 262144 | 4.29e+09 | True | — | 79.572 | 79.985 | -0.5 |
+| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | int64 vs int32 (%) |
+|---|---|---|---|---|---|---|---|
+| small | 8192 | 65536 | 1.34e+08 | False | 2.699 | 2.704 | +0.2 |
+| medium | 128000 | 1024000 | 2.10e+09 | False | 40.126 | 40.790 | +1.7 |
+| overflow_524k_s16 | 32768 | 262144 | 4.29e+09 | True | — | 80.105 | — |
 
-Acceptance: ≤5% regression on the int32 fast path at small/medium shapes, ≤25% regression on the int64 path vs the chunked workaround at overflow shapes.
+Acceptance: ≤5% regression on the int32 fast path at small/medium shapes (the auto-dispatch picks int32 there, so this row characterises the JIT overhead of having an int64 variant available).

--- a/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel_results.md
+++ b/tests/integrations/kernels/scattermoe_lora/bench_int64_kernel_results.md
@@ -1,0 +1,15 @@
+# scatter2scatter INT64_INDICES bench
+
+GPU: **NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition**
+
+Median of 10 iters, 3 warmup. `top_k=8`, dtype=bf16, 128 experts.
+
+`auto_int64` is the wrapper's auto-dispatch verdict from `_needs_int64_indices`. At overflow shapes the int32 path is silently incorrect, so the int32 column shows the chunked workaround's wall-clock from PR #3667 as the apples-to-apples baseline.
+
+| Shape | T | L_scattered | out elems | auto_int64 | int32 ms | int64 ms | chunked ms | int64 vs fast (%) |
+|---|---|---|---|---|---|---|---|---|
+| small | 8192 | 65536 | 1.34e+08 | False | 2.687 | 2.689 | — | +0.0 |
+| medium | 128000 | 1024000 | 2.10e+09 | False | 40.220 | 40.581 | — | +0.9 |
+| overflow_524k_s16 | 32768 | 262144 | 4.29e+09 | True | — | 79.572 | 79.985 | -0.5 |
+
+Acceptance: ≤5% regression on the int32 fast path at small/medium shapes, ≤25% regression on the int64 path vs the chunked workaround at overflow shapes.

--- a/tests/integrations/kernels/scattermoe_lora/test_parallel_experts_large_batch_repro.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_parallel_experts_large_batch_repro.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""
+Reproducer for the cuBLAS / illegal-memory-access failure surfaced at
+seq=512K with 16 shards in the tiled-MLP long-context bench.
+
+The originally-reported symptom (``CUBLAS_STATUS_EXECUTION_FAILED`` from
+``cublasGemmStridedBatchedEx`` at
+``parallel_experts.py:72``'s ``gates.unsqueeze(1) @ output_expanded``)
+is a downstream effect — the actual fault is in the upstream
+``scatter2scatter`` Triton kernel's pointer-offset arithmetic. When the
+output of the up-projection has
+``L_scattered * y_dim >= 2 ** 31`` elements (i.e. the kernel's
+``M_block * stride_ym`` int32 multiplication overflows), the kernel
+silently writes to wrong addresses, which can in turn trip the next
+kernel (the gates @ output_expanded bmm or whatever else follows).
+
+The repro shape mirrors the failing bench config:
+
+* shard tokens ``T = 32768`` (= 524288 // 16),
+* ``top_k = 8`` → ``L_scattered = T * top_k = 262144``,
+* ``num_experts = 128``, ``hidden = 2048``, ``intermediate = 8192``.
+
+At that shape, the up-projection's scatter2scatter output is
+``[262144, 2 * 8192] = [262144, 16384]`` = 2**32 elements. The
+overflow boundary for the M_block * stride_ym int32 product is
+``M_block < 2 ** 31 / 16384 = 131072`` — exactly half the output rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Failing-config constants (mirror tests/integrations/monkeypatch/
+# bench_tiled_mlp_moe.py at seq=524288, shards=16).
+_T = 32768
+_TOP_K = 8
+_NUM_EXPERTS = 128
+_HIDDEN = 2048
+_INTERMEDIATE = 8192
+_DTYPE = torch.bfloat16
+
+
+def _requires_cuda():
+    return pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA required for the repro"
+    )
+
+
+@_requires_cuda()
+def test_int32_safe_wrapper_matches_direct_call_below_threshold():
+    """The wrapper must be a no-op for shapes below the int32 threshold.
+
+    Specifically the fast path (single kernel launch) must produce
+    bit-identical output to ``kernels.ops.scatter2scatter``. This
+    guards against the wrapper accidentally penalising the common-case
+    path that does not need chunking.
+    """
+    from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
+        scatter2scatter,
+    )
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        _SCATTER2SCATTER_INT32_LIMIT,
+        _scatter2scatter_int32_safe,
+        flatten_sort_count,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+
+    # Small shape: T=512 tokens → L_scattered=4096 → output is
+    # 4096 * 16384 = 67 M elements, well below the 2**31 threshold.
+    T_small = 512
+    x = torch.randn(T_small, _HIDDEN, device=device, dtype=_DTYPE)
+    W = (
+        torch.randn(
+            _NUM_EXPERTS, _HIDDEN, 2 * _INTERMEDIATE, device=device, dtype=_DTYPE
+        )
+        * 0.01
+    )
+
+    logits = torch.randn(T_small, _NUM_EXPERTS, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, _NUM_EXPERTS)
+
+    assert sei.size(0) * W.size(-1) < _SCATTER2SCATTER_INT32_LIMIT
+
+    out_direct = scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+    )
+    out_wrapped = _scatter2scatter_int32_safe(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_direct, out_wrapped), (
+        "fast path must produce bit-identical output to the raw kernel"
+    )
+
+
+@_requires_cuda()
+def test_int32_safe_wrapper_no_corruption_at_overflow_shape():
+    """The int32-safe scatter2scatter wrapper must keep every output
+    row populated when the shape straddles the 2**31-element boundary.
+
+    Background: the raw ``kernels.ops.scatter2scatter`` Triton kernel
+    computes pointer offsets as
+    ``Y_ptr + M_block * stride_ym + N_block * stride_yn`` in int32. At
+    the bench shape (L_scattered=262144, y_dim=16384 → 2**32 elements
+    of output) the trailing rows past ``M_block >= 2**31 / y_dim``
+    overflow and their masked stores silently drop, leaving those rows
+    as all-zeros. The ``_scatter2scatter_int32_safe`` wrapper in
+    ``parallel_experts.py`` is expected to chunk the call so each
+    sub-launch keeps ``rows * y_dim < 2**31``.
+
+    This test asserts: a row at and past the would-overflow boundary
+    has at least one non-zero element. The same call against the raw
+    kernel (without the wrapper) is the failure mode the wrapper is
+    guarding against.
+    """
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        _SCATTER2SCATTER_INT32_LIMIT,
+        _scatter2scatter_int32_safe,
+        flatten_sort_count,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+
+    x = torch.randn(_T, _HIDDEN, device=device, dtype=_DTYPE)
+    W = (
+        torch.randn(
+            _NUM_EXPERTS, _HIDDEN, 2 * _INTERMEDIATE, device=device, dtype=_DTYPE
+        )
+        * 0.01
+    )
+
+    logits = torch.randn(_T, _NUM_EXPERTS, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, _NUM_EXPERTS)
+
+    L_scattered = sei.size(0)
+    y_dim = W.size(-1)
+    assert L_scattered * y_dim >= _SCATTER2SCATTER_INT32_LIMIT, (
+        f"repro precondition: L_scattered * y_dim ({L_scattered * y_dim}) "
+        f"must straddle the int32 overflow boundary "
+        f"({_SCATTER2SCATTER_INT32_LIMIT})"
+    )
+
+    output = _scatter2scatter_int32_safe(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+    )
+    torch.cuda.synchronize()
+
+    overflow_threshold_row = _SCATTER2SCATTER_INT32_LIMIT // y_dim
+    sample_rows = [
+        0,
+        overflow_threshold_row // 2,
+        overflow_threshold_row - 1,
+        overflow_threshold_row,
+        overflow_threshold_row + 1,
+        (overflow_threshold_row + L_scattered) // 2,
+        L_scattered - 1,
+    ]
+    for row in sample_rows:
+        nz = (output[row] != 0).any().item()
+        assert nz, (
+            f"row {row} of scatter2scatter output is all-zero "
+            f"(overflow_threshold_row={overflow_threshold_row}, "
+            f"L_scattered={L_scattered}, y_dim={y_dim})"
+        )
+
+
+@_requires_cuda()
+def test_parallel_linear_long_seq_routing_combination():
+    """End-to-end repro through ``parallel_linear`` matching the bench path.
+
+    Replicates the ``ScatterMoEGatedMLP.forward`` shape sequence (up
+    projection at line 374 → activation → down projection at line 385
+    with ``gates=routing_weights``) at the seq=524288/shards=16 inner
+    config. Before the fix this raises
+    ``CUBLAS_STATUS_EXECUTION_FAILED`` (or a subsequent illegal-memory-
+    access) at the down-projection's ``gates @ output_expanded`` bmm.
+    """
+    import torch.nn.functional as F
+
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        flatten_sort_count,
+        parallel_linear,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+
+    layer_input = torch.randn(_T, _HIDDEN, device=device, dtype=_DTYPE)
+    # Match the bench's ScatterMoEGatedMLP weight layout: input_linear
+    # is [E, 2*INTERMEDIATE, HIDDEN] then .transpose(2, 1) →
+    # [E, HIDDEN, 2*INTERMEDIATE]. output_linear is [E, HIDDEN,
+    # INTERMEDIATE] then .transpose(2, 1) → [E, INTERMEDIATE, HIDDEN].
+    in_w = (
+        torch.randn(
+            _NUM_EXPERTS, 2 * _INTERMEDIATE, _HIDDEN, device=device, dtype=_DTYPE
+        )
+        * 0.02
+    )
+    out_w = (
+        torch.randn(_NUM_EXPERTS, _HIDDEN, _INTERMEDIATE, device=device, dtype=_DTYPE)
+        * 0.02
+    )
+
+    router_logits = torch.randn(_T, _NUM_EXPERTS, device=device)
+    routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, _TOP_K, dim=-1)
+    routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(_DTYPE)
+
+    sei, ssi, eo = flatten_sort_count(selected_experts, _NUM_EXPERTS)
+
+    # Up projection — this is the overflow-prone call (output
+    # numel = T * top_k * 2*INTERMEDIATE = 2**32 at the bench shape).
+    with torch.no_grad():
+        gup = parallel_linear(
+            layer_input,
+            in_w.transpose(2, 1),
+            _TOP_K,
+            sei,
+            ssi,
+            eo,
+            grouped_in=False,
+            grouped_out=True,
+        )
+        gates, h = gup.chunk(2, dim=-1)
+        h = F.silu(gates) * h
+
+        # Down projection — its gates @ output_expanded bmm is where
+        # the reported CUBLAS_STATUS_EXECUTION_FAILED surfaces. The
+        # crash, however, is a downstream symptom of the up-projection
+        # corruption above.
+        layer_output = parallel_linear(
+            h,
+            out_w.transpose(2, 1),
+            1,
+            sei,
+            ssi,
+            eo,
+            grouped_in=True,
+            grouped_out=False,
+            gates=routing_weights,
+        )
+        # Force the (otherwise lazy) CUDA error to surface synchronously.
+        torch.cuda.synchronize()
+
+    assert layer_output.shape == (_T, _HIDDEN)
+    # The output must have real values, not zero rows or NaN/Inf.
+    # ``(.abs().sum(dim=-1) == 0)`` would catch the silent-zero
+    # corruption pattern even when the kernel did not crash hard.
+    assert torch.isfinite(layer_output).all().item(), (
+        "layer_output has non-finite values — likely overflow corruption"
+    )
+    row_sums = layer_output.float().abs().sum(dim=-1)
+    assert (row_sums > 0).all().item(), (
+        "layer_output has all-zero rows — silent overflow corruption "
+        "in the up-projection scatter2scatter"
+    )

--- a/tests/integrations/kernels/scattermoe_lora/test_parallel_experts_large_batch_repro.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_parallel_experts_large_batch_repro.py
@@ -50,21 +50,22 @@ def _requires_cuda():
     )
 
 
-@_requires_cuda()
-def test_int32_safe_wrapper_matches_direct_call_below_threshold():
-    """The wrapper must be a no-op for shapes below the int32 threshold.
+_SCATTER2SCATTER_INT32_LIMIT = 2**31
 
-    Specifically the fast path (single kernel launch) must produce
-    bit-identical output to ``kernels.ops.scatter2scatter``. This
-    guards against the wrapper accidentally penalising the common-case
-    path that does not need chunking.
+
+@_requires_cuda()
+def test_scatter2scatter_below_threshold_no_overhead():
+    """At shapes well below the int32 overflow boundary the auto-dispatch
+    in ``ParallelLinear`` picks ``INT64_INDICES=False`` and the kernel
+    output is bit-identical to a direct call with the same flag.
+
+    This is the regression guard for "don't accidentally penalise the
+    common-case path that does not need int64 indices".
     """
     from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
         scatter2scatter,
     )
     from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
-        _SCATTER2SCATTER_INT32_LIMIT,
-        _scatter2scatter_int32_safe,
         flatten_sort_count,
     )
 
@@ -88,7 +89,7 @@ def test_int32_safe_wrapper_matches_direct_call_below_threshold():
 
     assert sei.size(0) * W.size(-1) < _SCATTER2SCATTER_INT32_LIMIT
 
-    out_direct = scatter2scatter(
+    out_i32 = scatter2scatter(
         X=x,
         W=W,
         sorted_expert_idxs=sei,
@@ -96,8 +97,9 @@ def test_int32_safe_wrapper_matches_direct_call_below_threshold():
         k=_TOP_K,
         x_grouped=False,
         y_grouped=True,
+        int64_indices=False,
     )
-    out_wrapped = _scatter2scatter_int32_safe(
+    out_i64 = scatter2scatter(
         X=x,
         W=W,
         sorted_expert_idxs=sei,
@@ -105,36 +107,38 @@ def test_int32_safe_wrapper_matches_direct_call_below_threshold():
         k=_TOP_K,
         x_grouped=False,
         y_grouped=True,
+        int64_indices=True,
     )
     torch.cuda.synchronize()
-    assert torch.equal(out_direct, out_wrapped), (
-        "fast path must produce bit-identical output to the raw kernel"
+    assert torch.equal(out_i32, out_i64), (
+        "INT64_INDICES must not change MMA/accumulation order at small shapes"
     )
 
 
 @_requires_cuda()
-def test_int32_safe_wrapper_no_corruption_at_overflow_shape():
-    """The int32-safe scatter2scatter wrapper must keep every output
-    row populated when the shape straddles the 2**31-element boundary.
+def test_scatter2scatter_no_corruption_at_overflow_shape():
+    """The kernel-level int64 fix must keep every output row populated
+    when the shape straddles the 2**31-element boundary.
 
-    Background: the raw ``kernels.ops.scatter2scatter`` Triton kernel
-    computes pointer offsets as
+    Background: with INT64_INDICES=False the Triton ``scatter2scatter``
+    kernel computes pointer offsets as
     ``Y_ptr + M_block * stride_ym + N_block * stride_yn`` in int32. At
     the bench shape (L_scattered=262144, y_dim=16384 → 2**32 elements
     of output) the trailing rows past ``M_block >= 2**31 / y_dim``
     overflow and their masked stores silently drop, leaving those rows
-    as all-zeros. The ``_scatter2scatter_int32_safe`` wrapper in
-    ``parallel_experts.py`` is expected to chunk the call so each
-    sub-launch keeps ``rows * y_dim < 2**31``.
+    as all-zeros. With INT64_INDICES=True the M_block range is cast to
+    int64 before it enters the multiplication and the overflow is
+    eliminated at the kernel level.
 
-    This test asserts: a row at and past the would-overflow boundary
-    has at least one non-zero element. The same call against the raw
-    kernel (without the wrapper) is the failure mode the wrapper is
-    guarding against.
+    This test calls the kernel directly with INT64_INDICES=True and
+    asserts every sampled row past the boundary has at least one
+    non-zero element. (The ``ParallelLinear`` wrapper's auto-dispatch
+    is covered separately by ``test_parallel_linear_long_seq_routing_combination``.)
     """
+    from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
+        scatter2scatter,
+    )
     from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
-        _SCATTER2SCATTER_INT32_LIMIT,
-        _scatter2scatter_int32_safe,
         flatten_sort_count,
     )
 
@@ -161,7 +165,7 @@ def test_int32_safe_wrapper_no_corruption_at_overflow_shape():
         f"({_SCATTER2SCATTER_INT32_LIMIT})"
     )
 
-    output = _scatter2scatter_int32_safe(
+    output = scatter2scatter(
         X=x,
         W=W,
         sorted_expert_idxs=sei,
@@ -169,6 +173,7 @@ def test_int32_safe_wrapper_no_corruption_at_overflow_shape():
         k=_TOP_K,
         x_grouped=False,
         y_grouped=True,
+        int64_indices=True,
     )
     torch.cuda.synchronize()
 

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
@@ -421,7 +421,14 @@ def test_parallel_linear_overflow_takes_int64_kernel_path(monkeypatch):
 
     def _spy_compileable(*args, **kwargs):
         # int64_indices is positional arg 9 (after b, x_grouped, y_grouped).
-        launches.append({"args_len": len(args), "int64": args[9] if len(args) > 9 else kwargs.get("int64_indices", False)})
+        launches.append(
+            {
+                "args_len": len(args),
+                "int64": args[9]
+                if len(args) > 9
+                else kwargs.get("int64_indices", False),
+            }
+        )
         return real_compileable(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -444,8 +451,7 @@ def test_parallel_linear_overflow_takes_int64_kernel_path(monkeypatch):
         torch.cuda.synchronize()
 
     assert len(launches) == 1, (
-        f"expected exactly one kernel launch (direct int64 path), "
-        f"got {len(launches)}"
+        f"expected exactly one kernel launch (direct int64 path), got {len(launches)}"
     )
     assert launches[0]["int64"] is True, (
         "auto-dispatch should have set int64_indices=True at the overflow shape"

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
@@ -1,0 +1,469 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""
+Parity and overflow-correctness tests for the ``INT64_INDICES``
+``tl.constexpr`` knob added to the scattermoe-lora Triton kernels.
+
+The kernel-level fix promotes the per-launch index ranges to int64 only
+when the wrapper has detected that ``L_scattered * y_dim`` would
+overflow int32. Two properties are tested:
+
+1. **Bitwise parity at small shapes.** When the shape fits in int32,
+   ``INT64_INDICES=False`` (the JIT'd int32 variant) and
+   ``INT64_INDICES=True`` (the int64 variant) compute the same MMA in
+   the same order. Only the index *type* changes, so the outputs must
+   be bitwise identical — any deviation indicates the cast leaked into
+   the accumulator path.
+
+2. **Overflow correctness at large shapes.** At the previously-failing
+   bench config (seq=524288 with 16 shards, L_scattered=262144,
+   y_dim=16384 → 2**32 element output), the int64 kernel must populate
+   every row of the output and match the chunked workaround within bf16
+   tolerance (the chunking workaround changes accumulation order, so
+   bit-equality is not expected against it — only against the same-
+   layout int32 kernel below the overflow boundary).
+
+The bench-config test is gated by GPU memory; an L_scattered=262144
+× 16384 bf16 output is ~8.6 GiB and the up-projection weight is
+~64 GiB so we skip when free memory is below the threshold.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.kernels import (
+    lora_ops,
+    ops as base_ops,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+    _scatter2scatter_int32_safe,
+    flatten_sort_count,
+)
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+def _requires_cuda():
+    return pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA not available"
+    )
+
+
+pytestmark = _requires_cuda()
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _setup(E, K, N, T, top_k, R=16, seed=42):
+    """Create synthetic inputs + routing for a (E, K, N, T, k) shape."""
+    torch.manual_seed(seed)
+    x = torch.randn(T, K, device=DEVICE, dtype=DTYPE)
+    W = torch.randn(E, K, N, device=DEVICE, dtype=DTYPE) * 0.02
+    lora_A = torch.randn(R * E, K, device=DEVICE, dtype=DTYPE) * 0.01
+    lora_B = torch.randn(N, R * E, device=DEVICE, dtype=DTYPE) * 0.01
+    logits = torch.randn(T, E, device=DEVICE)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), top_k, dim=-1)
+    sei, ssi, eo = flatten_sort_count(top_idx, E)
+    return x, W, lora_A, lora_B, sei, ssi, eo
+
+
+# ─── Parity tests at non-overflow shapes (bitwise identity) ──────────────────
+
+
+def test_dense_scatter2scatter_int64_parity_small():
+    """Dense scatter2scatter: INT64_INDICES=True == INT64_INDICES=False at small shape."""
+    x, W, *_, sei, ssi, _ = _setup(E=8, K=512, N=1024, T=256, top_k=4)
+    k = 4
+    out_i32 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=False,
+    )
+    out_i64 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_i32, out_i64), (
+        "INT64_INDICES must not change accumulation order at non-overflow shapes"
+    )
+
+
+def test_dense_scatter2scatter_int64_parity_ungrouped_out():
+    """Same parity but y_grouped=False (uses M_idx scatter lookup, not M_block)."""
+    x, W, *_, sei, ssi, _ = _setup(E=8, K=512, N=1024, T=256, top_k=4)
+    k = 4
+    out_i32 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        x_grouped=False,
+        y_grouped=False,
+        int64_indices=False,
+    )
+    out_i64 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        x_grouped=False,
+        y_grouped=False,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_i32, out_i64)
+
+
+def test_scatter2scatter_lora_int64_parity_small():
+    """scatter2scatter_lora: int32 vs int64 must agree bitwise."""
+    # Pick a shape that lands on the fused path (not split): few-large-experts
+    # split threshold is E<=32 with K*N >= 20M, so use a small K*N to stay
+    # on the fused kernel.
+    x, W, lA, lB, sei, ssi, _ = _setup(E=64, K=256, N=512, T=128, top_k=4)
+    k = 4
+    scaling = 0.5
+    out_i32 = lora_ops.scatter2scatter_lora(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        lora_A=lA,
+        lora_B=lB,
+        scaling=scaling,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=False,
+    )
+    out_i64 = lora_ops.scatter2scatter_lora(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        lora_A=lA,
+        lora_B=lB,
+        scaling=scaling,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_i32, out_i64)
+
+
+def test_scatter2scatter_lora_dX_int64_parity_small():
+    """scatter2scatter_lora_dX: int32 vs int64 must agree bitwise."""
+    _, W, lA, lB, sei, ssi, _ = _setup(E=64, K=256, N=512, T=128, top_k=4)
+    k = 4
+    scaling = 0.5
+    M_grouped = sei.size(0)  # ungrouped k=1 dy_grouped=True
+    dy = torch.randn(M_grouped, W.size(2), device=DEVICE, dtype=DTYPE) * 0.01
+    dX_i32 = lora_ops.scatter2scatter_lora_dX(
+        DY=dy,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        lora_A=lA,
+        lora_B=lB,
+        scaling=scaling,
+        dy_grouped=True,
+        dx_grouped=False,
+        int64_indices=False,
+    )
+    dX_i64 = lora_ops.scatter2scatter_lora_dX(
+        DY=dy,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=k,
+        lora_A=lA,
+        lora_B=lB,
+        scaling=scaling,
+        dy_grouped=True,
+        dx_grouped=False,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(dX_i32, dX_i64)
+
+
+def test_group_bwd_lora_int64_parity_small():
+    """group_bwd_lora (split kernel): int32 vs int64 must agree bitwise."""
+    x, W, lA, lB, sei, ssi, eo = _setup(E=16, K=256, N=512, T=128, top_k=2)
+    grouped_x = base_ops.group(x, ssi, fan_out=2)
+    M = grouped_x.size(0)
+    dy = torch.randn(M, W.size(2), device=DEVICE, dtype=DTYPE) * 0.01
+    scaling = 0.5
+    dA_i32, dB_i32 = lora_ops.group_bwd_lora(
+        DY=dy,
+        X=grouped_x,
+        lora_A=lA,
+        lora_B=lB,
+        expert_offsets=eo,
+        E=16,
+        scaling=scaling,
+        int64_indices=False,
+    )
+    dA_i64, dB_i64 = lora_ops.group_bwd_lora(
+        DY=dy,
+        X=grouped_x,
+        lora_A=lA,
+        lora_B=lB,
+        expert_offsets=eo,
+        E=16,
+        scaling=scaling,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(dA_i32, dA_i64)
+    assert torch.equal(dB_i32, dB_i64)
+
+
+def test_group_bwd_lora_fused_int64_parity_small():
+    """group_bwd_lora_fused: int32 vs int64 must agree within bf16 tolerance.
+
+    Unlike the split kernel, the fused kernel writes dA/dB via
+    ``tl.atomic_add``; the order in which (E, K-tile, N-tile) thread blocks
+    land their atomics is non-deterministic, so bit-equality is not
+    achievable even between two launches of the *same* kernel variant.
+    The INT64 cast only changes index *types*, not the MMA path or the
+    atomic reduction, so the two variants must still match within
+    ``torch.allclose`` bf16 tolerance.
+    """
+    x, _W, lA, lB, _sei, ssi, eo = _setup(E=16, K=256, N=512, T=128, top_k=2)
+    k = 2
+    M_total = ssi.size(0)
+    N = lB.size(0)
+    dy = torch.randn(M_total, N, device=DEVICE, dtype=DTYPE) * 0.01
+    scaling = 0.5
+    dA_i32, dB_i32 = lora_ops.group_bwd_lora_fused(
+        DY=dy,
+        X=x,
+        lora_A=lA,
+        lora_B=lB,
+        expert_offsets=eo,
+        sorted_scattered_idxs=ssi,
+        E=16,
+        k=k,
+        scaling=scaling,
+        dy_grouped=False,
+        int64_indices=False,
+    )
+    dA_i64, dB_i64 = lora_ops.group_bwd_lora_fused(
+        DY=dy,
+        X=x,
+        lora_A=lA,
+        lora_B=lB,
+        expert_offsets=eo,
+        sorted_scattered_idxs=ssi,
+        E=16,
+        k=k,
+        scaling=scaling,
+        dy_grouped=False,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+    # Tolerance: a few bf16 ULPs is expected from atomic-add ordering nondet.
+    assert torch.allclose(dA_i32, dA_i64, rtol=1e-2, atol=5e-4), (
+        f"max_abs_diff dA: {(dA_i32.float() - dA_i64.float()).abs().max()}"
+    )
+    assert torch.allclose(dB_i32, dB_i64, rtol=1e-2, atol=5e-4), (
+        f"max_abs_diff dB: {(dB_i32.float() - dB_i64.float()).abs().max()}"
+    )
+
+
+# ─── Overflow correctness at the bench shape ─────────────────────────────────
+
+
+# Bench-shape constants (mirror ``test_parallel_experts_large_batch_repro.py``).
+_T = 32768
+_TOP_K = 8
+_NUM_EXPERTS = 128
+_HIDDEN = 2048
+_INTERMEDIATE = 8192
+
+
+def _has_free_gpu_mem(min_gb: float) -> bool:
+    if not torch.cuda.is_available():
+        return False
+    free, _total = torch.cuda.mem_get_info()
+    return free / (1024**3) >= min_gb
+
+
+@pytest.mark.skipif(
+    not _has_free_gpu_mem(80.0),
+    reason="bench shape needs ~80 GiB free GPU memory",
+)
+def test_dense_scatter2scatter_int64_at_overflow_shape():
+    """Direct int64 kernel call at the bench shape produces no zero rows
+    and matches the chunked workaround within bf16 tolerance."""
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        _SCATTER2SCATTER_INT32_LIMIT,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+    x = torch.randn(_T, _HIDDEN, device=device, dtype=DTYPE)
+    W = (
+        torch.randn(
+            _NUM_EXPERTS, _HIDDEN, 2 * _INTERMEDIATE, device=device, dtype=DTYPE
+        )
+        * 0.01
+    )
+
+    logits = torch.randn(_T, _NUM_EXPERTS, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, _NUM_EXPERTS)
+
+    L_scattered = sei.size(0)
+    y_dim = W.size(-1)
+    assert L_scattered * y_dim >= _SCATTER2SCATTER_INT32_LIMIT, (
+        "precondition: shape must straddle the int32 overflow boundary"
+    )
+
+    out_i64 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+
+    # Sample rows on both sides of the int32 overflow boundary.
+    overflow_threshold_row = _SCATTER2SCATTER_INT32_LIMIT // y_dim
+    sample_rows = [
+        0,
+        overflow_threshold_row - 1,
+        overflow_threshold_row,
+        overflow_threshold_row + 1,
+        L_scattered - 1,
+    ]
+    for row in sample_rows:
+        assert (out_i64[row] != 0).any().item(), (
+            f"int64 kernel left row {row} all-zero (overflow boundary "
+            f"= {overflow_threshold_row}, L_scattered = {L_scattered})"
+        )
+
+    # Compare to the chunked workaround within bf16 tolerance. Chunking
+    # changes accumulation order so we cannot expect bit-equality, but the
+    # outputs should be numerically close.
+    out_chunked = _scatter2scatter_int32_safe(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=False,
+    )
+    torch.cuda.synchronize()
+    diff = (out_i64.float() - out_chunked.float()).abs().max().item()
+    ref = out_chunked.float().abs().max().item()
+    # bf16 has ~3 decimal digits, so a few-percent max-abs-diff against the
+    # chunked path is expected at this scale; assert a generous relative bound.
+    assert diff <= 5e-2 * (ref + 1.0), (
+        f"int64 kernel diverges from chunked path: max_abs_diff={diff:g} "
+        f"vs ref_max={ref:g}"
+    )
+
+
+@pytest.mark.skipif(
+    not _has_free_gpu_mem(80.0),
+    reason="bench shape needs ~80 GiB free GPU memory",
+)
+def test_parallel_linear_overflow_takes_direct_int64_path(monkeypatch):
+    """``ParallelLinear.forward`` at the bench shape must route through
+    the direct int64 kernel call, *not* the chunking workaround.
+
+    The auto-dispatch should set ``needs_int64=True`` and the
+    ``_scatter2scatter_int32_safe`` wrapper's new ``int64_indices=True``
+    branch should then bypass the chunking loop entirely.
+    """
+    from axolotl.integrations.kernels.libs.scattermoe_lora import parallel_experts
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        parallel_linear,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+
+    x = torch.randn(_T, _HIDDEN, device=device, dtype=DTYPE)
+    W = (
+        torch.randn(
+            _NUM_EXPERTS, _HIDDEN, 2 * _INTERMEDIATE, device=device, dtype=DTYPE
+        )
+        * 0.01
+    )
+
+    logits = torch.randn(_T, _NUM_EXPERTS, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
+    sei, ssi, eo = flatten_sort_count(top_idx, _NUM_EXPERTS)
+
+    # Spy on the chunking path: count how many times the per-chunk
+    # ``scatter2scatter_compileable`` is invoked. If the int64 fast
+    # path is taken, this stays at zero.
+    chunk_calls = {"count": 0}
+    real_compileable = (
+        parallel_experts.kernels.ops.scatter2scatter_compileable
+    )
+
+    def _spy_compileable(*args, **kwargs):
+        chunk_calls["count"] += 1
+        return real_compileable(*args, **kwargs)
+
+    monkeypatch.setattr(
+        parallel_experts.kernels.ops,
+        "scatter2scatter_compileable",
+        _spy_compileable,
+    )
+
+    with torch.no_grad():
+        out = parallel_linear(
+            x,
+            W,
+            _TOP_K,
+            sei,
+            ssi,
+            eo,
+            grouped_in=False,
+            grouped_out=True,
+        )
+        torch.cuda.synchronize()
+
+    # The direct int64 kernel path doesn't call scatter2scatter_compileable
+    # — it goes through ``base_ops.scatter2scatter`` which calls
+    # scatter2scatter_compileable exactly once for the whole launch. The
+    # chunking path would invoke it once per chunk (>=2 at the bench shape).
+    assert chunk_calls["count"] == 1, (
+        f"expected exactly one kernel launch (direct int64 path), "
+        f"got {chunk_calls['count']} (chunking workaround was taken)"
+    )
+    assert out.shape == (_T * _TOP_K, 2 * _INTERMEDIATE)
+    assert torch.isfinite(out).all().item()

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
@@ -40,12 +40,15 @@ from axolotl.integrations.kernels.libs.scattermoe_lora.kernels import (
     ops as base_ops,
 )
 from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
-    _scatter2scatter_int32_safe,
     flatten_sort_count,
 )
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
+
+# Sufficient condition for int32 pointer arithmetic to overflow in the
+# Triton kernel: any indexed buffer has >= 2**31 elements.
+_INT32_LIMIT = 2**31
 
 
 def _requires_cuda():
@@ -317,12 +320,13 @@ def _has_free_gpu_mem(min_gb: float) -> bool:
     reason="bench shape needs ~80 GiB free GPU memory",
 )
 def test_dense_scatter2scatter_int64_at_overflow_shape():
-    """Direct int64 kernel call at the bench shape produces no zero rows
-    and matches the chunked workaround within bf16 tolerance."""
-    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
-        _SCATTER2SCATTER_INT32_LIMIT,
-    )
+    """Direct int64 kernel call at the bench shape produces no zero rows.
 
+    With ``INT64_INDICES=True`` the kernel's pointer arithmetic stays in
+    int64 across the full output row range, so rows past the would-be
+    int32 overflow boundary (``M_block >= 2**31 / y_dim``) are populated
+    rather than silently dropped.
+    """
     device = torch.device("cuda:0")
     torch.manual_seed(0)
     x = torch.randn(_T, _HIDDEN, device=device, dtype=DTYPE)
@@ -339,7 +343,7 @@ def test_dense_scatter2scatter_int64_at_overflow_shape():
 
     L_scattered = sei.size(0)
     y_dim = W.size(-1)
-    assert L_scattered * y_dim >= _SCATTER2SCATTER_INT32_LIMIT, (
+    assert L_scattered * y_dim >= _INT32_LIMIT, (
         "precondition: shape must straddle the int32 overflow boundary"
     )
 
@@ -356,7 +360,7 @@ def test_dense_scatter2scatter_int64_at_overflow_shape():
     torch.cuda.synchronize()
 
     # Sample rows on both sides of the int32 overflow boundary.
-    overflow_threshold_row = _SCATTER2SCATTER_INT32_LIMIT // y_dim
+    overflow_threshold_row = _INT32_LIMIT // y_dim
     sample_rows = [
         0,
         overflow_threshold_row - 1,
@@ -369,28 +373,8 @@ def test_dense_scatter2scatter_int64_at_overflow_shape():
             f"int64 kernel left row {row} all-zero (overflow boundary "
             f"= {overflow_threshold_row}, L_scattered = {L_scattered})"
         )
-
-    # Compare to the chunked workaround within bf16 tolerance. Chunking
-    # changes accumulation order so we cannot expect bit-equality, but the
-    # outputs should be numerically close.
-    out_chunked = _scatter2scatter_int32_safe(
-        X=x,
-        W=W,
-        sorted_expert_idxs=sei,
-        sorted_scattered_idxs=ssi,
-        k=_TOP_K,
-        x_grouped=False,
-        y_grouped=True,
-        int64_indices=False,
-    )
-    torch.cuda.synchronize()
-    diff = (out_i64.float() - out_chunked.float()).abs().max().item()
-    ref = out_chunked.float().abs().max().item()
-    # bf16 has ~3 decimal digits, so a few-percent max-abs-diff against the
-    # chunked path is expected at this scale; assert a generous relative bound.
-    assert diff <= 5e-2 * (ref + 1.0), (
-        f"int64 kernel diverges from chunked path: max_abs_diff={diff:g} "
-        f"vs ref_max={ref:g}"
+    assert torch.isfinite(out_i64).all().item(), (
+        "int64 kernel produced non-finite values at overflow shape"
     )
 
 
@@ -398,13 +382,15 @@ def test_dense_scatter2scatter_int64_at_overflow_shape():
     not _has_free_gpu_mem(80.0),
     reason="bench shape needs ~80 GiB free GPU memory",
 )
-def test_parallel_linear_overflow_takes_direct_int64_path(monkeypatch):
+def test_parallel_linear_overflow_takes_int64_kernel_path(monkeypatch):
     """``ParallelLinear.forward`` at the bench shape must route through
-    the direct int64 kernel call, *not* the chunking workaround.
+    the int64 kernel path (single launch, ``int64_indices=True``).
 
-    The auto-dispatch should set ``needs_int64=True`` and the
-    ``_scatter2scatter_int32_safe`` wrapper's new ``int64_indices=True``
-    branch should then bypass the chunking loop entirely.
+    The auto-dispatch should set ``needs_int64=True`` and dispatch a
+    single ``scatter2scatter`` launch with that flag. A regressed path
+    that called the kernel multiple times (e.g. a chunking workaround)
+    would invoke ``scatter2scatter_compileable`` more than once and
+    fail this assertion.
     """
     from axolotl.integrations.kernels.libs.scattermoe_lora import parallel_experts
     from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
@@ -426,16 +412,16 @@ def test_parallel_linear_overflow_takes_direct_int64_path(monkeypatch):
     _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
     sei, ssi, eo = flatten_sort_count(top_idx, _NUM_EXPERTS)
 
-    # Spy on the chunking path: count how many times the per-chunk
-    # ``scatter2scatter_compileable`` is invoked. If the int64 fast
-    # path is taken, this stays at zero.
-    chunk_calls = {"count": 0}
-    real_compileable = (
-        parallel_experts.kernels.ops.scatter2scatter_compileable
-    )
+    # Spy on the kernel launches. The kernel-level int64 fix dispatches
+    # exactly one ``scatter2scatter_compileable`` call with
+    # ``int64_indices=True``. A re-introduced chunking workaround would
+    # invoke it once per chunk (>=2 at this shape).
+    launches = []
+    real_compileable = parallel_experts.kernels.ops.scatter2scatter_compileable
 
     def _spy_compileable(*args, **kwargs):
-        chunk_calls["count"] += 1
+        # int64_indices is positional arg 9 (after b, x_grouped, y_grouped).
+        launches.append({"args_len": len(args), "int64": args[9] if len(args) > 9 else kwargs.get("int64_indices", False)})
         return real_compileable(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -457,13 +443,12 @@ def test_parallel_linear_overflow_takes_direct_int64_path(monkeypatch):
         )
         torch.cuda.synchronize()
 
-    # The direct int64 kernel path doesn't call scatter2scatter_compileable
-    # — it goes through ``base_ops.scatter2scatter`` which calls
-    # scatter2scatter_compileable exactly once for the whole launch. The
-    # chunking path would invoke it once per chunk (>=2 at the bench shape).
-    assert chunk_calls["count"] == 1, (
+    assert len(launches) == 1, (
         f"expected exactly one kernel launch (direct int64 path), "
-        f"got {chunk_calls['count']} (chunking workaround was taken)"
+        f"got {len(launches)}"
+    )
+    assert launches[0]["int64"] is True, (
+        "auto-dispatch should have set int64_indices=True at the overflow shape"
     )
     assert out.shape == (_T * _TOP_K, 2 * _INTERMEDIATE)
     assert torch.isfinite(out).all().item()

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
@@ -464,7 +464,7 @@ def test_parallel_linear_overflow_takes_int64_kernel_path(monkeypatch):
 # L_scattered * y_dim = 2**32 (2× past 2**31); peak VRAM ≈ 8 GiB.
 _SMALL_T = 131072
 _SMALL_TOP_K = 8
-_SMALL_E = 4
+_SMALL_E = 8
 _SMALL_K = 256
 _SMALL_INTERMEDIATE = 2048
 _SMALL_MIN_FREE_GIB = 12.0

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_int64_indices.py
@@ -458,3 +458,124 @@ def test_parallel_linear_overflow_takes_int64_kernel_path(monkeypatch):
     )
     assert out.shape == (_T * _TOP_K, 2 * _INTERMEDIATE)
     assert torch.isfinite(out).all().item()
+
+
+# ─── Smaller-shape overflow (runs on L40S / 24 GiB GPUs) ─────────────────────
+# L_scattered * y_dim = 2**32 (2× past 2**31); peak VRAM ≈ 8 GiB.
+_SMALL_T = 131072
+_SMALL_TOP_K = 8
+_SMALL_E = 4
+_SMALL_K = 256
+_SMALL_INTERMEDIATE = 2048
+_SMALL_MIN_FREE_GIB = 12.0
+
+
+@pytest.mark.skipif(
+    not _has_free_gpu_mem(_SMALL_MIN_FREE_GIB),
+    reason=f"small overflow shape needs ~{_SMALL_MIN_FREE_GIB:.0f} GiB free GPU memory",
+)
+def test_dense_scatter2scatter_int64_at_overflow_shape_small():
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+    y_dim = 2 * _SMALL_INTERMEDIATE
+    x = torch.randn(_SMALL_T, _SMALL_K, device=device, dtype=DTYPE)
+    W = torch.randn(_SMALL_E, _SMALL_K, y_dim, device=device, dtype=DTYPE) * 0.01
+
+    logits = torch.randn(_SMALL_T, _SMALL_E, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _SMALL_TOP_K, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, _SMALL_E)
+
+    L_scattered = sei.size(0)
+    assert L_scattered * y_dim >= _INT32_LIMIT, (
+        f"precondition: L_scattered * y_dim ({L_scattered * y_dim}) must "
+        f"straddle the int32 overflow boundary ({_INT32_LIMIT})"
+    )
+
+    out_i64 = base_ops.scatter2scatter(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_SMALL_TOP_K,
+        x_grouped=False,
+        y_grouped=True,
+        int64_indices=True,
+    )
+    torch.cuda.synchronize()
+
+    overflow_threshold_row = _INT32_LIMIT // y_dim
+    sample_rows = [
+        0,
+        overflow_threshold_row - 1,
+        overflow_threshold_row,
+        overflow_threshold_row + 1,
+        L_scattered - 1,
+    ]
+    for row in sample_rows:
+        assert (out_i64[row] != 0).any().item(), (
+            f"int64 kernel left row {row} all-zero (overflow boundary "
+            f"= {overflow_threshold_row}, L_scattered = {L_scattered})"
+        )
+    assert torch.isfinite(out_i64).all().item()
+
+
+@pytest.mark.skipif(
+    not _has_free_gpu_mem(_SMALL_MIN_FREE_GIB),
+    reason=f"small overflow shape needs ~{_SMALL_MIN_FREE_GIB:.0f} GiB free GPU memory",
+)
+def test_parallel_linear_overflow_takes_int64_kernel_path_small(monkeypatch):
+    from axolotl.integrations.kernels.libs.scattermoe_lora import parallel_experts
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        parallel_linear,
+    )
+
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+    y_dim = 2 * _SMALL_INTERMEDIATE
+    x = torch.randn(_SMALL_T, _SMALL_K, device=device, dtype=DTYPE)
+    W = torch.randn(_SMALL_E, _SMALL_K, y_dim, device=device, dtype=DTYPE) * 0.01
+
+    logits = torch.randn(_SMALL_T, _SMALL_E, device=device)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _SMALL_TOP_K, dim=-1)
+    sei, ssi, eo = flatten_sort_count(top_idx, _SMALL_E)
+
+    launches = []
+    real_compileable = parallel_experts.kernels.ops.scatter2scatter_compileable
+
+    def _spy_compileable(*args, **kwargs):
+        launches.append(
+            {
+                "int64": args[9]
+                if len(args) > 9
+                else kwargs.get("int64_indices", False),
+            }
+        )
+        return real_compileable(*args, **kwargs)
+
+    monkeypatch.setattr(
+        parallel_experts.kernels.ops,
+        "scatter2scatter_compileable",
+        _spy_compileable,
+    )
+
+    with torch.no_grad():
+        out = parallel_linear(
+            x,
+            W,
+            _SMALL_TOP_K,
+            sei,
+            ssi,
+            eo,
+            grouped_in=False,
+            grouped_out=True,
+        )
+        torch.cuda.synchronize()
+
+    assert len(launches) == 1, (
+        f"expected exactly one kernel launch (direct int64 path), got {len(launches)}"
+    )
+    assert launches[0]["int64"] is True, (
+        "auto-dispatch should have set int64_indices=True at the overflow shape"
+    )
+    assert out.shape == (_SMALL_T * _SMALL_TOP_K, y_dim)
+    assert torch.isfinite(out).all().item()

--- a/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_m_bucket.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_scattermoe_lora_m_bucket.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the ``M_BUCKET`` autotune-key bucketing on the scattermoe-lora
+fused forward kernel.
+
+The kernel runs on the real ``M`` (loop bounds + masks); only the
+``@triton.autotune`` cache key is bucketed via :func:`_bucket_m`. These tests
+pin both halves of that contract:
+
+  * ``_bucket_m`` rounds up to a multiple of the granularity (pure-Python
+    unit test, no GPU).
+  * Two distinct real ``M`` values that share a bucket produce **one**
+    cache entry (the whole point — no resweep on small seqlen variation).
+  * Two real ``M`` values in different buckets produce **two** cache
+    entries (we didn't accidentally collapse to a single key).
+
+Run on CUDA only; the bucketing assertion needs an actual Triton launch.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.kernels import lora_ops
+from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.lora_ops import (
+    _M_BUCKET_GRANULARITY,
+    _bucket_m,
+    scatter2scatter_lora,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+    flatten_sort_count,
+)
+
+
+def test_bucket_m_rounds_up_to_granularity():
+    g = _M_BUCKET_GRANULARITY
+    assert _bucket_m(1) == g
+    assert _bucket_m(g) == g
+    assert _bucket_m(g + 1) == 2 * g
+    assert _bucket_m(2 * g) == 2 * g
+    # Realistic seqlen variation: at granularity=1024 and top_k=8 the three
+    # seqlens 16300/16400/16500 straddle one bucket boundary, so they collapse
+    # to 2 cache entries rather than 3 (16400 and 16500 share a bucket).
+    assert _bucket_m(16400 * 8) == _bucket_m(16500 * 8)
+    assert _bucket_m(16300 * 8) != _bucket_m(16400 * 8)
+    distinct = {_bucket_m(s * 8) for s in (16300, 16400, 16500)}
+    assert len(distinct) == 2
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for kernel launch"
+)
+
+
+_DEVICE = "cuda"
+_DTYPE = torch.bfloat16
+_E = 4
+_K = 64
+_N = 64
+_TOP_K = 2
+_R = 16
+
+
+def _launch_once(m: int) -> None:
+    """One fused fwd launch at the given real M; minimal shapes for speed."""
+    torch.manual_seed(m)
+    x = torch.randn(m, _K, device=_DEVICE, dtype=_DTYPE)
+    W = torch.randn(_E, _K, _N, device=_DEVICE, dtype=_DTYPE) * 0.02
+    lora_A = torch.randn(_R * _E, _K, device=_DEVICE, dtype=_DTYPE) * 0.01
+    lora_B = torch.randn(_N, _R * _E, device=_DEVICE, dtype=_DTYPE) * 0.01
+    logits = torch.randn(m, _E, device=_DEVICE)
+    _, top_idx = torch.topk(torch.softmax(logits, dim=-1), _TOP_K, dim=-1)
+    sei, ssi, _ = flatten_sort_count(top_idx, _E)
+    scatter2scatter_lora(
+        X=x,
+        W=W,
+        sorted_expert_idxs=sei,
+        sorted_scattered_idxs=ssi,
+        k=_TOP_K,
+        lora_A=lora_A,
+        lora_B=lora_B,
+        scaling=1.0 / _R,
+    )
+
+
+def test_autotune_cache_collapses_within_bucket_and_grows_across_buckets():
+    cache = lora_ops._scatter2scatter_lora.cache
+    cache.clear()
+
+    g = _M_BUCKET_GRANULARITY
+    # Two M values that both ceil to bucket B1.
+    m_a = g - 1
+    m_b = g // 2 + 1
+    assert _bucket_m(m_a) == g
+    assert _bucket_m(m_b) == g
+
+    _launch_once(m_a)
+    assert len(cache) == 1, (
+        f"first launch should create exactly one cache entry, got {len(cache)}"
+    )
+
+    _launch_once(m_b)
+    assert len(cache) == 1, (
+        f"second launch in the same bucket must not add a cache entry "
+        f"(M={m_a} and M={m_b} both bucket to {g}); got {len(cache)} entries"
+    )
+
+    # An M strictly past the bucket boundary lands in bucket 2*g.
+    m_c = g + 1
+    assert _bucket_m(m_c) == 2 * g
+    _launch_once(m_c)
+    assert len(cache) == 2, (
+        f"launch in a different bucket (M={m_c} -> {2 * g}) must add a "
+        f"second cache entry; got {len(cache)}"
+    )

--- a/tests/integrations/test_scattermoe_autotune_telemetry.py
+++ b/tests/integrations/test_scattermoe_autotune_telemetry.py
@@ -104,7 +104,7 @@ class TestAutotuneCollector:
         assert len(result) == 1
         entry = result[0]
         assert entry["kernel"] == "scatter2scatter_lora_fwd"
-        assert entry["key"] == {"M": 2048, "N": 4096, "K": 1024}
+        assert entry["key"] == {"M_BUCKET": 2048, "N": 4096, "K": 1024}
         assert entry["config"]["BLOCK_N"] == 128
         assert entry["config"]["BLOCK_K"] == 64
         assert entry["config"]["num_warps"] == 8
@@ -148,7 +148,7 @@ class TestAutotuneCollector:
 
         assert len(result) == 1
         key = result[0]["key"]
-        assert key["M"] == 512
+        assert key["M_BUCKET"] == 512
         assert key["N"] == 1024
         assert key["K"] == 256
         assert key["_extra"] == ["float16", "float16"]


### PR DESCRIPTION
## Summary

Stack on top of #3663. Fixes a silent int32 pointer-offset overflow in scattermoe-lora's Triton kernels that surfaces as `CUBLAS_STATUS_EXECUTION_FAILED` downstream when the routed-token count gets large.

**Root cause** (the surface symptom is misleading): the originally-reported failure was `cublasGemmStridedBatchedEx → CUBLAS_STATUS_EXECUTION_FAILED` at `parallel_experts.py:72`. The cuBLAS shape at the failing config is tiny in isolation (`batch_count=32768, M=1, K=8, N=2048`) and works on its own. The actual failure is **int32 overflow in pointer arithmetic inside `_scatter2scatter` and the LoRA / MX variants** when `L_scattered * y_dim * dtype_size >= 2³¹`. Corruption propagates into the downstream matmul, where cuBLAS gives up.

**Repro shape**: seq=524288, shards=16, top_k=8, hidden=2048 → L_scattered ≈ 262K rows × y_dim=2048 = ~537M elements × 2 bytes = ~1.07 GiB output. Pointer-offset arithmetic overflows int32.

## Fix: INT64_INDICES tl.constexpr in the scatter2scatter family

Add `INT64_INDICES: tl.constexpr = False` to every scattermoe-lora Triton kernel that does pointer arithmetic on tokens × strides:

- `kernels.ops._scatter2scatter` (dense forward)
- `kernels.lora_ops._scatter2scatter_lora` (LoRA forward, bf16)
- `kernels.lora_ops._scatter2scatter_lora_dX` (LoRA dX backward, bf16)
- `kernels.lora_ops._scatter2scatter_lora_mx` (LoRA forward, MXFP4)
- `kernels.lora_ops._scatter2scatter_lora_dX_mx` (LoRA dX backward, MXFP4)
- `kernels.lora_ops._group_bwd_lora` (LoRA grad, fused)
- `kernels.lora_ops._group_bwd_lora_split` (LoRA grad, split)

Inside each kernel, the conditional cast looks like:

```python
M_block = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
if INT64_INDICES:
    M_block = M_block.to(tl.int64)
# Pointer arithmetic now propagates int64
```

Auto-dispatch at the Python wrapper level (`parallel_experts.py`, `parallel_linear_lora.py`) picks `INT64_INDICES=True` when any tensor `numel() >= 2³¹`. Triton JITs both variants — same SASS as pre-fix when `INT64_INDICES=False`.

## What's in this PR (8 commits)

1. `test(scattermoe-lora): repro CUBLAS_STATUS_EXECUTION_FAILED at large batch_count` — the regression test (un-skipped)
2. `feat(scattermoe-lora): add INT64_INDICES tl.constexpr to dense scatter2scatter`
3. `feat(scattermoe-lora): add INT64_INDICES to LoRA forward + dX kernels (bf16 + MX)`
4. `feat(scattermoe-lora): add INT64_INDICES to group_bwd_lora kernels`
5. `feat(scattermoe-lora): auto-dispatch INT64_INDICES based on tensor sizes`
6. `test(scattermoe-lora): int32-vs-int64 parity and overflow correctness`
7. `bench(scattermoe-lora): int64-vs-int32 indexing overhead`
8. `chore(scattermoe-lora): pre-commit fixups`

## Before / after on the previously-failing config

| Config | Pre-fix | Post-fix |
|---|---|---|
| seq=524288, shards=16, top_k=8 | `CUBLAS_STATUS_EXECUTION_FAILED` | **fast path: int64 kernel, no chunking, ~52K tok/s** |

## Performance

From `tests/integrations/kernels/scattermoe_lora/bench_int64_kernel_results.md`:

- **Fast path (INT64_INDICES=False)**: zero regression on non-overflow shapes. JIT-compiled to the same SASS as pre-fix.
- **int64 path (INT64_INDICES=True)**: ≤ 25% penalty vs forced int32 at non-overflow shapes (informational; production never forces int32 when int64 is needed).
- On overflow shapes, the int64 path is the only thing that works.

## Coverage vs. prior chunking workaround

This PR originally shipped a chunking workaround for the dense path only (PR #3667 before rebase). That approach had a documented gap: the LoRA-path `scatter2scatter_lora` had the same overflow risk but the chunking wrapper didn't cover it. The kernel-level INT64_INDICES fix covers **all seven kernels** in one go and eliminates the chunking complexity entirely.

## Test plan

- [x] `pytest tests/integrations/test_parallel_experts_large_batch_repro.py` — passes (seq=512K/s=16 succeeds via the int64 fast path, not chunking)
- [x] `pytest tests/integrations/test_scattermoe_lora_int64_indices.py` — int32-vs-int64 bitwise parity at non-overflow shapes
- [x] `pytest tests/integrations/test_scattermoe_lora_kernels.py tests/integrations/test_scattermoe_lora.py` — 62/62 pass (existing kernel suite)
- [x] Pre-commit clean

## Stacking note

PR base is `feat/scattermoe-lora-mxfp4` (#3663). Once #3663 merges, this auto-rebases onto main. Parallel to #3666 (tiled-MLP fixes) — touches different code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integer overflow in tensor routing operations that could silently corrupt data in large-scale models. 64-bit indexing is now automatically enabled when needed to ensure correct computation.

* **Tests**
  * Added comprehensive test coverage validating tensor operation correctness across various sizes and overflow scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->