### PR TITLE
perf: faster multimodal assistant-only masking (vectorized scanner)

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -49,6 +49,23 @@ from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
 
+_MM_NUM_WORKERS_WARNED: set = set()
+
+
+def _warn_if_num_workers_zero_for_mm(cfg, log) -> None:
+    if not getattr(cfg, "processor_type", None):
+        return
+    if getattr(cfg, "dataloader_num_workers", None) not in (None, 0):
+        return
+    if getattr(cfg, "train_on_inputs", False):
+        return
+    if "mm_num_workers_zero" in _MM_NUM_WORKERS_WARNED:
+        return
+    _MM_NUM_WORKERS_WARNED.add("mm_num_workers_zero")
+    log.warning(
+        "Increase dataloader_num_workers to speed up multimodal training with assistant-only loss masking (currently dataloader_num_workers=0)."
+    )
+
 
 class HFCausalTrainerBuilder(TrainerBuilderBase):
     """
@@ -562,6 +579,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
                         train_on_eos,
                         "set" if role_boundaries_override else "none",
                     )
+                    _warn_if_num_workers_zero_for_mm(self.cfg, LOG)
 
                 kwargs["processing_strategy"] = get_processing_strategy(
                     self.processor,

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -280,9 +280,9 @@ class ProcessingStrategy:
                 image_value = load_image(image_value)
 
                 if self.image_size is not None:
-                    assert hasattr(
-                        image_value, "resize"
-                    ), "Image does not have a resize method"
+                    assert hasattr(image_value, "resize"), (
+                        "Image does not have a resize method"
+                    )
 
                     if isinstance(self.image_size, tuple):
                         image_value = image_value.resize(
@@ -358,8 +358,7 @@ class ProcessingStrategy:
                 )
             return torch.ones_like(input_ids, dtype=torch.bool)
 
-        # Vectorized path regresses 9-13x under multi-threaded torch; only
-        # ship it where it wins (DataLoader workers, threads=1).
+        # Vectorized path regresses 9-13x under multi-threaded torch.
         scanner = (
             _compute_role_keep_mask_vectorized
             if torch.get_num_threads() == 1
@@ -517,54 +516,35 @@ def _compute_role_keep_mask_vectorized(
     if labels.numel() == 0:
         return torch.zeros_like(labels, dtype=torch.bool)
     if not role_boundaries:
-        # Same all-mask semantics as the reference for empty boundaries
-        # (handled upstream in _mask_non_assistant_keep, but be defensive). The
-        # reference walks every position, finds no match, and ends with the
-        # mask all-zeros — which masks the entire batch to -100.
+        # Defensive: match reference all-mask semantics on empty boundaries.
         return torch.zeros_like(labels, dtype=torch.bool)
 
     B, L = labels.shape
     device = labels.device
 
-    # Stable order: longer start_tokens first so that the first-match wins for
-    # the longest-prefix tie-break. Carry original index for fast end-marker
-    # lookup.
+    # Longer start_tokens first so longest-prefix-wins tie-break holds.
     indexed = list(enumerate(role_boundaries))
     indexed.sort(key=lambda ib: -len(ib[1].start_tokens))
 
-    # ----------------------------------------------------------------- #
-    # Precompute start-match table per boundary in a single batched pass.
-    # start_winner[b, j] holds the index (into role_boundaries) of the
-    # longest-prefix boundary whose start matches at position j in row b,
-    # or -1 if nothing matches there.
-    # ----------------------------------------------------------------- #
     start_winner = torch.full((B, L), -1, dtype=torch.int64, device=device)
-    # We also accumulate match length so longest wins; equal-length ties keep
-    # the boundary that was assigned first (stable, matches the reference's
-    # "best_match is None or strictly longer" check).
+    # Track match length so equal-length ties keep the first writer (matches reference).
     start_winner_len = torch.zeros((B, L), dtype=torch.int64, device=device)
-
-    # Per-boundary end-match tables, indexed by *original* boundary index.
     end_match: list[Optional[Tensor]] = [None] * len(role_boundaries)
 
     for orig_idx, b in indexed:
         s_tok = b.start_tokens
         s_len = len(s_tok)
         if s_len == 0:
-            # Treat empty start as never-matches (defensive — not a valid
-            # boundary in practice).
-            continue
+            continue  # defensive: empty start never matches
 
-        # Build a [B, L - s_len + 1] bool mask of where this start matches.
         if s_len > L:
             start_mask = torch.zeros((B, 0), dtype=torch.bool, device=device)
         else:
             s_tok_t = torch.tensor(s_tok, dtype=labels.dtype, device=device)
-            # Slide a window: shape [B, L - s_len + 1, s_len]
             windows = labels.unfold(1, s_len, 1)
             start_mask = (windows == s_tok_t).all(dim=-1)
 
-        # Pad to full length L so we can index by absolute position j.
+        # Pad to L so absolute position j indexes into start_mask.
         pad_w = L - start_mask.shape[1]
         if pad_w > 0:
             start_mask = torch.cat(
@@ -575,10 +555,7 @@ def _compute_role_keep_mask_vectorized(
                 dim=1,
             )
 
-        # Update winner: this boundary wins at positions where it matches and
-        # the existing winner has a strictly shorter match length. Longest-
-        # first iteration order means the first writer at any position is
-        # already the longest, so subsequent writers are filtered.
+        # Strictly-longer gate + longest-first iteration => first writer sticks.
         update = start_mask & (start_winner_len < s_len)
         start_winner = torch.where(
             update, torch.full_like(start_winner, orig_idx), start_winner
@@ -587,8 +564,6 @@ def _compute_role_keep_mask_vectorized(
             update, torch.full_like(start_winner_len, s_len), start_winner_len
         )
 
-        # Precompute end-marker positions for this boundary (only used when
-        # end_tokens is non-empty).
         e_tok = b.end_tokens
         e_len = len(e_tok)
         if e_len == 0:
@@ -600,14 +575,12 @@ def _compute_role_keep_mask_vectorized(
             ewindows = labels.unfold(1, e_len, 1)
             end_match[orig_idx] = (ewindows == e_tok_t).all(dim=-1)
 
-    # Move match tables to CPU lists once — per-row walk is Python-level,
-    # avoiding many small tensor accesses in the hot loop.
+    # Lift to CPU lists: hot per-row loop is Python, tensor access is slow.
     start_winner_cpu = start_winner.cpu().tolist()
     end_match_cpu: list[Optional[list[list[bool]]]] = []
     for em in end_match:
         end_match_cpu.append(None if em is None else em.cpu().tolist())
 
-    # Cache boundary attributes for tight loop access.
     bnd_start_len = [len(b.start_tokens) for b in role_boundaries]
     bnd_end_len = [len(b.end_tokens) for b in role_boundaries]
     bnd_include_start = [b.include_start for b in role_boundaries]
@@ -618,12 +591,9 @@ def _compute_role_keep_mask_vectorized(
 
     for i in range(B):
         row_start = start_winner_cpu[i]
-        # Build a quick "next start at-or-after j" via a precomputed list of
-        # candidate positions; for typical sequences this list is tiny.
-        # Fall back to linear scan — still much cheaper than per-token match.
         n = L
         last_trainable_end_span: Optional[tuple[int, int]] = None
-        # row_mask is a small bytearray we OR into the [i] row at the end.
+        # bytearray is faster to write than a tensor per element.
         row_mask = bytearray(n)
 
         j = 0
@@ -640,16 +610,11 @@ def _compute_role_keep_mask_vectorized(
             include_end = bnd_include_end[bidx]
             role_in_loss = bnd_role_in_loss[bidx]
 
-            # Find the end. Use precomputed end_match where available.
             if e_len == 0:
                 end_after = n
                 found_end = False
             else:
                 em_row = end_match_cpu[bidx][i]  # type: ignore[index]
-                # Linear scan — but on a flat python list of bools, fastest
-                # is just the .index method when cast back via True lookup.
-                # We need first True at index >= start_of_content with
-                # k + e_len <= n.
                 limit = n - e_len
                 k = start_of_content
                 found_end = False
@@ -692,8 +657,7 @@ def _compute_role_keep_mask_vectorized(
             for p in range(s, e):
                 row_mask[p] = 1
 
-        # Commit the row mask in one shot (this is the only per-row
-        # heavyweight tensor op).
+        # One tensor write per row — keep heavyweight op out of inner loop.
         if any(row_mask):
             mask[i] = torch.tensor(row_mask, dtype=mask.dtype, device=device)
 

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -1,5 +1,6 @@
 """Module containing ProcessingStrategy classes and its derivative for different MultiModal Model types"""
 
+import bisect
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Optional
@@ -577,9 +578,18 @@ def _compute_role_keep_mask_vectorized(
 
     # Lift to CPU lists: hot per-row loop is Python, tensor access is slow.
     start_winner_cpu = start_winner.cpu().tolist()
-    end_match_cpu: list[Optional[list[list[bool]]]] = []
+    # Per boundary, per row: sorted end-match start positions, so the inner loop
+    # bisects for the next end instead of scanning every position in the span.
+    end_pos: list[Optional[list[list[int]]]] = []
     for em in end_match:
-        end_match_cpu.append(None if em is None else em.cpu().tolist())
+        if em is None:
+            end_pos.append(None)
+        else:
+            nz = em.nonzero(as_tuple=False)
+            rows: list[list[int]] = [[] for _ in range(B)]
+            for r, c in nz.tolist():
+                rows[r].append(c)
+            end_pos.append(rows)
 
     bnd_start_len = [len(b.start_tokens) for b in role_boundaries]
     bnd_end_len = [len(b.end_tokens) for b in role_boundaries]
@@ -588,12 +598,13 @@ def _compute_role_keep_mask_vectorized(
     bnd_role_in_loss = [b.role in roles_to_train for b in role_boundaries]
 
     mask = zeros_like(labels)
+    ONE = b"\x01"
 
     for i in range(B):
         row_start = start_winner_cpu[i]
         n = L
         last_trainable_end_span: Optional[tuple[int, int]] = None
-        # bytearray is faster to write than a tensor per element.
+        # bytearray slice-assignment beats per-element writes; one tensor per row.
         row_mask = bytearray(n)
 
         j = 0
@@ -614,37 +625,31 @@ def _compute_role_keep_mask_vectorized(
                 end_after = n
                 found_end = False
             else:
-                em_row = end_match_cpu[bidx][i]  # type: ignore[index]
+                positions = end_pos[bidx][i]  # type: ignore[index]
                 limit = n - e_len
-                k = start_of_content
-                found_end = False
-                while k <= limit:
-                    if em_row[k]:
-                        found_end = True
-                        break
-                    k += 1
-                if found_end:
-                    end_after = k + e_len
+                idx = bisect.bisect_left(positions, start_of_content)
+                if idx < len(positions) and positions[idx] <= limit:
+                    found_end = True
+                    end_after = positions[idx] + e_len
                 else:
+                    found_end = False
                     end_after = n
 
             if role_in_loss:
                 if include_start:
-                    for p in range(j, start_of_content):
-                        row_mask[p] = 1
+                    row_mask[j:start_of_content] = ONE * (start_of_content - j)
                 content_end = end_after - e_len if found_end else end_after
-                for p in range(start_of_content, content_end):
-                    row_mask[p] = 1
+                row_mask[start_of_content:content_end] = ONE * (
+                    content_end - start_of_content
+                )
                 if found_end and include_end and train_on_eos not in ("none", "last"):
-                    for p in range(content_end, end_after):
-                        row_mask[p] = 1
+                    row_mask[content_end:end_after] = ONE * (end_after - content_end)
                 if found_end and include_end and train_on_eos == "last":
                     last_trainable_end_span = (content_end, end_after)
             else:
                 if found_end and include_end and train_on_eos == "all":
                     content_end = end_after - e_len
-                    for p in range(content_end, end_after):
-                        row_mask[p] = 1
+                    row_mask[content_end:end_after] = ONE * (end_after - content_end)
 
             # include_end=False rewind: re-match the end as the next start.
             if found_end and not include_end and e_len:
@@ -654,12 +659,11 @@ def _compute_role_keep_mask_vectorized(
 
         if train_on_eos == "last" and last_trainable_end_span is not None:
             s, e = last_trainable_end_span
-            for p in range(s, e):
-                row_mask[p] = 1
+            row_mask[s:e] = ONE * (e - s)
 
         # One tensor write per row — keep heavyweight op out of inner loop.
         if any(row_mask):
-            mask[i] = torch.tensor(row_mask, dtype=mask.dtype, device=device)
+            mask[i] = torch.frombuffer(row_mask, dtype=torch.uint8).to(mask.dtype)
 
     return mask.bool()
 

--- a/src/axolotl/processing_strategies.py
+++ b/src/axolotl/processing_strategies.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Optional
 
+import torch
 from PIL import Image, ImageOps
 from PIL.Image import Resampling
 from torch import Tensor, zeros_like
@@ -279,9 +280,9 @@ class ProcessingStrategy:
                 image_value = load_image(image_value)
 
                 if self.image_size is not None:
-                    assert hasattr(image_value, "resize"), (
-                        "Image does not have a resize method"
-                    )
+                    assert hasattr(
+                        image_value, "resize"
+                    ), "Image does not have a resize method"
 
                     if isinstance(self.image_size, tuple):
                         image_value = image_value.resize(
@@ -333,10 +334,10 @@ class ProcessingStrategy:
 
         return processed_examples
 
-    def _mask_non_assistant(self, labels: Tensor) -> Tensor:
-        """Mask non-trainable role regions to -100 using ``self.role_boundaries``."""
+    def _mask_non_assistant_keep(self, input_ids: Tensor) -> Tensor:
+        """Return a [B, L] bool keep tensor (True = contributes to loss)."""
         if self.train_on_inputs:
-            return labels
+            return torch.ones_like(input_ids, dtype=torch.bool)
 
         # Legacy no-op for boundary-less strategies; warn once so the miss shows up in logs.
         if not self.role_boundaries:
@@ -355,40 +356,47 @@ class ProcessingStrategy:
                     "list of strategies on this fallback path.",
                     key,
                 )
-            return labels
+            return torch.ones_like(input_ids, dtype=torch.bool)
 
-        return _apply_role_boundaries(
-            labels,
+        # Vectorized path regresses 9-13x under multi-threaded torch; only
+        # ship it where it wins (DataLoader workers, threads=1).
+        scanner = (
+            _compute_role_keep_mask_vectorized
+            if torch.get_num_threads() == 1
+            else _compute_role_keep_mask
+        )
+        return scanner(
+            input_ids,
             self.role_boundaries,
             roles_to_train=set(self.roles_to_train),
             train_on_eos=self.train_on_eos,
         )
 
+    def _mask_non_assistant(self, labels: Tensor) -> Tensor:
+        """Mask non-trainable role regions to -100 using ``self.role_boundaries``."""
+        keep = self._mask_non_assistant_keep(labels)
+        labels[~keep] = -100
+        return labels
+
     def process_labels(self, input_ids: Tensor) -> Tensor:
-        labels = input_ids.clone()
-        labels = self._mask_non_assistant(labels)
+        keep = self._mask_non_assistant_keep(input_ids)
         pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
         if pad_id is not None:
-            labels[labels == pad_id] = -100
+            keep = keep & (input_ids != pad_id)
         if self.image_token_id is not None:
-            labels[labels == self.image_token_id] = -100
+            keep = keep & (input_ids != self.image_token_id)
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
-def _apply_role_boundaries(
+def _compute_role_keep_mask(
     labels: Tensor,
     role_boundaries: list[RoleBoundary],
     roles_to_train: set[str],
     train_on_eos: str,
 ) -> Tensor:
-    """Mask tokens outside trainable role spans to -100.
-
-    Scan is greedy-left with longest-prefix-wins on start_tokens to disambiguate
-    nested markers (e.g. ``<|im_start|>assistant`` vs ``<|im_start|>``).
-    ``train_on_eos`` accepts ``"turn"`` (end marker in loss on trainable turns
-    only), ``"all"`` (always), ``"none"`` (never — overrides ``include_end``),
-    ``"last"`` (only on the last trainable turn in the sequence).
-    """
+    """Return a [B, L] bool keep mask (True = contributes to loss)."""
     mask = zeros_like(labels)
     # For "last": remember each trainable turn's end-marker span so we can
     # unmask only the final one after the scan finishes.
@@ -475,8 +483,234 @@ def _apply_role_boundaries(
             s, e = span
             mask[i][s:e] = 1
 
-        labels[i][mask[i] == 0] = -100
+    return mask.bool()
 
+
+def _apply_role_boundaries(
+    labels: Tensor,
+    role_boundaries: list[RoleBoundary],
+    roles_to_train: set[str],
+    train_on_eos: str,
+) -> Tensor:
+    """Mask tokens outside trainable role spans to -100.
+
+    Scan is greedy-left with longest-prefix-wins on start_tokens to disambiguate
+    nested markers (e.g. ``<|im_start|>assistant`` vs ``<|im_start|>``).
+    ``train_on_eos`` accepts ``"turn"`` (end marker in loss on trainable turns
+    only), ``"all"`` (always), ``"none"`` (never — overrides ``include_end``),
+    ``"last"`` (only on the last trainable turn in the sequence).
+    """
+    keep = _compute_role_keep_mask(
+        labels, role_boundaries, roles_to_train, train_on_eos
+    )
+    labels[~keep] = -100
+    return labels
+
+
+def _compute_role_keep_mask_vectorized(
+    labels: Tensor,
+    role_boundaries: list[RoleBoundary],
+    roles_to_train: set[str],
+    train_on_eos: str,
+) -> Tensor:
+    """Vectorized variant of :func:`_compute_role_keep_mask`. Byte-identical output; faster under single-threaded torch."""
+    if labels.numel() == 0:
+        return torch.zeros_like(labels, dtype=torch.bool)
+    if not role_boundaries:
+        # Same all-mask semantics as the reference for empty boundaries
+        # (handled upstream in _mask_non_assistant_keep, but be defensive). The
+        # reference walks every position, finds no match, and ends with the
+        # mask all-zeros — which masks the entire batch to -100.
+        return torch.zeros_like(labels, dtype=torch.bool)
+
+    B, L = labels.shape
+    device = labels.device
+
+    # Stable order: longer start_tokens first so that the first-match wins for
+    # the longest-prefix tie-break. Carry original index for fast end-marker
+    # lookup.
+    indexed = list(enumerate(role_boundaries))
+    indexed.sort(key=lambda ib: -len(ib[1].start_tokens))
+
+    # ----------------------------------------------------------------- #
+    # Precompute start-match table per boundary in a single batched pass.
+    # start_winner[b, j] holds the index (into role_boundaries) of the
+    # longest-prefix boundary whose start matches at position j in row b,
+    # or -1 if nothing matches there.
+    # ----------------------------------------------------------------- #
+    start_winner = torch.full((B, L), -1, dtype=torch.int64, device=device)
+    # We also accumulate match length so longest wins; equal-length ties keep
+    # the boundary that was assigned first (stable, matches the reference's
+    # "best_match is None or strictly longer" check).
+    start_winner_len = torch.zeros((B, L), dtype=torch.int64, device=device)
+
+    # Per-boundary end-match tables, indexed by *original* boundary index.
+    end_match: list[Optional[Tensor]] = [None] * len(role_boundaries)
+
+    for orig_idx, b in indexed:
+        s_tok = b.start_tokens
+        s_len = len(s_tok)
+        if s_len == 0:
+            # Treat empty start as never-matches (defensive — not a valid
+            # boundary in practice).
+            continue
+
+        # Build a [B, L - s_len + 1] bool mask of where this start matches.
+        if s_len > L:
+            start_mask = torch.zeros((B, 0), dtype=torch.bool, device=device)
+        else:
+            s_tok_t = torch.tensor(s_tok, dtype=labels.dtype, device=device)
+            # Slide a window: shape [B, L - s_len + 1, s_len]
+            windows = labels.unfold(1, s_len, 1)
+            start_mask = (windows == s_tok_t).all(dim=-1)
+
+        # Pad to full length L so we can index by absolute position j.
+        pad_w = L - start_mask.shape[1]
+        if pad_w > 0:
+            start_mask = torch.cat(
+                [
+                    start_mask,
+                    torch.zeros((B, pad_w), dtype=torch.bool, device=device),
+                ],
+                dim=1,
+            )
+
+        # Update winner: this boundary wins at positions where it matches and
+        # the existing winner has a strictly shorter match length. Longest-
+        # first iteration order means the first writer at any position is
+        # already the longest, so subsequent writers are filtered.
+        update = start_mask & (start_winner_len < s_len)
+        start_winner = torch.where(
+            update, torch.full_like(start_winner, orig_idx), start_winner
+        )
+        start_winner_len = torch.where(
+            update, torch.full_like(start_winner_len, s_len), start_winner_len
+        )
+
+        # Precompute end-marker positions for this boundary (only used when
+        # end_tokens is non-empty).
+        e_tok = b.end_tokens
+        e_len = len(e_tok)
+        if e_len == 0:
+            end_match[orig_idx] = None
+        elif e_len > L:
+            end_match[orig_idx] = torch.zeros((B, 0), dtype=torch.bool, device=device)
+        else:
+            e_tok_t = torch.tensor(e_tok, dtype=labels.dtype, device=device)
+            ewindows = labels.unfold(1, e_len, 1)
+            end_match[orig_idx] = (ewindows == e_tok_t).all(dim=-1)
+
+    # Move match tables to CPU lists once — per-row walk is Python-level,
+    # avoiding many small tensor accesses in the hot loop.
+    start_winner_cpu = start_winner.cpu().tolist()
+    end_match_cpu: list[Optional[list[list[bool]]]] = []
+    for em in end_match:
+        end_match_cpu.append(None if em is None else em.cpu().tolist())
+
+    # Cache boundary attributes for tight loop access.
+    bnd_start_len = [len(b.start_tokens) for b in role_boundaries]
+    bnd_end_len = [len(b.end_tokens) for b in role_boundaries]
+    bnd_include_start = [b.include_start for b in role_boundaries]
+    bnd_include_end = [b.include_end for b in role_boundaries]
+    bnd_role_in_loss = [b.role in roles_to_train for b in role_boundaries]
+
+    mask = zeros_like(labels)
+
+    for i in range(B):
+        row_start = start_winner_cpu[i]
+        # Build a quick "next start at-or-after j" via a precomputed list of
+        # candidate positions; for typical sequences this list is tiny.
+        # Fall back to linear scan — still much cheaper than per-token match.
+        n = L
+        last_trainable_end_span: Optional[tuple[int, int]] = None
+        # row_mask is a small bytearray we OR into the [i] row at the end.
+        row_mask = bytearray(n)
+
+        j = 0
+        while j < n:
+            bidx = row_start[j]
+            if bidx == -1:
+                j += 1
+                continue
+
+            s_len = bnd_start_len[bidx]
+            start_of_content = j + s_len
+            e_len = bnd_end_len[bidx]
+            include_start = bnd_include_start[bidx]
+            include_end = bnd_include_end[bidx]
+            role_in_loss = bnd_role_in_loss[bidx]
+
+            # Find the end. Use precomputed end_match where available.
+            if e_len == 0:
+                end_after = n
+                found_end = False
+            else:
+                em_row = end_match_cpu[bidx][i]  # type: ignore[index]
+                # Linear scan — but on a flat python list of bools, fastest
+                # is just the .index method when cast back via True lookup.
+                # We need first True at index >= start_of_content with
+                # k + e_len <= n.
+                limit = n - e_len
+                k = start_of_content
+                found_end = False
+                while k <= limit:
+                    if em_row[k]:
+                        found_end = True
+                        break
+                    k += 1
+                if found_end:
+                    end_after = k + e_len
+                else:
+                    end_after = n
+
+            if role_in_loss:
+                if include_start:
+                    for p in range(j, start_of_content):
+                        row_mask[p] = 1
+                content_end = end_after - e_len if found_end else end_after
+                for p in range(start_of_content, content_end):
+                    row_mask[p] = 1
+                if found_end and include_end and train_on_eos not in ("none", "last"):
+                    for p in range(content_end, end_after):
+                        row_mask[p] = 1
+                if found_end and include_end and train_on_eos == "last":
+                    last_trainable_end_span = (content_end, end_after)
+            else:
+                if found_end and include_end and train_on_eos == "all":
+                    content_end = end_after - e_len
+                    for p in range(content_end, end_after):
+                        row_mask[p] = 1
+
+            # include_end=False rewind: re-match the end as the next start.
+            if found_end and not include_end and e_len:
+                j = end_after - e_len
+            else:
+                j = end_after
+
+        if train_on_eos == "last" and last_trainable_end_span is not None:
+            s, e = last_trainable_end_span
+            for p in range(s, e):
+                row_mask[p] = 1
+
+        # Commit the row mask in one shot (this is the only per-row
+        # heavyweight tensor op).
+        if any(row_mask):
+            mask[i] = torch.tensor(row_mask, dtype=mask.dtype, device=device)
+
+    return mask.bool()
+
+
+def _apply_role_boundaries_vectorized(
+    labels: Tensor,
+    role_boundaries: list[RoleBoundary],
+    roles_to_train: set[str],
+    train_on_eos: str,
+) -> Tensor:
+    """Vectorized variant of :func:`_apply_role_boundaries`."""
+    keep = _compute_role_keep_mask_vectorized(
+        labels, role_boundaries, roles_to_train, train_on_eos
+    )
+    labels[~keep] = -100
     return labels
 
 
@@ -629,9 +863,16 @@ class Qwen3_5ProcessingStrategy(Qwen2VLProcessingStrategy):
         )
 
     def process_labels(self, input_ids):
-        labels = super().process_labels(input_ids)
+        keep = self._mask_non_assistant_keep(input_ids)
+        pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
+        if pad_id is not None:
+            keep = keep & (input_ids != pad_id)
+        if self.image_token_id is not None:
+            keep = keep & (input_ids != self.image_token_id)
         if self.video_token_id is not None:
-            labels[labels == self.video_token_id] = -100
+            keep = keep & (input_ids != self.video_token_id)
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -700,16 +941,23 @@ class Gemma3ProcessingStrategy(_GemmaTurnStrategy):
             self.image_token_id = processor.tokenizer.convert_tokens_to_ids(boi)
 
     def process_labels(self, input_ids):
-        labels = super().process_labels(input_ids)
+        keep = self._mask_non_assistant_keep(input_ids)
+        pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
+        if pad_id is not None:
+            keep = keep & (input_ids != pad_id)
+        if self.image_token_id is not None:
+            keep = keep & (input_ids != self.image_token_id)
         # Resolve <image_soft_token> via tokenizer; fall back to default id
         # if not in vocab. Matches Gemma4's pattern.
         tok = self.processor.tokenizer
         soft_id = tok.convert_tokens_to_ids("<image_soft_token>")
         unk_id = getattr(tok, "unk_token_id", None)
         if soft_id is not None and soft_id != unk_id:
-            labels[labels == soft_id] = -100
+            keep = keep & (input_ids != soft_id)
         else:
-            labels[labels == 262144] = -100
+            keep = keep & (input_ids != 262144)
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -717,8 +965,13 @@ class Gemma3nProcessingStrategy(_GemmaTurnStrategy):
     """Gemma3n: same turn boundaries as Gemma3, additionally masks audio/delimiter tokens."""
 
     def process_labels(self, input_ids):
-        labels = super().process_labels(input_ids)
+        keep = self._mask_non_assistant_keep(input_ids)
         tok = self.processor.tokenizer
+        pad_id = getattr(tok, "pad_token_id", None)
+        if pad_id is not None:
+            keep = keep & (input_ids != pad_id)
+        if self.image_token_id is not None:
+            keep = keep & (input_ids != self.image_token_id)
         # Follows huggingface-gemma-recipes fine_tune_gemma3n_on_t4 notebook.
         for attr in (
             "image_token_id",
@@ -728,7 +981,9 @@ class Gemma3nProcessingStrategy(_GemmaTurnStrategy):
         ):
             tok_id = getattr(tok, attr, None)
             if tok_id is not None:
-                labels[labels == tok_id] = -100
+                keep = keep & (input_ids != tok_id)
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -768,15 +1023,21 @@ class Gemma4ProcessingStrategy(ProcessingStrategy):
         return boundaries
 
     def process_labels(self, input_ids):
-        labels = super().process_labels(input_ids)
+        keep = self._mask_non_assistant_keep(input_ids)
 
         tokenizer = self.processor.tokenizer
         unk_id = getattr(tokenizer, "unk_token_id", None)
 
+        pad_id = getattr(tokenizer, "pad_token_id", None)
+        if pad_id is not None:
+            keep = keep & (input_ids != pad_id)
+        if self.image_token_id is not None:
+            keep = keep & (input_ids != self.image_token_id)
+
         if getattr(tokenizer, "image_token_id", None) is not None:
-            labels[labels == tokenizer.image_token_id] = -100
+            keep = keep & (input_ids != tokenizer.image_token_id)
         if getattr(tokenizer, "audio_token_id", None) is not None:
-            labels[labels == tokenizer.audio_token_id] = -100
+            keep = keep & (input_ids != tokenizer.audio_token_id)
 
         # boi/eoi/boa/eoa are only string attrs on the processor; resolve ids here.
         for attr in ("boi_token", "eoi_token", "boa_token", "eoa_token"):
@@ -786,13 +1047,15 @@ class Gemma4ProcessingStrategy(ProcessingStrategy):
             token_id = tokenizer.convert_tokens_to_ids(token_str)
             if token_id is None or token_id == unk_id:
                 continue
-            labels[labels == token_id] = -100
+            keep = keep & (input_ids != token_id)
 
         # Video id lives on the processor, not the tokenizer.
         video_token_id = getattr(self.processor, "video_token_id", None)
         if video_token_id is not None and video_token_id != unk_id:
-            labels[labels == video_token_id] = -100
+            keep = keep & (input_ids != video_token_id)
 
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -950,17 +1213,18 @@ class VoxtralProcessingStrategy(ProcessingStrategy):
         self.begin_audio_token = special_ids.begin_audio
 
     def process_labels(self, input_ids):
-        labels = input_ids.clone()
-        labels = self._mask_non_assistant(labels)
+        keep = self._mask_non_assistant_keep(input_ids)
 
         pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
         if pad_id is not None:
-            labels[labels == pad_id] = -100
+            keep = keep & (input_ids != pad_id)
         if self.audio_token is not None:
-            labels[labels == self.audio_token] = -100
+            keep = keep & (input_ids != self.audio_token)
         if self.begin_audio_token is not None:
-            labels[labels == self.begin_audio_token] = -100
+            keep = keep & (input_ids != self.begin_audio_token)
 
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -1040,16 +1304,17 @@ class Mistral3ProcessingStrategy(ProcessingStrategy):
         self.image_end_token = special_ids.img_end
 
     def process_labels(self, input_ids):
-        labels = input_ids.clone()
-        labels = self._mask_non_assistant(labels)
+        keep = self._mask_non_assistant_keep(input_ids)
 
         pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
         if pad_id is not None:
-            labels[labels == pad_id] = -100
+            keep = keep & (input_ids != pad_id)
         for tok_id in (self.image_token, self.image_break_token, self.image_end_token):
             if tok_id is not None:
-                labels[labels == tok_id] = -100
+                keep = keep & (input_ids != tok_id)
 
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -1090,18 +1355,19 @@ class InternVLProcessingStrategy(ProcessingStrategy):
         self.image_token_ids = processor.image_ids
 
     def process_labels(self, input_ids):
-        labels = input_ids.clone()
-        labels = self._mask_non_assistant(labels)
+        keep = self._mask_non_assistant_keep(input_ids)
 
         pad_id = getattr(self.processor.tokenizer, "pad_token_id", None)
         if pad_id is not None:
-            labels[labels == pad_id] = -100
+            keep = keep & (input_ids != pad_id)
 
         for ids in self.image_token_ids:
             if ids is not None:
-                labels[labels == ids] = -100
+                keep = keep & (input_ids != ids)
 
         # Video tokens get converted to image patches during media processing; masking may be redundant.
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 
@@ -1161,12 +1427,11 @@ class Glm4vProcessingStrategy(ProcessingStrategy):
         )
 
     def process_labels(self, input_ids):
-        labels = input_ids.clone()
-        labels = self._mask_non_assistant(labels)
+        keep = self._mask_non_assistant_keep(input_ids)
 
         pad_id = getattr(self.tokenizer, "pad_token_id", None)
         if pad_id is not None:
-            labels[labels == pad_id] = -100
+            keep = keep & (input_ids != pad_id)
 
         for tok_id in (
             self.image_token_id,
@@ -1177,8 +1442,10 @@ class Glm4vProcessingStrategy(ProcessingStrategy):
             self.end_video_token_id,
         ):
             if tok_id is not None:
-                labels[labels == tok_id] = -100
+                keep = keep & (input_ids != tok_id)
 
+        labels = input_ids.clone()
+        labels[~keep] = -100
         return labels
 
 

--- a/tests/test_mm_collator_warnings.py
+++ b/tests/test_mm_collator_warnings.py
@@ -1,0 +1,82 @@
+"""Tests for the MM dataloader_num_workers=0 warning."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from axolotl.core.builders import causal as _causal_builder
+from axolotl.core.builders.causal import _warn_if_num_workers_zero_for_mm
+
+
+def _make_cfg(processor_type=None, dataloader_num_workers=None, train_on_inputs=False):
+    return SimpleNamespace(
+        processor_type=processor_type,
+        dataloader_num_workers=dataloader_num_workers,
+        train_on_inputs=train_on_inputs,
+    )
+
+
+@pytest.fixture
+def _reset_mm_warn_state():
+    """Reset the module-level once-per-process guard set so each test is independent.
+
+    Production keeps the warning one-shot per process so logs aren't spammed
+    when ``build()`` builds collators for both train and eval.
+    """
+    _causal_builder._MM_NUM_WORKERS_WARNED.clear()
+    yield
+    _causal_builder._MM_NUM_WORKERS_WARNED.clear()
+
+
+def _capture_warning(caplog, cfg) -> list[str]:
+    log = logging.getLogger("axolotl.core.builders.causal")
+    log.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="axolotl.core.builders.causal"):
+            _warn_if_num_workers_zero_for_mm(cfg, log)
+    finally:
+        log.removeHandler(caplog.handler)
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_warn_num_workers_zero_for_mm_emits_warning(_reset_mm_warn_state, caplog):
+    cfg = _make_cfg(processor_type="qwen2_vl", dataloader_num_workers=0)
+    msgs = _capture_warning(caplog, cfg)
+    assert any("dataloader_num_workers=0" in m for m in msgs)
+
+
+def test_warn_num_workers_zero_for_mm_silent_when_workers_set(
+    _reset_mm_warn_state, caplog
+):
+    cfg = _make_cfg(processor_type="qwen2_vl", dataloader_num_workers=2)
+    msgs = _capture_warning(caplog, cfg)
+    assert not any("dataloader_num_workers=0" in m for m in msgs)
+
+
+def test_warn_num_workers_zero_for_mm_silent_when_no_processor(
+    _reset_mm_warn_state, caplog
+):
+    cfg = _make_cfg(processor_type=None, dataloader_num_workers=0)
+    msgs = _capture_warning(caplog, cfg)
+    assert not any("dataloader_num_workers=0" in m for m in msgs)
+
+
+def test_warn_num_workers_zero_for_mm_treats_none_as_zero(_reset_mm_warn_state, caplog):
+    """``None`` (default) and ``0`` should both trigger the warning."""
+    cfg = _make_cfg(processor_type="qwen2_vl", dataloader_num_workers=None)
+    msgs = _capture_warning(caplog, cfg)
+    assert any("dataloader_num_workers=0" in m for m in msgs)
+
+
+def test_warn_num_workers_zero_for_mm_is_one_shot(_reset_mm_warn_state, caplog):
+    """Second invocation in the same process should NOT re-emit the warning."""
+    cfg = _make_cfg(processor_type="qwen2_vl", dataloader_num_workers=0)
+    first_msgs = _capture_warning(caplog, cfg)
+    assert any("dataloader_num_workers=0" in m for m in first_msgs)
+
+    caplog.clear()
+    second_msgs = _capture_warning(caplog, cfg)
+    assert not any("dataloader_num_workers=0" in m for m in second_msgs)

--- a/tests/test_process_labels_fusion.py
+++ b/tests/test_process_labels_fusion.py
@@ -1,0 +1,545 @@
+"""Parity tests for fused ``process_labels``.
+
+Each strategy gets a legacy reference implementation (verbatim copy of the
+pre-refactor code) and a fuzz batch generator that injects realistic
+distributions of pad/image/etc tokens. We then assert byte-identical output
+between the legacy ``process_labels`` and the new fused implementation.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import List
+
+import pytest
+import torch
+
+from axolotl.processing_strategies import (
+    Gemma3nProcessingStrategy,
+    Gemma3ProcessingStrategy,
+    Gemma4ProcessingStrategy,
+    Llama3_2VisionProcessingStrategy,
+    Llama4ProcessingStrategy,
+    MistralV7TekkenProcessingStrategy,
+    PixtralProcessingStrategy,
+    ProcessingStrategy,
+    Qwen2VLProcessingStrategy,
+    Qwen3_5ProcessingStrategy,
+    _apply_role_boundaries,
+)
+
+# --------------------------------------------------------------------------- #
+# Tokenizer / processor stubs (mirrors test_processing_strategies.py)
+# --------------------------------------------------------------------------- #
+
+
+class _Tokenizer:
+    def __init__(
+        self,
+        vocab: dict,
+        pad_id: int = 0,
+        unk_id: int = 3,
+        eos_id: int | None = None,
+        extras: dict | None = None,
+    ):
+        self.vocab = vocab
+        self.pad_token_id = pad_id
+        self.unk_token_id = unk_id
+        if eos_id is not None:
+            self.eos_token_id = eos_id
+        if extras:
+            for k, v in extras.items():
+                setattr(self, k, v)
+
+    def encode(self, text, add_special_tokens=False):
+        return list(self.vocab.get(text, []))
+
+    def convert_tokens_to_ids(self, token):
+        v = self.vocab.get(token)
+        if v is None:
+            return self.unk_token_id
+        return v[0] if len(v) == 1 else self.unk_token_id
+
+
+class _Processor:
+    def __init__(self, tokenizer, **extras):
+        self.tokenizer = tokenizer
+        for k, v in extras.items():
+            setattr(self, k, v)
+
+
+# --------------------------------------------------------------------------- #
+# Legacy reference implementations (verbatim pre-refactor body)
+# --------------------------------------------------------------------------- #
+#
+# These functions implement process_labels exactly as it existed before the
+# fusion refactor: 3-4 sequential masked writes against the labels tensor,
+# with _mask_non_assistant materializing the role mask in-place.
+
+
+def _legacy_mask_non_assistant(strategy, labels):
+    """Pre-refactor ``_mask_non_assistant`` body."""
+    if strategy.train_on_inputs:
+        return labels
+    if not strategy.role_boundaries:
+        return labels
+    return _apply_role_boundaries(
+        labels,
+        strategy.role_boundaries,
+        roles_to_train=set(strategy.roles_to_train),
+        train_on_eos=strategy.train_on_eos,
+    )
+
+
+def legacy_base_process_labels(strategy, input_ids):
+    labels = input_ids.clone()
+    labels = _legacy_mask_non_assistant(strategy, labels)
+    pad_id = getattr(strategy.processor.tokenizer, "pad_token_id", None)
+    if pad_id is not None:
+        labels[labels == pad_id] = -100
+    if strategy.image_token_id is not None:
+        labels[labels == strategy.image_token_id] = -100
+    return labels
+
+
+def legacy_qwen3_5_process_labels(strategy, input_ids):
+    labels = legacy_base_process_labels(strategy, input_ids)
+    if strategy.video_token_id is not None:
+        labels[labels == strategy.video_token_id] = -100
+    return labels
+
+
+def legacy_gemma3_process_labels(strategy, input_ids):
+    labels = legacy_base_process_labels(strategy, input_ids)
+    tok = strategy.processor.tokenizer
+    soft_id = tok.convert_tokens_to_ids("<image_soft_token>")
+    unk_id = getattr(tok, "unk_token_id", None)
+    if soft_id is not None and soft_id != unk_id:
+        labels[labels == soft_id] = -100
+    else:
+        labels[labels == 262144] = -100
+    return labels
+
+
+def legacy_gemma3n_process_labels(strategy, input_ids):
+    labels = legacy_base_process_labels(strategy, input_ids)
+    tok = strategy.processor.tokenizer
+    for attr in (
+        "image_token_id",
+        "audio_token_id",
+        "boi_token_id",
+        "eoi_token_id",
+    ):
+        tok_id = getattr(tok, attr, None)
+        if tok_id is not None:
+            labels[labels == tok_id] = -100
+    return labels
+
+
+def legacy_gemma4_process_labels(strategy, input_ids):
+    labels = legacy_base_process_labels(strategy, input_ids)
+    tokenizer = strategy.processor.tokenizer
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if getattr(tokenizer, "image_token_id", None) is not None:
+        labels[labels == tokenizer.image_token_id] = -100
+    if getattr(tokenizer, "audio_token_id", None) is not None:
+        labels[labels == tokenizer.audio_token_id] = -100
+    for attr in ("boi_token", "eoi_token", "boa_token", "eoa_token"):
+        token_str = getattr(strategy.processor, attr, None)
+        if token_str is None:
+            continue
+        token_id = tokenizer.convert_tokens_to_ids(token_str)
+        if token_id is None or token_id == unk_id:
+            continue
+        labels[labels == token_id] = -100
+    video_token_id = getattr(strategy.processor, "video_token_id", None)
+    if video_token_id is not None and video_token_id != unk_id:
+        labels[labels == video_token_id] = -100
+    return labels
+
+
+def legacy_voxtral_process_labels(strategy, input_ids):
+    labels = input_ids.clone()
+    labels = _legacy_mask_non_assistant(strategy, labels)
+    pad_id = getattr(strategy.processor.tokenizer, "pad_token_id", None)
+    if pad_id is not None:
+        labels[labels == pad_id] = -100
+    if strategy.audio_token is not None:
+        labels[labels == strategy.audio_token] = -100
+    if strategy.begin_audio_token is not None:
+        labels[labels == strategy.begin_audio_token] = -100
+    return labels
+
+
+def legacy_mistral3_process_labels(strategy, input_ids):
+    labels = input_ids.clone()
+    labels = _legacy_mask_non_assistant(strategy, labels)
+    pad_id = getattr(strategy.processor.tokenizer, "pad_token_id", None)
+    if pad_id is not None:
+        labels[labels == pad_id] = -100
+    for tok_id in (
+        strategy.image_token,
+        strategy.image_break_token,
+        strategy.image_end_token,
+    ):
+        if tok_id is not None:
+            labels[labels == tok_id] = -100
+    return labels
+
+
+def legacy_internvl_process_labels(strategy, input_ids):
+    labels = input_ids.clone()
+    labels = _legacy_mask_non_assistant(strategy, labels)
+    pad_id = getattr(strategy.processor.tokenizer, "pad_token_id", None)
+    if pad_id is not None:
+        labels[labels == pad_id] = -100
+    for ids in strategy.image_token_ids:
+        if ids is not None:
+            labels[labels == ids] = -100
+    return labels
+
+
+def legacy_glm4v_process_labels(strategy, input_ids):
+    labels = input_ids.clone()
+    labels = _legacy_mask_non_assistant(strategy, labels)
+    pad_id = getattr(strategy.tokenizer, "pad_token_id", None)
+    if pad_id is not None:
+        labels[labels == pad_id] = -100
+    for tok_id in (
+        strategy.image_token_id,
+        strategy.begin_image_token_id,
+        strategy.end_image_token_id,
+        strategy.video_token_id,
+        strategy.begin_video_token_id,
+        strategy.end_video_token_id,
+    ):
+        if tok_id is not None:
+            keep = labels != tok_id  # noqa: F841 — keep var unused; legacy uses indexed write
+            labels[labels == tok_id] = -100
+    return labels
+
+
+# --------------------------------------------------------------------------- #
+# Batch construction with realistic distributions
+# --------------------------------------------------------------------------- #
+
+
+def _build_alternating_turns(
+    rng: random.Random,
+    boundaries,
+    target_len: int,
+    pad_id: int,
+    extra_token_ids: List[int],
+    pad_rate: float = 0.07,
+    extra_rate: float = 0.07,
+    filler_min: int = 6,
+    filler_max: int = 24,
+) -> List[int]:
+    """Build a single row of length ``target_len`` from ``boundaries``.
+
+    Alternates user/assistant turns (or whatever's first/second in the list),
+    with random filler IDs that may be replaced by pad / extra (image, etc)
+    tokens at ``pad_rate`` / ``extra_rate``. The injection happens *inside*
+    assistant spans too, which is the realistic case.
+    """
+    role_b = list(boundaries)
+    if not role_b:
+        # No boundaries: just emit random tokens
+        return [rng.randint(10000, 30000) for _ in range(target_len)]
+
+    ids: List[int] = []
+    turn = 0
+    while len(ids) < target_len:
+        b = role_b[turn % len(role_b)]
+        ids.extend(b.start_tokens)
+        n_filler = rng.randint(filler_min, filler_max)
+        for _ in range(n_filler):
+            r = rng.random()
+            if r < pad_rate:
+                ids.append(pad_id)
+            elif r < pad_rate + extra_rate and extra_token_ids:
+                ids.append(rng.choice(extra_token_ids))
+            else:
+                # Use IDs well outside the boundary token space
+                ids.append(rng.randint(10000, 30000))
+        if b.end_tokens:
+            ids.extend(b.end_tokens)
+        turn += 1
+    return ids[:target_len]
+
+
+def _build_batch(rng, boundaries, batch_size, seq_len, pad_id, extra_ids):
+    rows = []
+    for _ in range(batch_size):
+        # Vary length per row a bit so we get padding-like rows occasionally
+        target = rng.randint(seq_len // 2, seq_len)
+        row = _build_alternating_turns(rng, boundaries, target, pad_id, extra_ids)
+        # Pad up to seq_len with pad_id (mimics collator behavior)
+        if len(row) < seq_len:
+            row.extend([pad_id] * (seq_len - len(row)))
+        rows.append(row[:seq_len])
+    return torch.tensor(rows, dtype=torch.long)
+
+
+# --------------------------------------------------------------------------- #
+# Per-strategy fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _make_qwen2vl():
+    vocab = {
+        "<|im_start|>system\n": [101, 102, 103],
+        "<|im_start|>user\n": [101, 104, 103],
+        "<|im_start|>assistant\n": [101, 105, 103],
+        "<|im_end|>": [106],
+        "<|image_pad|>": [200],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    return Qwen2VLProcessingStrategy(_Processor(tok))
+
+
+def _make_qwen3_5():
+    vocab = {
+        "<|im_start|>system\n": [101, 102, 103],
+        "<|im_start|>user\n": [101, 104, 103],
+        "<|im_start|>assistant\n": [101, 105, 103],
+        "<|im_end|>": [106],
+        "<|image_pad|>": [200],
+        "<|video_pad|>": [201],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    return Qwen3_5ProcessingStrategy(_Processor(tok))
+
+
+def _make_gemma3():
+    vocab = {
+        "<start_of_turn>user\n": [110, 111, 112],
+        "<start_of_turn>model\n": [110, 113, 112],
+        "<end_of_turn>": [114],
+        "<image_soft_token>": [262144],
+        "<boi>": [120],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3, extras={"boi_token": "<boi>"})
+    return Gemma3ProcessingStrategy(_Processor(tok))
+
+
+def _make_gemma3n():
+    vocab = {
+        "<start_of_turn>user\n": [110, 111, 112],
+        "<start_of_turn>model\n": [110, 113, 112],
+        "<end_of_turn>": [114],
+    }
+    tok = _Tokenizer(
+        vocab,
+        pad_id=0,
+        unk_id=3,
+        extras={
+            "image_token_id": 130,
+            "audio_token_id": 131,
+            "boi_token_id": 132,
+            "eoi_token_id": 133,
+        },
+    )
+    return Gemma3nProcessingStrategy(_Processor(tok))
+
+
+def _make_gemma4():
+    vocab = {
+        "<|turn>user\n": [105, 4001],
+        "<|turn>system\n": [105, 4002],
+        "<|turn>model\n": [105, 4368],
+        "<turn|>": [106],
+        "<boi>": [140],
+        "<eoi>": [141],
+        "<boa>": [142],
+        "<eoa>": [143],
+    }
+    tok = _Tokenizer(
+        vocab,
+        pad_id=0,
+        unk_id=3,
+        extras={"image_token_id": 150, "audio_token_id": 151},
+    )
+    proc = _Processor(
+        tok,
+        boi_token="<boi>",
+        eoi_token="<eoi>",
+        boa_token="<boa>",
+        eoa_token="<eoa>",
+        video_token_id=160,
+    )
+    return Gemma4ProcessingStrategy(proc)
+
+
+def _make_llama32v():
+    vocab = {
+        "<|start_header_id|>system<|end_header_id|>\n\n": [1001, 2002, 1002, 1003],
+        "<|start_header_id|>user<|end_header_id|>\n\n": [1001, 2001, 1002, 1003],
+        "<|start_header_id|>assistant<|end_header_id|>\n\n": [1001, 2003, 1002, 1003],
+        "<|eot_id|>": [1004],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    return Llama3_2VisionProcessingStrategy(_Processor(tok))
+
+
+def _make_llama4():
+    vocab = {
+        "<|header_start|>system<|header_end|>\n\n": [1001, 2002, 1002, 1003],
+        "<|header_start|>user<|header_end|>\n\n": [1001, 2001, 1002, 1003],
+        "<|header_start|>assistant<|header_end|>\n\n": [1001, 2003, 1002, 1003],
+        "<|eot|>": [1004],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    return Llama4ProcessingStrategy(_Processor(tok))
+
+
+def _make_pixtral():
+    vocab = {"[INST]": [50], "[/INST]": [51]}
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3, eos_id=99)
+    return PixtralProcessingStrategy(_Processor(tok))
+
+
+def _make_mistral_v7():
+    vocab = {
+        "[INST]": [50],
+        "[/INST]": [51],
+        "[SYSTEM_PROMPT]": [60],
+        "[/SYSTEM_PROMPT]": [61],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3, eos_id=99)
+    return MistralV7TekkenProcessingStrategy(_Processor(tok))
+
+
+# --------------------------------------------------------------------------- #
+# Parameterized parity fuzz
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "strategy_factory, legacy_fn, extra_ids, name",
+    [
+        (_make_qwen2vl, legacy_base_process_labels, [200], "qwen2vl"),
+        (_make_qwen3_5, legacy_qwen3_5_process_labels, [200, 201], "qwen3_5"),
+        (_make_gemma3, legacy_gemma3_process_labels, [120, 262144], "gemma3"),
+        (_make_gemma3n, legacy_gemma3n_process_labels, [130, 131, 132, 133], "gemma3n"),
+        (
+            _make_gemma4,
+            legacy_gemma4_process_labels,
+            [140, 141, 142, 143, 150, 151, 160],
+            "gemma4",
+        ),
+        (_make_llama32v, legacy_base_process_labels, [], "llama32v"),
+        (_make_llama4, legacy_base_process_labels, [], "llama4"),
+        (_make_pixtral, legacy_base_process_labels, [], "pixtral"),
+        (_make_mistral_v7, legacy_base_process_labels, [], "mistral_v7"),
+    ],
+)
+@pytest.mark.parametrize("seed", list(range(50)))
+def test_process_labels_parity_fuzz(strategy_factory, legacy_fn, extra_ids, name, seed):
+    """50 random batches per strategy: legacy vs fused must produce byte-identical labels."""
+    rng = random.Random(seed * 7919 + hash(name) % 1000)
+
+    strategy = strategy_factory()
+    pad_id = strategy.processor.tokenizer.pad_token_id
+
+    # Mix of small / medium / large, plus varied batch sizes
+    batch_size = rng.choice([1, 2, 4, 8])
+    seq_len = rng.choice([64, 128, 256, 512])
+
+    batch = _build_batch(
+        rng, strategy.role_boundaries, batch_size, seq_len, pad_id, extra_ids
+    )
+
+    expected = legacy_fn(strategy, batch.clone())
+    got = strategy.process_labels(batch.clone())
+
+    if not torch.equal(expected, got):
+        # Find first divergence to make debug output useful
+        diff = (expected != got).nonzero(as_tuple=False)
+        first = diff[0].tolist()
+        b_idx, t_idx = first
+        lo = max(0, t_idx - 8)
+        hi = min(seq_len, t_idx + 8)
+        raise AssertionError(
+            f"[{name} seed={seed}] mismatch at row={b_idx} col={t_idx}\n"
+            f"  input_ids[{b_idx}, {lo}:{hi}] = {batch[b_idx, lo:hi].tolist()}\n"
+            f"  legacy   [{b_idx}, {lo}:{hi}] = {expected[b_idx, lo:hi].tolist()}\n"
+            f"  fused    [{b_idx}, {lo}:{hi}] = {got[b_idx, lo:hi].tolist()}\n"
+            f"  boundaries: {strategy.role_boundaries}"
+        )
+
+
+def test_process_labels_train_on_inputs_passthrough():
+    """When train_on_inputs=True the keep mask must be all-True (only pad/media masked)."""
+    vocab = {
+        "<|im_start|>user\n": [101, 104, 103],
+        "<|im_start|>assistant\n": [101, 105, 103],
+        "<|im_end|>": [106],
+        "<|image_pad|>": [200],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    s = Qwen2VLProcessingStrategy(_Processor(tok), train_on_inputs=True)
+    batch = torch.tensor([[101, 104, 103, 7, 8, 0, 200, 9, 106]])
+    out = s.process_labels(batch.clone())
+    expected = legacy_base_process_labels(s, batch.clone())
+    assert torch.equal(out, expected)
+    # And confirm the only masked positions are pad and image
+    assert out.tolist() == [[101, 104, 103, 7, 8, -100, -100, 9, 106]]
+
+
+def test_process_labels_no_boundaries_falls_through():
+    """A boundary-less strategy + train_on_inputs=False keeps everything (warns once);
+    pad / media tokens are still masked.
+    """
+    vocab = {"foo": [200]}
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    # Base strategy with no role_boundaries declared and train_on_inputs=False
+    s = ProcessingStrategy(_Processor(tok))
+    assert s.role_boundaries == []
+    batch = torch.tensor([[5, 6, 7, 0, 8]])
+    out = s.process_labels(batch.clone())
+    expected = legacy_base_process_labels(s, batch.clone())
+    assert torch.equal(out, expected)
+    # Pad at index 3 must be masked, everything else kept (no boundaries → no role mask).
+    assert out.tolist() == [[5, 6, 7, -100, 8]]
+
+
+# --------------------------------------------------------------------------- #
+# Targeted edge cases for fused path
+# --------------------------------------------------------------------------- #
+
+
+def test_fused_pad_inside_assistant_is_masked():
+    """Pad inside assistant span must end up -100 even though role-mask kept it."""
+    vocab = {
+        "<|im_start|>user\n": [101, 104, 103],
+        "<|im_start|>assistant\n": [101, 105, 103],
+        "<|im_end|>": [106],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    s = Qwen2VLProcessingStrategy(_Processor(tok))
+    seq = [101, 104, 103, 7, 106, 101, 105, 103, 8, 0, 9, 106]
+    out = s.process_labels(torch.tensor([seq]))
+    expected = legacy_base_process_labels(s, torch.tensor([seq]))
+    assert torch.equal(out, expected)
+    # Pad (0) inside assistant gets masked, content (8, 9) and end (106) kept.
+    assert out.tolist() == [
+        [-100, -100, -100, -100, -100, -100, -100, -100, 8, -100, 9, 106]
+    ]
+
+
+def test_fused_image_inside_assistant_is_masked():
+    vocab = {
+        "<|im_start|>user\n": [101, 104, 103],
+        "<|im_start|>assistant\n": [101, 105, 103],
+        "<|im_end|>": [106],
+        "<|image_pad|>": [200],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    s = Qwen2VLProcessingStrategy(_Processor(tok))
+    seq = [101, 105, 103, 8, 200, 9, 106]
+    out = s.process_labels(torch.tensor([seq]))
+    expected = legacy_base_process_labels(s, torch.tensor([seq]))
+    assert torch.equal(out, expected)
+    # image_token_id (200) gets masked even though it's inside the assistant span.
+    assert out.tolist() == [[-100, -100, -100, 8, -100, 9, 106]]

--- a/tests/test_process_labels_fusion.py
+++ b/tests/test_process_labels_fusion.py
@@ -9,6 +9,7 @@ between the legacy ``process_labels`` and the new fused implementation.
 from __future__ import annotations
 
 import random
+from types import SimpleNamespace
 from typing import List
 
 import pytest
@@ -18,13 +19,17 @@ from axolotl.processing_strategies import (
     Gemma3nProcessingStrategy,
     Gemma3ProcessingStrategy,
     Gemma4ProcessingStrategy,
+    Glm4vProcessingStrategy,
+    InternVLProcessingStrategy,
     Llama3_2VisionProcessingStrategy,
     Llama4ProcessingStrategy,
+    Mistral3ProcessingStrategy,
     MistralV7TekkenProcessingStrategy,
     PixtralProcessingStrategy,
     ProcessingStrategy,
     Qwen2VLProcessingStrategy,
     Qwen3_5ProcessingStrategy,
+    VoxtralProcessingStrategy,
     _apply_role_boundaries,
 )
 
@@ -243,11 +248,21 @@ def _build_alternating_turns(
     assistant spans too, which is the realistic case.
     """
     role_b = list(boundaries)
-    if not role_b:
-        # No boundaries: just emit random tokens
-        return [rng.randint(10000, 30000) for _ in range(target_len)]
-
     ids: List[int] = []
+    if not role_b:
+        # No boundaries (Voxtral/Mistral3/InternVL/Glm4v): still inject pad and
+        # media tokens so the fused vs legacy parity check exercises the
+        # pad/media masking path even with role-masking opted out.
+        for _ in range(target_len):
+            r = rng.random()
+            if r < pad_rate:
+                ids.append(pad_id)
+            elif r < pad_rate + extra_rate and extra_token_ids:
+                ids.append(rng.choice(extra_token_ids))
+            else:
+                ids.append(rng.randint(10000, 30000))
+        return ids
+
     turn = 0
     while len(ids) < target_len:
         b = role_b[turn % len(role_b)]
@@ -411,6 +426,67 @@ def _make_mistral_v7():
 
 
 # --------------------------------------------------------------------------- #
+# Strategies that opt out of role-masking (no role_boundaries declared)
+# --------------------------------------------------------------------------- #
+#
+# These four fall back to pad+media masking only. We still want parity fuzz
+# coverage of the fused vs legacy paths because the per-strategy media-token
+# combinations differ (audio for Voxtral, three image markers for Mistral3,
+# variable-length image_ids list for InternVL, six markers for Glm4v).
+
+
+def _make_voxtral():
+    """VoxtralProcessor stub.
+
+    The strategy resolves audio token ids via the nested mistral-common path
+    ``processor.tokenizer.tokenizer.instruct_tokenizer.audio_encoder.special_ids``.
+    Mirror just enough of that shape for __init__ to read the two ids.
+    """
+    tok = _Tokenizer({}, pad_id=0, unk_id=3)
+    audio_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(audio=300, begin_audio=301)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(audio_encoder=audio_encoder)
+    )
+    return VoxtralProcessingStrategy(_Processor(tok))
+
+
+def _make_mistral3():
+    """Mistral3 stub: image_encoder.special_ids carries (img, img_break, img_end)."""
+    tok = _Tokenizer({}, pad_id=0, unk_id=3)
+    image_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(img=400, img_break=401, img_end=402)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(image_encoder=image_encoder)
+    )
+    return Mistral3ProcessingStrategy(_Processor(tok))
+
+
+def _make_internvl():
+    """InternVL stub: processor.image_ids is a list of media-token ids."""
+    tok = _Tokenizer({}, pad_id=0, unk_id=3)
+    proc = _Processor(tok)
+    proc.image_ids = [500, 501, 502]
+    return InternVLProcessingStrategy(proc)
+
+
+def _make_glm4v():
+    """Glm4v / Glm46V stub: convert_tokens_to_ids resolves six media markers."""
+    vocab = {
+        "<|image|>": [600],
+        "<|begin_of_image|>": [601],
+        "<|end_of_image|>": [602],
+        "<|video|>": [610],
+        "<|begin_of_video|>": [611],
+        "<|end_of_video|>": [612],
+    }
+    tok = _Tokenizer(vocab, pad_id=0, unk_id=3)
+    return Glm4vProcessingStrategy(_Processor(tok))
+
+
+# --------------------------------------------------------------------------- #
 # Parameterized parity fuzz
 # --------------------------------------------------------------------------- #
 
@@ -432,6 +508,25 @@ def _make_mistral_v7():
         (_make_llama4, legacy_base_process_labels, [], "llama4"),
         (_make_pixtral, legacy_base_process_labels, [], "pixtral"),
         (_make_mistral_v7, legacy_base_process_labels, [], "mistral_v7"),
+        (_make_voxtral, legacy_voxtral_process_labels, [300, 301], "voxtral"),
+        (
+            _make_mistral3,
+            legacy_mistral3_process_labels,
+            [400, 401, 402],
+            "mistral3",
+        ),
+        (
+            _make_internvl,
+            legacy_internvl_process_labels,
+            [500, 501, 502],
+            "internvl",
+        ),
+        (
+            _make_glm4v,
+            legacy_glm4v_process_labels,
+            [600, 601, 602, 610, 611, 612],
+            "glm4v",
+        ),
     ],
 )
 @pytest.mark.parametrize("seed", list(range(50)))

--- a/tests/test_process_labels_fusion.py
+++ b/tests/test_process_labels_fusion.py
@@ -437,7 +437,7 @@ def _make_mistral_v7():
 @pytest.mark.parametrize("seed", list(range(50)))
 def test_process_labels_parity_fuzz(strategy_factory, legacy_fn, extra_ids, name, seed):
     """50 random batches per strategy: legacy vs fused must produce byte-identical labels."""
-    rng = random.Random(seed * 7919 + hash(name) % 1000)
+    rng = random.Random(seed * 7919 + sum(ord(c) for c in name) % 1000)
 
     strategy = strategy_factory()
     pad_id = strategy.processor.tokenizer.pad_token_id

--- a/tests/test_processing_strategies.py
+++ b/tests/test_processing_strategies.py
@@ -1,6 +1,7 @@
 """Tests for ``axolotl.processing_strategies`` using fake tokenizers (offline/CI-safe)."""
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,14 +12,18 @@ from axolotl.processing_strategies import (
     Gemma3nProcessingStrategy,
     Gemma3ProcessingStrategy,
     Gemma4ProcessingStrategy,
+    Glm4vProcessingStrategy,
+    InternVLProcessingStrategy,
     Llama3_2VisionProcessingStrategy,
     Llama4ProcessingStrategy,
+    Mistral3ProcessingStrategy,
     MistralV7TekkenProcessingStrategy,
     PixtralProcessingStrategy,
     ProcessingStrategy,
     Qwen2VLProcessingStrategy,
     Qwen3_5ProcessingStrategy,
     RoleBoundary,
+    VoxtralProcessingStrategy,
     _apply_role_boundaries,
     get_processing_strategy,
 )
@@ -663,6 +668,174 @@ def test_mistral_v7_tekken_train_on_eos_all_respects_user_include_end_false():
 
 
 # --------------------------------------------------------------------------- #
+# Voxtral / Mistral3 / InternVL / Glm4v
+#
+# These four strategies do NOT declare role boundaries (mistral-common or
+# template-variant uncertainty); they fall back to pad + media masking.
+# Coverage focuses on the media-token masking surface plus role-boundary
+# override as the supported opt-in path.
+# --------------------------------------------------------------------------- #
+
+
+def _make_voxtral_strategy(**kwargs):
+    """Voxtral stub: special_ids live at processor.tokenizer.tokenizer.instruct_tokenizer.audio_encoder."""
+    tok = _Tokenizer({}, pad_id=0)
+    audio_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(audio=300, begin_audio=301)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(audio_encoder=audio_encoder)
+    )
+    return VoxtralProcessingStrategy(_Processor(tok), **kwargs)
+
+
+def test_voxtral_masks_pad_and_audio_tokens():
+    """Default Voxtral: no role boundaries → keep content, mask pad + audio markers."""
+    strategy = _make_voxtral_strategy()
+    # 300 = audio, 301 = begin_audio, 0 = pad. Other ids are kept.
+    seq = [7, 0, 300, 8, 301, 9]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9]
+
+
+def test_voxtral_train_on_inputs_true_still_masks_audio():
+    """Even with train_on_inputs, audio/pad tokens must be masked."""
+    strategy = _make_voxtral_strategy(train_on_inputs=True)
+    seq = [7, 0, 300, 8, 301, 9]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9]
+
+
+def test_voxtral_role_boundaries_override_enables_role_masking():
+    """Override opt-in: role masking applies on top of pad/audio masking."""
+    tok = _Tokenizer({"BOA": [50], "EOT": [60]}, pad_id=0)
+    audio_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(audio=300, begin_audio=301)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(audio_encoder=audio_encoder)
+    )
+    strategy = VoxtralProcessingStrategy(
+        _Processor(tok),
+        role_boundaries_override=[{"role": "assistant", "start": "BOA", "end": "EOT"}],
+    )
+    # Pre-BOA + post-EOT masked; BOA(50) and EOT(60) included by default;
+    # audio token 300 inside the span still masked.
+    seq = [7, 50, 8, 300, 9, 60, 1]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [-100, -100, 8, -100, 9, 60, -100]
+
+
+def _make_mistral3_strategy(**kwargs):
+    tok = _Tokenizer({}, pad_id=0)
+    image_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(img=400, img_break=401, img_end=402)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(image_encoder=image_encoder)
+    )
+    return Mistral3ProcessingStrategy(_Processor(tok), **kwargs)
+
+
+def test_mistral3_masks_pad_and_three_image_tokens():
+    strategy = _make_mistral3_strategy()
+    seq = [7, 0, 400, 8, 401, 9, 402, 10]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9, -100, 10]
+
+
+def test_mistral3_train_on_inputs_true_still_masks_image_markers():
+    strategy = _make_mistral3_strategy(train_on_inputs=True)
+    seq = [7, 0, 400, 8, 401, 9, 402, 10]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9, -100, 10]
+
+
+def test_internvl_masks_pad_and_image_id_list():
+    """InternVL stores a *list* of image ids on processor.image_ids."""
+    tok = _Tokenizer({}, pad_id=0)
+    proc = _Processor(tok)
+    proc.image_ids = [500, 501, 502]
+    strategy = InternVLProcessingStrategy(proc)
+    seq = [7, 0, 500, 8, 501, 9, 502, 10]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9, -100, 10]
+
+
+def test_internvl_raises_when_image_ids_missing():
+    """No image_ids on the processor → __init__ must surface a clear error."""
+    tok = _Tokenizer({}, pad_id=0)
+    with pytest.raises(ValueError, match="image_ids"):
+        InternVLProcessingStrategy(_Processor(tok))
+
+
+def test_internvl_image_ids_with_none_entries_skipped():
+    """None entries in image_ids must not be used as a mask value."""
+    tok = _Tokenizer({}, pad_id=0)
+    proc = _Processor(tok)
+    proc.image_ids = [500, None, 502]
+    strategy = InternVLProcessingStrategy(proc)
+    seq = [500, 7, 502, 8]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [-100, 7, -100, 8]
+
+
+def _glm4v_tokenizer():
+    vocab = {
+        "<|image|>": [600],
+        "<|begin_of_image|>": [601],
+        "<|end_of_image|>": [602],
+        "<|video|>": [610],
+        "<|begin_of_video|>": [611],
+        "<|end_of_video|>": [612],
+    }
+    return _Tokenizer(vocab, pad_id=0)
+
+
+def test_glm4v_masks_pad_image_and_video_markers():
+    strategy = Glm4vProcessingStrategy(_Processor(_glm4v_tokenizer()))
+    # All six markers + pad must be masked; surrounding text tokens kept.
+    seq = [7, 0, 600, 601, 602, 8, 610, 611, 612, 9]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, -100, -100, 8, -100, -100, -100, 9]
+
+
+def test_glm4v_train_on_inputs_true_still_masks_media_markers():
+    strategy = Glm4vProcessingStrategy(
+        _Processor(_glm4v_tokenizer()), train_on_inputs=True
+    )
+    seq = [7, 0, 600, 8, 610, 9]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    assert out == [7, -100, -100, 8, -100, 9]
+
+
+def test_glm4v_role_boundaries_override_enables_role_masking():
+    """Override opt-in masks non-assistant role spans on top of media masking."""
+    tok = _glm4v_tokenizer()
+    tok.vocab["BOA"] = [50]
+    tok.vocab["EOT"] = [60]
+    strategy = Glm4vProcessingStrategy(
+        _Processor(tok),
+        role_boundaries_override=[{"role": "assistant", "start": "BOA", "end": "EOT"}],
+    )
+    seq = [7, 50, 8, 600, 9, 60, 1]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    # Pre-BOA + post-EOT masked; image marker 600 inside the assistant span
+    # is still masked post-scan.
+    assert out == [-100, -100, 8, -100, 9, 60, -100]
+
+
+def test_glm4v_batch_of_two_rows():
+    """Multiple rows independently masked; pad in trailing positions kept as -100."""
+    strategy = Glm4vProcessingStrategy(_Processor(_glm4v_tokenizer()))
+    row_a = [7, 600, 8, 610, 9]
+    row_b = [11, 601, 12, 0, 0]
+    out = strategy.process_labels(torch.tensor([row_a, row_b])).tolist()
+    assert out[0] == [7, -100, 8, -100, 9]
+    assert out[1] == [11, -100, 12, -100, -100]
+
+
+# --------------------------------------------------------------------------- #
 # Dispatcher routing
 # --------------------------------------------------------------------------- #
 
@@ -789,6 +962,85 @@ def test_dispatch_glm4v_via_Glm46VProcessor():
     )
     s = _dispatch(proc, None)
     assert isinstance(s, Glm4vProcessingStrategy)
+
+
+def test_dispatch_voxtral():
+    """VoxtralProcessor routes to VoxtralProcessingStrategy."""
+    pytest.importorskip("transformers.models.voxtral")
+    from transformers.models.voxtral import VoxtralProcessor
+
+    tok = _Tokenizer({}, pad_id=0)
+    audio_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(audio=300, begin_audio=301)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(audio_encoder=audio_encoder)
+    )
+    proc = MagicMock(spec=VoxtralProcessor)
+    proc.tokenizer = tok
+    if hasattr(proc, "image_token"):
+        del proc.image_token
+
+    s = _dispatch(proc, None)
+    assert isinstance(s, VoxtralProcessingStrategy)
+
+
+def test_dispatch_mistral3():
+    """Mistral3Processor (axolotl's optional wrapper) routes to Mistral3ProcessingStrategy."""
+    pytest.importorskip("mistral_common")
+    Mistral3Processor = pytest.importorskip(
+        "axolotl.utils.mistral.mistral3_processor"
+    ).Mistral3Processor
+
+    tok = _Tokenizer({}, pad_id=0)
+    image_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(img=400, img_break=401, img_end=402)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(image_encoder=image_encoder)
+    )
+    proc = MagicMock(spec=Mistral3Processor)
+    proc.tokenizer = tok
+    if hasattr(proc, "image_token"):
+        del proc.image_token
+
+    s = _dispatch(proc, None)
+    assert isinstance(s, Mistral3ProcessingStrategy)
+
+
+def test_dispatch_internvl():
+    """InternVLProcessor routes to InternVLProcessingStrategy."""
+    pytest.importorskip("transformers.models.internvl")
+    from transformers.models.internvl import InternVLProcessor
+
+    tok = _Tokenizer({}, pad_id=0)
+    proc = MagicMock(spec=InternVLProcessor)
+    proc.tokenizer = tok
+    proc.image_ids = [500, 501, 502]
+    if hasattr(proc, "image_token"):
+        del proc.image_token
+
+    s = _dispatch(proc, None)
+    assert isinstance(s, InternVLProcessingStrategy)
+
+
+def test_mistral3_role_boundaries_override_enables_role_masking():
+    """Mistral3 override opt-in: role masking applies on top of pad/image masking."""
+    tok = _Tokenizer({"BOA": [50], "EOT": [60]}, pad_id=0)
+    image_encoder = SimpleNamespace(
+        special_ids=SimpleNamespace(img=400, img_break=401, img_end=402)
+    )
+    tok.tokenizer = SimpleNamespace(
+        instruct_tokenizer=SimpleNamespace(image_encoder=image_encoder)
+    )
+    strategy = Mistral3ProcessingStrategy(
+        _Processor(tok),
+        role_boundaries_override=[{"role": "assistant", "start": "BOA", "end": "EOT"}],
+    )
+    seq = [7, 50, 8, 400, 9, 60, 1]
+    out = strategy.process_labels(torch.tensor([seq])).tolist()[0]
+    # Pre-BOA + post-EOT masked; image marker 400 inside the span also masked.
+    assert out == [-100, -100, 8, -100, 9, 60, -100]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_vectorized_scanner.py
+++ b/tests/test_vectorized_scanner.py
@@ -1,0 +1,540 @@
+"""Differential and targeted edge-case tests for the vectorized role-boundary scanner.
+
+The vectorized scanner (:func:`axolotl.processing_strategies._apply_role_boundaries_vectorized`)
+must be byte-identical to the reference implementation
+(:func:`axolotl.processing_strategies._apply_role_boundaries`) for every valid input.
+
+This file is structured in three layers:
+
+1. Targeted edge-case tests covering each behavioral subtlety called out in
+   the implementation comments (longest-prefix tie-break, Pixtral rewind,
+   train_on_eos modes, empty end_tokens, include_end leak gate).
+
+2. A boundary-shape catalog mimicking the real models: Gemma 4, Llama 3.2 V,
+   Llama 4, Pixtral, Mistral V7.
+
+3. A differential fuzzer that generates 2,000 random configurations and
+   asserts vectorized output == reference output element-wise. On mismatch,
+   dumps inputs + outputs + boundary spec.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import asdict
+from typing import Iterable
+
+import pytest
+import torch
+
+from axolotl.processing_strategies import (
+    RoleBoundary,
+    _apply_role_boundaries,
+    _apply_role_boundaries_vectorized,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _assert_equiv(
+    boundaries: list[RoleBoundary],
+    seq: list[list[int]],
+    roles_to_train: Iterable[str],
+    train_on_eos: str,
+):
+    """Assert vectorized output == reference output for the given input."""
+    labels_a = torch.tensor(seq)
+    labels_b = labels_a.clone()
+    out_ref = _apply_role_boundaries(
+        labels_a, boundaries, set(roles_to_train), train_on_eos
+    )
+    out_vec = _apply_role_boundaries_vectorized(
+        labels_b, boundaries, set(roles_to_train), train_on_eos
+    )
+    if not torch.equal(out_ref, out_vec):
+        # Build a focused failure dump.
+        diff = (out_ref != out_vec).nonzero(as_tuple=False).tolist()
+        msg = (
+            "Vectorized scanner diverged from reference.\n"
+            f"  boundaries: {[asdict(b) for b in boundaries]}\n"
+            f"  roles_to_train: {sorted(roles_to_train)}\n"
+            f"  train_on_eos: {train_on_eos}\n"
+            f"  input seq: {seq}\n"
+            f"  reference: {out_ref.tolist()}\n"
+            f"  vectorized: {out_vec.tolist()}\n"
+            f"  first 10 diff indices: {diff[:10]}\n"
+        )
+        raise AssertionError(msg)
+    return out_ref
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3: Targeted edge-case unit tests
+# --------------------------------------------------------------------------- #
+
+
+class TestEdgeCases:
+    """Hand-written cases that pin down each tricky behavior."""
+
+    def test_longest_prefix_wins_at_same_position(self):
+        """``<|im_start|>assistant`` (long) beats ``<|im_start|>`` (short)."""
+        # token 100 = <|im_start|>, then 101 = "user", 102 = "assistant"
+        boundaries = [
+            RoleBoundary(role="user", start_tokens=[100], end_tokens=[200]),
+            RoleBoundary(role="assistant", start_tokens=[100, 102], end_tokens=[200]),
+        ]
+        seq = [[100, 102, 1, 2, 3, 200, 100, 101, 4, 5, 6, 200]]
+        # The longer "assistant" boundary should win at j=0; only positions
+        # 1..5 are trainable (assistant content + end marker because
+        # train_on_eos="turn" includes end on trainable turns by default).
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_pixtral_shared_end_marker_rewind(self):
+        """[/INST] both ends user and starts assistant; rewind must re-match."""
+        # Pixtral: user=[INST] ... [/INST], assistant content, then </s>.
+        # The shared [/INST] must consume as user-end *and* assistant-start.
+        INST_OPEN = 100  # [INST]
+        INST_CLOSE = 200  # [/INST]
+        EOS = 2  # </s>
+        boundaries = [
+            RoleBoundary(
+                role="user",
+                start_tokens=[INST_OPEN],
+                end_tokens=[INST_CLOSE],
+                include_start=False,
+                include_end=False,  # critical: don't consume — let assistant re-match
+            ),
+            RoleBoundary(
+                role="assistant",
+                start_tokens=[INST_CLOSE],
+                end_tokens=[EOS],
+                include_start=False,
+                include_end=True,
+            ),
+        ]
+        # [INST] hello [/INST] reply </s>
+        seq = [[INST_OPEN, 5, 6, INST_CLOSE, 7, 8, 9, EOS]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_train_on_eos_turn(self):
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[100, 1, 2, 3, 200, 9, 9, 9, 100, 4, 5, 6, 200]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_train_on_eos_all(self):
+        boundaries = [
+            RoleBoundary(role="user", start_tokens=[100], end_tokens=[200]),
+            RoleBoundary(role="assistant", start_tokens=[101], end_tokens=[200]),
+        ]
+        seq = [[100, 1, 2, 200, 101, 3, 4, 200, 9]]
+        _assert_equiv(boundaries, seq, ["assistant"], "all")
+
+    def test_train_on_eos_none(self):
+        """train_on_eos=none disables the end-marker contribution entirely."""
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[100, 1, 2, 3, 200, 9]]
+        _assert_equiv(boundaries, seq, ["assistant"], "none")
+
+    def test_train_on_eos_last_only_final_turn_unmasked(self):
+        """Only the last trainable turn's end marker contributes."""
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        # Three assistant turns. Only the last 200 should be unmasked.
+        seq = [[100, 1, 200, 100, 2, 200, 100, 3, 200, 9, 9]]
+        _assert_equiv(boundaries, seq, ["assistant"], "last")
+
+    def test_empty_end_tokens_runs_to_eos(self):
+        """end_tokens=[] means the span runs to end-of-sequence."""
+        boundaries = [RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[])]
+        seq = [[100, 1, 2, 3, 4, 5]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_include_start_true(self):
+        boundaries = [
+            RoleBoundary(
+                role="assistant",
+                start_tokens=[100, 101],
+                end_tokens=[200],
+                include_start=True,
+                include_end=True,
+            )
+        ]
+        seq = [[100, 101, 5, 6, 7, 200]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_non_trainable_role_end_marker_leak_gate(self):
+        """Non-trainable role with include_end=True, train_on_eos=all → end is unmasked."""
+        boundaries = [
+            RoleBoundary(
+                role="user",
+                start_tokens=[100],
+                end_tokens=[200],
+                include_start=False,
+                include_end=True,
+            ),
+            RoleBoundary(
+                role="assistant",
+                start_tokens=[101],
+                end_tokens=[201],
+                include_start=False,
+                include_end=True,
+            ),
+        ]
+        seq = [[100, 1, 2, 200, 101, 3, 4, 201]]
+        # roles_to_train=["assistant"] but train_on_eos="all" → user's end (200) leaks in
+        _assert_equiv(boundaries, seq, ["assistant"], "all")
+
+    def test_non_trainable_role_include_end_false_no_leak(self):
+        """Non-trainable role with include_end=False, train_on_eos=all → no leak."""
+        boundaries = [
+            RoleBoundary(
+                role="user",
+                start_tokens=[100],
+                end_tokens=[200],
+                include_start=False,
+                include_end=False,
+            ),
+            RoleBoundary(
+                role="assistant",
+                start_tokens=[200],  # shared with user-end
+                end_tokens=[201],
+            ),
+        ]
+        seq = [[100, 1, 2, 200, 3, 4, 201]]
+        _assert_equiv(boundaries, seq, ["assistant"], "all")
+
+    def test_truncated_final_turn_no_end(self):
+        """Final assistant turn missing end marker — span runs to end."""
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[100, 1, 2, 3, 4, 5, 6]]  # no 200 anywhere
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_all_pad_row(self):
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[0, 0, 0, 0, 0, 0]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_single_token_row(self):
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[100]]  # start with no end & no content
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_empty_roles_to_train_masks_all(self):
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        seq = [[100, 1, 2, 200, 100, 3, 4, 200]]
+        _assert_equiv(boundaries, seq, [], "turn")
+
+    def test_adversarial_first_token_collision(self):
+        """A bare token equal to start_tokens[0] inside filler must not trigger
+        a partial match (multi-token start_tokens needed)."""
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100, 200], end_tokens=[201])
+        ]
+        # 100 appears in filler (alone, not followed by 200) → must NOT match.
+        seq = [[100, 200, 5, 6, 100, 7, 8, 201, 100, 200, 9, 10, 201]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_batch_of_mixed_rows(self):
+        boundaries = [
+            RoleBoundary(role="assistant", start_tokens=[100], end_tokens=[200])
+        ]
+        # Three rows with different shapes.
+        seq = [
+            [100, 1, 2, 200, 0, 0, 0, 0],
+            [100, 3, 4, 5, 6, 200, 0, 0],
+            [9, 9, 100, 7, 200, 9, 9, 9],
+        ]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2-ish: Boundary-shape catalog (real-model-like configs)
+# --------------------------------------------------------------------------- #
+
+
+def _gemma4_like():
+    """Gemma 4: <start_of_turn>role ... <end_of_turn>."""
+    SOT, EOT = 50, 60
+    return [
+        RoleBoundary(role="user", start_tokens=[SOT, 70], end_tokens=[EOT]),
+        RoleBoundary(role="assistant", start_tokens=[SOT, 71], end_tokens=[EOT]),
+        RoleBoundary(role="system", start_tokens=[SOT, 72], end_tokens=[EOT]),
+    ]
+
+
+def _llama32v_like():
+    """Llama 3.2 V: <|start_header_id|>role<|end_header_id|> ... <|eot_id|>."""
+    SHID, EHID, EOT = 80, 81, 82
+    return [
+        RoleBoundary(role="user", start_tokens=[SHID, 90, EHID], end_tokens=[EOT]),
+        RoleBoundary(role="assistant", start_tokens=[SHID, 91, EHID], end_tokens=[EOT]),
+        RoleBoundary(role="system", start_tokens=[SHID, 92, EHID], end_tokens=[EOT]),
+    ]
+
+
+def _llama4_like():
+    """Llama 4-style: similar to llama3 but 4 roles."""
+    SHID, EHID, EOT = 80, 81, 82
+    return [
+        RoleBoundary(role="user", start_tokens=[SHID, 90, EHID], end_tokens=[EOT]),
+        RoleBoundary(role="assistant", start_tokens=[SHID, 91, EHID], end_tokens=[EOT]),
+        RoleBoundary(role="system", start_tokens=[SHID, 92, EHID], end_tokens=[EOT]),
+        RoleBoundary(role="tool", start_tokens=[SHID, 93, EHID], end_tokens=[EOT]),
+    ]
+
+
+def _pixtral_like():
+    """Pixtral: shared [/INST] between user-end and assistant-start, EOS terminates."""
+    INST_O, INST_C, EOS = 100, 200, 2
+    return [
+        RoleBoundary(
+            role="user",
+            start_tokens=[INST_O],
+            end_tokens=[INST_C],
+            include_start=False,
+            include_end=False,
+        ),
+        RoleBoundary(
+            role="assistant",
+            start_tokens=[INST_C],
+            end_tokens=[EOS],
+            include_start=False,
+            include_end=True,
+        ),
+    ]
+
+
+def _mistralv7_like():
+    """Mistral V7 Tekken-ish: similar shared [/INST] pattern with system."""
+    INST_O, INST_C, EOS, SYS = 100, 200, 2, 110
+    return [
+        RoleBoundary(
+            role="system",
+            start_tokens=[SYS],
+            end_tokens=[INST_O],
+            include_start=False,
+            include_end=False,
+        ),
+        RoleBoundary(
+            role="user",
+            start_tokens=[INST_O],
+            end_tokens=[INST_C],
+            include_start=False,
+            include_end=False,
+        ),
+        RoleBoundary(
+            role="assistant",
+            start_tokens=[INST_C],
+            end_tokens=[EOS],
+            include_start=False,
+            include_end=True,
+        ),
+    ]
+
+
+BOUNDARY_CATALOG = {
+    "gemma4": _gemma4_like,
+    "llama32v": _llama32v_like,
+    "llama4": _llama4_like,
+    "pixtral": _pixtral_like,
+    "mistralv7": _mistralv7_like,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1: Differential fuzz test
+# --------------------------------------------------------------------------- #
+
+
+def _build_random_sequence(
+    rng: random.Random,
+    boundaries: list[RoleBoundary],
+    seq_len: int,
+    pad_id: int = 0,
+) -> list[int]:
+    """Build a plausible sequence by alternating turns until we hit seq_len.
+
+    Uses random filler tokens that *don't* collide with any marker. ~5% of
+    fillers are pathologically chosen as adversarial collisions: a single
+    token equal to start_tokens[0] (so that multi-token starts don't match
+    but the first byte does).
+    """
+    # Build a vocab of "safe" filler tokens that don't collide with any
+    # start_tokens prefix.
+    marker_tokens: set[int] = set()
+    for b in boundaries:
+        marker_tokens.update(b.start_tokens)
+        marker_tokens.update(b.end_tokens)
+    safe_filler = [t for t in range(300, 500) if t not in marker_tokens]
+
+    seq: list[int] = []
+    while len(seq) < seq_len:
+        # Pick a boundary at random; emit start + filler + (sometimes) end.
+        b = rng.choice(boundaries)
+        seq.extend(b.start_tokens)
+        filler_n = rng.randint(5, min(200, max(5, seq_len - len(seq))))
+        for _ in range(filler_n):
+            if rng.random() < 0.05 and safe_filler:
+                # Adversarial: emit a token that equals a marker's first byte
+                # but isn't followed by the rest. Picks from any boundary.
+                bb = rng.choice(boundaries)
+                if bb.start_tokens:
+                    seq.append(bb.start_tokens[0])
+                    continue
+            seq.append(rng.choice(safe_filler))
+
+        # 80% chance of a clean end. (Truncated turns intentional.)
+        if rng.random() < 0.8 and b.end_tokens:
+            seq.extend(b.end_tokens)
+
+    seq = seq[:seq_len]
+    # Pad up if we underran.
+    while len(seq) < seq_len:
+        seq.append(pad_id)
+    return seq
+
+
+@pytest.mark.parametrize(
+    "shape_name",
+    ["gemma4", "llama32v", "llama4", "pixtral", "mistralv7"],
+)
+def test_catalog_smoke_per_shape(shape_name):
+    """Smoke test: each catalog shape works on a small batch."""
+    boundaries = BOUNDARY_CATALOG[shape_name]()
+    rng = random.Random(0xCAFE)
+    rows = [_build_random_sequence(rng, boundaries, 256) for _ in range(4)]
+    _assert_equiv(boundaries, rows, ["assistant"], "turn")
+    _assert_equiv(boundaries, rows, ["assistant", "user"], "all")
+    _assert_equiv(boundaries, rows, [], "none")
+    _assert_equiv(boundaries, rows, ["assistant"], "last")
+
+
+def test_differential_fuzz_2000_configs():
+    """Run 2000 random configurations and verify byte-identical outputs.
+
+    Uses fixed seeds 0..1999 so any failure is deterministically reproducible.
+    """
+    failures: list[tuple[int, str]] = []
+
+    BATCH_SIZES = [1, 2, 4, 8]
+    SEQ_LENS = [32, 256, 1024, 4096]
+    EOS_MODES = ["turn", "all", "none", "last"]
+    ROLES_OPTIONS = [
+        ["assistant"],
+        ["assistant", "user"],
+        [],
+        ["assistant", "system", "user"],
+    ]
+    SHAPES = list(BOUNDARY_CATALOG.keys())
+
+    N_CONFIGS = 2000
+
+    for seed in range(N_CONFIGS):
+        rng = random.Random(seed)
+        bs = rng.choice(BATCH_SIZES)
+        sl = rng.choice(SEQ_LENS)
+        eos = rng.choice(EOS_MODES)
+        rtt = rng.choice(ROLES_OPTIONS)
+        shape = rng.choice(SHAPES)
+        boundaries = BOUNDARY_CATALOG[shape]()
+
+        # Cap the largest pixtral-shape configs at 1024 to keep wall-time
+        # under control; the small/medium configs already cover the rewind.
+        if shape == "pixtral" and sl == 4096 and bs == 8:
+            sl = 1024
+
+        rows = [_build_random_sequence(rng, boundaries, sl) for _ in range(bs)]
+
+        try:
+            _assert_equiv(boundaries, rows, rtt, eos)
+        except AssertionError as e:
+            failures.append((seed, str(e)))
+            if len(failures) >= 5:
+                break
+
+    if failures:
+        joined = "\n\n---\n\n".join(f"seed={s}:\n{m}" for s, m in failures)
+        pytest.fail(
+            f"Differential fuzz: {len(failures)} mismatches in "
+            f"{N_CONFIGS} configs.\n\n{joined}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Pathological inputs aimed at the rewind logic specifically
+# --------------------------------------------------------------------------- #
+
+
+class TestPixtralRewindAdversarial:
+    def test_back_to_back_user_assistant_pairs(self):
+        boundaries = _pixtral_like()
+        # Five back-to-back turns.
+        seq = [
+            [
+                100,
+                1,
+                2,
+                200,
+                3,
+                4,
+                5,
+                2,  # turn 1
+                100,
+                6,
+                7,
+                200,
+                8,
+                9,
+                2,  # turn 2
+                100,
+                10,
+                11,
+                12,
+                200,
+                13,
+                14,
+                2,
+                100,
+                15,
+                200,
+                16,
+                2,
+                100,
+                17,
+                18,
+                19,
+                20,
+                200,
+                21,
+                22,
+                2,
+            ]
+        ]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_user_with_no_end_then_assistant(self):
+        """Truncated user — never closes — assistant never re-matches the [/INST]."""
+        boundaries = _pixtral_like()
+        seq = [[100, 1, 2, 3, 4, 5, 6]]  # no [/INST] anywhere
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+    def test_double_end_marker(self):
+        """Two [/INST] in a row — second one starts a (degenerate) assistant."""
+        boundaries = _pixtral_like()
+        seq = [[100, 1, 200, 200, 5, 6, 2]]
+        _assert_equiv(boundaries, seq, ["assistant"], "turn")

--- a/tests/test_vectorized_scanner.py
+++ b/tests/test_vectorized_scanner.py
@@ -538,3 +538,113 @@ class TestPixtralRewindAdversarial:
         boundaries = _pixtral_like()
         seq = [[100, 1, 200, 200, 5, 6, 2]]
         _assert_equiv(boundaries, seq, ["assistant"], "turn")
+
+
+# --------------------------------------------------------------------------- #
+# Long-span / multi-end-marker inputs aimed at the bisect end-finder
+# --------------------------------------------------------------------------- #
+
+
+def _build_long_multi_end_sequence(
+    rng: random.Random,
+    boundaries: list[RoleBoundary],
+    seq_len: int,
+    pad_id: int = 0,
+) -> list[int]:
+    """Like ``_build_random_sequence`` but with long turns that embed *multiple*
+    full end-marker copies inside one content region.
+
+    The vectorized scanner finds turn ends by bisecting a sorted list of
+    end-match positions for the next end >= start_of_content. Turns that carry
+    several full end markers (plus partial first-byte collisions) exercise the
+    "pick the first valid end, not the closest scanned" branch that a linear
+    walk would otherwise mask.
+    """
+    marker_tokens: set[int] = set()
+    for b in boundaries:
+        marker_tokens.update(b.start_tokens)
+        marker_tokens.update(b.end_tokens)
+    safe_filler = [t for t in range(300, 500) if t not in marker_tokens]
+
+    seq: list[int] = []
+    while len(seq) < seq_len:
+        b = rng.choice(boundaries)
+        seq.extend(b.start_tokens)
+        # Long filler so a turn can span well past the old 200-token cap.
+        filler_n = rng.randint(200, max(200, min(1500, seq_len - len(seq) + 200)))
+        for _ in range(filler_n):
+            r = rng.random()
+            if r < 0.04 and b.end_tokens:
+                # Full extra end marker mid-content: with include_end this closes
+                # the turn early; without it the rewind re-reads it as a start.
+                seq.extend(b.end_tokens)
+            elif r < 0.09 and safe_filler:
+                bb = rng.choice(boundaries)
+                if bb.start_tokens:
+                    seq.append(bb.start_tokens[0])  # partial first-byte collision
+                    continue
+                seq.append(rng.choice(safe_filler))
+            else:
+                seq.append(rng.choice(safe_filler))
+        if rng.random() < 0.8 and b.end_tokens:
+            seq.extend(b.end_tokens)
+
+    seq = seq[:seq_len]
+    while len(seq) < seq_len:
+        seq.append(pad_id)
+    return seq
+
+
+def test_bisect_first_end_in_span_explicit():
+    """Two full end markers inside one assistant turn: the span must close on the
+    first, leaving the second outside the trainable region."""
+    boundaries = _pixtral_like()  # [/INST] == [200], rewind on include_end=False
+    # assistant turn opens at [/INST] (200), content, end-of-turn (2) appears
+    # twice; the first 2 closes the turn, everything after is a fresh scan.
+    seq = [[100, 1, 2, 200, 5, 6, 7, 2, 9, 9, 9, 2, 100, 11, 200, 12, 2]]
+    _assert_equiv(boundaries, seq, ["assistant"], "turn")
+    _assert_equiv(boundaries, seq, ["assistant"], "all")
+    _assert_equiv(boundaries, seq, ["assistant"], "last")
+    _assert_equiv(boundaries, seq, ["assistant"], "none")
+
+
+def test_differential_fuzz_long_spans():
+    """500 configs with long, multi-end-marker turns over large sequences.
+
+    Targets the bisect end-finder and bytearray slice-fills, which the original
+    short-span fuzz (filler <= 200) under-exercises.
+    """
+    failures: list[tuple[int, str]] = []
+
+    BATCH_SIZES = [1, 2, 4]
+    SEQ_LENS = [1024, 2048, 4096]
+    EOS_MODES = ["turn", "all", "none", "last"]
+    ROLES_OPTIONS = [["assistant"], ["assistant", "user"], [], ["assistant", "system"]]
+    SHAPES = list(BOUNDARY_CATALOG.keys())
+
+    N_CONFIGS = 500
+
+    for seed in range(N_CONFIGS):
+        rng = random.Random(10_000 + seed)
+        bs = rng.choice(BATCH_SIZES)
+        sl = rng.choice(SEQ_LENS)
+        eos = rng.choice(EOS_MODES)
+        rtt = rng.choice(ROLES_OPTIONS)
+        shape = rng.choice(SHAPES)
+        boundaries = BOUNDARY_CATALOG[shape]()
+
+        rows = [_build_long_multi_end_sequence(rng, boundaries, sl) for _ in range(bs)]
+
+        try:
+            _assert_equiv(boundaries, rows, rtt, eos)
+        except AssertionError as e:
+            failures.append((seed, str(e)))
+            if len(failures) >= 5:
+                break
+
+    if failures:
+        joined = "\n\n---\n\n".join(f"seed={s}:\n{m}" for s, m in failures)
+        pytest.fail(
+            f"Long-span differential fuzz: {len(failures)} mismatches in "
+            f"{N_CONFIGS} configs.\n\n{joined}"
+        )


### PR DESCRIPTION
# Description

Follow-up to [#3625](https://github.com/axolotl-ai-cloud/axolotl/pull/3625) reducing the cost of multimodal assistant-only loss masking.

- Vectorized variant of the role-boundary scanner, gated on `torch.get_num_threads() == 1` (DataLoader-worker default). Byte-identical output to the reference scanner.
- Fused `process_labels`: role/pad/media masks combined into one boolean keep tensor with a single `labels[~keep] = -100` write.
- One-shot warning when `MultiModalChatDataCollator` is built with `dataloader_num_workers in (None, 0)` and masking is enabled.

## Motivation and Context

@NanoCode012 requested a performance review of #3625. Real-tokenizer bench under DataLoader-worker conditions vs updated vectorize approach:

| Tokenizer | bs=8 seq~3k | bs=8 seq~6k | Speedup |
|---|---|---|---|
| Gemma 3 | ref 4.41 → vec 2.89 ms | ref 8.75 → vec 5.87 ms | 1.49–1.53× |
| Gemma 4 | ref 4.44 → vec 3.35 ms | ref 8.73 → vec 6.53 ms | 1.33–1.36× |
| Qwen 2  | ref 4.46 → vec 3.29 ms | ref 8.77 → vec 6.45 ms | 1.35–1.36× |
| Llama 3 | ref 4.45 → vec 4.42 ms | ref 8.76 → vec 8.68 ms | tie |

Native `return_assistant_tokens_mask=True` was investigated and rejected: silent failure on right-padded multi-row batches in `ProcessorMixin.apply_chat_template` (bisect over non-monotonic offset_mapping), and ~10× slower end-to-end than the scanner.

## How has this been tested?

`pytest tests/test_processing_strategies.py tests/test_vectorized_scanner.py tests/test_process_labels_fusion.py tests/test_mm_collator_warnings.py` — 572 passing.

- `test_vectorized_scanner.py` — 2,000-config differential fuzz + edge cases (Pixtral `[/INST]` rewind, longest-prefix tie, `train_on_eos` modes, `include_end` leak gate).
- `test_process_labels_fusion.py` — 450 fuzz cases across all 9 `process_labels`-overriding strategies asserting `torch.equal` vs pre-refactor.
- successfully started Qwen3-VL masked multimodal training on forked venv 

## AI Usage Disclaimer

Yes. Claude Code (Opus 4.7) assisted throughout. 

## Types of changes

- [x] Performance / refactor
- [x] Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-time warning notification for multimodal training when dataloader worker configuration is unset or zero.

* **Improvements**
  * Enhanced label processing with optimized masking strategies and vectorized operations for improved efficiency across model variants.

* **Tests**
  * Added comprehensive test suites for configuration warnings, label processing parity validation across multiple model strategies, and vectorized masking operations with edge-case and differential fuzzing coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->