### PR TITLE
Honor curriculum_sampling in AxolotlGRPOTrainer (fixes #2376)

### DIFF
--- a/src/axolotl/core/trainers/grpo/trainer.py
+++ b/src/axolotl/core/trainers/grpo/trainer.py
@@ -190,7 +190,7 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
             // self.args.context_parallel_size,
             repeat_count=self.num_iterations * self.args.gradient_accumulation_steps,
             context_parallel_size=self.args.context_parallel_size,
-            shuffle=True,
+            shuffle=not self.args.curriculum_sampling,
             seed=self.args.seed,
             drop_last=True,
         )


### PR DESCRIPTION
### Problem (#2376)

The base trainer honors `curriculum_sampling` by using a `SequentialSampler` (`core/trainers/base.py`), but `AxolotlGRPOTrainer._get_train_sampler` hardcodes `shuffle=True`:

```python
return SequenceParallelRepeatRandomSampler(
    ...
    shuffle=True,
    ...
)
```

So with `curriculum_sampling: true` a GRPO run still shuffles the dataset, breaking curriculum order.

### Fix

Wire `shuffle` to `not self.args.curriculum_sampling`, mirroring the base trainer. `SequenceParallelRepeatRandomSampler` already emits `list(range(num_samples))` (dataset order) when `shuffle=False`.

### Verification

Instantiated `SequenceParallelRepeatRandomSampler` on a toy dataset:

```
shuffle=False (curriculum_sampling=True):  [0, 1, 2, 3, 4, 5, 6, 7]   # dataset order
shuffle=True  (curriculum_sampling=False): [4, 0, 7, 3, 2, 5, 1, 6]   # shuffled
```

— AI assistance was used for this change; I reviewed it and verified the sampler behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GRPO trainer to properly respect curriculum sampling configuration when controlling data shuffling. Shuffle is now disabled when curriculum sampling is active and enabled otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->