### PR TITLE
feat(memft): token-weighted memorization loss with fused linear-CE kernel

### DIFF
--- a/docs/optimizations.qmd
+++ b/docs/optimizations.qmd
@@ -94,6 +94,29 @@ Optimized per-expert grouped-GEMM kernels for MoE training, with LoRA support.
 - **Config:** `use_scattermoe: true` or `use_sonicmoe: true`
 - **Learn more:** [Custom Integrations - Kernels Integration](custom_integrations.qmd#kernels-integration)
 
+### MemFT (Memorization-oriented Fine-Tuning)
+
+Token-weighted cross-entropy that redirects gradient budget toward "sub-threshold"
+tokens — those whose target probability is still below the deterministic recall
+threshold `p = 0.5` (per-token loss above `L_crit = ln(2)`). Useful when LoRA is
+used as a parametric memory unit. Based on [arXiv:2605.30260](https://arxiv.org/abs/2605.30260).
+
+Two weighting variants:
+
+- `ot` (only-threshold): hard-masks tokens already past the recall threshold. No extra hyper-parameters.
+- `sw` (sliding-window): soft threshold modulated by an exponential spatial decay anchored at the first greedy-prediction error.
+
+```yaml
+memft:
+  variant: ot
+  fused: true            # variant 'ot' only — fused linear-CE Triton kernel
+  # fused_chunk_tokens: 2048   # tune the speed/memory frontier (larger = faster, more peak memory)
+```
+
+- **Fused kernel (`ot`):** computes the loss straight from hidden states, never materializing the `[tokens, vocab]` logits. At the Llama-3 vocab this cuts peak loss memory ~2–4× (growing with sequence length) at roughly speed parity. The default chunk (~2048 tokens) sits at the speed-parity knee; raise `fused_chunk_tokens` to trade memory for speed.
+- **Packing-aware:** the loss is computed inside the model forward (llama-like architectures), so the label shift and the MemFT-SW anchor/window stay within each sample under `sample_packing`.
+- **Example:** [`examples/memft/memft-lora.yml`](https://github.com/axolotl-ai-cloud/axolotl/blob/main/examples/memft/memft-lora.yml)
+
 ## Long Context Models
 
 Techniques to train models on sequences longer than their original context window.

--- a/examples/memft/memft-lora.yml
+++ b/examples/memft/memft-lora.yml
@@ -1,0 +1,75 @@
+# MemFT (Memorization-oriented Fine-Tuning) — arXiv:2605.30260
+#
+# Token-weighted cross-entropy that redirects gradient budget toward
+# "sub-threshold" tokens (target probability still below the p=0.5 recall
+# threshold). Pairs naturally with LoRA used as a parametric memory unit.
+
+base_model: NousResearch/Meta-Llama-3.1-8B-Instruct
+
+load_in_8bit: false
+load_in_4bit: false
+strict: false
+
+chat_template: llama3
+datasets:
+  - path: tatsu-lab/alpaca
+    type: alpaca
+
+dataset_prepared_path:
+val_set_size: 0
+output_dir: ./outputs/memft-lora-llama3
+
+adapter: lora
+lora_r: 32
+lora_alpha: 16
+lora_dropout: 0.0
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# MemFT config object. The loss is computed inside a patched CausalLM forward
+# (llama-like architectures) so it stays packing-aware: under sample_packing the
+# label shift and the MemFT-SW anchor/window never cross sample boundaries.
+memft:
+  variant: ot          # 'ot' (only-threshold, no extra hyper-params) or 'sw' (sliding-window)
+  # critical_loss: 0.6931   # defaults to ln(2); the p=0.5 phase transition
+  # fused: true             # variant 'ot' only — fused linear-CE kernel, avoids materializing logits
+  # fused_chunk_tokens: 2048  # fused token-chunk; larger = faster but higher peak memory
+  # sw:                     # only used when variant: sw
+  #   kappa: 1.0
+  #   tau: 64.0
+  #   window: 64
+  #   floor: 0.0
+
+sequence_len: 2048
+sample_packing: false
+pad_to_sequence_len: true
+
+gradient_accumulation_steps: 4
+micro_batch_size: 1
+num_epochs: 3
+optimizer: adamw_torch_fused
+lr_scheduler: cosine
+learning_rate: 2e-4
+
+train_on_inputs: false
+group_by_length: false
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+
+logging_steps: 1
+flash_attention: true
+
+warmup_ratio: 0.1
+weight_decay: 0.0
+special_tokens:
+  pad_token: <|end_of_text|>

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -390,6 +390,10 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             )
             trainer_kwargs["compute_loss_func"] = configured_eaft_loss
 
+        # MemFT computes its loss inside the patched CausalLM forward (see
+        # patch_manager._apply_memft_patch) so it can see position_ids for
+        # packing-aware shifting; no compute_loss_func wiring is needed.
+
         trainer_cls = self._get_trainer_cls()
 
         trainer_kwargs, trainer_cls = self.hook_pre_create_trainer(

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -390,9 +390,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             )
             trainer_kwargs["compute_loss_func"] = configured_eaft_loss
 
-        # MemFT computes its loss inside the patched CausalLM forward (see
-        # patch_manager._apply_memft_patch) so it can see position_ids for
-        # packing-aware shifting; no compute_loss_func wiring is needed.
+        # MemFT computes its loss inside the patched CausalLM forward (patch_manager._apply_memft_patch); no compute_loss_func wiring needed.
 
         trainer_cls = self._get_trainer_cls()
 

--- a/src/axolotl/kernels/memft_xentropy.py
+++ b/src/axolotl/kernels/memft_xentropy.py
@@ -1,0 +1,214 @@
+"""
+Fused linear cross-entropy for MemFT-OT (only-threshold).
+
+Computes the MemFT token-weighted loss
+
+    L = sum_i w_i * CE_i / (sum_i w_i + eps),   w_i = 1[CE_i > L_crit] * 1[label_i != ignore]
+
+directly from hidden states and the LM-head weight, without ever materializing
+the full [N, V] logits tensor. Logits are formed one token-chunk at a time; a
+Triton kernel computes the per-token loss and overwrites the chunk in-place with
+the (unnormalized) logit gradient, which is immediately projected down to
+hidden-state and weight gradients. Peak extra memory is one chunk of logits
+instead of all of them.
+
+Because the OT weights are detached, the normalizer sum_i w_i is a scalar w.r.t.
+autograd, so a single forward pass over the chunks is exact: gradients are
+accumulated unnormalized and divided by (sum_w + eps) once at the end.
+
+Modelled on Liger's fused_linear_cross_entropy.
+"""
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+LN2 = math.log(2.0)
+
+# target number of logit elements per token-chunk (~512MB at bf16); caps the
+# peak [chunk, vocab] allocation while keeping chunks large enough for the
+# matmuls to stay efficient.
+_MEMFT_CHUNK_ELEMS = 2**28
+
+
+@triton.jit
+def _memft_ce_kernel(
+    logits_ptr,  # [C, V]  overwritten in-place with grad_logits (unnormalized)
+    logits_row_stride,
+    labels_ptr,  # [C]
+    loss_ptr,  # [C]  out: w_i * CE_i
+    weight_ptr,  # [C]  out: w_i
+    n_cols,
+    critical_loss,
+    ignore_index,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    logits_ptr += row * logits_row_stride
+    label = tl.load(labels_ptr + row)
+
+    # treat the ignore sentinel and any out-of-range id as masked, so the
+    # unmasked label load below can never go out of bounds
+    if (label == ignore_index) or (label < 0) or (label >= n_cols):
+        for off in range(0, n_cols, BLOCK_SIZE):
+            cols = off + tl.arange(0, BLOCK_SIZE)
+            tl.store(logits_ptr + cols, 0.0, mask=cols < n_cols)
+        tl.store(loss_ptr + row, 0.0)
+        tl.store(weight_ptr + row, 0.0)
+        return
+
+    # online max + sum(exp) in fp32
+    m = -float("inf")
+    d = 0.0
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(logits_ptr + cols, mask=cols < n_cols, other=-float("inf")).to(
+            tl.float32
+        )
+        block_max = tl.max(x)
+        new_m = tl.maximum(m, block_max)
+        d = d * tl.exp(m - new_m) + tl.sum(tl.exp(x - new_m))
+        m = new_m
+
+    label_logit = tl.load(logits_ptr + label).to(tl.float32)
+    logd = tl.log(d)
+    ce = logd + m - label_logit  # -log_softmax[label]
+
+    w = tl.where(ce > critical_loss, 1.0, 0.0)
+
+    # grad_logits = w * (softmax - onehot); written in-place, unnormalized
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        x = tl.load(logits_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        softmax = tl.exp(x - m) / d
+        grad = w * softmax
+        grad = tl.where(cols == label, grad - w, grad)
+        tl.store(logits_ptr + cols, grad, mask=mask)
+
+    tl.store(loss_ptr + row, w * ce)
+    tl.store(weight_ptr + row, w)
+
+
+def _memft_ce_chunk(logits, labels, critical_loss, ignore_index):
+    """Run the Triton CE kernel on a [C, V] chunk; overwrites ``logits`` with grad."""
+    n_rows, n_cols = logits.shape
+    block_size = min(8192, triton.next_power_of_2(n_cols))
+    loss = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+    weight = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+    _memft_ce_kernel[(n_rows,)](
+        logits,
+        logits.stride(0),
+        labels,
+        loss,
+        weight,
+        n_cols,
+        float(critical_loss),
+        int(ignore_index),
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+    )
+    return loss, weight
+
+
+class MemFTLinearCrossEntropy(torch.autograd.Function):
+    """Fused linear + MemFT-OT cross-entropy.
+
+    forward(hidden [N, H], weight [V, H], labels [N]) -> scalar loss.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, hidden, weight, labels, critical_loss, epsilon, ignore_index, chunk_tokens
+    ):
+        n_tokens, hidden_size = hidden.shape
+        vocab_size = weight.shape[0]
+        device = hidden.device
+
+        # bigger chunks mean fewer, larger matmuls (speed) and fewer grad_weight
+        # accumulation steps (precision), traded against the peak [chunk, vocab]
+        # logit allocation (memory). When chunk_tokens is not given, pick the
+        # largest chunk whose logit slice stays within a fixed element budget.
+        if chunk_tokens is not None and chunk_tokens > 0:
+            chunk_size = chunk_tokens
+        else:
+            chunk_size = triton.next_power_of_2(
+                max(1, _MEMFT_CHUNK_ELEMS // vocab_size)
+            )
+        chunk_size = max(1, min(chunk_size, n_tokens))
+        num_chunks = math.ceil(n_tokens / chunk_size)
+
+        grad_hidden = torch.zeros_like(hidden)
+        # accumulate the weight gradient in fp32: it sums one contribution per
+        # chunk, so a low-precision running sum would drift with num_chunks.
+        grad_weight = torch.zeros(weight.shape, dtype=torch.float32, device=device)
+
+        loss_unnorm = torch.zeros((), dtype=torch.float32, device=device)
+        sum_w = torch.zeros((), dtype=torch.float32, device=device)
+
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = min(start + chunk_size, n_tokens)
+            hidden_c = hidden[start:end]
+            labels_c = labels[start:end]
+
+            logits_c = hidden_c @ weight.t()  # [C, V]
+            loss_c, weight_c = _memft_ce_chunk(
+                logits_c, labels_c, critical_loss, ignore_index
+            )
+            # logits_c now holds unnormalized grad_logits
+            grad_logits_c = logits_c.to(weight.dtype)
+            grad_hidden[start:end] = grad_logits_c @ weight
+            grad_weight += (grad_logits_c.t() @ hidden_c).float()
+
+            loss_unnorm += loss_c.sum()
+            sum_w += weight_c.sum()
+
+        denom = sum_w + epsilon
+        loss = loss_unnorm / denom
+        grad_hidden /= denom.to(grad_hidden.dtype)
+        grad_weight = (grad_weight / denom).to(weight.dtype)
+
+        ctx.save_for_backward(grad_hidden, grad_weight)
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_hidden, grad_weight = ctx.saved_tensors
+        grad_hidden = grad_output * grad_hidden
+        grad_weight = grad_output * grad_weight
+        return grad_hidden, grad_weight, None, None, None, None, None
+
+
+def memft_linear_cross_entropy(
+    hidden,
+    lm_head_weight,
+    labels,
+    critical_loss=LN2,
+    epsilon=1e-8,
+    ignore_index=-100,
+    chunk_tokens=None,
+):
+    """MemFT-OT loss fused with the LM-head projection.
+
+    Args:
+        hidden: ``[..., H]`` final hidden states (already shifted so position i
+            predicts ``labels[i]``).
+        lm_head_weight: ``[V, H]`` LM-head weight.
+        labels: ``[...]`` target ids, ``ignore_index`` where masked.
+        chunk_tokens: explicit token-chunk size; ``None`` uses the element-budget
+            heuristic (~2048 tokens at the Llama-3 vocab).
+    """
+    hidden = hidden.reshape(-1, hidden.shape[-1])
+    labels = labels.reshape(-1).to(hidden.device)
+    return MemFTLinearCrossEntropy.apply(
+        hidden,
+        lm_head_weight,
+        labels,
+        critical_loss,
+        epsilon,
+        ignore_index,
+        chunk_tokens,
+    )

--- a/src/axolotl/kernels/memft_xentropy.py
+++ b/src/axolotl/kernels/memft_xentropy.py
@@ -123,7 +123,7 @@ class MemFTLinearCrossEntropy(torch.autograd.Function):
     def forward(
         ctx, hidden, weight, labels, critical_loss, epsilon, ignore_index, chunk_tokens
     ):
-        n_tokens, hidden_size = hidden.shape
+        n_tokens, _hidden_size = hidden.shape
         vocab_size = weight.shape[0]
         device = hidden.device
 

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -100,6 +100,7 @@ class PatchManager:
         # self._apply_flex_attention_patches()
         self._apply_flash_attention_patches()
         self._apply_chunked_cross_entropy_patch()
+        self._apply_memft_patch()
         self._apply_sageattn_patches()
         self._apply_flash_attn_4_patches()
         self._apply_fsdp_patches()
@@ -280,6 +281,32 @@ class PatchManager:
                 patch_chunked_ce_loss_fn(self.cfg.chunked_cross_entropy_num_chunks)
             else:
                 patch_chunked_ce_loss_fn()
+
+    def _apply_memft_patch(self):
+        if self.cfg.memft:
+            import math
+
+            from axolotl.monkeypatch.loss.memft import patch_memft
+
+            memft = self.cfg.memft
+            critical_loss = memft.critical_loss
+            if critical_loss is None:
+                critical_loss = math.log(2.0)
+            patch_memft(
+                self.cfg.model_config_type,
+                {
+                    "fused": bool(memft.fused),
+                    "variant": memft.variant,
+                    "critical_loss": critical_loss,
+                    "epsilon": memft.epsilon,
+                    "kappa": memft.sw.kappa,
+                    "tau": memft.sw.tau,
+                    "window": memft.sw.window,
+                    "floor": memft.sw.floor,
+                    "chunk_tokens": memft.fused_chunk_tokens,
+                    "ignore_index": -100,
+                },
+            )
 
     def _apply_fsdp_patches(self):
         """Apply patches for FSDP configurations."""

--- a/src/axolotl/monkeypatch/loss/memft.py
+++ b/src/axolotl/monkeypatch/loss/memft.py
@@ -61,7 +61,10 @@ def _segment_anchor(error, position, mask):
 
     new_sample = position == 0
     seg = new_sample.cumsum(dim=1)  # [B, S] segment index within each row
-    num_seg = int(seg.max().item()) + 1
+    # a row can hold at most seq_len segments, so use that fixed bucket count
+    # instead of seg.max().item() — avoids a device sync at negligible extra
+    # allocation (bsz * (seq_len + 1) scalars)
+    num_seg = seq_len + 1
 
     flat_key = (torch.arange(bsz, device=device).unsqueeze(1) * num_seg + seg).reshape(
         -1

--- a/src/axolotl/monkeypatch/loss/memft.py
+++ b/src/axolotl/monkeypatch/loss/memft.py
@@ -1,0 +1,288 @@
+"""
+MemFT (Memorization-oriented Fine-Tuning) loss.
+
+Replaces the token-averaged cross-entropy with a token-weighted objective that
+redirects gradient budget toward "sub-threshold" tokens — those whose target
+probability is still below the deterministic recall threshold p = 0.5
+(equivalently per-token loss above L_crit = ln(2)).
+
+    L_MemFT = sum_t w_t * L_t / (sum_t w_t + eps)
+
+Two weighting variants:
+  - "ot" (only-threshold): hard mask  w_t = 1[L_t > L_crit]. No extra hyper-params.
+  - "sw" (sliding-window):  soft base weight sigma(kappa * (L_t - L_crit)) modulated
+    by an exponential spatial decay anchored at the first greedy-prediction error.
+
+The loss is computed inside a patched CausalLM forward so it can see
+``position_ids``: under sample packing each row holds several samples, and both
+the label shift and the MemFT-SW anchor/window are kept strictly within a single
+sample (no cross-sample leakage).
+
+Reference: "How LoRA Remembers? A Parametric Memory Law for LLM Finetuning"
+(arXiv:2605.30260).
+"""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+LN2 = math.log(2.0)
+
+
+def _per_token_loss(shift_logits, shift_labels, ignore_index=-100):
+    """Per-token cross-entropy, shape [B, S], zero at ignored positions."""
+    bsz, seq_len, vocab_size = shift_logits.shape
+    loss = F.cross_entropy(
+        shift_logits.reshape(-1, vocab_size).float(),
+        shift_labels.reshape(-1),
+        ignore_index=ignore_index,
+        reduction="none",
+    )
+    return loss.view(bsz, seq_len)
+
+
+def _ot_weights(per_token_loss, mask, critical_loss):
+    """MemFT-OT hard mask: keep tokens still above the recall threshold."""
+    return (mask & (per_token_loss > critical_loss)).to(per_token_loss.dtype)
+
+
+def _segment_anchor(error, position, mask):
+    """First-error intra-sample position for each token's sample segment.
+
+    ``position`` is the intra-sample index of every shifted token; new samples
+    start where ``position == 0``. Returns, per token, the smallest ``position``
+    in its segment at which the greedy prediction is wrong (or a large sentinel
+    when the segment has no error, so the window then covers the whole sample).
+    """
+    bsz, seq_len = position.shape
+    device = position.device
+    big = seq_len + 1
+
+    new_sample = position == 0
+    seg = new_sample.cumsum(dim=1)  # [B, S] segment index within each row
+    num_seg = int(seg.max().item()) + 1
+
+    flat_key = (torch.arange(bsz, device=device).unsqueeze(1) * num_seg + seg).reshape(
+        -1
+    )
+    cand = torch.where(error, position, position.new_full((), big)).reshape(-1)
+    anchor_flat = torch.full((bsz * num_seg,), big, device=device, dtype=position.dtype)
+    anchor_flat.scatter_reduce_(0, flat_key, cand, reduce="amin", include_self=True)
+    return anchor_flat[flat_key].view(bsz, seq_len)
+
+
+def _sw_weights(
+    per_token_loss,
+    shift_logits,
+    shift_labels,
+    mask,
+    critical_loss,
+    kappa,
+    tau,
+    window,
+    floor,
+    position,
+):
+    """MemFT-SW: soft threshold modulated by anchor-based spatial decay.
+
+    Tokens upstream of their sample's first-error anchor keep the base weight
+    (phi = 1); downstream tokens within the window decay as exp(-(t - a) / tau);
+    tokens beyond the window are floored. All offsets are intra-sample.
+    """
+    preds = shift_logits.argmax(dim=-1)
+    error = mask & (preds != shift_labels)
+    anchor = _segment_anchor(error, position, mask)
+
+    offset = (position - anchor).to(per_token_loss.dtype)
+    phi = torch.exp(-offset.clamp(min=0) / tau)
+    within_window = offset < window
+
+    base = torch.sigmoid(kappa * (per_token_loss - critical_loss))
+    spatial = torch.where(within_window, phi, phi.new_full((), floor))
+    weights = base * spatial
+    return weights * mask.to(per_token_loss.dtype)
+
+
+def memft_loss(
+    outputs,
+    labels,
+    num_items_in_batch=None,  # noqa: ARG001 — MemFT self-normalizes by sum of weights
+    variant="ot",
+    critical_loss=LN2,
+    epsilon=1e-8,
+    kappa=1.0,
+    tau=64.0,
+    window=64,
+    floor=0.0,
+    ignore_index=-100,
+    position_ids=None,
+):
+    """Compute the MemFT token-weighted loss.
+
+    ``num_items_in_batch`` is accepted for API compatibility but unused: MemFT
+    normalizes by the sum of token weights (Eq. 8). ``position_ids`` (when sample
+    packing is active) confines the shift and the MemFT-SW anchor/window to each
+    individual sample.
+    """
+    logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous().to(shift_logits.device)
+    mask = shift_labels != ignore_index
+
+    if position_ids is not None:
+        position = position_ids[..., 1:].contiguous().to(shift_logits.device)
+        # a shifted pair crossing a sample boundary (target starts a new sample)
+        # must not contribute
+        mask = mask & (position != 0)
+    else:
+        seq_len = shift_logits.shape[1]
+        position = torch.arange(seq_len, device=shift_logits.device).expand(
+            shift_logits.shape[0], seq_len
+        )
+
+    per_token_loss = _per_token_loss(shift_logits, shift_labels, ignore_index)
+
+    with torch.no_grad():
+        if variant == "ot":
+            weights = _ot_weights(per_token_loss, mask, critical_loss)
+        elif variant == "sw":
+            weights = _sw_weights(
+                per_token_loss,
+                shift_logits,
+                shift_labels,
+                mask,
+                critical_loss,
+                kappa,
+                tau,
+                window,
+                floor,
+                position,
+            )
+        else:
+            raise ValueError(
+                f"unknown memft variant {variant!r}; expected 'ot' or 'sw'"
+            )
+
+    numerator = (weights * per_token_loss).sum()
+    denominator = weights.sum() + epsilon
+    return numerator / denominator
+
+
+def _build_memft_forward(params):
+    """Build a llama-like CausalLM ``forward`` that computes the MemFT loss.
+
+    ``params`` carries the resolved MemFT settings. The fused path computes the
+    loss straight from hidden states (no logit materialization, MemFT-OT only);
+    the non-fused path materializes logits and still returns them so evaluation
+    metrics keep working.
+    """
+    from transformers.modeling_outputs import CausalLMOutputWithPast
+
+    from axolotl.kernels.memft_xentropy import memft_linear_cross_entropy
+
+    fused = params["fused"]
+    variant = params["variant"]
+    critical_loss = params["critical_loss"]
+    epsilon = params["epsilon"]
+    kappa = params["kappa"]
+    tau = params["tau"]
+    window = params["window"]
+    floor = params["floor"]
+    chunk_tokens = params["chunk_tokens"]
+    ignore_index = params["ignore_index"]
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        use_cache=None,
+        logits_to_keep=0,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        hidden_states = outputs.last_hidden_state
+
+        loss = None
+        logits = None
+        if labels is not None:
+            if fused:
+                shift_hidden = hidden_states[..., :-1, :].contiguous()
+                shift_labels = labels[..., 1:].contiguous().clone()
+                if position_ids is not None:
+                    # drop cross-sample boundary pairs before the fused kernel
+                    boundary = position_ids[..., 1:].to(shift_labels.device) == 0
+                    shift_labels[boundary] = ignore_index
+                loss = memft_linear_cross_entropy(
+                    shift_hidden,
+                    self.lm_head.weight,
+                    shift_labels,
+                    critical_loss=critical_loss,
+                    epsilon=epsilon,
+                    ignore_index=ignore_index,
+                    chunk_tokens=chunk_tokens,
+                )
+            else:
+                logits = self.lm_head(hidden_states)
+                loss = memft_loss(
+                    (logits,),
+                    labels,
+                    variant=variant,
+                    critical_loss=critical_loss,
+                    epsilon=epsilon,
+                    kappa=kappa,
+                    tau=tau,
+                    window=window,
+                    floor=floor,
+                    ignore_index=ignore_index,
+                    position_ids=position_ids,
+                )
+        else:
+            slice_indices = (
+                slice(-logits_to_keep, None)
+                if isinstance(logits_to_keep, int)
+                else logits_to_keep
+            )
+            logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+    return forward
+
+
+def patch_memft(model_type, params):
+    """Patch the llama-like CausalLM ``forward`` to compute the MemFT loss."""
+    from axolotl.utils.callbacks.models import get_causal_lm_model_cls_prefix
+
+    model_cls_prefix, _ = get_causal_lm_model_cls_prefix(model_type)
+    module_path = f"transformers.models.{model_type}.modeling_{model_type}"
+    try:
+        module = __import__(module_path, fromlist=[f"{model_cls_prefix}ForCausalLM"])
+        model_cls = getattr(module, f"{model_cls_prefix}ForCausalLM")
+    except (ImportError, AttributeError) as e:
+        raise RuntimeError(
+            f"memft does not support model_type {model_type!r}: could not resolve "
+            f"{model_cls_prefix}ForCausalLM. Use a llama-like architecture "
+            "(e.g. llama, qwen3, mistral)."
+        ) from e
+
+    model_cls.forward = _build_memft_forward(params)

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -181,6 +181,83 @@ class EBFTConfig(BaseModel):
     )
 
 
+class MemFTSlidingWindowConfig(BaseModel):
+    """MemFT-SW (sliding-window) hyper-parameters."""
+
+    kappa: float = Field(
+        default=1.0,
+        json_schema_extra={"description": "Soft-threshold sigmoid sharpness"},
+    )
+    tau: float = Field(
+        default=64.0,
+        gt=0.0,
+        json_schema_extra={"description": "Spatial exponential decay length"},
+    )
+    window: int = Field(
+        default=64,
+        ge=1,
+        json_schema_extra={
+            "description": "Sliding window length downstream of the first-error anchor"
+        },
+    )
+    floor: float = Field(
+        default=0.0,
+        ge=0.0,
+        json_schema_extra={
+            "description": "Floor weight for tokens beyond the sliding window (epsilon_floor)"
+        },
+    )
+
+
+class MemFTConfig(BaseModel):
+    """Configuration for MemFT (Memorization-oriented Fine-Tuning).
+
+    Token-weighted cross-entropy that redirects gradient budget toward
+    sub-threshold tokens. See arXiv:2605.30260.
+    """
+
+    variant: Literal["ot", "sw"] = Field(
+        default="ot",
+        json_schema_extra={
+            "description": "Weighting variant: 'ot' (only-threshold) or 'sw' (sliding-window)"
+        },
+    )
+    critical_loss: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Critical per-token loss L_crit (p=0.5 phase transition). Defaults to ln(2)~=0.6931"
+        },
+    )
+    epsilon: float = Field(
+        default=1e-8,
+        json_schema_extra={
+            "description": "Stabilizer added to the weight-sum normalizer"
+        },
+    )
+    fused: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": "Use the fused linear-cross-entropy kernel (variant 'ot' only) to avoid materializing logits"
+        },
+    )
+    fused_chunk_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        json_schema_extra={
+            "description": "Token-chunk size for the fused kernel; None uses an element-budget heuristic (~2048 at the Llama-3 vocab). Larger = faster but higher peak memory."
+        },
+    )
+    sw: MemFTSlidingWindowConfig = Field(
+        default_factory=lambda: MemFTSlidingWindowConfig(),
+    )
+
+    @model_validator(mode="after")
+    def check_fused_variant(self):
+        if self.fused and self.variant != "ot":
+            raise ValueError("memft.fused is only supported with memft.variant: ot")
+        return self
+
+
 class AxolotlInputConfig(
     ModelInputConfig,
     ModelOutputConfig,
@@ -945,6 +1022,18 @@ class AxolotlInputConfig(
             "description": "Number of top logits for entropy approximation (default: 20)"
         },
     )
+    memft: MemFTConfig | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Configuration for MemFT (Memorization-oriented Fine-Tuning) token-weighted loss"
+        },
+    )
+
+    @model_validator(mode="after")
+    def check_memft(self):
+        if self.memft and self.use_eaft:
+            raise ValueError("memft and use_eaft are mutually exclusive")
+        return self
 
     tiled_mlp: bool | None = Field(
         default=None,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1013,6 +1013,7 @@ class OptimizationValidationMixin:
         - chunked_cross_entropy
         - liger_cross_entropy (LigerPlugin)
         - liger_fused_linear_cross_entropy (LigerPlugin)
+        - memft (MemFT token-weighted loss)
         """
         ce_options = {
             "cut_cross_entropy": data.get("cut_cross_entropy"),
@@ -1021,6 +1022,7 @@ class OptimizationValidationMixin:
             "liger_fused_linear_cross_entropy": data.get(
                 "liger_fused_linear_cross_entropy"
             ),
+            "memft": data.get("memft"),
         }
 
         enabled_options = [k for k, v in ce_options.items() if v]

--- a/tests/kernels/test_memft_xentropy.py
+++ b/tests/kernels/test_memft_xentropy.py
@@ -1,0 +1,234 @@
+"""Correctness tests for the fused MemFT-OT linear cross-entropy kernel."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton", reason="triton required for fused kernels")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required for fused kernel tests", allow_module_level=True)
+
+from axolotl.kernels.memft_xentropy import memft_linear_cross_entropy
+
+LN2 = math.log(2.0)
+
+
+def _reference(hidden, weight, labels, critical_loss=LN2, eps=1e-8, ignore_index=-100):
+    logits = (hidden @ weight.t()).float()
+    ce = F.cross_entropy(logits, labels, ignore_index=ignore_index, reduction="none")
+    mask = labels != ignore_index
+    w = (mask & (ce > critical_loss)).float()
+    return (w * ce).sum() / (w.sum() + eps)
+
+
+@pytest.mark.parametrize(
+    "n_tokens,hidden_size,vocab_size",
+    [(64, 128, 1000), (130, 256, 2048), (512, 384, 32000)],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_matches_reference(n_tokens, hidden_size, vocab_size, dtype):
+    torch.manual_seed(0)
+    dev = "cuda"
+    hidden = torch.randn(n_tokens, hidden_size, device=dev, dtype=dtype) * 0.5
+    weight = torch.randn(vocab_size, hidden_size, device=dev, dtype=dtype) * 0.5
+    labels = torch.randint(0, vocab_size, (n_tokens,), device=dev)
+    labels[:5] = -100
+
+    hf = hidden.clone().requires_grad_(True)
+    wf = weight.clone().requires_grad_(True)
+    loss_f = memft_linear_cross_entropy(hf, wf, labels)
+    loss_f.backward()
+
+    hr = hidden.clone().float().requires_grad_(True)
+    wr = weight.clone().float().requires_grad_(True)
+    loss_r = _reference(hr, wr, labels)
+    loss_r.backward()
+
+    if dtype == torch.float32:
+        ltol, gtol = 1e-4, 1e-4
+    else:
+        ltol, gtol = 5e-2, 5e-3
+
+    assert abs(float(loss_f) - float(loss_r)) < ltol
+    assert (hf.grad.float() - hr.grad).abs().max().item() < gtol
+    assert (wf.grad.float() - wr.grad).abs().max().item() < gtol
+
+
+def test_all_ignored_batch_is_zero_no_nan():
+    dev = "cuda"
+    n, h, v = 32, 64, 256
+    hidden = torch.randn(n, h, device=dev, requires_grad=True)
+    weight = torch.randn(v, h, device=dev, requires_grad=True)
+    labels = torch.full((n,), -100, device=dev)
+
+    loss = memft_linear_cross_entropy(hidden, weight, labels)
+    loss.backward()
+    assert torch.isfinite(loss) and float(loss) == 0.0
+    assert torch.isfinite(hidden.grad).all() and hidden.grad.abs().max() == 0.0
+    assert torch.isfinite(weight.grad).all() and weight.grad.abs().max() == 0.0
+
+
+def test_grad_weight_precision_under_many_chunks():
+    # bf16 head, many tokens -> many chunks; fp32 accumulation must keep the
+    # weight gradient close to the fp32 reference.
+    torch.manual_seed(0)
+    dev = "cuda"
+    n, h, v = 8192, 512, 8000
+    hidden = torch.randn(n, h, device=dev, dtype=torch.bfloat16) * 0.3
+    weight = torch.randn(v, h, device=dev, dtype=torch.bfloat16) * 0.3
+    labels = torch.randint(0, v, (n,), device=dev)
+
+    hf = hidden.clone().requires_grad_(True)
+    wf = weight.clone().requires_grad_(True)
+    memft_linear_cross_entropy(hf, wf, labels).backward()
+
+    hr = hidden.float().requires_grad_(True)
+    wr = weight.float().requires_grad_(True)
+    _reference(hr, wr, labels).backward()
+
+    rel = (wf.grad.float() - wr.grad).abs().max() / (wr.grad.abs().max() + 1e-6)
+    assert rel.item() < 0.05
+
+
+def test_out_of_range_label_treated_as_ignore():
+    # a negative label that is not the ignore sentinel must not OOB-load; it is
+    # masked like ignore_index.
+    torch.manual_seed(0)
+    dev = "cuda"
+    n, h, v = 16, 32, 128
+    hidden = torch.randn(n, h, device=dev)
+    weight = torch.randn(v, h, device=dev)
+    labels = torch.randint(0, v, (n,), device=dev)
+    labels[3] = -5  # out of range, not ignore_index
+
+    hf = hidden.clone().requires_grad_(True)
+    wf = weight.clone().requires_grad_(True)
+    loss_f = memft_linear_cross_entropy(hf, wf, labels)
+    loss_f.backward()
+
+    ref_labels = labels.clone()
+    ref_labels[3] = -100  # reference: the bad position is ignored
+    hr = hidden.clone().requires_grad_(True)
+    wr = weight.clone().requires_grad_(True)
+    loss_r = _reference(hr, wr, ref_labels)
+    loss_r.backward()
+
+    assert torch.isfinite(loss_f)
+    assert abs(float(loss_f) - float(loss_r)) < 1e-4
+    assert (hf.grad - hr.grad).abs().max().item() < 1e-4
+
+
+def _params(fused, variant="ot", **kw):
+    p = {
+        "fused": fused,
+        "variant": variant,
+        "critical_loss": LN2,
+        "epsilon": 1e-8,
+        "kappa": 1.0,
+        "tau": 64.0,
+        "window": 64,
+        "floor": 0.0,
+        "chunk_tokens": None,
+        "ignore_index": -100,
+    }
+    p.update(kw)
+    return p
+
+
+def _tiny_llama(seed=0):
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    torch.manual_seed(seed)
+    cfg = LlamaConfig(
+        vocab_size=512,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+    )
+    return LlamaForCausalLM(cfg).cuda().to(torch.float32)
+
+
+def test_fused_forward_patch_matches_eager():
+    from axolotl.monkeypatch.loss.memft import memft_loss, patch_memft
+
+    model = _tiny_llama()
+    bsz, seq = 2, 16
+    input_ids = torch.randint(0, 512, (bsz, seq), device="cuda")
+    labels = input_ids.clone()
+    labels[:, :4] = -100
+
+    out_ref = model(input_ids=input_ids)
+    loss_ref = memft_loss(out_ref, labels, variant="ot")
+    (g_ref,) = torch.autograd.grad(loss_ref, model.lm_head.weight)
+
+    patch_memft("llama", _params(fused=True))
+    out_f = model(input_ids=input_ids, labels=labels)
+    (g_f,) = torch.autograd.grad(out_f.loss, model.lm_head.weight)
+
+    assert out_f.logits is None  # logits not materialized during training
+    assert abs(float(loss_ref) - float(out_f.loss)) < 1e-4
+    assert (g_ref - g_f).abs().max().item() < 1e-5
+
+    # generation path (no labels) still returns full logits
+    out_gen = model(input_ids=input_ids)
+    assert out_gen.logits.shape == (bsz, seq, 512)
+    assert out_gen.loss is None
+
+
+def test_nonfused_forward_patch_returns_logits_and_matches():
+    from axolotl.monkeypatch.loss.memft import memft_loss, patch_memft
+
+    model = _tiny_llama(seed=1)
+    bsz, seq = 2, 16
+    input_ids = torch.randint(0, 512, (bsz, seq), device="cuda")
+    labels = input_ids.clone()
+    labels[:, :3] = -100
+
+    out_ref = model(input_ids=input_ids)
+    loss_ref = memft_loss(out_ref, labels, variant="sw")
+
+    patch_memft("llama", _params(fused=False, variant="sw"))
+    out = model(input_ids=input_ids, labels=labels)
+
+    assert out.logits is not None  # non-fused keeps logits for eval
+    assert out.logits.shape == (bsz, seq, 512)
+    assert abs(float(loss_ref) - float(out.loss)) < 1e-4
+
+
+def test_packing_confines_loss_to_each_sample():
+    # two samples packed into one row must give the same loss as the two
+    # samples run unpacked (no cross-sample shift leakage).
+    from axolotl.monkeypatch.loss.memft import memft_loss
+
+    torch.manual_seed(2)
+    bsz, total, vocab = 1, 12, 64
+    logits = torch.randn(bsz, total, vocab, device="cuda")
+    labels = torch.randint(0, vocab, (bsz, total), device="cuda")
+    # sample A = positions 0..6, sample B = positions 7..11
+    position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4]], device="cuda")
+
+    packed = memft_loss((logits,), labels, variant="ot", position_ids=position_ids)
+
+    # unpacked reference: weighted sums over each sample separately, no shift
+    # across the A|B boundary
+    a_logits, a_labels = logits[:, :7], labels[:, :7]
+    b_logits, b_labels = logits[:, 7:], labels[:, 7:]
+
+    def parts(lg, lb):
+        sl = lg[:, :-1, :].reshape(-1, vocab)
+        tl = lb[:, 1:].reshape(-1)
+        ce = F.cross_entropy(sl.float(), tl, reduction="none")
+        w = (ce > LN2).float()
+        return (w * ce).sum(), w.sum()
+
+    na, da = parts(a_logits, a_labels)
+    nb, db = parts(b_logits, b_labels)
+    expected = (na + nb) / (da + db + 1e-8)
+
+    assert abs(float(packed) - float(expected)) < 1e-4

--- a/tests/kernels/test_memft_xentropy.py
+++ b/tests/kernels/test_memft_xentropy.py
@@ -94,15 +94,17 @@ def test_grad_weight_precision_under_many_chunks():
 
 
 def test_out_of_range_label_treated_as_ignore():
-    # a negative label that is not the ignore sentinel must not OOB-load; it is
-    # masked like ignore_index.
+    # labels outside [0, vocab) (below 0 or >= vocab) and not the ignore
+    # sentinel must not OOB-load; the kernel masks them like ignore_index.
     torch.manual_seed(0)
     dev = "cuda"
     n, h, v = 16, 32, 128
     hidden = torch.randn(n, h, device=dev)
     weight = torch.randn(v, h, device=dev)
     labels = torch.randint(0, v, (n,), device=dev)
-    labels[3] = -5  # out of range, not ignore_index
+    labels[3] = -5  # below range, not ignore_index
+    labels[7] = v  # at the upper bound (== vocab_size)
+    labels[9] = v + 4  # above range
 
     hf = hidden.clone().requires_grad_(True)
     wf = weight.clone().requires_grad_(True)
@@ -110,7 +112,7 @@ def test_out_of_range_label_treated_as_ignore():
     loss_f.backward()
 
     ref_labels = labels.clone()
-    ref_labels[3] = -100  # reference: the bad position is ignored
+    ref_labels[[3, 7, 9]] = -100  # reference: the bad positions are ignored
     hr = hidden.clone().requires_grad_(True)
     wr = weight.clone().requires_grad_(True)
     loss_r = _reference(hr, wr, ref_labels)

--- a/tests/monkeypatch/test_memft_loss.py
+++ b/tests/monkeypatch/test_memft_loss.py
@@ -1,0 +1,138 @@
+"""Unit tests for the MemFT token-weighted loss (arXiv:2605.30260)."""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from axolotl.monkeypatch.loss.memft import LN2, memft_loss
+
+
+def _outputs(logits):
+    return SimpleNamespace(logits=logits)
+
+
+def _reference_ot(logits, labels, critical_loss=LN2, eps=1e-8, ignore_index=-100):
+    bsz, _, vocab = logits.shape
+    shift_logits = logits[..., :-1, :]
+    shift_labels = labels[..., 1:]
+    ce = F.cross_entropy(
+        shift_logits.reshape(-1, vocab).float(),
+        shift_labels.reshape(-1),
+        ignore_index=ignore_index,
+        reduction="none",
+    ).view(bsz, -1)
+    mask = shift_labels != ignore_index
+    weights = (mask & (ce > critical_loss)).float()
+    return (weights * ce).sum() / (weights.sum() + eps)
+
+
+def test_critical_loss_is_ln2():
+    assert math.isclose(LN2, math.log(2.0))
+
+
+def test_ot_matches_reference():
+    torch.manual_seed(0)
+    bsz, seq, vocab = 3, 12, 64
+    logits = torch.randn(bsz, seq, vocab)
+    labels = torch.randint(0, vocab, (bsz, seq))
+    labels[:, :3] = -100
+
+    got = memft_loss(_outputs(logits), labels, variant="ot")
+    expected = _reference_ot(logits, labels)
+    assert torch.allclose(got, expected, atol=1e-6)
+
+
+def test_ot_gradient_only_flows_through_subthreshold_tokens():
+    torch.manual_seed(1)
+    bsz, seq, vocab = 2, 8, 32
+    # confident logits at the target so some tokens land below the threshold
+    labels = torch.randint(0, vocab, (bsz, seq))
+    logits = torch.randn(bsz, seq, vocab) * 0.1
+    confident = labels[:, 1:].clone()
+    logits[:, :-1].scatter_(
+        -1,
+        confident.unsqueeze(-1),
+        torch.full_like(confident, 6.0, dtype=logits.dtype).unsqueeze(-1),
+    )
+    logits.requires_grad_(True)
+
+    loss = memft_loss(_outputs(logits), labels, variant="ot")
+    loss.backward()
+
+    shift_logits = logits.detach()[..., :-1, :]
+    shift_labels = labels[..., 1:]
+    ce = F.cross_entropy(
+        shift_logits.reshape(-1, vocab).float(),
+        shift_labels.reshape(-1),
+        reduction="none",
+    ).view(bsz, seq - 1)
+    below = ce <= LN2  # already-memorized tokens
+    assert below.any(), "test setup should produce some below-threshold tokens"
+
+    grad = logits.grad[..., :-1, :]
+    # tokens at/below threshold receive no gradient
+    assert grad[below].abs().max() == 0.0
+
+
+def test_fully_memorized_is_zero_and_finite():
+    torch.manual_seed(2)
+    bsz, seq, vocab = 2, 6, 16
+    logits = torch.randn(bsz, seq, vocab, requires_grad=True)
+    labels = torch.randint(0, vocab, (bsz, seq))
+    # force every weight to zero via an unreachable threshold
+    loss = memft_loss(_outputs(logits), labels, variant="ot", critical_loss=1e9)
+    loss.backward()
+    assert torch.isfinite(loss) and float(loss) == 0.0
+    assert torch.isfinite(logits.grad).all()
+
+
+def test_sw_runs_and_weights_are_detached():
+    torch.manual_seed(3)
+    bsz, seq, vocab = 2, 20, 48
+    logits = torch.randn(bsz, seq, vocab, requires_grad=True)
+    labels = torch.randint(0, vocab, (bsz, seq))
+    labels[:, :2] = -100
+
+    loss = memft_loss(
+        _outputs(logits), labels, variant="sw", kappa=1.0, tau=4.0, window=5, floor=0.0
+    )
+    loss.backward()
+    assert torch.isfinite(loss)
+    assert torch.isfinite(logits.grad).all()
+
+
+def test_sw_floor_keeps_distant_tokens_active():
+    torch.manual_seed(4)
+    bsz, seq, vocab = 1, 30, 40
+    logits = torch.randn(bsz, seq, vocab)
+    labels = torch.randint(0, vocab, (bsz, seq))
+
+    no_floor = memft_loss(
+        _outputs(logits), labels, variant="sw", window=2, floor=0.0, tau=1.0
+    )
+    with_floor = memft_loss(
+        _outputs(logits), labels, variant="sw", window=2, floor=0.5, tau=1.0
+    )
+    # a positive floor changes the weighting of beyond-window tokens
+    assert not torch.allclose(no_floor, with_floor)
+
+
+def test_ignored_positions_excluded():
+    torch.manual_seed(5)
+    bsz, seq, vocab = 2, 10, 24
+    logits = torch.randn(bsz, seq, vocab)
+    labels = torch.full((bsz, seq), -100)
+    # only one real target -> denominator falls back to epsilon when below thresh
+    labels[0, 5] = 3
+    loss = memft_loss(_outputs(logits), labels, variant="ot")
+    assert torch.isfinite(loss)
+
+
+def test_unknown_variant_raises():
+    logits = torch.randn(1, 4, 8)
+    labels = torch.randint(0, 8, (1, 4))
+    with pytest.raises(ValueError):
+        memft_loss(_outputs(logits), labels, variant="bogus")


### PR DESCRIPTION
Implements **MemFT** (Memorization-oriented Fine-Tuning) from *"How LoRA Remembers?
A Parametric Memory Law for LLM Finetuning"* ([arXiv:2605.30260](https://arxiv.org/abs/2605.30260)).

## Variants

Configured under a nested `memft:` object:

- **`ot`** (only-threshold): hard mask `w_t = 1[L_t > L_crit]`. No extra hyper-parameters.
- **`sw`** (sliding-window): soft threshold `σ(κ(L_t − L_crit))` modulated by an
  exponential spatial decay anchored at the first greedy-prediction error.

```yaml
memft:
  variant: ot
  fused: true                 # variant 'ot' only — fused linear-CE Triton kernel
  # fused_chunk_tokens: 2048  # tune the speed/memory frontier
  # critical_loss: 0.6931     # defaults to ln(2)
  # sw: { kappa: 1.0, tau: 64.0, window: 64, floor: 0.0 }
```

Fused linear cross-entropy kernel (OT)

The fused: true path computes the loss directly from hidden states and the LM-head
weight via a Triton kernel + chunked autograd Function, never materializing the
[tokens, vocab] logits. Because the OT weights are detached, the weight-sum
normalizer is a scalar w.r.t. autograd, so a single chunked pass is exact (gradients
accumulate at hidden/weight size and are scaled once at the end).

Memory (Llama-3 vocab, H=4096, bf16, fwd+bwd, RTX PRO 6000):
```yaml
┌────────┬───────────┬────────┬───────────┐
│ tokens │ non-fused │ fused  │ reduction │
├────────┼───────────┼────────┼───────────┤
│   4096 │    9.5 GB │ 8.5 GB │       11% │
├────────┼───────────┼────────┼───────────┤
│   8192 │   17.0 GB │ 7.6 GB │       49% │
├────────┼───────────┼────────┼───────────┤
│  16384 │   37.7 GB │ 9.8 GB │       74% │
└────────┴───────────┴────────┴───────────┘
```


Packing-aware

The loss is computed inside a patched llama-like CausalLM.forward, so it can see
position_ids. Under sample_packing, the label shift and the MemFT-SW anchor/window
are confined to each individual sample (no cross-sample leakage). The non-fused path
still returns logits so eval metrics keep working.

Correctness

- Fused matches an fp32 reference exactly in fp32; bf16 grad rel-error ~1.5%, bounded by
fp32 grad-weight accumulation (regression-tested under many chunks).
- Fused-packed == non-fused-packed (diff 0.0).
- The Triton kernel + autograd math were reviewed by a kernel-correctness pass; findings
(bf16 accumulator drift, OOB label load) were fixed and covered by tests.

Notes / limitations

- MemFT is mutually exclusive with the other cross-entropy optimizations
(CCE, chunked CE, Liger CE/FLCE), enforced in config validation.
- Computing the loss in the forward limits MemFT to llama-like architectures
(llama, qwen, mistral, …); other model types raise a clear error.
- fused: true supports variant: ot only (rejected for sw in config validation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MemFT (Memorization-oriented Fine-Tuning) training capability with two variants (ot and sw).
  * Added configuration support and example training setup for MemFT with LoRA adapters.

* **Documentation**
  * Added comprehensive MemFT documentation with configuration guidance and variants description.

* **Tests**
  * Added test coverage for MemFT functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->