### PR TITLE
fix: ep test missed teardown

### DIFF
--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -180,6 +180,10 @@ class TestShardingSingleRank:
             os.environ.setdefault("WORLD_SIZE", "1")
             dist.init_process_group(backend="gloo", rank=0, world_size=1)
 
+    def teardown_method(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
     def test_no_op_at_world_size_1(self):
         block = _build_qwen3moe_block(num_experts=16)
         original_shape = tuple(block.experts.gate_up_proj.shape)

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -1,6 +1,7 @@
 """Tests for the Expert-Parallel (DeepEP) integration."""
 
 import os
+import socket
 from importlib.util import find_spec
 
 import pytest
@@ -341,13 +342,20 @@ def _ep_topology_worker_expects_error(
         ExpertParallelPlugin._device_mesh = None
 
 
-def _spawn_topology_check(world_size, ep_size, dp_shard_size, port_base):
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _spawn_topology_check(world_size, ep_size, dp_shard_size):
     ctx = mp.get_context("spawn")
     q = ctx.Queue()
+    port = _find_free_port()
     procs = [
         ctx.Process(
             target=_ep_topology_worker,
-            args=(r, world_size, ep_size, dp_shard_size, port_base, q),
+            args=(r, world_size, ep_size, dp_shard_size, port, q),
         )
         for r in range(world_size)
     ]
@@ -367,10 +375,7 @@ class TestMeshTopology:
         """At world=4 with ep=2 and dp_shard=2, EP groups must be strided
         ({0,2}, {1,3}) and dp_shard groups contiguous ({0,1}, {2,3}).
         """
-        # Use large random-ish port base to avoid collision with anything else.
-        results = _spawn_topology_check(
-            world_size=4, ep_size=2, dp_shard_size=2, port_base=37610
-        )
+        results = _spawn_topology_check(world_size=4, ep_size=2, dp_shard_size=2)
         # Build per-rank groupings from results.
         ep_groups_by_rank = {r: tuple(eps) for r, eps, _ in results}
         dp_groups_by_rank = {r: tuple(dps) for r, _, dps in results}
@@ -389,9 +394,7 @@ class TestMeshTopology:
 
     def test_world4_ep4_dp1_uses_world(self):
         """ep_size == world_size short-circuits to dist.group.WORLD."""
-        results = _spawn_topology_check(
-            world_size=4, ep_size=4, dp_shard_size=1, port_base=37710
-        )
+        results = _spawn_topology_check(world_size=4, ep_size=4, dp_shard_size=1)
         for rank, ep_ranks, dp_ranks in results:
             assert ep_ranks == [0, 1, 2, 3], (rank, ep_ranks)
             assert dp_ranks is None  # no 2D mesh built
@@ -400,10 +403,11 @@ class TestMeshTopology:
         """ep<world without dp_shard filling the rest must raise (product mismatch)."""
         ctx = mp.get_context("spawn")
         q = ctx.Queue()
+        port = _find_free_port()
         procs = [
             ctx.Process(
                 target=_ep_topology_worker_expects_error,
-                args=(r, 4, 2, 1, 37810, q),
+                args=(r, 4, 2, 1, port, q),
             )
             for r in range(4)
         ]
@@ -422,10 +426,11 @@ class TestMeshTopology:
         """world=4 with ep=2*dp=4 (product 8 != 4) raises clearly."""
         ctx = mp.get_context("spawn")
         q = ctx.Queue()
+        port = _find_free_port()
         procs = [
             ctx.Process(
                 target=_ep_topology_worker_expects_error,
-                args=(r, 4, 2, 4, 37910, q),
+                args=(r, 4, 2, 4, port, q),
             )
             for r in range(4)
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Worker could have the xdist state continued and break other test.  This PR makes sure to teardown.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup and resource management to enhance test reliability and ensure proper isolation between test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->