### PR TITLE
Fix RAM OOM when loading large preprocessed SFT datasets

### DIFF
--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -415,9 +415,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
     ):
         # Avoid .to_pandas() on the input_ids list column
         if "length" in train_dataset.column_names:
-            total_num_tokens = int(
-                pc.sum(train_dataset.data.column("length")).as_py()
-            )
+            total_num_tokens = int(pc.sum(train_dataset.data.column("length")).as_py())
         else:
             total_num_tokens = int(
                 pc.sum(
@@ -441,9 +439,7 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         total_supervised_tokens = 0
         for batch in train_dataset.data.to_batches(max_chunksize=1024):
             labels = batch.column("labels")
-            if pa.types.is_list(labels.type) or pa.types.is_large_list(
-                labels.type
-            ):
+            if pa.types.is_list(labels.type) or pa.types.is_large_list(labels.type):
                 flat = labels.values.to_numpy(zero_copy_only=False)
             else:
                 flat = labels.to_numpy(zero_copy_only=False)

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -413,13 +413,15 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         and not cfg.skip_prepare_dataset
         and not cfg.reward_model
     ):
-        # Avoid .to_pandas() on the input_ids list column
         if "length" in train_dataset.column_names:
-            total_num_tokens = int(pc.sum(train_dataset.data.column("length")).as_py())
+            total_num_tokens = int(
+                pc.sum(train_dataset.data.column("length"), min_count=0).as_py()
+            )
         else:
             total_num_tokens = int(
                 pc.sum(
-                    pc.list_value_length(train_dataset.data.column("input_ids"))
+                    pc.list_value_length(train_dataset.data.column("input_ids")),
+                    min_count=0,
                 ).as_py()
             )
         LOG.debug(f"total_num_tokens: {total_num_tokens:_}")
@@ -440,11 +442,11 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         for batch in train_dataset.data.to_batches(max_chunksize=1024):
             labels = batch.column("labels")
             if pa.types.is_list(labels.type) or pa.types.is_large_list(labels.type):
-                flat = labels.values.to_numpy(zero_copy_only=False)
+                flat = labels.flatten().to_numpy(zero_copy_only=False)
             else:
                 flat = labels.to_numpy(zero_copy_only=False)
             total_supervised_tokens += int((flat != -100).sum())
-        LOG.debug(f"`total_supervised_tokens: {total_supervised_tokens:_}`")
+        LOG.debug(f"total_supervised_tokens: {total_supervised_tokens:_}")
         if update:
             cfg.total_supervised_tokens = total_supervised_tokens
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -10,6 +10,8 @@ from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
 import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
 import torch
 import torch.cuda
 from datasets import IterableDataset, disable_caching, enable_caching
@@ -411,12 +413,17 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         and not cfg.skip_prepare_dataset
         and not cfg.reward_model
     ):
-        total_num_tokens = np.sum(
-            train_dataset.select_columns("input_ids")
-            .to_pandas()["input_ids"]
-            .apply(len)
-            .values
-        )
+        # Avoid .to_pandas() on the input_ids list column
+        if "length" in train_dataset.column_names:
+            total_num_tokens = int(
+                pc.sum(train_dataset.data.column("length")).as_py()
+            )
+        else:
+            total_num_tokens = int(
+                pc.sum(
+                    pc.list_value_length(train_dataset.data.column("input_ids"))
+                ).as_py()
+            )
         LOG.debug(f"total_num_tokens: {total_num_tokens:_}")
         if update:
             cfg.total_num_tokens = total_num_tokens
@@ -429,12 +436,18 @@ def calculate_total_num_steps(cfg, train_dataset, update=True):
         and not cfg.skip_prepare_dataset
         and not cfg.reward_model
     ):
-        total_supervised_tokens = (
-            train_dataset.data.column("labels")
-            .to_pandas()
-            .apply(lambda x: np.sum(np.array(x) != -100))
-            .sum()
-        )
+        # Stream the labels column in record-batch chunks instead of
+        # .to_pandas(), which materializes one Python list per row.
+        total_supervised_tokens = 0
+        for batch in train_dataset.data.to_batches(max_chunksize=1024):
+            labels = batch.column("labels")
+            if pa.types.is_list(labels.type) or pa.types.is_large_list(
+                labels.type
+            ):
+                flat = labels.values.to_numpy(zero_copy_only=False)
+            else:
+                flat = labels.to_numpy(zero_copy_only=False)
+            total_supervised_tokens += int((flat != -100).sum())
         LOG.debug(f"`total_supervised_tokens: {total_supervised_tokens:_}`")
         if update:
             cfg.total_supervised_tokens = total_supervised_tokens

--- a/tests/test_calculate_total_num_steps.py
+++ b/tests/test_calculate_total_num_steps.py
@@ -1,0 +1,118 @@
+"""Tests for token counting in calculate_total_num_steps"""
+
+import math
+
+import pytest
+from datasets import Dataset, Features, LargeList, Sequence, Value, load_from_disk
+
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.trainer import calculate_total_num_steps
+
+NUM_ROWS = 3000
+
+FEATURES = Features(
+    {
+        "input_ids": Sequence(Value("int64")),
+        "labels": Sequence(Value("int64")),
+    }
+)
+
+
+def build_columns(num_rows):
+    input_ids = []
+    labels = []
+    for i in range(num_rows):
+        seq_len = 5 + (i % 50)
+        input_ids.append(list(range(seq_len)))
+        labels.append([-100 if j < seq_len // 2 else j for j in range(seq_len)])
+    return {"input_ids": input_ids, "labels": labels}
+
+
+@pytest.fixture(name="columns")
+def fixture_columns():
+    return build_columns(NUM_ROWS)
+
+
+@pytest.fixture(name="expected_counts")
+def fixture_expected_counts(columns):
+    total_tokens = sum(len(row) for row in columns["input_ids"])
+    supervised_tokens = sum(
+        1 for row in columns["labels"] for token in row if token != -100
+    )
+    return total_tokens, supervised_tokens
+
+
+def make_cfg():
+    return DictDefault(
+        {
+            "num_epochs": 1,
+            "batch_size": 2,
+            "micro_batch_size": 1,
+        }
+    )
+
+
+def assert_counts(dataset, expected_counts):
+    cfg = make_cfg()
+    total_num_steps = calculate_total_num_steps(cfg, dataset)
+    expected_tokens, expected_supervised = expected_counts
+    assert cfg.total_num_tokens == expected_tokens
+    assert cfg.total_supervised_tokens == expected_supervised
+    assert total_num_steps == math.ceil(len(dataset) / cfg.batch_size)
+
+
+class TestCalculateTotalNumSteps:
+    """
+    Test token counting against hand-computed ground truth across Arrow layouts
+    """
+
+    def test_in_memory_single_chunk(self, columns, expected_counts):
+        dataset = Dataset.from_dict(columns, features=FEATURES)
+        # a single chunk larger than the to_batches chunksize is the layout
+        # where ListArray.values (vs .flatten()) silently over-counts
+        assert dataset.data.column("labels").num_chunks == 1
+        assert len(dataset) > 1024
+        assert_counts(dataset, expected_counts)
+
+    def test_disk_round_trip(self, columns, expected_counts, tmp_path):
+        dataset = Dataset.from_dict(columns, features=FEATURES)
+        dataset.save_to_disk(str(tmp_path / "ds"))
+        dataset = load_from_disk(str(tmp_path / "ds"))
+        assert_counts(dataset, expected_counts)
+
+    def test_large_list(self, columns, expected_counts):
+        dataset = Dataset.from_dict(columns, features=FEATURES).cast(
+            Features(
+                {
+                    "input_ids": LargeList(Value("int64")),
+                    "labels": LargeList(Value("int64")),
+                }
+            )
+        )
+        assert_counts(dataset, expected_counts)
+
+    def test_length_column_takes_precedence(self, columns, expected_counts):
+        columns = dict(columns)
+        # offset lengths by one so the result proves which branch ran
+        columns["length"] = [len(row) + 1 for row in columns["input_ids"]]
+        dataset = Dataset.from_dict(columns, features=None)
+        cfg = make_cfg()
+        calculate_total_num_steps(cfg, dataset)
+        expected_tokens, expected_supervised = expected_counts
+        assert cfg.total_num_tokens == expected_tokens + NUM_ROWS
+        assert cfg.total_supervised_tokens == expected_supervised
+
+    def test_empty_dataset(self):
+        dataset = Dataset.from_dict({"input_ids": [], "labels": []}, features=FEATURES)
+        cfg = make_cfg()
+        total_num_steps = calculate_total_num_steps(cfg, dataset)
+        assert not cfg.total_num_tokens
+        assert not cfg.total_supervised_tokens
+        assert total_num_steps == 0
+
+    def test_update_false_does_not_mutate_cfg(self, columns):
+        dataset = Dataset.from_dict(columns, features=FEATURES)
+        cfg = make_cfg()
+        calculate_total_num_steps(cfg, dataset, update=False)
+        assert cfg.total_num_tokens is None
+        assert cfg.total_supervised_tokens is None


### PR DESCRIPTION

# Description
fixes #2975
 calculate_total_num_steps materialized the entire input_ids and labels columns into Python objects via .to_pandas() to compute two scalars. On long-context datasets this defeats Arrow's mmap and balloons RAM by
  ~7–8 bytes per token — ~1.3 TB on the 9.5M-row × ~16k-ctx config from #2975.


## Motivation and Context

#2975

## How has this been tested?
config  from the issue works 

## AI Usage Disclaimer

calude help with the diagnose



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster, more memory-efficient token counting for large training datasets, improving processing speed and reducing peak memory use.
  * More accurate estimation of supervised token counts when label data is present, using streamed processing to avoid full dataset materialization.

* **Chores**
  * No changes to public APIs or function signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->