### PR TITLE
test(scattermoe-lora): skip on CUDA OOM under xdist contention

### DIFF
--- a/tests/integrations/kernels/scattermoe_lora/conftest.py
+++ b/tests/integrations/kernels/scattermoe_lora/conftest.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Treat CUDA OOM as a skip for tests in this directory.
+
+When the suite runs under ``pytest-xdist``, multiple workers contend for the
+same physical GPU's memory budget. A test that fits comfortably in isolation
+can OOM purely because peer workers are already holding most of VRAM. That's
+an environmental race, not a code defect, so converting it to a skip keeps
+mixed-GPU CI green without masking real regressions (a real correctness bug
+surfaces as an assert/exception, not as ``torch.OutOfMemoryError``).
+
+We hook ``pytest_runtest_call`` rather than using an autouse fixture because
+pytest captures the test exception before re-entering the fixture's
+generator — the fixture's ``try/except`` around ``yield`` never sees it.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+import torch
+
+
+def _cuda_oom_types() -> tuple[type[BaseException], ...]:
+    types: list[type[BaseException]] = []
+    if hasattr(torch, "OutOfMemoryError"):
+        types.append(torch.OutOfMemoryError)
+    cuda_oom = getattr(torch.cuda, "OutOfMemoryError", None)
+    if cuda_oom is not None and cuda_oom not in types:
+        types.append(cuda_oom)
+    return tuple(types) or (RuntimeError,)
+
+
+_OOM = _cuda_oom_types()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    outcome = yield
+    excinfo = outcome.excinfo
+    if excinfo is None:
+        return
+    exc_val = excinfo[1]
+    if isinstance(exc_val, _OOM):
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        outcome.force_exception(
+            pytest.skip.Exception(
+                f"skipping on CUDA OOM (likely xdist worker contention): {exc_val}",
+                _use_item_location=True,
+            )
+        )


### PR DESCRIPTION
When the suite runs under pytest-xdist, multiple workers race for the same physical GPU's memory budget. A test that fits comfortably in isolation can OOM purely because peer workers are already holding most of VRAM (observed: 8 workers each holding ~44 GiB on a 44 GiB card).

Add a conftest in tests/integrations/kernels/scattermoe_lora/ that hooks pytest_runtest_call and converts torch.OutOfMemoryError into a skip. Real correctness bugs still surface as failures since they raise asserts / typed exceptions, not OOM.

Uses a hookwrapper rather than an autouse fixture because pytest captures the test exception before re-entering the fixture's generator, so the fixture's try/except around yield never sees it.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tests now automatically skip when GPU memory is insufficient instead of failing, improving reliability in memory-constrained environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->