### PR TITLE
fix broken MX tests from transformers 5.8.1 upgrade

### DIFF
--- a/cicd/cicd.sh
+++ b/cicd/cicd.sh
@@ -43,8 +43,17 @@ pytest --full-trace -vvv --durations=10 \
   --cov-append
 
 # Run solo tests with coverage append
+# test_rm_lora is run in its own process below (it fails on py3.11 when sharing
+# the solo process with other tests; isolating it avoids cross-test state).
 pytest -v --durations=10 -n1 \
+  --ignore=tests/e2e/solo/test_reward_model_smollm2.py \
   /workspace/axolotl/tests/e2e/solo/ \
+  --cov=axolotl \
+  --cov-append
+
+# Run reward-model test isolated in its own process
+pytest -v --durations=10 -s \
+  /workspace/axolotl/tests/e2e/solo/test_reward_model_smollm2.py \
   --cov=axolotl \
   --cov-append
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -223,11 +223,15 @@ class ModelLoader:
 
         # MX-quantized checkpoints carry MXTensor weights but no HF quantizer, so
         # transformers' load-time weight re-init would crash on them; this guards it.
-        from axolotl.utils.quantization import (
-            patch_transformers_skip_quantized_init,
-        )
+        # torchao is absent on macOS/aarch64, where MX checkpoints can't exist anyway.
+        try:
+            from axolotl.utils.quantization import (
+                patch_transformers_skip_quantized_init,
+            )
 
-        patch_transformers_skip_quantized_init()
+            patch_transformers_skip_quantized_init()
+        except ImportError:
+            pass
 
     def _apply_post_model_load_setup(self):
         """Configure the model after it has been loaded."""

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -245,10 +245,52 @@ class ModelLoader:
         self._configure_experts_implementation()
         self._apply_activation_checkpointing()
         self._resize_token_embeddings()
+        self._reinitialize_classification_head()
         self._adjust_model_config()
         self._configure_embedding_dtypes()
         self._configure_qat()
         log_gpu_memory_usage(LOG, "Memory usage after model load", 0)
+
+    def _reinitialize_classification_head(self):
+        """Re-init an uninitialized reward / PRM classification head.
+
+        The ``score``/``classifier`` head is missing from a base-LM checkpoint, so
+        transformers allocates it with ``torch.empty`` and is then supposed to
+        initialize it. But transformers 5.8's ``_init_weights`` does
+        ``init.normal_(module.weight.float(), ...)`` — the ``.float()`` copy makes
+        this a no-op on a ``bfloat16`` head, leaving uninitialized memory: harmless
+        zeros on some allocators, NaN/inf garbage on others (→ NaN grads, 0 loss).
+        Detect that state and initialize the head ourselves.
+        """
+        if not (self.cfg.reward_model or self.cfg.process_reward_model):
+            return
+
+        head = getattr(self.model, "score", None) or getattr(
+            self.model, "classifier", None
+        )
+        if not isinstance(head, torch.nn.Linear):
+            return
+
+        weight = head.weight
+        # A freshly-initialized head is all-zero (benign) or garbage (huge/non-finite);
+        # a head loaded from a real reward checkpoint is finite and reasonably scaled.
+        looks_uninitialized = (
+            not torch.isfinite(weight).all()
+            or weight.abs().max() > 100
+            or bool((weight == 0).all())
+        )
+        if not looks_uninitialized:
+            return
+
+        std = getattr(self.model.config, "initializer_range", 0.02) or 0.02
+        with torch.no_grad():
+            weight.normal_(mean=0.0, std=std)
+            if head.bias is not None:
+                head.bias.zero_()
+        LOG.info(
+            f"Re-initialized {type(self.model).__name__} classification head "
+            f"(std={std})."
+        )
 
     def _configure_experts_implementation(self):
         if self.cfg.experts_implementation is not None:

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -221,6 +221,14 @@ class ModelLoader:
         self._set_attention_config()
         self._check_model_requirements()
 
+        # MX-quantized checkpoints carry MXTensor weights but no HF quantizer, so
+        # transformers' load-time weight re-init would crash on them; this guards it.
+        from axolotl.utils.quantization import (
+            patch_transformers_skip_quantized_init,
+        )
+
+        patch_transformers_skip_quantized_init()
+
     def _apply_post_model_load_setup(self):
         """Configure the model after it has been loaded."""
         # Handle PeftModel if needed

--- a/src/axolotl/utils/quantization.py
+++ b/src/axolotl/utils/quantization.py
@@ -2,6 +2,8 @@
 Utilities for quantization including QAT and PTQ using torchao.
 """
 
+import functools
+
 import torch
 from packaging import version
 from torchao.core.config import AOBaseConfig
@@ -164,6 +166,39 @@ def _attach_torchao_quantizer(
     model.hf_quantizer = quantizer
 
 
+def patch_transformers_skip_quantized_init():
+    """Stop ``from_pretrained`` from re-initializing torchao-quantized weights.
+
+    transformers re-runs ``_init_weights`` on every module during loading; the
+    generic implementation does ``init.normal_(module.weight.float(), ...)``.
+    ``.float()`` on a torchao tensor subclass (e.g. ``MXTensor``) returns a new
+    tensor that both drops the ``_is_hf_initialized`` skip flag and does not
+    implement ``normal_``, so loading an MX checkpoint raises NotImplementedError.
+    Re-initializing an already-loaded quantized weight is never correct, so we
+    skip those modules entirely.
+    """
+    from torchao.utils import TorchAOBaseTensor
+    from transformers import PreTrainedModel
+
+    if getattr(PreTrainedModel._initialize_weights, "_axolotl_torchao_patched", False):
+        return
+
+    original = PreTrainedModel._initialize_weights
+
+    @functools.wraps(original)
+    def _initialize_weights(self, module, *args, **kwargs):
+        if any(
+            isinstance(param, TorchAOBaseTensor)
+            for param in module.parameters(recurse=False)
+        ):
+            module._is_hf_initialized = True
+            return None
+        return original(self, module, *args, **kwargs)
+
+    _initialize_weights._axolotl_torchao_patched = True
+    PreTrainedModel._initialize_weights = _initialize_weights
+
+
 def quantize_model(
     model,
     weight_dtype: TorchAOQuantDType,
@@ -214,6 +249,9 @@ def quantize_model(
         # cannot serialize it.  Mark the model so the caller can use
         # safe_serialization=False (torch.save) which supports __tensor_flatten__.
         model._is_mx_quantized = True
+        # MX checkpoints reload via plain from_pretrained (no HF quantizer), so guard
+        # transformers' weight re-init against the MXTensor weights it will encounter.
+        patch_transformers_skip_quantized_init()
     else:
         _attach_torchao_quantizer(
             model,

--- a/tests/e2e/solo/test_reward_model_smollm2.py
+++ b/tests/e2e/solo/test_reward_model_smollm2.py
@@ -9,7 +9,7 @@ from axolotl.train import train
 from axolotl.utils.config import normalize_config, validate_config
 from axolotl.utils.dict import DictDefault
 
-from .utils import check_model_output_exists, check_tensorboard, with_temp_dir
+from ..utils import check_model_output_exists, check_tensorboard, with_temp_dir
 
 
 class TestRewardModelLoraSmolLM2(unittest.TestCase):

--- a/tests/e2e/test_quantization.py
+++ b/tests/e2e/test_quantization.py
@@ -480,6 +480,58 @@ class TestMXQuantizeSaveLoad:
         loaded_keys = set(loaded.state_dict().keys())
         assert original_keys == loaded_keys
 
+    @require_torch_2_8_0
+    def test_mxfp4_cross_process_load(self, tmp_path):
+        """A saved MX checkpoint loads in a fresh interpreter that never quantized.
+
+        The other tests call ``quantize_model`` in-process, which installs the
+        transformers init guard as a side effect, masking the real reload path.
+        Here we save, then load in a subprocess that only installs the guard the
+        way ``ModelLoader._apply_pre_model_load_setup`` does — no ``quantize_model``.
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        model = self._make_tiny_model()
+        save_dir = str(tmp_path / "mxfp4_xproc_model")
+        quantize_model(model, TorchAOQuantDType.mxfp4, 32)
+        save_quantized_model(model, save_dir)
+
+        script = textwrap.dedent(
+            f"""
+            import torch
+            from torch import nn
+            from transformers import AutoModelForCausalLM
+            # mirrors ModelLoader._apply_pre_model_load_setup (no quantize_model here)
+            from axolotl.utils.quantization import (
+                patch_transformers_skip_quantized_init,
+            )
+
+            patch_transformers_skip_quantized_init()
+            model = AutoModelForCausalLM.from_pretrained(
+                {save_dir!r}, dtype=torch.bfloat16
+            )
+            from torchao.prototype.mx_formats.mx_tensor import MXTensor
+            assert any(
+                isinstance(m.weight, MXTensor)
+                for m in model.modules()
+                if isinstance(m, nn.Linear)
+            ), "expected MXTensor weights after reload"
+            print("CROSS_PROCESS_LOAD_OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert "CROSS_PROCESS_LOAD_OK" in result.stdout, (
+            f"cross-process MX load failed:\nstdout={result.stdout}\n"
+            f"stderr={result.stderr[-2000:]}"
+        )
+
 
 class TestQuantizationCallback:
     """

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -196,7 +196,9 @@ def check_tensorboard(
     else:
         assert df.value.values[-1] < lt_val, assertion_err
     if gt_zero:
-        assert df.value.values[-1] > 1e-5, "Expected loss to be greater than zero"
+        assert df.value.values[-1] > 1e-5, (
+            f"Expected {tag} to be greater than zero, got {df.value.values[-1]}"
+        )
 
 
 def check_tensorboard_loss_decreased(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crashes when loading MX-quantized model checkpoints in fresh Python processes by preventing unnecessary weight re-initialization during model loading.

* **Tests**
  * Added test to verify MX-quantized checkpoints load correctly across process boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->