### PR TITLE
fix(gemma4): key shared KV by layer_type on transformers >=5.8

### DIFF
--- a/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
+++ b/src/axolotl/monkeypatch/models/gemma4/fused_attn.py
@@ -31,6 +31,19 @@ def _get_shared_kv_states():
     return _GEMMA4_SHARED_KV_STORE["store"]
 
 
+def _shared_kv_read_key(attn):
+    # transformers >=5.8 keys shared kv by layer_type; older builds used kv_shared_layer_index
+    if hasattr(attn, "kv_shared_layer_index"):
+        return attn.kv_shared_layer_index
+    return attn.layer_type
+
+
+def _shared_kv_store_key(attn):
+    if hasattr(attn, "kv_shared_layer_index"):
+        return attn.layer_idx
+    return attn.layer_type
+
+
 def _make_fused_forward(original_forward):
     """Create a patched forward that uses fused RMSNorm+RoPE kernels."""
 
@@ -85,7 +98,7 @@ def _make_fused_forward(original_forward):
 
         # ---- K/V path ----
         if self.is_kv_shared_layer:
-            key_states, value_states = shared_kv_states[self.kv_shared_layer_index]
+            key_states, value_states = shared_kv_states[_shared_kv_read_key(self)]
             key_states = key_states.to(query_states.device)
             value_states = value_states.to(query_states.device)
         else:
@@ -124,7 +137,7 @@ def _make_fused_forward(original_forward):
                 key_states, value_states, self.layer_idx
             )
         if self.store_full_length_kv:
-            shared_kv_states[self.layer_idx] = key_states, value_states
+            shared_kv_states[_shared_kv_store_key(self)] = key_states, value_states
 
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":

--- a/tests/monkeypatch/test_gemma4_fused_attn.py
+++ b/tests/monkeypatch/test_gemma4_fused_attn.py
@@ -170,6 +170,77 @@ class TestGemma4FusedAttnLoRACompose:
                 pass
 
 
+def _build_kv_shared_config():
+    """Hybrid Gemma 4 with ``num_kv_shared_layers > 0`` so the fused shared-KV branch runs."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    cfg = Gemma4TextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=4,
+        num_kv_shared_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=64,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        sliding_window=64,
+        max_position_embeddings=2048,
+        hidden_size_per_layer_input=16,
+        vocab_size_per_layer_input=128,
+        rope_parameters={
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+            "full_attention": {
+                "rope_type": "proportional",
+                "rope_theta": 1000000.0,
+                "partial_rotary_factor": 0.25,
+            },
+        },
+    )
+    cfg._attn_implementation = "sdpa"
+    return cfg
+
+
+class TestFusedAttnSharedKV:
+    """Regression: ``num_kv_shared_layers > 0`` hit the ``kv_shared_layer_index`` key removed in transformers>=5.8."""
+
+    def test_shared_kv_forward_backward(self, restore_gemma4_attention):
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
+
+        from axolotl.monkeypatch.models.gemma4.fused_attn import (
+            patch_gemma4_fused_attn,
+        )
+
+        torch.manual_seed(4)
+        m = Gemma4TextModel(_build_kv_shared_config()).cuda().to(torch.bfloat16).train()
+        assert any(layer.self_attn.is_kv_shared_layer for layer in m.layers), (
+            "test config must exercise at least one kv-shared layer"
+        )
+
+        ids = torch.randint(0, 128, (2, 16), device="cuda")
+        mask = torch.ones(2, 16, dtype=torch.long, device="cuda")
+
+        with torch.no_grad():
+            ref = m(input_ids=ids, attention_mask=mask).last_hidden_state.clone()
+
+        patch_gemma4_fused_attn()
+        out = m(input_ids=ids, attention_mask=mask).last_hidden_state
+        out.sum().backward()
+
+        assert out.shape == ref.shape
+        assert torch.isfinite(out).all()
+        cos_sim = torch.nn.functional.cosine_similarity(
+            ref.flatten().float(), out.detach().flatten().float(), dim=0
+        )
+        assert cos_sim > 0.999, f"shared-kv fused vs stock cosine_sim={cos_sim:.6f}"
+
+
 class TestFusedAttnSignature:
     """Pin the fused forward against the live ``Gemma4TextDecoderLayer.forward`` call shape."""
 


### PR DESCRIPTION
# Description

Fix Gemma4 KV-sharing fine-tuning on transformers >=5.8. The fused Gemma4 attention monkeypatch keyed `shared_kv_states` by `kv_shared_layer_index`/`layer_idx`, but transformers 5.8 removed `kv_shared_layer_index` and now keys by `layer_type`. The key is now derived from whichever attribute the installed transformers exposes, keeping both the old (<=5.5) and new (>=5.8) APIs working.

## Motivation and Context

On Axolotl v0.17.0 (pinned `transformers==5.9.0`), LoRA fine-tuning Gemma4 vision models (e.g. `gemma-4-E2B-it`, `gemma-4-E4B-it`) fails with `AttributeError: 'Gemma4TextAttention' object has no attribute 'kv_shared_layer_index'`. Only models with `num_kv_shared_layers > 0` hit it (E2B: 20/35 layers, E4B: 18/42); `gemma-4-31B-it` and `gemma-4-26B-A4B-it` have 0 shared layers and were unaffected. v0.16 worked.

## How has this been tested?

- Real-weights GPU reproduce->fix (transformers 5.8.1, bf16, sdpa, gradient checkpointing): E2B reproduces the exact error with the old key, then runs a clean forward+backward (finite loss & grads); E4B reproduces and passes forward.
- Config-level rendezvous check across E2B/E4B/31B/26B-A4B: every shared layer's read-key is written by a storing layer under both keying conventions.
- New regression test `TestFusedAttnSharedKV` with `num_kv_shared_layers > 0`; suite: 7 passed, 1 xfailed.

## AI Usage Disclaimer

Yes — Claude Code Opus 4.8 assisted with debug and fix

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Gemma4 shared KV attention mechanism to properly support multiple Transformers library conventions.

* **Tests**
  * Added regression tests validating Gemma4 shared KV forward and backward propagation with various layer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->