### PR TITLE
fix: ray batch_size derivation, fsdp schema migration, FakeExperts peft 0.19 compat

### DIFF
--- a/src/axolotl/utils/config/__init__.py
+++ b/src/axolotl/utils/config/__init__.py
@@ -112,13 +112,13 @@ def resolve_dtype(cfg):
 def normalize_config(cfg):
     # setup some derived config / hyperparams
     if not cfg.use_ray:
-        # Defer derivation to the Ray worker; its re-validate forbids both being set.
+        # Ray worker's re-validate forbids both being set, so defer this one.
         cfg.gradient_accumulation_steps = cfg.gradient_accumulation_steps or (
             cfg.batch_size // cfg.micro_batch_size
         )
-        cfg.batch_size = (
-            cfg.batch_size or cfg.micro_batch_size * cfg.gradient_accumulation_steps
-        )
+    cfg.batch_size = (
+        cfg.batch_size or cfg.micro_batch_size * cfg.gradient_accumulation_steps
+    )
     if cfg.eval_batch_size is None:
         cfg.eval_batch_size = cfg.micro_batch_size
     cfg.world_size = int(os.environ.get("WORLD_SIZE", 1))

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -647,7 +647,11 @@ def prepare_optim_env(cfg):
             os.environ["NCCL_P2P_DISABLE"] = "1"
     # TODO @SalmanMohammadi remove the cfg.fsdp check in 0.12
     if cfg.fsdp or cfg.fsdp_config:
-        cfg.fsdp = True if not cfg.fsdp else cfg.fsdp
+        # Don't mutate cfg.fsdp to True when fsdp_config is the source of
+        # truth: the schema types fsdp as list[str] | None, and Ray workers
+        # re-validate the controller's dumped config, where a bool would
+        # fail (`list_type` ValidationError). Downstream callers
+        # (`if cfg.fsdp or cfg.fsdp_config:`) handle the None case.
         setup_fsdp_envs(cfg)
     elif cfg.deepspeed:
         stage = None

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -647,11 +647,7 @@ def prepare_optim_env(cfg):
             os.environ["NCCL_P2P_DISABLE"] = "1"
     # TODO @SalmanMohammadi remove the cfg.fsdp check in 0.12
     if cfg.fsdp or cfg.fsdp_config:
-        # Don't mutate cfg.fsdp to True when fsdp_config is the source of
-        # truth: the schema types fsdp as list[str] | None, and Ray workers
-        # re-validate the controller's dumped config, where a bool would
-        # fail (`list_type` ValidationError). Downstream callers
-        # (`if cfg.fsdp or cfg.fsdp_config:`) handle the None case.
+        # fsdp_config is source of truth; mutating cfg.fsdp to bool breaks Ray worker schema validation
         setup_fsdp_envs(cfg)
     elif cfg.deepspeed:
         stage = None

--- a/tests/utils/schemas/validation/test_moe_quant.py
+++ b/tests/utils/schemas/validation/test_moe_quant.py
@@ -181,6 +181,10 @@ class TestMoeAdapterTrainMergeRoundtrip:
                 # Model definition order: gate_up_proj first, then down_proj.
                 self.gate_up_proj = nn.Parameter(torch.randn(4, 16, 8))
                 self.down_proj = nn.Parameter(torch.randn(4, 8, 16))
+                # peft >= 0.19 reads base_layer.weight.device unconditionally
+                # in _maybe_shard_state_dict_for_tp; target_parameters-style
+                # modules legitimately don't have .weight, so stub a buffer.
+                self.register_buffer("weight", torch.empty(0), persistent=False)
 
             def forward(self, x):
                 x = torch.matmul(x, self.gate_up_proj[0].T)  # (batch, 16)


### PR DESCRIPTION
## Summary

Three independent CI regressions on `main`. Two were introduced by [`afd74ae`](https://github.com/axolotl-ai-cloud/axolotl/commit/afd74aed71da70898ef7ea1a16b7c59dc765cede) (#3664 "Fix: ci being broken (fa2, ray)"); the third is from a `peft` upgrade to 0.19.x. All three reproduce on `main` independent of any feature branch.

Failing job: `test-axolotl-multigpu (130, 13.0.0, 3.11, 2.9.1, 2)`

## Failure 1 — Ray workers crash with `cfg.batch_size = None`

`tests/e2e/multigpu/test_ray.py::TestMultiGPURay::{test_lora_ddp,test_ds_zero2_packed[1|2]}` fail with `TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'` at `trainer.py:519` (`calculate_total_num_steps`).

**Cause**: `afd74ae` wrapped both `batch_size` and `gradient_accumulation_steps` derivations in `normalize_config` under `if not cfg.use_ray:`. The Ray worker's re-validate rejects having BOTH set, but doesn't derive `batch_size` either — so it stays `None` and blows up downstream.

**Fix**: only defer `gradient_accumulation_steps` (the field the worker validator rejects); always derive `batch_size` on the controller.

## Failure 2 — `fsdp` schema rejects bool after deprecation shim

`tests/e2e/multigpu/test_ray.py::TestMultiGPURay::test_sft_fsdp2_packed[1|2]` fails inside the Ray worker's re-validation with `pydantic_core._pydantic_core.ValidationError: fsdp / Input should be a valid list [type=list_type, input_value=True, input_type=bool]`.

**Cause**: `src/axolotl/utils/trainer.py::prepare_optim_env` mutates `cfg.fsdp = True` when migrating from `fsdp_config`-style configs (line 650). The schema types `fsdp: list[str] | None`, so the bool fails the worker's re-validate.

**Fix**: drop the gratuitous mutation. Every downstream caller already handles `cfg.fsdp_config or cfg.fsdp` (verified across `core/builders/base.py`, `core/builders/rl.py`, `loaders/model.py`, `train.py`, `utils/config/__init__.py`, `utils/distributed.py`). The existing TODO to remove the legacy `cfg.fsdp` check in 0.12 still stands.

## Failure 3 — `FakeExperts` mock breaks under `peft >= 0.19`

`tests/utils/schemas/validation/test_moe_quant.py::TestMoeAdapterTrainMergeRoundtrip::test_train_save_merge_no_size_mismatch` fails with `AttributeError: 'FakeExperts' object has no attribute 'weight'` in `peft/utils/save_and_load.py:520`.

**Cause**: peft 0.19 added `_maybe_shard_state_dict_for_tp` (called unconditionally from `set_peft_model_state_dict`), which reads `base_layer.weight.device`. `FakeExperts` uses the `target_parameters` style (gate_up_proj / down_proj) and legitimately has no `.weight` — real `nn.Linear`-style modules always do, peft assumed it.

**Fix**: stub a zero-size buffer on `FakeExperts.weight`. Optional follow-up: upstream PEFT could guard the call with `if hasattr(base_layer, "weight")`.

## Test plan

- [x] `pytest tests/utils/ -k "normalize_config or batch_size" -x` — 2 pass
- [x] `pytest tests/patched/test_validation.py -x` — 65 pass, 1 skipped
- [x] `pytest tests/utils/schemas/validation/test_moe_quant.py::TestMoeAdapterTrainMergeRoundtrip -x` — 1 pass
- [x] `pre-commit run --files <changed files>` — all 8 hooks pass
- Multi-GPU `test_ray.py` failures are CI-environment-specific; verifying via this PR's CI run

## Out of scope (per handoff)

- The pre-existing "Ray Train Controller actor state" log spam
- The `torchao` cpp-extensions import warning
- The Modal runner kernel-version warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FSDP configuration handling during initialization to prevent unintended state mutations and ensure consistent behavior.

* **Tests**
  * Enhanced test suite for expert model configurations to ensure better compatibility with distributed training frameworks.

* **Refactor**
  * Updated internal code documentation and formatting to improve clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->