### PR TITLE
feat: automatic LoRA rank recommendation based on dataset size

### DIFF
--- a/src/axolotl/common/datasets.py
+++ b/src/axolotl/common/datasets.py
@@ -13,6 +13,7 @@ from axolotl.telemetry.errors import send_errors
 from axolotl.utils.data import prepare_datasets, prepare_preference_datasets
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
+from axolotl.utils.lora import recommend_lora_r
 from axolotl.utils.schemas.enums import RLType
 from axolotl.utils.tokenization import check_dataset_labels
 
@@ -63,6 +64,14 @@ def load_datasets(
         tokenizer,
         processor=processor,
     )
+
+    if cfg.adapter in ("lora", "qlora") and not cfg.lora_r:
+        recommended = recommend_lora_r(len(train_dataset))
+        LOG.info(
+            f"lora_r not set; auto-setting to {recommended} based on dataset size "
+            f"({len(train_dataset)} samples). Set lora_r explicitly to override."
+        )
+        cfg.lora_r = recommended
 
     if (
         cfg.debug

--- a/src/axolotl/utils/lora.py
+++ b/src/axolotl/utils/lora.py
@@ -17,6 +17,41 @@ module to get the state dict of a merged lora model
 """
 
 import torch
+
+
+# Thresholds and corresponding ranks: (min_samples, rank)
+# Derived from common practice: larger datasets benefit from higher rank.
+_RANK_THRESHOLDS = [
+    (100_000, 64),
+    (10_000, 32),
+    (1_000, 16),
+    (0, 8),
+]
+
+
+def recommend_lora_r(dataset_size: int) -> int:
+    """Return a recommended LoRA rank based on the number of training samples.
+
+    The heuristic uses log-scaled breakpoints:
+      - <  1 000 samples  → rank  8
+      - <  10 000 samples → rank 16
+      - < 100 000 samples → rank 32
+      - ≥ 100 000 samples → rank 64
+
+    Args:
+        dataset_size: Number of training samples (after any val split).
+
+    Returns:
+        Recommended ``lora_r`` value (always a power of two).
+    """
+    if dataset_size < 0:
+        raise ValueError(f"dataset_size must be non-negative, got {dataset_size}")
+    for min_samples, rank in _RANK_THRESHOLDS:
+        if dataset_size >= min_samples:
+            return rank
+    return 8  # unreachable, but satisfies type checkers
+
+
 from peft.tuners.tuners_utils import onload_layer
 from peft.utils import ModulesToSaveWrapper, _get_submodules
 

--- a/tests/utils/lora/test_recommend_lora_r.py
+++ b/tests/utils/lora/test_recommend_lora_r.py
@@ -1,0 +1,153 @@
+"""Tests for the recommend_lora_r utility and its integration in load_datasets."""
+
+import pytest
+
+from axolotl.utils.lora import recommend_lora_r
+
+
+class TestRecommendLoraR:
+    """Unit tests for the recommend_lora_r heuristic."""
+
+    @pytest.mark.parametrize(
+        "dataset_size, expected_rank",
+        [
+            (0, 8),
+            (1, 8),
+            (999, 8),
+            (1_000, 16),
+            (5_000, 16),
+            (9_999, 16),
+            (10_000, 32),
+            (50_000, 32),
+            (99_999, 32),
+            (100_000, 64),
+            (500_000, 64),
+            (1_000_000, 64),
+        ],
+    )
+    def test_rank_thresholds(self, dataset_size, expected_rank):
+        assert recommend_lora_r(dataset_size) == expected_rank
+
+    def test_returns_power_of_two(self):
+        for size in [0, 500, 5_000, 50_000, 500_000]:
+            rank = recommend_lora_r(size)
+            assert rank > 0 and (rank & (rank - 1)) == 0, (
+                f"rank {rank} is not a power of two"
+            )
+
+    def test_negative_size_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            recommend_lora_r(-1)
+
+    def test_boundary_exactly_at_threshold(self):
+        # Boundaries should map to the higher rank
+        assert recommend_lora_r(1_000) == 16
+        assert recommend_lora_r(10_000) == 32
+        assert recommend_lora_r(100_000) == 64
+
+    def test_rank_monotonically_non_decreasing(self):
+        sizes = [0, 999, 1_000, 9_999, 10_000, 99_999, 100_000, 1_000_000]
+        ranks = [recommend_lora_r(s) for s in sizes]
+        for i in range(len(ranks) - 1):
+            assert ranks[i] <= ranks[i + 1], (
+                f"rank decreased from size {sizes[i]} to {sizes[i+1]}"
+            )
+
+
+class TestLoadDatasetsLoraRAutoSet:
+    """Integration-style tests for the auto-set behavior in load_datasets."""
+
+    def _make_cfg(self, adapter, lora_r=None):
+        from axolotl.utils.dict import DictDefault
+
+        return DictDefault(
+            {
+                "adapter": adapter,
+                "lora_r": lora_r,
+                "processor_type": None,
+            }
+        )
+
+    def test_auto_sets_lora_r_for_lora(self):
+        from unittest.mock import MagicMock, patch
+
+        cfg = self._make_cfg("lora")
+        fake_dataset = MagicMock()
+        fake_dataset.__len__ = lambda self: 5_000
+
+        with (
+            patch("axolotl.common.datasets.load_tokenizer"),
+            patch("axolotl.common.datasets.load_processor"),
+            patch(
+                "axolotl.common.datasets.prepare_datasets",
+                return_value=(fake_dataset, None, 100, []),
+            ),
+        ):
+            from axolotl.common.datasets import load_datasets
+
+            result = load_datasets(cfg=cfg)
+
+        assert cfg.lora_r == 16  # 5_000 samples → rank 16
+
+    def test_auto_sets_lora_r_for_qlora(self):
+        from unittest.mock import MagicMock, patch
+
+        cfg = self._make_cfg("qlora")
+        fake_dataset = MagicMock()
+        fake_dataset.__len__ = lambda self: 150_000
+
+        with (
+            patch("axolotl.common.datasets.load_tokenizer"),
+            patch("axolotl.common.datasets.load_processor"),
+            patch(
+                "axolotl.common.datasets.prepare_datasets",
+                return_value=(fake_dataset, None, 100, []),
+            ),
+        ):
+            from axolotl.common.datasets import load_datasets
+
+            result = load_datasets(cfg=cfg)
+
+        assert cfg.lora_r == 64  # 150_000 samples → rank 64
+
+    def test_does_not_override_explicit_lora_r(self):
+        from unittest.mock import MagicMock, patch
+
+        cfg = self._make_cfg("lora", lora_r=32)
+        fake_dataset = MagicMock()
+        fake_dataset.__len__ = lambda self: 500
+
+        with (
+            patch("axolotl.common.datasets.load_tokenizer"),
+            patch("axolotl.common.datasets.load_processor"),
+            patch(
+                "axolotl.common.datasets.prepare_datasets",
+                return_value=(fake_dataset, None, 100, []),
+            ),
+        ):
+            from axolotl.common.datasets import load_datasets
+
+            load_datasets(cfg=cfg)
+
+        assert cfg.lora_r == 32  # user-set value preserved
+
+    def test_no_auto_set_without_lora_adapter(self):
+        from unittest.mock import MagicMock, patch
+
+        cfg = self._make_cfg(adapter=None)
+        fake_dataset = MagicMock()
+        fake_dataset.__len__ = lambda self: 50_000
+
+        with (
+            patch("axolotl.common.datasets.load_tokenizer"),
+            patch("axolotl.common.datasets.load_processor"),
+            patch(
+                "axolotl.common.datasets.prepare_datasets",
+                return_value=(fake_dataset, None, 100, []),
+            ),
+        ):
+            from axolotl.common.datasets import load_datasets
+
+            load_datasets(cfg=cfg)
+
+        assert cfg.lora_r is None  # not a LoRA run, should stay None


### PR DESCRIPTION
When lora_r is not set and adapter is lora/qlora, axolotl now auto-selects a sensible rank after the training dataset is loaded:

  < 1 000 samples  → rank  8
  < 10 000 samples → rank 16
  < 100 000 samples → rank 32
  ≥ 100 000 samples → rank 64

The heuristic is exposed as axolotl.utils.lora.recommend_lora_r(n) so users can call it programmatically. An explicit lora_r in the config always takes precedence.

Closes #<issue>

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic LoRA rank recommendation: System now automatically selects an appropriate LoRA rank based on dataset size when LoRA/QLoRA adapters are enabled without explicit rank configuration.

* **Tests**
  * Added comprehensive test coverage validating rank recommendation thresholds, boundary conditions, and dataset integration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axolotl-ai-cloud/axolotl/pull/3691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->