### PR TITLE
fix: gc_collect_steps not honored

### DIFF
--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -122,8 +122,9 @@ class TrainerBuilderBase(abc.ABC):
         if self.cfg.resume_from_checkpoint:
             callbacks.append(SkipEvalOnResumeCallback())
 
-        if self.cfg.gc_steps:
-            callbacks.append(GCCallback(gc_steps=self.cfg.gc_steps))
+        gc_collect_steps = self.cfg.gc_collect_steps or self.cfg.gc_steps
+        if gc_collect_steps:
+            callbacks.append(GCCallback(gc_collect_steps=gc_collect_steps))
 
         if self.cfg.dynamic_checkpoint and self.cfg.dynamic_checkpoint.enabled:
             from axolotl.utils.callbacks.dynamic_checkpoint import (

--- a/tests/core/test_gc_steps_wiring.py
+++ b/tests/core/test_gc_steps_wiring.py
@@ -1,0 +1,40 @@
+"""get_callbacks must register GCCallback whenever gc_collect_steps (or legacy gc_steps) is set."""
+
+from unittest.mock import MagicMock, patch
+
+from axolotl.core.builders import HFCausalTrainerBuilder
+from axolotl.utils.callbacks import GCCallback
+from axolotl.utils.dict import DictDefault
+
+
+def _get_callbacks(cfg_dict):
+    builder = HFCausalTrainerBuilder.__new__(HFCausalTrainerBuilder)
+    builder.cfg = DictDefault(cfg_dict)
+    builder.model = MagicMock()
+    with patch("axolotl.core.builders.base.PluginManager") as pm, patch(
+        "axolotl.core.builders.base.TelemetryManager"
+    ) as tm:
+        pm.get_instance.return_value.add_callbacks_pre_trainer.return_value = []
+        tm.get_instance.return_value.enabled = False
+        return builder.get_callbacks()
+
+
+def _gc(callbacks):
+    return next((c for c in callbacks if isinstance(c, GCCallback)), None)
+
+
+def test_gc_collect_steps_alone_registers_callback():
+    """gc_collect_steps set without the deprecated gc_steps must still register GCCallback."""
+    gc = _gc(_get_callbacks({"gc_collect_steps": 5}))
+    assert gc is not None
+    assert gc.gc_collect_steps == 5
+
+
+def test_legacy_gc_steps_still_registers_callback():
+    gc = _gc(_get_callbacks({"gc_steps": 7}))
+    assert gc is not None
+    assert gc.gc_collect_steps == 7
+
+
+def test_no_gc_config_registers_nothing():
+    assert _gc(_get_callbacks({})) is None

--- a/tests/core/test_gc_steps_wiring.py
+++ b/tests/core/test_gc_steps_wiring.py
@@ -11,9 +11,10 @@ def _get_callbacks(cfg_dict):
     builder = HFCausalTrainerBuilder.__new__(HFCausalTrainerBuilder)
     builder.cfg = DictDefault(cfg_dict)
     builder.model = MagicMock()
-    with patch("axolotl.core.builders.base.PluginManager") as pm, patch(
-        "axolotl.core.builders.base.TelemetryManager"
-    ) as tm:
+    with (
+        patch("axolotl.core.builders.base.PluginManager") as pm,
+        patch("axolotl.core.builders.base.TelemetryManager") as tm,
+    ):
         pm.get_instance.return_value.add_callbacks_pre_trainer.return_value = []
         tm.get_instance.return_value.enabled = False
         return builder.get_callbacks()


### PR DESCRIPTION
# Description

`get_callbacks()` only registered `GCCallback` when the deprecated `gc_steps` was set in config yml, so setting the current `gc_collect_steps` on its own was silently ignored. This wires the callback off `gc_collect_steps` (falling back to the deprecated `gc_steps`) and passes it through to `GCCallback`.

## Motivation and Context

`gc_steps` was deprecated in favor of `torch_empty_cache_steps` (native HF Trainer CUDA cache clearing) and `gc_collect_steps` (Python `gc.collect()`). The `migrate_gc_steps` validator only maps `gc_steps` → the new fields; it never
back-fills `gc_steps`. So a config that sets `gc_collect_steps` directly leaves `cfg.gc_steps = None`, the `if self.cfg.gc_steps:` guard is skipped, and no periodic Python GC runs. Only the deprecated knob actually worked.

## How has this been tested?

- Added `tests/core/test_gc_steps_wiring.py` (3 tests) exercising `get_callbacks()`:  `gc_collect_steps` alone registers the callback, the legacy `gc_steps` path  still works, and neither set registers nothing.
- On current `main`, the `gc_collect_steps`-only test **fails** (reproduces the  bug); with the fix all 3 pass.
- Environment: Python 3.12, `transformers==5.9.0`,

## AI Usage Disclaimer

Opus 4.8 identified error and assisted with fix

## Types of changes

- [x] Bug fix (non-breaking)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved garbage collection configuration handling with enhanced settings support and backward compatibility.

* **Tests**
  * Added tests for garbage collection callback configuration verification across multiple configuration scenarios and legacy support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->