### PR TITLE
fix: shim Gemma4 use_kernels kernelize() crash on vision tower

### DIFF
--- a/examples/gemma4/26b-a4b-moe-qlora.yaml
+++ b/examples/gemma4/26b-a4b-moe-qlora.yaml
@@ -25,6 +25,12 @@ liger_glu_activation: true
 liger_rms_norm_gated: true
 strict: false
 
+# Multi-GPU (DDP) only: LoRA targets the text backbone, so the frozen vision/
+# audio encoders and Gemma4's KV-sharing layers leave some adapter params
+# without gradients. Required to avoid "parameters that were not used in
+# producing loss". No effect on single-GPU runs.
+ddp_find_unused_parameters: true
+
 chat_template: gemma4
 datasets:
   - path: mlabonne/FineTome-100k

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -352,6 +352,17 @@ class PatchManager:
 
     def _apply_model_specific_patches(self):
         """Apply patches specific to model architectures."""
+        if self.cfg.model_config_type == "gemma4" and self.cfg.use_kernels:
+            # transformers' Gemma4VisionAttention registers a bare function via
+            # @use_kernelized_func, which crashes model.kernelize() (triggered by
+            # use_kernels=True) when it tries to register_module() a non-Module.
+            # Strip the dead entry so kernelize() succeeds. The MoE itself is
+            # accelerated via the ExpertsInterface (experts_implementation),
+            # independent of this path.
+            from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+            patch_gemma4_kernelize()
+
         if (
             self.cfg.model_config_type == "llama4"
             and self.cfg.llama4_linearized_experts

--- a/src/axolotl/monkeypatch/gemma4_kernelize.py
+++ b/src/axolotl/monkeypatch/gemma4_kernelize.py
@@ -1,0 +1,113 @@
+"""Fix for transformers' Gemma 4 ``kernelize()`` crash under ``use_kernels``.
+
+In transformers, ``Gemma4VisionAttention`` is decorated with
+``@use_kernelized_func(apply_rotary_pos_emb)`` where ``apply_rotary_pos_emb``
+is a **plain function**, not a ``@use_kernel_func_from_hub``-wrapped kernel
+layer. That decorator stashes the bare function in each instance's
+``_hidden_kernels`` dict.
+
+When ``use_kernels=True`` (which axolotl's ``KernelsArgs`` force-enables for the
+ScatterMoE path), ``from_pretrained`` calls ``model.kernelize()``, whose
+``attach_hidden_kernels`` step does ``module.register_module(name, fn)`` for each
+``_hidden_kernels`` entry. ``register_module`` rejects a non-``nn.Module``::
+
+    TypeError: ...apply_rotary_pos_emb is not a Module subclass
+
+and the ``finally``-block cleanup then raises the visible::
+
+    AttributeError: 'Gemma4VisionAttention' object has no attribute apply_rotary_pos_emb
+
+This is a transformers bug, not Gemma4-specific in spirit (qwen3_moe avoids it
+by wrapping the func with ``@use_kernel_func_from_hub`` so a Module-like ``Func``
+is registered). Notably, ``Gemma4VisionAttention.forward`` calls
+``apply_multidimensional_rope`` and never references ``apply_rotary_pos_emb``, so
+the registered entry is dead weight — dropping the non-Module ``_hidden_kernels``
+entries makes ``kernelize()`` a no-op for vision attention with zero behavior
+change.
+
+The patch wraps ``Gemma4VisionAttention.__init__`` to strip any non-``nn.Module``
+``_hidden_kernels`` entries after construction. Properly-wrapped (Module) entries,
+including ones a fixed transformers might introduce, are left intact, so the patch
+is forward-compatible. Idempotent; install before the model is built.
+"""
+
+from __future__ import annotations
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+_PATCH_APPLIED = False
+
+
+def patch_gemma4_kernelize() -> bool:
+    """Strip dead non-Module ``_hidden_kernels`` entries on ``Gemma4VisionAttention``.
+
+    Returns ``True`` if the patch is installed (or already was), ``False`` if the
+    target class could not be imported (e.g. transformers predates Gemma 4) — in
+    which case nothing is done and the caller can continue unaffected.
+    """
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return True
+
+    try:
+        from transformers.models.gemma4 import modeling_gemma4
+    except ImportError:
+        LOG.debug(
+            "gemma4_kernelize: transformers.models.gemma4 not importable, "
+            "skipping. This is fine for non-Gemma4 training."
+        )
+        return False
+
+    cls = getattr(modeling_gemma4, "Gemma4VisionAttention", None)
+    if cls is None:
+        LOG.warning(
+            "gemma4_kernelize: modeling_gemma4 has no 'Gemma4VisionAttention', "
+            "skipping. Transformers API may have changed."
+        )
+        return False
+
+    import torch.nn as nn
+
+    orig_init = cls.__init__
+
+    def init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        hidden_kernels = self.__dict__.get("_hidden_kernels")
+        if hidden_kernels:
+            stale = [
+                name
+                for name, fn in hidden_kernels.items()
+                if not isinstance(fn, nn.Module)
+            ]
+            for name in stale:
+                del hidden_kernels[name]
+
+    # Preserve the original for teardown / idempotency checks.
+    init._axolotl_original = orig_init  # type: ignore[attr-defined]
+    cls.__init__ = init
+    _PATCH_APPLIED = True
+    LOG.info(
+        "gemma4_kernelize: patched Gemma4VisionAttention to drop non-Module "
+        "_hidden_kernels entries so use_kernels/kernelize() does not crash"
+    )
+    return True
+
+
+def unpatch_gemma4_kernelize() -> None:
+    """Restore the original ``Gemma4VisionAttention.__init__``. Useful for tests."""
+    global _PATCH_APPLIED
+    if not _PATCH_APPLIED:
+        return
+    try:
+        from transformers.models.gemma4 import modeling_gemma4
+    except ImportError:
+        _PATCH_APPLIED = False
+        return
+    cls = getattr(modeling_gemma4, "Gemma4VisionAttention", None)
+    if cls is not None:
+        original = getattr(cls.__init__, "_axolotl_original", None)
+        if original is not None:
+            cls.__init__ = original
+    _PATCH_APPLIED = False

--- a/tests/monkeypatch/test_gemma4_kernelize.py
+++ b/tests/monkeypatch/test_gemma4_kernelize.py
@@ -1,0 +1,196 @@
+"""Tests for the Gemma 4 ``kernelize()`` / ``use_kernels`` crash fix.
+
+transformers decorates ``Gemma4VisionAttention`` with
+``@use_kernelized_func(apply_rotary_pos_emb)`` where the target is a plain
+function. Under ``use_kernels=True``, ``model.kernelize()`` then tries to
+``register_module()`` that function and crashes with::
+
+    TypeError: ...apply_rotary_pos_emb is not a Module subclass
+
+(and a follow-on ``AttributeError`` from the cleanup path). The patch strips the
+dead non-Module ``_hidden_kernels`` entry so ``kernelize()`` succeeds. The entry
+is never read by ``Gemma4VisionAttention.forward`` (which uses
+``apply_multidimensional_rope``), so removing it is behavior-neutral.
+"""
+
+import pytest
+
+pytest.importorskip(
+    "transformers.models.gemma4",
+    reason="gemma4_kernelize patch only matters when Gemma 4 is available",
+)
+
+
+@pytest.fixture
+def restore_gemma4_vision_attention():
+    """Snapshot ``Gemma4VisionAttention.__init__`` and reset patch state after
+    each test so patch state doesn't leak across the suite."""
+    from transformers.models.gemma4 import modeling_gemma4
+
+    saved_init = modeling_gemma4.Gemma4VisionAttention.__init__
+    yield modeling_gemma4
+    modeling_gemma4.Gemma4VisionAttention.__init__ = saved_init
+    from axolotl.monkeypatch import gemma4_kernelize
+
+    gemma4_kernelize._PATCH_APPLIED = False
+
+
+def _vision_config():
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+    return Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+    )
+
+
+def test_patch_installs_and_is_idempotent(restore_gemma4_vision_attention):
+    from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+    assert patch_gemma4_kernelize() is True
+    init_first = restore_gemma4_vision_attention.Gemma4VisionAttention.__init__
+    # Second call must not re-wrap.
+    assert patch_gemma4_kernelize() is True
+    init_second = restore_gemma4_vision_attention.Gemma4VisionAttention.__init__
+    assert init_first is init_second
+    assert hasattr(init_first, "_axolotl_original")
+
+
+def test_patch_strips_non_module_hidden_kernels(restore_gemma4_vision_attention):
+    modeling_gemma4 = restore_gemma4_vision_attention
+    from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+    cfg = _vision_config()
+
+    # Before the patch, the bare function is registered (the crash source).
+    attn_before = modeling_gemma4.Gemma4VisionAttention(cfg, layer_idx=0)
+    assert "apply_rotary_pos_emb" in getattr(attn_before, "_hidden_kernels", {})
+
+    patch_gemma4_kernelize()
+    attn_after = modeling_gemma4.Gemma4VisionAttention(cfg, layer_idx=0)
+    assert dict(getattr(attn_after, "_hidden_kernels", {})) == {}
+
+
+def test_register_module_path_no_longer_crashes(restore_gemma4_vision_attention):
+    """The exact step that crashed: kernelize()'s ``attach_hidden_kernels``
+    does ``register_module(name, fn)`` for each ``_hidden_kernels`` entry."""
+    modeling_gemma4 = restore_gemma4_vision_attention
+    from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+    cfg = _vision_config()
+    patch_gemma4_kernelize()
+    attn = modeling_gemma4.Gemma4VisionAttention(cfg, layer_idx=0)
+
+    # Replicate attach_hidden_kernels; with the entry stripped there is nothing
+    # to (mis)register, so this must not raise.
+    for name, fn in getattr(attn, "_hidden_kernels", {}).items():
+        if name not in dict(attn.named_children()):
+            attn.register_module(name, fn)
+
+
+def test_patch_does_not_alter_weights(restore_gemma4_vision_attention):
+    """The shim only mutates ``_hidden_kernels``; parameters are untouched."""
+    import torch
+
+    modeling_gemma4 = restore_gemma4_vision_attention
+    from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+    cfg = _vision_config()
+    torch.manual_seed(0)
+    before = modeling_gemma4.Gemma4VisionAttention(cfg, layer_idx=0).state_dict()
+
+    patch_gemma4_kernelize()
+    torch.manual_seed(0)
+    after = modeling_gemma4.Gemma4VisionAttention(cfg, layer_idx=0).state_dict()
+
+    assert before.keys() == after.keys()
+    assert all(torch.equal(before[k], after[k]) for k in before)
+
+
+def test_forward_does_not_reference_stripped_entry(restore_gemma4_vision_attention):
+    """Behavior-invariance guarantee: forward never reads the stripped names,
+    so dropping them cannot change the forward result."""
+    modeling_gemma4 = restore_gemma4_vision_attention
+    names = modeling_gemma4.Gemma4VisionAttention.forward.__code__.co_names
+    assert "apply_rotary_pos_emb" not in names
+    assert "_hidden_kernels" not in names
+
+
+def test_unpatch_restores_original(restore_gemma4_vision_attention):
+    modeling_gemma4 = restore_gemma4_vision_attention
+    from axolotl.monkeypatch.gemma4_kernelize import (
+        patch_gemma4_kernelize,
+        unpatch_gemma4_kernelize,
+    )
+
+    original = modeling_gemma4.Gemma4VisionAttention.__init__
+    patch_gemma4_kernelize()
+    assert modeling_gemma4.Gemma4VisionAttention.__init__ is not original
+    unpatch_gemma4_kernelize()
+    assert modeling_gemma4.Gemma4VisionAttention.__init__ is original
+
+
+def test_unpatch_is_safe_without_prior_patch(restore_gemma4_vision_attention):
+    from axolotl.monkeypatch.gemma4_kernelize import unpatch_gemma4_kernelize
+
+    # No-op, no exception.
+    unpatch_gemma4_kernelize()
+
+
+def test_full_model_kernelize_succeeds_with_patch(restore_gemma4_vision_attention):
+    """End-to-end: a tiny full Gemma4 model crashes in ``kernelize()`` without
+    the patch and succeeds with it. No real 26B weights or CUDA required."""
+    modeling_gemma4 = restore_gemma4_vision_attention
+    from transformers.models.gemma4.configuration_gemma4 import (
+        Gemma4AudioConfig,
+        Gemma4Config,
+        Gemma4TextConfig,
+        Gemma4VisionConfig,
+    )
+
+    from axolotl.monkeypatch.gemma4_kernelize import patch_gemma4_kernelize
+
+    def build():
+        text = Gemma4TextConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            vocab_size=128,
+            num_experts=4,
+            num_experts_per_tok=2,
+        )
+        vis = Gemma4VisionConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+        )
+        aud = Gemma4AudioConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+        )
+        cfg = Gemma4Config(text_config=text, vision_config=vis, audio_config=aud)
+        return modeling_gemma4.Gemma4ForConditionalGeneration(cfg)
+
+    # Without the patch, kernelize() crashes.
+    model = build()
+    model.train()
+    with pytest.raises((TypeError, AttributeError)):
+        model.kernelize()
+
+    # With the patch, it succeeds.
+    patch_gemma4_kernelize()
+    model = build()
+    model.train()
+    model.kernelize()


### PR DESCRIPTION
transformers decorates Gemma4VisionAttention with
@use_kernelized_func(apply_rotary_pos_emb) where the target is a bare function. Under use_kernels=True (force-enabled by KernelsArgs for the ScatterMoE path), from_pretrained calls model.kernelize(), whose attach_hidden_kernels step does register_module(name, fn) for each _hidden_kernels entry. register_module rejects the non-Module function:

    TypeError: ...apply_rotary_pos_emb is not a Module subclass

with a follow-on AttributeError from the cleanup path. The MoE itself is accelerated via the transformers ExpertsInterface (experts_implementation), independent of this path, and the vision forward uses apply_multidimensional_rope, never apply_rotary_pos_emb -- so the registered entry is dead weight.

Add monkeypatch gemma4_kernelize that strips non-Module _hidden_kernels entries from Gemma4VisionAttention, wired in
patch_manager._apply_model_specific_patches for gemma4 when use_kernels is set. state_dict is unchanged, so the fix is behavior-neutral.

Also add ddp_find_unused_parameters: true to the 26b-a4b MoE QLoRA example (multi-GPU only -- text-backbone LoRA plus KV-sharing layers leave some adapter params gradient-less under DDP).

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DDP multi-GPU training configuration with improved parameter gradient handling in distributed environments.

* **Bug Fixes**
  * Resolved crashes when Gemma4 model uses kernel optimization during training.

* **Tests**
  * Added comprehensive test suite validating Gemma4 kernel functionality and multi-GPU compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->