### PR TITLE
feat(fsdp2): add fp32_norms for keeping RMSNorm/LayerNorm in fp32

### DIFF
--- a/docs/mixed_precision.qmd
+++ b/docs/mixed_precision.qmd
@@ -54,6 +54,26 @@ bf16: true
 bf16: full  # Equivalent to bf16_full_eval in the HF trainer
 ```
 
+### Keeping norms in fp32 (FSDP2) {#sec-fp32-norms}
+
+Some models declare RMSNorm/LayerNorm layers as fp32 for training
+stability — the variance computation in RMSNorm is numerically poor in
+bf16, and the learned gain γ quantizes harshly. With FSDP1 this fights
+the flat-param dtype uniformity constraint; with FSDP2 each norm can have
+its own `MixedPrecisionPolicy`. Enable with:
+
+```{.yaml}
+fsdp_version: 2
+fp32_norms: true
+# fp32_norm_classes:        # optional override
+#   - RMSNorm
+#   - LayerNorm
+```
+
+Defaults match any class whose name ends in `RMSNorm` or `LayerNorm`. Use
+fully qualified names (`module.path.ClassName`) to pin a specific
+implementation.
+
 ## FP8 Mixed Precision {#sec-fp8}
 
 ::: {.callout-note}

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -7,7 +7,7 @@ import math
 import os
 from functools import cached_property
 from importlib.util import find_spec
-from typing import Any, Sequence
+from typing import Any
 
 import peft
 import torch
@@ -56,109 +56,17 @@ from axolotl.utils.distributed import (
     get_device_count,
     get_device_type,
 )
+from axolotl.utils.fp32_norms import (
+    _matches_norm_class,
+    get_fp32_norm_patterns,
+    tag_model_fp32_norms,
+)
 from axolotl.utils.logging import get_logger
 from axolotl.utils.model_shard_quant import load_sharded_model_quant
 from axolotl.utils.schemas.enums import RLType
 
 LOG = get_logger(__name__)
 PLUGIN_MANAGER = PluginManager.get_instance()
-
-
-# Shard RMSNorm/LayerNorm as fp32 before decoder wrapping so FSDP2 can keep
-# per-module MixedPrecisionPolicy (workaround for FSDP1 flat-param dtype constraints).
-
-DEFAULT_FP32_NORM_SUFFIXES: tuple[str, ...] = ("RMSNorm", "LayerNorm")
-
-
-def _matches_norm_class(module: "torch.nn.Module", patterns: Sequence[str]) -> bool:
-    """Match a module against class-name patterns.
-
-    Two matching modes, chosen per-pattern by presence of a dot:
-      - Fully qualified (contains "."): matches f"{module.__module__}.{cls}" exactly.
-      - Suffix (no dot): matches type(module).__name__.endswith(pattern).
-    Empty / whitespace-only patterns are skipped (``cls_name.endswith("")``
-    is True for every class, which would silently match everything).
-    """
-    cls = type(module)
-    cls_name = cls.__name__
-    qualified = f"{cls.__module__}.{cls_name}"
-    for pattern in patterns:
-        if not pattern or not pattern.strip():
-            continue
-        if "." in pattern:
-            if qualified == pattern:
-                return True
-        elif cls_name.endswith(pattern):
-            return True
-    return False
-
-
-def shard_norms_fp32(model: "torch.nn.Module", cfg) -> int:
-    """Wrap matching norm modules with FSDP2 + fp32 MixedPrecisionPolicy.
-
-    Must run AFTER model materialization and BEFORE accelerator.prepare().
-    Returns the number of modules sharded.
-
-    Norms are sharded on the default process group; mesh-scoped sharding for
-    composed TP + FSDP2 is not handled here (the device mesh is only available
-    once accelerator.prepare() runs), so combining fp32_norms with tensor
-    parallelism is unsupported.
-    """
-    if not getattr(cfg, "fp32_norms", False):
-        return 0
-
-    from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-
-    if getattr(cfg, "fsdp_version", None) != 2:
-        raise ValueError(
-            "fp32_norms requires fsdp_version: 2. FSDP1 enforces flat-param "
-            "dtype uniformity within each wrap group, which is incompatible "
-            "with keeping norms in fp32 while the rest of the layer is bf16."
-        )
-
-    patterns = (
-        list(cfg.fp32_norm_classes)
-        if cfg.fp32_norm_classes
-        else list(DEFAULT_FP32_NORM_SUFFIXES)
-    )
-
-    fp32_policy = MixedPrecisionPolicy(
-        param_dtype=torch.float32,
-        reduce_dtype=torch.float32,
-    )
-
-    matches = [
-        (name, module)
-        for name, module in model.named_modules()
-        if _matches_norm_class(module, patterns)
-    ]
-
-    if not matches:
-        LOG.warning(
-            "fp32_norms enabled but no modules matched patterns %s. Check "
-            "fp32_norm_classes against the model's actual norm class names.",
-            patterns,
-        )
-        return 0
-
-    for name, module in matches:
-        if any(p.is_meta for p in module.parameters(recurse=False)):
-            raise RuntimeError(
-                f"Cannot shard meta-device module {name!r} "
-                f"({type(module).__name__}). fp32_norms currently requires "
-                "materialized parameters. Disable cpu_ram_efficient_loading "
-                "or materialize before this call."
-            )
-
-    for _name, module in matches:
-        fully_shard(module, mp_policy=fp32_policy)
-
-    LOG.info(
-        "Sharded %d norm modules with fp32 MixedPrecisionPolicy (patterns=%s)",
-        len(matches),
-        patterns,
-    )
-    return len(matches)
 
 
 class ModelLoader:
@@ -289,7 +197,7 @@ class ModelLoader:
         PLUGIN_MANAGER.post_model_load(self.cfg, self.model)
 
         if self.cfg.fp32_norms:
-            shard_norms_fp32(self.model, self.cfg)
+            tag_model_fp32_norms(self.model, self.cfg)
 
         return self.model, lora_config
 
@@ -1011,8 +919,11 @@ class ModelLoader:
         dest = {"dtype": dist_dtype}
         if self.cfg.lora_on_cpu:
             dest["device"] = "cpu"
+        fp32_norm_patterns = get_fp32_norm_patterns(self.cfg)
         for name, module in self.model.named_modules():
-            if "norm" in name:
+            if fp32_norm_patterns and _matches_norm_class(module, fp32_norm_patterns):
+                module.to(torch.float32)
+            elif "norm" in name:
                 module.to(dist_dtype)
             if before_kbit_train_or_finetune:
                 if name.endswith(".gate"):

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -7,7 +7,7 @@ import math
 import os
 from functools import cached_property
 from importlib.util import find_spec
-from typing import Any
+from typing import Any, Sequence
 
 import peft
 import torch
@@ -62,6 +62,108 @@ from axolotl.utils.schemas.enums import RLType
 
 LOG = get_logger(__name__)
 PLUGIN_MANAGER = PluginManager.get_instance()
+
+
+# ---------------------------------------------------------------------------
+# fp32 norm sharding for FSDP2
+#
+# Some models declare RMSNorm/LayerNorm as fp32 for training stability (the
+# variance computation in RMSNorm accumulates poorly in bf16). FSDP1 enforces
+# flat-param dtype uniformity within each wrap group, which is incompatible
+# with keeping norms in fp32 while decoder layers run in bf16. FSDP2 allows
+# per-module MixedPrecisionPolicy: we shard each norm with its own fp32
+# policy BEFORE the standard decoder-layer wrap, so the two groups stay
+# independent.
+# ---------------------------------------------------------------------------
+
+DEFAULT_FP32_NORM_SUFFIXES: tuple[str, ...] = ("RMSNorm", "LayerNorm")
+
+
+def _matches_norm_class(module: "torch.nn.Module", patterns: Sequence[str]) -> bool:
+    """Match a module against class-name patterns.
+
+    Two matching modes, chosen per-pattern by presence of a dot:
+      - Fully qualified (contains "."): matches f"{module.__module__}.{cls}" exactly.
+      - Suffix (no dot): matches type(module).__name__.endswith(pattern).
+    """
+    cls = type(module)
+    cls_name = cls.__name__
+    qualified = f"{cls.__module__}.{cls_name}"
+    for pattern in patterns:
+        if "." in pattern:
+            if qualified == pattern:
+                return True
+        elif cls_name.endswith(pattern):
+            return True
+    return False
+
+
+def shard_norms_fp32(model: "torch.nn.Module", cfg) -> int:
+    """Wrap matching norm modules with FSDP2 + fp32 MixedPrecisionPolicy.
+
+    Must run AFTER model materialization and BEFORE accelerator.prepare().
+    Returns the number of modules sharded.
+
+    Norms are sharded on the default process group; mesh-scoped sharding for
+    composed TP + FSDP2 is not handled here (the device mesh is only available
+    once accelerator.prepare() runs), so combining fp32_norms with tensor
+    parallelism is unsupported.
+    """
+    if not getattr(cfg, "fp32_norms", False):
+        return 0
+
+    from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+
+    if getattr(cfg, "fsdp_version", None) != 2:
+        raise ValueError(
+            "fp32_norms requires fsdp_version: 2. FSDP1 enforces flat-param "
+            "dtype uniformity within each wrap group, which is incompatible "
+            "with keeping norms in fp32 while the rest of the layer is bf16."
+        )
+
+    patterns = (
+        list(cfg.fp32_norm_classes)
+        if cfg.fp32_norm_classes
+        else list(DEFAULT_FP32_NORM_SUFFIXES)
+    )
+
+    fp32_policy = MixedPrecisionPolicy(
+        param_dtype=torch.float32,
+        reduce_dtype=torch.float32,
+    )
+
+    matches = [
+        (name, module)
+        for name, module in model.named_modules()
+        if _matches_norm_class(module, patterns)
+    ]
+
+    if not matches:
+        LOG.warning(
+            "fp32_norms enabled but no modules matched patterns %s. Check "
+            "fp32_norm_classes against the model's actual norm class names.",
+            patterns,
+        )
+        return 0
+
+    for name, module in matches:
+        if any(p.is_meta for p in module.parameters(recurse=False)):
+            raise RuntimeError(
+                f"Cannot shard meta-device module {name!r} "
+                f"({type(module).__name__}). fp32_norms currently requires "
+                "materialized parameters. Disable cpu_ram_efficient_loading "
+                "or materialize before this call."
+            )
+
+    for _name, module in matches:
+        fully_shard(module, mp_policy=fp32_policy)
+
+    LOG.info(
+        "Sharded %d norm modules with fp32 MixedPrecisionPolicy (patterns=%s)",
+        len(matches),
+        patterns,
+    )
+    return len(matches)
 
 
 class ModelLoader:
@@ -190,6 +292,9 @@ class ModelLoader:
         self._apply_post_lora_load_setup(skip_move_to_device)
         self.patch_manager.apply_post_model_load_patches(self.model)
         PLUGIN_MANAGER.post_model_load(self.cfg, self.model)
+
+        if self.cfg.fp32_norms:
+            shard_norms_fp32(self.model, self.cfg)
 
         return self.model, lora_config
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -64,17 +64,8 @@ LOG = get_logger(__name__)
 PLUGIN_MANAGER = PluginManager.get_instance()
 
 
-# ---------------------------------------------------------------------------
-# fp32 norm sharding for FSDP2
-#
-# Some models declare RMSNorm/LayerNorm as fp32 for training stability (the
-# variance computation in RMSNorm accumulates poorly in bf16). FSDP1 enforces
-# flat-param dtype uniformity within each wrap group, which is incompatible
-# with keeping norms in fp32 while decoder layers run in bf16. FSDP2 allows
-# per-module MixedPrecisionPolicy: we shard each norm with its own fp32
-# policy BEFORE the standard decoder-layer wrap, so the two groups stay
-# independent.
-# ---------------------------------------------------------------------------
+# Shard RMSNorm/LayerNorm as fp32 before decoder wrapping so FSDP2 can keep
+# per-module MixedPrecisionPolicy (workaround for FSDP1 flat-param dtype constraints).
 
 DEFAULT_FP32_NORM_SUFFIXES: tuple[str, ...] = ("RMSNorm", "LayerNorm")
 
@@ -85,11 +76,15 @@ def _matches_norm_class(module: "torch.nn.Module", patterns: Sequence[str]) -> b
     Two matching modes, chosen per-pattern by presence of a dot:
       - Fully qualified (contains "."): matches f"{module.__module__}.{cls}" exactly.
       - Suffix (no dot): matches type(module).__name__.endswith(pattern).
+    Empty / whitespace-only patterns are skipped (``cls_name.endswith("")``
+    is True for every class, which would silently match everything).
     """
     cls = type(module)
     cls_name = cls.__name__
     qualified = f"{cls.__module__}.{cls_name}"
     for pattern in patterns:
+        if not pattern or not pattern.strip():
+            continue
         if "." in pattern:
             if qualified == pattern:
                 return True

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -13,6 +13,7 @@ import torch.distributed as dist
 from torch import nn
 
 from axolotl.utils.bench import log_gpu_memory_usage
+from axolotl.utils.fp32_norms import get_fp32_norm_patterns, shard_norms_fp32
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
@@ -426,6 +427,14 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
 
     auto_wrap_policy = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
     log_bias_dtype_mismatch = False
+    fp32_norm_patterns = get_fp32_norm_patterns(model)
+    if fp32_norm_patterns:
+        shard_norms_fp32(
+            model,
+            patterns=fp32_norm_patterns,
+            fully_shard_kwargs=fsdp2_kwargs,
+        )
+
     if auto_wrap_policy is not None:
         for module in get_module_children_bottom_up(model)[:-1]:
             if is_peft_model and isinstance(module, LoraLayer):

--- a/src/axolotl/utils/fp32_norms.py
+++ b/src/axolotl/utils/fp32_norms.py
@@ -1,0 +1,135 @@
+"""Helpers for keeping selected norm modules in fp32 under FSDP2."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import torch
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+DEFAULT_FP32_NORM_SUFFIXES: tuple[str, ...] = ("RMSNorm", "LayerNorm")
+
+
+def _matches_norm_class(module: "torch.nn.Module", patterns: Sequence[str]) -> bool:
+    """Match a module against class-name patterns.
+
+    Two matching modes, chosen per-pattern by presence of a dot:
+      - Fully qualified (contains "."): matches f"{module.__module__}.{cls}" exactly.
+      - Suffix (no dot): matches type(module).__name__.endswith(pattern).
+    Empty / whitespace-only patterns are skipped (``cls_name.endswith("")``
+    is True for every class, which would silently match everything).
+    """
+    cls = type(module)
+    cls_name = cls.__name__
+    qualified = f"{cls.__module__}.{cls_name}"
+    for pattern in patterns:
+        if not pattern or not pattern.strip():
+            continue
+        if "." in pattern:
+            if qualified == pattern:
+                return True
+        elif cls_name.endswith(pattern):
+            return True
+    return False
+
+
+def get_fp32_norm_patterns(source) -> list[str] | None:
+    """Resolve configured fp32 norm patterns from a config or tagged model."""
+    tagged_patterns = getattr(source, "_axolotl_fp32_norm_patterns", None)
+    if tagged_patterns is not None:
+        return list(tagged_patterns)
+
+    if not getattr(source, "fp32_norms", False):
+        return None
+
+    configured_patterns = getattr(source, "fp32_norm_classes", None)
+    if configured_patterns:
+        return list(configured_patterns)
+
+    return list(DEFAULT_FP32_NORM_SUFFIXES)
+
+
+def tag_model_fp32_norms(model: "torch.nn.Module", cfg) -> list[str] | None:
+    """Attach the resolved fp32 norm patterns to the model for FSDP2 prepare."""
+    patterns = get_fp32_norm_patterns(cfg)
+    if patterns is None:
+        if hasattr(model, "_axolotl_fp32_norm_patterns"):
+            delattr(model, "_axolotl_fp32_norm_patterns")
+        return None
+
+    model._axolotl_fp32_norm_patterns = list(patterns)
+    return patterns
+
+
+def shard_norms_fp32(
+    model: "torch.nn.Module",
+    source=None,
+    *,
+    patterns: Sequence[str] | None = None,
+    fully_shard_kwargs: dict[str, Any] | None = None,
+) -> int:
+    """Wrap matching norm modules with FSDP2 + fp32 MixedPrecisionPolicy."""
+    if source is not None and not getattr(source, "fp32_norms", False):
+        return 0
+
+    if source is not None and getattr(source, "fsdp_version", None) != 2:
+        raise ValueError(
+            "fp32_norms requires fsdp_version: 2. FSDP1 enforces flat-param "
+            "dtype uniformity within each wrap group, which is incompatible "
+            "with keeping norms in fp32 while the rest of the layer is bf16."
+        )
+
+    patterns = (
+        list(patterns)
+        if patterns is not None
+        else get_fp32_norm_patterns(source or model)
+    )
+    if not patterns:
+        return 0
+
+    from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+
+    outer_policy = (fully_shard_kwargs or {}).get("mp_policy")
+    output_dtype = getattr(outer_policy, "param_dtype", None)
+    fp32_policy = MixedPrecisionPolicy(
+        param_dtype=torch.float32,
+        reduce_dtype=torch.float32,
+        output_dtype=output_dtype,
+    )
+
+    matches = [
+        (name, module)
+        for name, module in model.named_modules()
+        if _matches_norm_class(module, patterns)
+    ]
+
+    if not matches:
+        LOG.warning(
+            "fp32_norms enabled but no modules matched patterns %s. Check "
+            "fp32_norm_classes against the model's actual norm class names.",
+            patterns,
+        )
+        return 0
+
+    shard_kwargs = dict(fully_shard_kwargs or {})
+    shard_kwargs["mp_policy"] = fp32_policy
+
+    for _name, module in matches:
+        for param in module.parameters(recurse=False):
+            param.data = param.data.to(torch.float32)
+        for buffer in module.buffers(recurse=False):
+            if buffer.dtype.is_floating_point:
+                buffer.data = buffer.data.to(torch.float32)
+        fully_shard(module, **shard_kwargs)
+
+    LOG.info(
+        "Sharded %d norm modules with fp32 MixedPrecisionPolicy "
+        "(patterns=%s, output_dtype=%s)",
+        len(matches),
+        patterns,
+        output_dtype,
+    )
+    return len(matches)

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1500,12 +1500,21 @@ class AxolotlInputConfig(
 
     @model_validator(mode="after")
     def check_fp32_norms(self):
-        if self.fp32_norms and str(self.fsdp_version) != "2":
-            raise ValueError(
-                "fp32_norms requires fsdp_version: 2. FSDP1's flat-param "
-                "dtype uniformity constraint is incompatible with keeping "
-                "norms in fp32 while decoder layers run in bf16."
-            )
+        if self.fp32_norms:
+            # FSDP must actually be configured — fsdp_version alone is not
+            # sufficient since the rest of axolotl treats fsdp_config as the
+            # canonical "is_fsdp" signal.
+            if self.fsdp_config is None:
+                raise ValueError(
+                    "fp32_norms requires FSDP to be enabled "
+                    "(fsdp_config block must be set)."
+                )
+            if str(self.fsdp_version) != "2":
+                raise ValueError(
+                    "fp32_norms requires fsdp_version: 2. FSDP1's flat-param "
+                    "dtype uniformity constraint is incompatible with keeping "
+                    "norms in fp32 while decoder layers run in bf16."
+                )
         if self.fp32_norm_classes and not self.fp32_norms:
             LOG.warning(
                 "fp32_norm_classes is set but fp32_norms is not enabled; "

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -974,6 +974,27 @@ class AxolotlInputConfig(
         default=None,
         json_schema_extra={"description": "FSDP version"},
     )
+    fp32_norms: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Keep norm modules (RMSNorm/LayerNorm) in fp32 by sharding them "
+                "under their own FSDP2 MixedPrecisionPolicy. Requires fsdp_version: 2."
+            )
+        },
+    )
+    fp32_norm_classes: list[str] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Class-name patterns to match for fp32 norm sharding. Patterns "
+                "without a '.' match against type(module).__name__ as a suffix. "
+                "Patterns containing a '.' match the fully qualified class path "
+                "exactly. Defaults to ['RMSNorm', 'LayerNorm'] when fp32_norms is "
+                "true and this is unset."
+            )
+        },
+    )
     fsdp_final_state_dict_type: (
         Literal["FULL_STATE_DICT", "LOCAL_STATE_DICT", "SHARDED_STATE_DICT"] | None
     ) = Field(
@@ -1476,6 +1497,21 @@ class AxolotlInputConfig(
             f"Expected one of: {sorted(CANONICAL_ATTN_IMPLS)}, or a hub-kernel "
             f"path containing '/'."
         )
+
+    @model_validator(mode="after")
+    def check_fp32_norms(self):
+        if self.fp32_norms and str(self.fsdp_version) != "2":
+            raise ValueError(
+                "fp32_norms requires fsdp_version: 2. FSDP1's flat-param "
+                "dtype uniformity constraint is incompatible with keeping "
+                "norms in fp32 while decoder layers run in bf16."
+            )
+        if self.fp32_norm_classes and not self.fp32_norms:
+            LOG.warning(
+                "fp32_norm_classes is set but fp32_norms is not enabled; "
+                "it will be ignored."
+            )
+        return self
 
     @model_validator(mode="after")
     def check_sageattn_wo_sample_packing(self):

--- a/tests/e2e/multigpu/_fp32_norms_dtype_capture.py
+++ b/tests/e2e/multigpu/_fp32_norms_dtype_capture.py
@@ -1,0 +1,58 @@
+"""Test-only plugin that captures param dtypes after the first optimizer step
+and dumps them as JSON to ``$FP32_NORMS_DTYPE_DUMP_PATH``.
+
+Loaded via ``plugins: [tests.e2e.multigpu._fp32_norms_dtype_capture.DtypeCapturePlugin]``
+in the test yaml config; the dump path is the contract between the subprocess
+and the outer pytest function. Rank 0 only — dtype is identical across ranks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+from transformers.trainer_callback import TrainerCallback
+
+from axolotl.integrations.base import BasePlugin
+
+
+def _dtype_name(dtype: torch.dtype) -> str:
+    return str(dtype).removeprefix("torch.")
+
+
+class _DtypeCaptureCallback(TrainerCallback):
+    """Capture norm vs non-norm param dtypes after step 1, dump to JSON, exit."""
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):  # type: ignore[override]
+        if state.global_step != 1 or model is None:
+            return
+        # Rank 0 only — every rank sees the same dtype info under FSDP2.
+        if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+            return
+        dump_path = os.environ.get("FP32_NORMS_DTYPE_DUMP_PATH")
+        if not dump_path:
+            return
+
+        norm_dtypes: dict[str, str] = {}
+        non_norm_dtypes: dict[str, str] = {}
+        for name, param in model.named_parameters():
+            entry = (name, _dtype_name(param.dtype))
+            if "norm" in name.lower():
+                norm_dtypes[entry[0]] = entry[1]
+            else:
+                non_norm_dtypes[entry[0]] = entry[1]
+
+        with open(dump_path, "w", encoding="utf-8") as fout:
+            json.dump(
+                {"norms": norm_dtypes, "non_norms": non_norm_dtypes},
+                fout,
+                indent=2,
+            )
+
+
+class DtypeCapturePlugin(BasePlugin):
+    """Plugin that registers :class:`_DtypeCaptureCallback` with the trainer."""
+
+    def add_callbacks_pre_trainer(self, cfg, model):  # type: ignore[override]
+        return [_DtypeCaptureCallback()]

--- a/tests/e2e/multigpu/test_fsdp2_fp32_norms.py
+++ b/tests/e2e/multigpu/test_fsdp2_fp32_norms.py
@@ -1,0 +1,131 @@
+"""Multi-GPU e2e test for ``fp32_norms`` under FSDP2.
+
+Two-GPU subprocess run with ``fp32_norms: true`` + ``fsdp_version: 2`` + bf16
+training. The test plugin
+``tests.e2e.multigpu._fp32_norms_dtype_capture.DtypeCapturePlugin`` dumps
+post-step-1 param dtypes as JSON; the outer test asserts norms stayed fp32 and
+at least one non-norm param dropped to bf16 (proving the two policies are
+genuinely independent, not a globally-cast model).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import yaml
+from accelerate.test_utils import execute_subprocess_async
+from transformers.testing_utils import get_torch_dist_unique_port
+
+from axolotl.utils.dict import DictDefault
+
+from tests.e2e.utils import require_torch_2_7_0
+
+AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _base_fp32_norms_config(temp_dir: str, **overrides) -> DictDefault:
+    """Base config for fp32_norms + FSDP2 multi-GPU."""
+    cfg = {
+        "base_model": "axolotl-ai-co/tiny-qwen3-129m",
+        "sequence_len": 256,
+        "val_set_size": 0.0,
+        "datasets": [
+            {
+                "path": "tatsu-lab/alpaca",
+                "type": "alpaca",
+                "split": "train[:1%]",
+            },
+        ],
+        # Full FT (no adapter) — fp32_norms is about base-model norm precision,
+        # which adapters wouldn't exercise.
+        "num_epochs": 1,
+        "max_steps": 2,
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "output_dir": temp_dir,
+        "learning_rate": 1e-4,
+        "optimizer": "adamw_torch_fused",
+        "lr_scheduler": "cosine",
+        "flash_attention": True,
+        "bf16": True,
+        "fp32_norms": True,
+        "fsdp_version": 2,
+        "fsdp_config": {
+            "offload_params": False,
+            "cpu_ram_efficient_loading": False,
+            "transformer_layer_cls_to_wrap": "Qwen3DecoderLayer",
+            "state_dict_type": "FULL_STATE_DICT",
+            "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+            "reshard_after_forward": True,
+        },
+        "plugins": [
+            "tests.e2e.multigpu._fp32_norms_dtype_capture.DtypeCapturePlugin",
+        ],
+        "save_safetensors": True,
+    }
+    cfg.update(overrides)
+    return DictDefault(cfg)
+
+
+def _run_training(temp_dir: str, cfg: DictDefault, dump_path: Path) -> None:
+    """Write yaml + spawn 2-process training; plugin path goes via PYTHONPATH."""
+    Path(temp_dir).mkdir(parents=True, exist_ok=True)
+    with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+        fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+    env = os.environ | {
+        # Make the test-only plugin module importable in the subprocess.
+        "PYTHONPATH": (f"{AXOLOTL_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}"),
+        "FP32_NORMS_DTYPE_DUMP_PATH": str(dump_path),
+    }
+    execute_subprocess_async(
+        [
+            "axolotl",
+            "train",
+            str(Path(temp_dir) / "config.yaml"),
+            "--num-processes",
+            "2",
+            "--main-process-port",
+            f"{get_torch_dist_unique_port()}",
+        ],
+        env=env,
+    )
+
+
+class TestFSDP2Fp32Norms:
+    """Verifies the fp32_norms FSDP2 path end-to-end across 2 GPUs."""
+
+    @require_torch_2_7_0
+    def test_norms_stay_fp32_under_fsdp2_bf16(self, temp_dir):
+        """fp32_norms keeps RMSNorm params in fp32 while the rest stays bf16."""
+        dump_path = Path(temp_dir) / "dtype_capture.json"
+        cfg = _base_fp32_norms_config(temp_dir)
+        _run_training(temp_dir, cfg, dump_path)
+
+        # Training completed (no FSDP1-style flat-param dtype crash) AND the
+        # plugin captured dtypes after step 1.
+        assert dump_path.exists(), (
+            f"plugin did not dump dtype capture to {dump_path}; "
+            "training may have failed before step 1"
+        )
+
+        captured = json.loads(dump_path.read_text())
+        norms = captured["norms"]
+        non_norms = captured["non_norms"]
+
+        assert norms, "no norm params captured — matcher likely failed"
+        assert all(d == "float32" for d in norms.values()), (
+            "fp32_norms claim violated: at least one norm param is not fp32. "
+            f"Captured norm dtypes: {norms}"
+        )
+
+        # At least one non-norm param must be bf16. Without this check the
+        # test would pass on a globally-fp32 model that didn't shard anything.
+        non_norm_dtypes = set(non_norms.values())
+        assert "bfloat16" in non_norm_dtypes, (
+            "expected at least one non-norm param in bfloat16 (proves the two "
+            "policies are independent); got non-norm dtypes: "
+            f"{non_norm_dtypes}"
+        )

--- a/tests/e2e/multigpu/test_fsdp2_fp32_norms.py
+++ b/tests/e2e/multigpu/test_fsdp2_fp32_norms.py
@@ -14,6 +14,7 @@ import json
 import os
 from pathlib import Path
 
+import pytest
 import yaml
 from accelerate.test_utils import execute_subprocess_async
 from transformers.testing_utils import get_torch_dist_unique_port
@@ -25,7 +26,9 @@ from tests.e2e.utils import require_torch_2_7_0
 AXOLOTL_ROOT = Path(__file__).parent.parent.parent.parent
 
 
-def _base_fp32_norms_config(temp_dir: str, **overrides) -> DictDefault:
+def _base_fp32_norms_config(
+    temp_dir: str, *, cpu_ram_efficient_loading: bool = False, **overrides
+) -> DictDefault:
     """Base config for fp32_norms + FSDP2 multi-GPU."""
     cfg = {
         "base_model": "axolotl-ai-co/tiny-qwen3-129m",
@@ -54,7 +57,7 @@ def _base_fp32_norms_config(temp_dir: str, **overrides) -> DictDefault:
         "fsdp_version": 2,
         "fsdp_config": {
             "offload_params": False,
-            "cpu_ram_efficient_loading": False,
+            "cpu_ram_efficient_loading": cpu_ram_efficient_loading,
             "transformer_layer_cls_to_wrap": "Qwen3DecoderLayer",
             "state_dict_type": "FULL_STATE_DICT",
             "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
@@ -98,10 +101,20 @@ class TestFSDP2Fp32Norms:
     """Verifies the fp32_norms FSDP2 path end-to-end across 2 GPUs."""
 
     @require_torch_2_7_0
-    def test_norms_stay_fp32_under_fsdp2_bf16(self, temp_dir):
+    @pytest.mark.parametrize(
+        "cpu_ram_efficient_loading",
+        [False, True],
+        ids=["materialized-load", "cpu-ram-efficient-load"],
+    )
+    def test_norms_stay_fp32_under_fsdp2_bf16(
+        self, temp_dir, cpu_ram_efficient_loading
+    ):
         """fp32_norms keeps RMSNorm params in fp32 while the rest stays bf16."""
         dump_path = Path(temp_dir) / "dtype_capture.json"
-        cfg = _base_fp32_norms_config(temp_dir)
+        cfg = _base_fp32_norms_config(
+            temp_dir,
+            cpu_ram_efficient_loading=cpu_ram_efficient_loading,
+        )
         _run_training(temp_dir, cfg, dump_path)
 
         # Training completed (no FSDP1-style flat-param dtype crash) AND the

--- a/tests/test_fp32_norms.py
+++ b/tests/test_fp32_norms.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
+from torch.distributed.fsdp import MixedPrecisionPolicy
 
-from axolotl.loaders.model import (
+from axolotl.loaders.model import ModelLoader
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.fp32_norms import (
     DEFAULT_FP32_NORM_SUFFIXES,
     _matches_norm_class,
     shard_norms_fp32,
@@ -31,6 +35,13 @@ class CustomNorm(nn.Module):
     def __init__(self, dim: int = 8) -> None:
         super().__init__()
         self.weight = nn.Parameter(torch.ones(dim))
+
+
+class CustomNormWithBuffer(nn.Module):
+    def __init__(self, dim: int = 8) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.bfloat16))
+        self.register_buffer("running_scale", torch.ones(dim, dtype=torch.float16))
 
 
 class MLP(nn.Module):
@@ -76,6 +87,9 @@ class _Cfg:
         self.fp32_norms = kwargs.get("fp32_norms", False)
         self.fp32_norm_classes = kwargs.get("fp32_norm_classes", None)
         self.fsdp_version = kwargs.get("fsdp_version", None)
+        self.fsdp_config = kwargs.get("fsdp_config", None)
+        self.tensor_parallel_size = kwargs.get("tensor_parallel_size", 1)
+        self.lora_on_cpu = kwargs.get("lora_on_cpu", False)
 
 
 def test_disabled_is_noop():
@@ -90,12 +104,56 @@ def test_enabled_requires_fsdp2():
         shard_norms_fp32(model, cfg)
 
 
-def test_meta_device_is_rejected():
+def test_meta_device_is_supported(monkeypatch):
     with torch.device("meta"):
         model = nn.Sequential(LlamaRMSNorm())
     cfg = _Cfg(fp32_norms=True, fsdp_version=2)
-    with pytest.raises(RuntimeError, match="meta-device"):
-        shard_norms_fp32(model, cfg)
+
+    import torch.distributed.fsdp as fsdp_module
+
+    calls = []
+
+    def fake_fully_shard(module, mp_policy=None, **kwargs):
+        calls.append((type(module).__name__, mp_policy, kwargs))
+        return module
+
+    monkeypatch.setattr(fsdp_module, "fully_shard", fake_fully_shard)
+
+    n = shard_norms_fp32(model, cfg)
+    assert n == 1
+    assert calls[0][0] == "LlamaRMSNorm"
+    assert calls[0][1].param_dtype == torch.float32
+
+
+def test_passthrough_fully_shard_kwargs_are_used(monkeypatch):
+    model = nn.Sequential(LlamaRMSNorm())
+    cfg = _Cfg(fp32_norms=True, fsdp_version=2)
+
+    import torch.distributed.fsdp as fsdp_module
+
+    calls = []
+
+    def fake_fully_shard(module, mp_policy=None, **kwargs):
+        calls.append((module, mp_policy, kwargs))
+        return module
+
+    monkeypatch.setattr(fsdp_module, "fully_shard", fake_fully_shard)
+
+    sentinel_mesh = object()
+    outer_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
+    n = shard_norms_fp32(
+        model,
+        cfg,
+        fully_shard_kwargs={
+            "mesh": sentinel_mesh,
+            "reshard_after_forward": True,
+            "mp_policy": outer_policy,
+        },
+    )
+    assert n == 1
+    assert calls[0][2]["mesh"] is sentinel_mesh
+    assert calls[0][2]["reshard_after_forward"] is True
+    assert calls[0][1].output_dtype == torch.bfloat16
 
 
 def test_no_matches_warns_and_returns_zero(caplog):
@@ -135,3 +193,72 @@ def test_explicit_classes_override_defaults(monkeypatch):
     assert calls[0][0] == "CustomNorm"
     assert calls[0][1].param_dtype == torch.float32
     assert calls[0][1].reduce_dtype == torch.float32
+
+
+def test_matched_norm_storage_is_cast_to_fp32_before_sharding(monkeypatch):
+    model = nn.Sequential(CustomNormWithBuffer(), MLP())
+    cfg = _Cfg(
+        fp32_norms=True,
+        fsdp_version=2,
+        fp32_norm_classes=["CustomNormWithBuffer"],
+    )
+
+    import torch.distributed.fsdp as fsdp_module
+
+    seen = []
+
+    def fake_fully_shard(module, mp_policy=None, **kwargs):
+        seen.append(
+            (
+                module.weight.dtype,
+                module.running_scale.dtype,
+                mp_policy.output_dtype,
+                kwargs,
+            )
+        )
+        return module
+
+    monkeypatch.setattr(fsdp_module, "fully_shard", fake_fully_shard)
+
+    outer_policy = MixedPrecisionPolicy(param_dtype=torch.float16)
+    n = shard_norms_fp32(
+        model,
+        cfg,
+        fully_shard_kwargs={"mp_policy": outer_policy},
+    )
+
+    assert n == 1
+    assert model[0].weight.dtype == torch.float32
+    assert model[0].running_scale.dtype == torch.float32
+    assert seen[0][0] == torch.float32
+    assert seen[0][1] == torch.float32
+    assert seen[0][2] == torch.float16
+
+
+class TinyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_tokens = nn.Embedding(8, 8)
+        self.input_norm = CustomNorm()
+        self.fc = nn.Linear(8, 8)
+
+
+def test_convert_embedding_modules_dtype_keeps_fp32_norm_matches():
+    loader = ModelLoader.__new__(ModelLoader)
+    loader.cfg = DictDefault(
+        fp32_norms=True,
+        fp32_norm_classes=["CustomNorm"],
+        lora_on_cpu=False,
+    )
+    loader.model = TinyModel()
+    loader.model_config = SimpleNamespace(model_type="llama")
+
+    loader._convert_embedding_modules_dtype(
+        embedding_modules=["embed_tokens"],
+        dist_dtype=torch.bfloat16,
+        before_kbit_train_or_finetune=False,
+    )
+
+    assert loader.model.input_norm.weight.dtype == torch.float32
+    assert loader.model.embed_tokens.weight.dtype == torch.bfloat16
+    assert loader.model.fc.weight.dtype == torch.float32

--- a/tests/test_fp32_norms.py
+++ b/tests/test_fp32_norms.py
@@ -1,0 +1,126 @@
+"""Unit tests for fp32 norm sharding (FSDP2). Pure-CPU, no dist init."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from axolotl.loaders.model import (
+    DEFAULT_FP32_NORM_SUFFIXES,
+    _matches_norm_class,
+    shard_norms_fp32,
+)
+
+
+class LlamaRMSNorm(nn.Module):
+    def __init__(self, dim: int = 8) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+
+
+class AfmoeRMSNorm(nn.Module):
+    def __init__(self, dim: int = 8) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+
+
+class CustomNorm(nn.Module):
+    def __init__(self, dim: int = 8) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+
+
+class MLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = nn.Linear(8, 8)
+
+
+def test_suffix_matches_multiple_norm_families():
+    patterns = list(DEFAULT_FP32_NORM_SUFFIXES)
+    assert _matches_norm_class(LlamaRMSNorm(), patterns)
+    assert _matches_norm_class(AfmoeRMSNorm(), patterns)
+    assert _matches_norm_class(nn.LayerNorm(8), patterns)
+
+
+def test_suffix_does_not_match_non_norm_modules():
+    patterns = list(DEFAULT_FP32_NORM_SUFFIXES)
+    assert not _matches_norm_class(MLP(), patterns)
+    assert not _matches_norm_class(nn.Linear(8, 8), patterns)
+    assert not _matches_norm_class(CustomNorm(), patterns)
+
+
+def test_explicit_classname_matches_custom_norm():
+    assert _matches_norm_class(CustomNorm(), ["CustomNorm"])
+
+
+def test_fully_qualified_pattern_matches_exact_path():
+    qualified = f"{LlamaRMSNorm.__module__}.LlamaRMSNorm"
+    assert _matches_norm_class(LlamaRMSNorm(), [qualified])
+    assert not _matches_norm_class(AfmoeRMSNorm(), [qualified])
+
+
+def test_mixed_patterns_suffix_and_qualified():
+    qualified = f"{LlamaRMSNorm.__module__}.LlamaRMSNorm"
+    patterns = [qualified, "LayerNorm"]
+    assert _matches_norm_class(LlamaRMSNorm(), patterns)
+    assert _matches_norm_class(nn.LayerNorm(8), patterns)
+    assert not _matches_norm_class(AfmoeRMSNorm(), patterns)
+
+
+class _Cfg:
+    def __init__(self, **kwargs):
+        self.fp32_norms = kwargs.get("fp32_norms", False)
+        self.fp32_norm_classes = kwargs.get("fp32_norm_classes", None)
+        self.fsdp_version = kwargs.get("fsdp_version", None)
+
+
+def test_disabled_is_noop():
+    model = nn.Sequential(LlamaRMSNorm(), MLP())
+    assert shard_norms_fp32(model, _Cfg(fp32_norms=False)) == 0
+
+
+def test_enabled_requires_fsdp2():
+    model = nn.Sequential(LlamaRMSNorm())
+    cfg = _Cfg(fp32_norms=True, fsdp_version=1)
+    with pytest.raises(ValueError, match="fsdp_version: 2"):
+        shard_norms_fp32(model, cfg)
+
+
+def test_meta_device_is_rejected():
+    with torch.device("meta"):
+        model = nn.Sequential(LlamaRMSNorm())
+    cfg = _Cfg(fp32_norms=True, fsdp_version=2)
+    with pytest.raises(RuntimeError, match="meta-device"):
+        shard_norms_fp32(model, cfg)
+
+
+def test_no_matches_warns_and_returns_zero(caplog):
+    model = nn.Sequential(MLP(), nn.Linear(8, 8))
+    cfg = _Cfg(fp32_norms=True, fsdp_version=2)
+    with caplog.at_level("WARNING", logger="axolotl.loaders.model"):
+        n = shard_norms_fp32(model, cfg)
+    assert n == 0
+    assert "no modules matched" in caplog.text
+
+
+def test_explicit_classes_override_defaults(monkeypatch):
+    model = nn.Sequential(CustomNorm(), MLP())
+    cfg = _Cfg(fp32_norms=True, fsdp_version=2, fp32_norm_classes=["CustomNorm"])
+
+    import torch.distributed.fsdp as fsdp_module
+
+    calls = []
+
+    def fake_fully_shard(module, mp_policy=None, **_):
+        calls.append((type(module).__name__, mp_policy))
+        return module
+
+    monkeypatch.setattr(fsdp_module, "fully_shard", fake_fully_shard)
+
+    n = shard_norms_fp32(model, cfg)
+    assert n == 1
+    assert calls[0][0] == "CustomNorm"
+    assert calls[0][1].param_dtype == torch.float32
+    assert calls[0][1].reduce_dtype == torch.float32

--- a/tests/test_fp32_norms.py
+++ b/tests/test_fp32_norms.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 import torch
 import torch.nn as nn
@@ -99,8 +101,17 @@ def test_meta_device_is_rejected():
 def test_no_matches_warns_and_returns_zero(caplog):
     model = nn.Sequential(MLP(), nn.Linear(8, 8))
     cfg = _Cfg(fp32_norms=True, fsdp_version=2)
-    with caplog.at_level("WARNING", logger="axolotl.loaders.model"):
-        n = shard_norms_fp32(model, cfg)
+    # axolotl.cli.configure_logging() sets propagate=False on the `axolotl`
+    # logger, so pytest caplog can't see records by default. Temporarily
+    # re-enable propagation for this assertion.
+    ax_logger = logging.getLogger("axolotl")
+    old_propagate = ax_logger.propagate
+    ax_logger.propagate = True
+    try:
+        with caplog.at_level("WARNING", logger="axolotl"):
+            n = shard_norms_fp32(model, cfg)
+    finally:
+        ax_logger.propagate = old_propagate
     assert n == 0
     assert "no modules matched" in caplog.text
 

--- a/tests/utils/schemas/validation/test_fsdp.py
+++ b/tests/utils/schemas/validation/test_fsdp.py
@@ -2,6 +2,8 @@
 tests for pydantic fsdp validation
 """
 
+import logging
+
 import pytest
 
 from axolotl.utils.config import validate_config
@@ -136,10 +138,20 @@ class TestFSDPValidation:
         assert cfg.fsdp_config.transformer_layer_cls_to_wrap == "LlamaDecoderLayer"
         assert cfg.fsdp_config.reshard_after_forward is True
 
+    def test_fp32_norms_requires_fsdp_config(self, min_base_cfg):
+        # fsdp_config is the canonical "is_fsdp" signal; fp32_norms requires it.
+        cfg = min_base_cfg | DictDefault(
+            fp32_norms=True,
+            fsdp_version=2,
+        )
+        with pytest.raises(ValueError, match="fp32_norms requires FSDP to be enabled"):
+            validate_config(cfg)
+
     def test_fp32_norms_requires_fsdp2(self, min_base_cfg):
         cfg = min_base_cfg | DictDefault(
             fp32_norms=True,
             fsdp_version=1,
+            fsdp_config={"reshard_after_forward": True},
         )
         with pytest.raises(ValueError, match="fp32_norms requires fsdp_version: 2"):
             validate_config(cfg)
@@ -149,6 +161,7 @@ class TestFSDPValidation:
             fp32_norms=True,
             fp32_norm_classes=["AfmoeRMSNorm"],
             fsdp_version=2,
+            fsdp_config={"reshard_after_forward": True},
         )
         validated_cfg = validate_config(cfg)
         assert validated_cfg.fp32_norms is True
@@ -158,8 +171,17 @@ class TestFSDPValidation:
         cfg = min_base_cfg | DictDefault(
             fp32_norm_classes=["AfmoeRMSNorm"],
         )
-        with caplog.at_level("WARNING", logger="axolotl.utils.schemas.config"):
-            validated_cfg = validate_config(cfg)
+        # axolotl.cli.configure_logging() sets propagate=False on the `axolotl`
+        # logger, so pytest caplog (attached to root) can't see records by
+        # default. Temporarily re-enable propagation for this assertion.
+        ax_logger = logging.getLogger("axolotl")
+        old_propagate = ax_logger.propagate
+        ax_logger.propagate = True
+        try:
+            with caplog.at_level("WARNING", logger="axolotl"):
+                validated_cfg = validate_config(cfg)
+        finally:
+            ax_logger.propagate = old_propagate
         assert not validated_cfg.fp32_norms
         assert "fp32_norm_classes is set but fp32_norms is not enabled" in caplog.text
 

--- a/tests/utils/schemas/validation/test_fsdp.py
+++ b/tests/utils/schemas/validation/test_fsdp.py
@@ -136,6 +136,33 @@ class TestFSDPValidation:
         assert cfg.fsdp_config.transformer_layer_cls_to_wrap == "LlamaDecoderLayer"
         assert cfg.fsdp_config.reshard_after_forward is True
 
+    def test_fp32_norms_requires_fsdp2(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
+            fp32_norms=True,
+            fsdp_version=1,
+        )
+        with pytest.raises(ValueError, match="fp32_norms requires fsdp_version: 2"):
+            validate_config(cfg)
+
+    def test_fp32_norms_fsdp2_ok(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
+            fp32_norms=True,
+            fp32_norm_classes=["AfmoeRMSNorm"],
+            fsdp_version=2,
+        )
+        validated_cfg = validate_config(cfg)
+        assert validated_cfg.fp32_norms is True
+        assert validated_cfg.fp32_norm_classes == ["AfmoeRMSNorm"]
+
+    def test_fp32_norm_classes_without_fp32_norms_warns(self, min_base_cfg, caplog):
+        cfg = min_base_cfg | DictDefault(
+            fp32_norm_classes=["AfmoeRMSNorm"],
+        )
+        with caplog.at_level("WARNING", logger="axolotl.utils.schemas.config"):
+            validated_cfg = validate_config(cfg)
+        assert not validated_cfg.fp32_norms
+        assert "fp32_norm_classes is set but fp32_norms is not enabled" in caplog.text
+
     def test_muon_fsdp1_rejected(self, min_base_cfg):
         cfg = min_base_cfg | DictDefault(
             optimizer="muon",

--- a/tests/utils/schemas/validation/test_fsdp.py
+++ b/tests/utils/schemas/validation/test_fsdp.py
@@ -156,6 +156,30 @@ class TestFSDPValidation:
         with pytest.raises(ValueError, match="fp32_norms requires fsdp_version: 2"):
             validate_config(cfg)
 
+    def test_fp32_norms_cpu_ram_efficient_loading_ok(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
+            fp32_norms=True,
+            fsdp_version=2,
+            fsdp_config={
+                "reshard_after_forward": True,
+                "cpu_ram_efficient_loading": True,
+            },
+        )
+        validated_cfg = validate_config(cfg)
+        assert validated_cfg.fp32_norms is True
+        assert validated_cfg.fsdp_config.cpu_ram_efficient_loading is True
+
+    def test_fp32_norms_tensor_parallel_ok(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(
+            fp32_norms=True,
+            fsdp_version=2,
+            tensor_parallel_size=2,
+            fsdp_config={"reshard_after_forward": True},
+        )
+        validated_cfg = validate_config(cfg)
+        assert validated_cfg.fp32_norms is True
+        assert validated_cfg.tensor_parallel_size == 2
+
     def test_fp32_norms_fsdp2_ok(self, min_base_cfg):
         cfg = min_base_cfg | DictDefault(
             fp32_norms=True,


### PR DESCRIPTION
## Summary

Adds two config fields and a helper so users can keep norm modules in fp32 while training the rest of the model in bf16/fp16 under FSDP2. The mechanism is per-module `fully_shard` with a dedicated `MixedPrecisionPolicy(param_dtype=fp32, reduce_dtype=fp32)`; once a norm is sharded, the surrounding decoder-layer wrap treats it as a boundary and doesn't fold it into the bf16 flat-param group.

```yaml
fp32_norms: true
fsdp_version: 2

# Optional override; defaults to ["RMSNorm", "LayerNorm"] (suffix match).
# fp32_norm_classes:
#   - AfmoeRMSNorm
#   - transformers.models.llama.modeling_llama.LlamaRMSNorm
```

## Motivation

Surfaced during full-FT continued pretraining on `arcee-ai/Trinity-Mini-Base` (AFMOE, 26B-A4B MoE) on 8×H200. Two paths, both broken:

- **transformers 5.x + patched `modeling_afmoe.py`**: clearing `_keep_in_fp32_modules = []` to get the model loading produces 5–60× worse held-out PPL (PPL 24–346 vs 1.3–6 on the same prompts). The plain `_keep_in_fp32_modules` attribute only fires for fp16 in current transformers, so on the bf16 path norms silently drop to bf16 even with the attribute set.
- **transformers 4.57.5 (canonical, no patches)**: inference works perfectly. Training fails at FSDP1 init with `ValueError: Must flatten tensors with uniform dtype but got torch.bfloat16 and torch.float32` — FSDP1's flat-param dtype uniformity constraint hitting fp32 norms inside an otherwise-bf16 decoder layer.

Any model declaring fp32 norms (Llama, Mistral, Qwen3, etc.) hits the same FSDP1 wall. FSDP2's per-module `MixedPrecisionPolicy` is the supported escape hatch; this PR wires it up via config so users don't have to hand-write `fully_shard` calls.

## Changes

- `src/axolotl/loaders/model.py`: add `shard_norms_fp32`, `_matches_norm_class`, `DEFAULT_FP32_NORM_SUFFIXES`, plus a call site in `ModelLoader.load()` gated on `cfg.fp32_norms`. *(The handoff named `utils/models.py`; that file no longer exists — model loading now lives in `loaders/model.py`.)*
- `src/axolotl/utils/schemas/config.py`: add `fp32_norms: bool | None` and `fp32_norm_classes: list[str] | None` fields with a `check_fp32_norms` model-validator that requires `fsdp_version: 2`.
- `tests/test_fp32_norms.py`: 10 pure-CPU unit tests (matcher + guard-rail).
- `tests/utils/schemas/validation/test_fsdp.py`: 3 new schema-validator tests.
- `docs/mixed_precision.qmd`: "Keeping norms in fp32 (FSDP2)" subsection.

## Matching semantics

Patterns without `.` match as a suffix against `type(module).__name__`. Catches the whole RMSNorm family (`LlamaRMSNorm`, `Qwen3RMSNorm`, `AfmoeRMSNorm`, `MistralRMSNorm`) without enumeration and also catches `nn.LayerNorm`.

Patterns containing `.` match the fully qualified `f"{module.__module__}.{cls_name}"`. Use this when disambiguating same-named norms across model families or pinning a `trust_remote_code` modeling file precisely.

## Scope (deliberately minimal)

- **FSDP2 only.** Enabling `fp32_norms` with FSDP1 or DeepSpeed raises in the validator. An FSDP1 path is possible (custom wrap policy that segregates norms) but deferred.
- **No meta-device support.** If params are on meta when `shard_norms_fp32` runs, it raises with a clear message. The common cause is `cpu_ram_efficient_loading: true`; follow-up PR can add a post-materialization hook.
- **No surprise behavior for existing configs.** Users opt in explicitly.

## Validator behavior

- `fp32_norms: true` + `fsdp_version: 2` validates ✓
- `fp32_norms: true` + `fsdp_version: 1` → `ValueError("fp32_norms requires fsdp_version: 2 …")`
- `fp32_norm_classes` set + `fp32_norms` unset → `LOG.warning("… will be ignored.")`

## Testing

- [x] `python3 -m pytest tests/test_fp32_norms.py tests/utils/schemas/validation/test_fsdp.py` — **27 passed**
- [x] Pre-existing schema validator tests (`test_config_validators.py` / `test_default_values.py`) — 40 passed
- [x] `pre-commit run --from-ref origin/main --to-ref HEAD` — all 8 hooks pass (ruff, ruff-format, mypy, bandit, etc.)
- Trinity-Mini-Base full FSDP2 validation deferred until upstream `modeling_afmoe.py` is updated for transformers 5.x.

## Out of scope / explicit non-goals

- FSDP1 wrap-policy path
- DeepSpeed equivalent
- Meta-device materialization handling for `cpu_ram_efficient_loading: true`
- Auto-detection of fp32 norms from `_keep_in_fp32_modules`
- Per-pattern policy overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for keeping normalization layers in fp32 precision with FSDP2 through configurable `fp32_norms` and `fp32_norm_classes` settings.

* **Documentation**
  * Added configuration guidance for fp32 normalization handling with FSDP2.

* **Tests**
  * Added comprehensive validation and unit tests for fp32 norm sharding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->