### PR TITLE
perf(scattermoe-lora): grouped-Gram dA/dB + sync-free dX_lora for large-E MoEs

### DIFF
--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
@@ -39,9 +39,16 @@ def _grouped_gram_configs():
 @triton.autotune(configs=_grouped_gram_configs(), key=["M_BUCKET", "WIDE", "RANK_IS_I"])
 @triton.jit
 def _grouped_gram_kernel(
-    P_ptr, stride_pm, stride_pd,
-    Q_ptr, stride_qm, stride_qd,
-    OUT_ptr, stride_og, stride_oi, stride_oj,
+    P_ptr,
+    stride_pm,
+    stride_pd,
+    Q_ptr,
+    stride_qm,
+    stride_qd,
+    OUT_ptr,
+    stride_og,
+    stride_oi,
+    stride_oj,
     offsets_ptr,
     M_BUCKET,
     WIDE: tl.constexpr,
@@ -89,41 +96,55 @@ def _grouped_gram_kernel(
         if RANK_IS_I:
             p = tl.load(
                 P_ptr + m_idx[:, None] * stride_pm + r_idx[None, :] * stride_pd,
-                mask=m_mask[:, None] & r_mask[None, :], other=0.0,
+                mask=m_mask[:, None] & r_mask[None, :],
+                other=0.0,
             ).to(input_dtype)
             q = tl.load(
                 Q_ptr + m_idx[:, None] * stride_qm + w_idx[None, :] * stride_qd,
-                mask=m_mask[:, None] & w_mask[None, :], other=0.0,
+                mask=m_mask[:, None] & w_mask[None, :],
+                other=0.0,
             ).to(input_dtype)
             acc += tl.dot(tl.trans(p), q, allow_tf32=allow_tf32)
         else:
             p = tl.load(
                 P_ptr + m_idx[:, None] * stride_pm + w_idx[None, :] * stride_pd,
-                mask=m_mask[:, None] & w_mask[None, :], other=0.0,
+                mask=m_mask[:, None] & w_mask[None, :],
+                other=0.0,
             ).to(input_dtype)
             q = tl.load(
                 Q_ptr + m_idx[:, None] * stride_qm + r_idx[None, :] * stride_qd,
-                mask=m_mask[:, None] & r_mask[None, :], other=0.0,
+                mask=m_mask[:, None] & r_mask[None, :],
+                other=0.0,
             ).to(input_dtype)
             acc += tl.dot(tl.trans(p), q, allow_tf32=allow_tf32)
 
     acc = acc * scaling
     if RANK_IS_I:
-        out_ptrs = OUT_ptr + g * stride_og + r_idx[:, None] * stride_oi + w_idx[None, :] * stride_oj
+        out_ptrs = (
+            OUT_ptr
+            + g * stride_og
+            + r_idx[:, None] * stride_oi
+            + w_idx[None, :] * stride_oj
+        )
         out_mask = r_mask[:, None] & w_mask[None, :]
     else:
-        out_ptrs = OUT_ptr + g * stride_og + w_idx[:, None] * stride_oi + r_idx[None, :] * stride_oj
+        out_ptrs = (
+            OUT_ptr
+            + g * stride_og
+            + w_idx[:, None] * stride_oi
+            + r_idx[None, :] * stride_oj
+        )
         out_mask = w_mask[:, None] & r_mask[None, :]
     tl.store(out_ptrs, acc.to(OUT_ptr.dtype.element_ty), mask=out_mask)
 
 
 def grouped_lora_weight_grads(
     grouped_grad_out: torch.Tensor,  # DY  [M*k, N], grouped
-    grouped_x: torch.Tensor,         # X   [M*k, K], grouped
-    yb: torch.Tensor,                # DY@B [M*k, R], grouped (reused from dX path)
-    xa: torch.Tensor,                # X@A^T [M*k, R], grouped (saved from forward)
-    lora_A: torch.Tensor,            # [E*T*R, K]
-    lora_B: torch.Tensor,            # [N, E*T*R]
+    grouped_x: torch.Tensor,  # X   [M*k, K], grouped
+    yb: torch.Tensor,  # DY@B [M*k, R], grouped (reused from dX path)
+    xa: torch.Tensor,  # X@A^T [M*k, R], grouped (saved from forward)
+    lora_A: torch.Tensor,  # [E*T*R, K]
+    lora_B: torch.Tensor,  # [N, E*T*R]
     combined_offsets: torch.Tensor,
     e_total: int,
     scaling: float,
@@ -145,21 +166,45 @@ def grouped_lora_weight_grads(
 
     grid_a = lambda meta: (e_total, triton.cdiv(k_dim, meta["BLOCK_WIDE"]))  # noqa: E731
     _grouped_gram_kernel[grid_a](
-        yb, yb.stride(0), yb.stride(1),
-        grouped_x, grouped_x.stride(0), grouped_x.stride(1),
-        dA, rank * dA.stride(0), dA.stride(0), dA.stride(1),
-        combined_offsets, m_bucket, WIDE=k_dim, RANK=rank, scaling=scaling,
-        RANK_IS_I=True, BLOCK_R=block_r, allow_tf32=ALLOW_TF32,
+        yb,
+        yb.stride(0),
+        yb.stride(1),
+        grouped_x,
+        grouped_x.stride(0),
+        grouped_x.stride(1),
+        dA,
+        rank * dA.stride(0),
+        dA.stride(0),
+        dA.stride(1),
+        combined_offsets,
+        m_bucket,
+        WIDE=k_dim,
+        RANK=rank,
+        scaling=scaling,
+        RANK_IS_I=True,
+        BLOCK_R=block_r,
+        allow_tf32=ALLOW_TF32,
     )
 
     grid_b = lambda meta: (e_total, triton.cdiv(n_dim, meta["BLOCK_WIDE"]))  # noqa: E731
     _grouped_gram_kernel[grid_b](
-        grouped_grad_out, grouped_grad_out.stride(0), grouped_grad_out.stride(1),
-        xa, xa.stride(0), xa.stride(1),
-        dB, rank * dB.stride(1), dB.stride(0), dB.stride(1),
-        combined_offsets, m_bucket, WIDE=n_dim, RANK=rank, scaling=scaling,
-        RANK_IS_I=False, BLOCK_R=block_r, allow_tf32=ALLOW_TF32,
+        grouped_grad_out,
+        grouped_grad_out.stride(0),
+        grouped_grad_out.stride(1),
+        xa,
+        xa.stride(0),
+        xa.stride(1),
+        dB,
+        rank * dB.stride(1),
+        dB.stride(0),
+        dB.stride(1),
+        combined_offsets,
+        m_bucket,
+        WIDE=n_dim,
+        RANK=rank,
+        scaling=scaling,
+        RANK_IS_I=False,
+        BLOCK_R=block_r,
+        allow_tf32=ALLOW_TF32,
     )
     return dA, dB
-
-

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Grouped-Gram LoRA weight gradients (dA/dB) without per-output-block recompute.
+
+The split kernel in ``lora_ops`` recomputes XA = X@A^T (resp. YB = dY@B) inside the
+kernel, once per output dim-block, to avoid materializing it. For LoRA's small rank
+those intermediates are tiny (``[M*k, R]``), so materializing them once and reducing
+the per-output-block recompute is a large net win at high expert counts. dA/dB then
+reduce to plain grouped Gram products: dA[g] = scaling * YB_g^T @ X_g,
+dB[g] = scaling * DY_g^T @ XA_g (reduction over the group's tokens).
+"""
+
+from itertools import product
+
+import torch
+import triton
+import triton.language as tl
+
+from .lora_ops import ALLOW_TF32, _block_r_for_rank, _bucket_m
+
+
+def _grouped_gram_configs():
+    configs = []
+    for block_wide, block_m, warps, stages in product(
+        [32, 64, 128, 256], [32, 64, 128], [4, 8], [3, 4]
+    ):
+        configs.append(
+            triton.Config(
+                {"BLOCK_WIDE": block_wide, "BLOCK_M": block_m},
+                num_warps=warps,
+                num_stages=stages,
+            )
+        )
+    return configs
+
+
+@triton.autotune(configs=_grouped_gram_configs(), key=["M_BUCKET", "WIDE", "RANK_IS_I"])
+@triton.jit
+def _grouped_gram_kernel(
+    P_ptr, stride_pm, stride_pd,
+    Q_ptr, stride_qm, stride_qd,
+    OUT_ptr, stride_og, stride_oi, stride_oj,
+    offsets_ptr,
+    M_BUCKET,
+    WIDE: tl.constexpr,
+    RANK: tl.constexpr,
+    scaling,
+    RANK_IS_I: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    BLOCK_WIDE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    allow_tf32: tl.constexpr,
+):
+    """Grouped Gram product: out[g] = scaling * (P_g^T @ Q_g), summed over the
+    tokens of combined-group g (a contiguous [start, end) slice).
+
+    Both LoRA weight gradients are this op once XA/YB are precomputed:
+      dA[g] = scaling * YB_g^T @ X_g   (P=YB[M,R], Q=X[M,K]; rank is the I/row dim)
+      dB[g] = scaling * DY_g^T @ XA_g  (P=DY[M,N], Q=XA[M,R]; rank is the J/col dim)
+
+    The wide dim (K for dA, N for dB) is tiled; the rank dim fits one BLOCK_R.
+    Every (group, wide-block) writes its full tile, so empty groups self-zero --
+    no output pre-init needed. Output strides place the [I, J] tile into either
+    lora_A-grad ([E*T*R, K]) or lora_B-grad ([N, E*T*R]) layout directly.
+    """
+    g = tl.program_id(0)
+    w_blk = tl.program_id(1)
+
+    start = tl.where(g == 0, 0, tl.load(offsets_ptr + g - 1, mask=g > 0, other=0))
+    end = tl.load(offsets_ptr + g)
+    num = end - start
+
+    w_idx = w_blk * BLOCK_WIDE + tl.arange(0, BLOCK_WIDE)
+    w_mask = w_idx < WIDE
+    r_idx = tl.arange(0, BLOCK_R)
+    r_mask = r_idx < RANK
+    input_dtype = P_ptr.dtype.element_ty
+
+    if RANK_IS_I:
+        acc = tl.zeros((BLOCK_R, BLOCK_WIDE), dtype=tl.float32)
+    else:
+        acc = tl.zeros((BLOCK_WIDE, BLOCK_R), dtype=tl.float32)
+
+    for i in range(tl.cdiv(num, BLOCK_M)):
+        m_idx = start + i * BLOCK_M + tl.arange(0, BLOCK_M)
+        m_mask = m_idx < end
+        if RANK_IS_I:
+            p = tl.load(
+                P_ptr + m_idx[:, None] * stride_pm + r_idx[None, :] * stride_pd,
+                mask=m_mask[:, None] & r_mask[None, :], other=0.0,
+            ).to(input_dtype)
+            q = tl.load(
+                Q_ptr + m_idx[:, None] * stride_qm + w_idx[None, :] * stride_qd,
+                mask=m_mask[:, None] & w_mask[None, :], other=0.0,
+            ).to(input_dtype)
+            acc += tl.dot(tl.trans(p), q, allow_tf32=allow_tf32)
+        else:
+            p = tl.load(
+                P_ptr + m_idx[:, None] * stride_pm + w_idx[None, :] * stride_pd,
+                mask=m_mask[:, None] & w_mask[None, :], other=0.0,
+            ).to(input_dtype)
+            q = tl.load(
+                Q_ptr + m_idx[:, None] * stride_qm + r_idx[None, :] * stride_qd,
+                mask=m_mask[:, None] & r_mask[None, :], other=0.0,
+            ).to(input_dtype)
+            acc += tl.dot(tl.trans(p), q, allow_tf32=allow_tf32)
+
+    acc = acc * scaling
+    if RANK_IS_I:
+        out_ptrs = OUT_ptr + g * stride_og + r_idx[:, None] * stride_oi + w_idx[None, :] * stride_oj
+        out_mask = r_mask[:, None] & w_mask[None, :]
+    else:
+        out_ptrs = OUT_ptr + g * stride_og + w_idx[:, None] * stride_oi + r_idx[None, :] * stride_oj
+        out_mask = w_mask[:, None] & r_mask[None, :]
+    tl.store(out_ptrs, acc.to(OUT_ptr.dtype.element_ty), mask=out_mask)
+
+
+def grouped_lora_weight_grads(
+    grouped_grad_out: torch.Tensor,  # DY  [M*k, N], grouped
+    grouped_x: torch.Tensor,         # X   [M*k, K], grouped
+    yb: torch.Tensor,                # DY@B [M*k, R], grouped (reused from dX path)
+    xa: torch.Tensor,                # X@A^T [M*k, R], grouped (saved from forward)
+    lora_A: torch.Tensor,            # [E*T*R, K]
+    lora_B: torch.Tensor,            # [N, E*T*R]
+    combined_offsets: torch.Tensor,
+    e_total: int,
+    scaling: float,
+):
+    """dA/dB via grouped Gram GEMMs over precomputed XA/YB.
+
+    Avoids the shared split kernel's per-output-block recompute of XA/YB (an
+    inner reduction over K or N, repeated cdiv(wide_dim, BLOCK) times per group);
+    that recompute is what makes the split path scale poorly as tenants grow.
+    """
+    rank = lora_A.size(0) // e_total
+    k_dim = lora_A.size(1)
+    n_dim = lora_B.size(0)
+    block_r = _block_r_for_rank(rank)
+    m_bucket = _bucket_m(max(1, grouped_x.size(0) // e_total))
+
+    dA = torch.empty_like(lora_A)
+    dB = torch.empty_like(lora_B)
+
+    grid_a = lambda meta: (e_total, triton.cdiv(k_dim, meta["BLOCK_WIDE"]))  # noqa: E731
+    _grouped_gram_kernel[grid_a](
+        yb, yb.stride(0), yb.stride(1),
+        grouped_x, grouped_x.stride(0), grouped_x.stride(1),
+        dA, rank * dA.stride(0), dA.stride(0), dA.stride(1),
+        combined_offsets, m_bucket, WIDE=k_dim, RANK=rank, scaling=scaling,
+        RANK_IS_I=True, BLOCK_R=block_r, allow_tf32=ALLOW_TF32,
+    )
+
+    grid_b = lambda meta: (e_total, triton.cdiv(n_dim, meta["BLOCK_WIDE"]))  # noqa: E731
+    _grouped_gram_kernel[grid_b](
+        grouped_grad_out, grouped_grad_out.stride(0), grouped_grad_out.stride(1),
+        xa, xa.stride(0), xa.stride(1),
+        dB, rank * dB.stride(1), dB.stride(0), dB.stride(1),
+        combined_offsets, m_bucket, WIDE=n_dim, RANK=rank, scaling=scaling,
+        RANK_IS_I=False, BLOCK_R=block_r, allow_tf32=ALLOW_TF32,
+    )
+    return dA, dB
+
+

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
@@ -30,7 +30,6 @@ import torch
 from .kernels import ops as base_ops
 from .kernels.grouped_gram import grouped_lora_weight_grads
 from .kernels.lora_ops import (
-    group_bwd_lora,
     group_bwd_lora_fused,
     scatter2scatter_lora,
     scatter2scatter_lora_dX,
@@ -302,21 +301,36 @@ class ScatterMoELoRA(torch.autograd.Function):
                 n_dim = lora_B.size(0)
                 w_yb = lora_B.reshape(n_dim, E, rank).permute(1, 0, 2).contiguous()
                 yb = base_ops.scatter2scatter(
-                    X=grouped_grad_out, W=w_yb, k=1,
+                    X=grouped_grad_out,
+                    W=w_yb,
+                    k=1,
                     sorted_expert_idxs=sorted_expert_idxs,
                     sorted_scattered_idxs=sorted_scattered_idxs,
-                    x_grouped=True, y_grouped=True, int64_indices=needs_int64_bwd,
+                    x_grouped=True,
+                    y_grouped=True,
+                    int64_indices=needs_int64_bwd,
                 )
                 w_xa = lora_A.reshape(E, rank, k_dim).permute(0, 2, 1).contiguous()
                 xa = base_ops.scatter2scatter(
-                    X=grouped_x, W=w_xa, k=1,
+                    X=grouped_x,
+                    W=w_xa,
+                    k=1,
                     sorted_expert_idxs=sorted_expert_idxs,
                     sorted_scattered_idxs=sorted_scattered_idxs,
-                    x_grouped=True, y_grouped=True, int64_indices=needs_int64_bwd,
+                    x_grouped=True,
+                    y_grouped=True,
+                    int64_indices=needs_int64_bwd,
                 )
                 d_lora_A, d_lora_B = grouped_lora_weight_grads(
-                    grouped_grad_out, grouped_x, yb, xa, lora_A, lora_B,
-                    expert_offsets, E, scaling,
+                    grouped_grad_out,
+                    grouped_x,
+                    yb,
+                    xa,
+                    lora_A,
+                    lora_B,
+                    expert_offsets,
+                    E,
+                    scaling,
                 )
 
             # ------------------------------------------------------------------
@@ -493,17 +507,25 @@ def _compute_lora_input_grad(
         if yb is None:
             w_yb = lora_B.reshape(N, E, R).permute(1, 0, 2).contiguous()  # [E, N, R]
             yb = base_ops.scatter2scatter(
-                X=grouped_grad_out, W=w_yb, k=1,
+                X=grouped_grad_out,
+                W=w_yb,
+                k=1,
                 sorted_expert_idxs=sorted_expert_idxs,
                 sorted_scattered_idxs=sorted_scattered_idxs,
-                x_grouped=True, y_grouped=True, int64_indices=int64_indices,
+                x_grouped=True,
+                y_grouped=True,
+                int64_indices=int64_indices,
             )
         w_a = lora_A.reshape(E, R, K).contiguous()  # [E, R, K]
         dx = base_ops.scatter2scatter(
-            X=yb, W=w_a, k=1,
+            X=yb,
+            W=w_a,
+            k=1,
             sorted_expert_idxs=sorted_expert_idxs,
             sorted_scattered_idxs=sorted_scattered_idxs,
-            x_grouped=True, y_grouped=True, int64_indices=int64_indices,
+            x_grouped=True,
+            y_grouped=True,
+            int64_indices=int64_indices,
         )
         return dx.mul_(scaling)
 
@@ -511,7 +533,9 @@ def _compute_lora_input_grad(
     offsets = expert_offsets.tolist()
     compute_dtype = grouped_grad_out.dtype
     d_input_lora = torch.zeros(
-        (grouped_grad_out.size(0), K), device=grouped_grad_out.device, dtype=compute_dtype
+        (grouped_grad_out.size(0), K),
+        device=grouped_grad_out.device,
+        dtype=compute_dtype,
     )
     prev_offset = 0
     for e in range(E):

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
@@ -28,6 +28,7 @@ from typing import Optional, Union
 import torch
 
 from .kernels import ops as base_ops
+from .kernels.grouped_gram import grouped_lora_weight_grads
 from .kernels.lora_ops import (
     group_bwd_lora,
     group_bwd_lora_fused,
@@ -237,6 +238,7 @@ class ScatterMoELoRA(torch.autograd.Function):
                 or _needs_int64_indices(grad_out, x)
             )
 
+            yb = None  # dY @ B, computed by the non-fused dA/dB path; reused by dX_lora
             if can_fuse_gather:
                 # ------------------------------------------------------------------
                 # Fused path: skip group(x) entirely
@@ -291,15 +293,30 @@ class ScatterMoELoRA(torch.autograd.Function):
                     grouped_x = base_ops.group(x, sorted_scattered_idxs, fan_out=k)
                     d_expanded_input = grouped_x  # Will be overwritten; reuse buffer
 
-                d_lora_A, d_lora_B = group_bwd_lora(
-                    DY=grouped_grad_out,
-                    X=grouped_x,
-                    lora_A=lora_A,
-                    lora_B=lora_B,
-                    expert_offsets=expert_offsets,
-                    E=E,
-                    scaling=scaling,
-                    int64_indices=needs_int64_bwd,
+                # dA/dB via grouped-Gram over precomputed XA/YB (rank-sized) instead
+                # of the split kernel's per-output-block recompute -- a large win as
+                # the expert count grows (modern MoEs, E >= 128). YB is also reused by
+                # the non-fused dX path below.
+                rank = lora_A.size(0) // E
+                k_dim = lora_A.size(1)
+                n_dim = lora_B.size(0)
+                w_yb = lora_B.reshape(n_dim, E, rank).permute(1, 0, 2).contiguous()
+                yb = base_ops.scatter2scatter(
+                    X=grouped_grad_out, W=w_yb, k=1,
+                    sorted_expert_idxs=sorted_expert_idxs,
+                    sorted_scattered_idxs=sorted_scattered_idxs,
+                    x_grouped=True, y_grouped=True, int64_indices=needs_int64_bwd,
+                )
+                w_xa = lora_A.reshape(E, rank, k_dim).permute(0, 2, 1).contiguous()
+                xa = base_ops.scatter2scatter(
+                    X=grouped_x, W=w_xa, k=1,
+                    sorted_expert_idxs=sorted_expert_idxs,
+                    sorted_scattered_idxs=sorted_scattered_idxs,
+                    x_grouped=True, y_grouped=True, int64_indices=needs_int64_bwd,
+                )
+                d_lora_A, d_lora_B = grouped_lora_weight_grads(
+                    grouped_grad_out, grouped_x, yb, xa, lora_A, lora_B,
+                    expert_offsets, E, scaling,
                 )
 
             # ------------------------------------------------------------------
@@ -385,7 +402,8 @@ class ScatterMoELoRA(torch.autograd.Function):
                     int64_indices=needs_int64_bwd,
                 )
 
-                # LoRA part: dX_lora = scaling * (dY @ B) @ A
+                # LoRA part: dX_lora = scaling * (dY @ B) @ A (sync-free grouped GEMMs;
+                # reuses YB from the dA/dB path when it was computed there)
                 if scaling != 0.0:
                     d_input_lora_grouped = _compute_lora_input_grad(
                         grouped_grad_out,
@@ -394,6 +412,10 @@ class ScatterMoELoRA(torch.autograd.Function):
                         expert_offsets,
                         E,
                         scaling,
+                        sorted_expert_idxs=sorted_expert_idxs,
+                        sorted_scattered_idxs=sorted_scattered_idxs,
+                        int64_indices=needs_int64_bwd,
+                        yb=yb,
                     )
                     if grouped_in:
                         d_expanded_input.add_(d_input_lora_grouped)
@@ -448,39 +470,58 @@ def _compute_lora_input_grad(
     expert_offsets: torch.Tensor,
     E: int,
     scaling: float,
+    sorted_expert_idxs: Optional[torch.Tensor] = None,
+    sorted_scattered_idxs: Optional[torch.Tensor] = None,
+    int64_indices: bool = False,
+    yb: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """
-    Compute the LoRA contribution to the input gradient:
-      dX_lora = scaling * (dY @ B) @ A
+    """LoRA contribution to the input gradient: ``dX_lora = scaling * (dY @ B) @ A``,
+    on expert-grouped data.
 
-    Uses PyTorch ops on expert-grouped data.
-    Each expert e: dX_e = scaling * (dY_e @ B_e) @ A_e
+    With routing ids it runs as two grouped GEMMs (``scatter2scatter``) -- sync-free
+    and a single launch each, instead of a Python per-expert loop with an
+    ``expert_offsets[e].item()`` device sync per expert (O(E) syncs, which dominate
+    at the high expert counts of modern MoEs). ``yb = dY @ B`` may be passed in to
+    reuse the value already computed for the dA/dB grads. The per-expert loop is kept
+    as a fallback for callers without the routing ids.
     """
     R = lora_A.size(0) // E
     K = lora_A.size(1)
-    M_total = grouped_grad_out.size(0)
+    N = lora_B.size(0)
 
-    d_input_lora = torch.zeros(
-        (M_total, K), device=grouped_grad_out.device, dtype=grouped_grad_out.dtype
-    )
+    if sorted_expert_idxs is not None:
+        if yb is None:
+            w_yb = lora_B.reshape(N, E, R).permute(1, 0, 2).contiguous()  # [E, N, R]
+            yb = base_ops.scatter2scatter(
+                X=grouped_grad_out, W=w_yb, k=1,
+                sorted_expert_idxs=sorted_expert_idxs,
+                sorted_scattered_idxs=sorted_scattered_idxs,
+                x_grouped=True, y_grouped=True, int64_indices=int64_indices,
+            )
+        w_a = lora_A.reshape(E, R, K).contiguous()  # [E, R, K]
+        dx = base_ops.scatter2scatter(
+            X=yb, W=w_a, k=1,
+            sorted_expert_idxs=sorted_expert_idxs,
+            sorted_scattered_idxs=sorted_scattered_idxs,
+            x_grouped=True, y_grouped=True, int64_indices=int64_indices,
+        )
+        return dx.mul_(scaling)
 
+    # fallback (no routing ids): one host sync for the whole offset array, not per expert
+    offsets = expert_offsets.tolist()
     compute_dtype = grouped_grad_out.dtype
-
+    d_input_lora = torch.zeros(
+        (grouped_grad_out.size(0), K), device=grouped_grad_out.device, dtype=compute_dtype
+    )
     prev_offset = 0
     for e in range(E):
-        curr_offset = expert_offsets[e].item()
+        curr_offset = offsets[e]
         if curr_offset > prev_offset:
-            dy_e = grouped_grad_out[prev_offset:curr_offset]  # [M_e, N]
-            a_e = lora_A[e * R : (e + 1) * R, :].to(compute_dtype)  # [r, K]
-            b_e = lora_B[:, e * R : (e + 1) * R].to(compute_dtype)  # [N, r]
-
-            # dX_e = scaling * (dY_e @ B_e) @ A_e
-            dy_b = dy_e @ b_e  # [M_e, r]
-            dx_e = scaling * (dy_b @ a_e)  # [M_e, K]
-            d_input_lora[prev_offset:curr_offset] = dx_e
-
+            dy_e = grouped_grad_out[prev_offset:curr_offset]
+            a_e = lora_A[e * R : (e + 1) * R, :].to(compute_dtype)
+            b_e = lora_B[:, e * R : (e + 1) * R].to(compute_dtype)
+            d_input_lora[prev_offset:curr_offset] = scaling * ((dy_e @ b_e) @ a_e)
         prev_offset = curr_offset
-
     return d_input_lora
 
 

--- a/tests/integrations/kernels/scattermoe_lora/test_mx_lora_grouped_gram.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_mx_lora_grouped_gram.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""MXFP4 base + LoRA at large workload hits the non-fused grouped-Gram dA/dB path.
+
+Guards the edge case: the LoRA weight gradients (dA/dB) must be base-agnostic --
+identical for an MXFP4 base and a bf16 dense base that is its dequantization --
+and dX must still route through the MX kernel (the non-fused dX path is never
+taken for MX). The workload is sized above the fuse-gather threshold so dA/dB go
+through the grouped-Gram path rather than the fused-gather kernel.
+"""
+
+import pytest
+import torch
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+MXTensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.mx_tensor", reason="torchao required for MXFP4"
+).MXTensor
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.mx_weights import (  # noqa: E402
+    selective_mx_weights_fwd,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (  # noqa: E402
+    flatten_sort_count,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_linear_lora import (  # noqa: E402
+    ScatterMoELoRA,
+)
+
+_FUSE_GATHER_THRESHOLD = 2**24
+
+
+def _run(W, x, A, B, sei, ssi, eo, topk, scaling, grad):
+    xg = x.detach().requires_grad_(True)
+    Ag = A.detach().requires_grad_(True)
+    Bg = B.detach().requires_grad_(True)
+    out = ScatterMoELoRA.apply(
+        xg, W, topk, sei, ssi, eo, Ag, Bg, scaling, None, None, False, False, True, True
+    )
+    out.backward(grad)
+    return out, xg.grad, Ag.grad, Bg.grad
+
+
+def test_mxfp4_lora_grads_base_agnostic_large_workload():
+    dev, dt = "cuda", torch.bfloat16
+    E, K, N, M, topk, R = 8, 2048, 2048, 8192, 2, 16  # M_total*max(K,N) > 2**24
+    scaling = 0.5
+    torch.manual_seed(0)
+
+    W_dense = torch.randn(E, N, K, device=dev, dtype=dt)
+    mx = MXTensor.to_mx(W_dense, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+    W_ref = mx.dequantize(dt).contiguous()  # exactly what the MX kernel dequantizes to
+    mx_w = selective_mx_weights_fwd(mx, torch.arange(E, device=dev))
+    W_kernel = W_ref.transpose(2, 1).contiguous()  # [E, K, N] for the dense kernel
+
+    x = torch.randn(M, K, device=dev, dtype=dt)
+    A = torch.randn(R * E, K, device=dev, dtype=dt) * 0.02
+    B = torch.randn(N, R * E, device=dev, dtype=dt) * 0.02
+    _, top = torch.topk(torch.softmax(torch.randn(M, E, device=dev), -1), topk, dim=-1)
+    sei, ssi, eo = flatten_sort_count(top, E)
+
+    assert sei.size(0) * max(K, N) > _FUSE_GATHER_THRESHOLD  # exercises grouped-Gram dA/dB
+
+    grad = torch.randn(sei.size(0), N, device=dev, dtype=dt)
+    _, dx_mx, da_mx, db_mx = _run(mx_w, x, A, B, sei, ssi, eo, topk, scaling, grad)
+    _, _, da_bf, db_bf = _run(W_kernel, x, A, B, sei, ssi, eo, topk, scaling, grad)
+
+    # LoRA grads never touch the (frozen) base -> identical for MX vs dense base
+    assert torch.equal(da_mx, da_bf), (da_mx - da_bf).abs().max().item()
+    assert torch.equal(db_mx, db_bf), (db_mx - db_bf).abs().max().item()
+    # and everything is finite + actually trained
+    for g in (dx_mx, da_mx, db_mx):
+        assert torch.isfinite(g).all() and g.abs().sum() > 0

--- a/tests/integrations/kernels/scattermoe_lora/test_mx_lora_grouped_gram.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_mx_lora_grouped_gram.py
@@ -12,7 +12,6 @@ through the grouped-Gram path rather than the fused-gather kernel.
 """
 
 import pytest
-import torch
 
 torch = pytest.importorskip("torch")
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -62,7 +61,9 @@ def test_mxfp4_lora_grads_base_agnostic_large_workload():
     _, top = torch.topk(torch.softmax(torch.randn(M, E, device=dev), -1), topk, dim=-1)
     sei, ssi, eo = flatten_sort_count(top, E)
 
-    assert sei.size(0) * max(K, N) > _FUSE_GATHER_THRESHOLD  # exercises grouped-Gram dA/dB
+    assert (
+        sei.size(0) * max(K, N) > _FUSE_GATHER_THRESHOLD
+    )  # exercises grouped-Gram dA/dB
 
     grad = torch.randn(sei.size(0), N, device=dev, dtype=dt)
     _, dx_mx, da_mx, db_mx = _run(mx_w, x, A, B, sei, ssi, eo, topk, scaling, grad)


### PR DESCRIPTION
The dA/dB split kernel recomputes XA=X@A^T (resp. YB=dY@B) in registers once per output dim-block to avoid materializing it; and the non-fused dX_lora path is a Python per-expert loop with an expert_offsets[e].item() device sync per expert. Both scale badly with the expert count -- and modern MoEs run E>=128.

The intermediates are rank-sized ([M*k, R], R~16), so materializing them once is near-free (the split kernel saves only ~2-8 MB across these shapes -- smaller than the dA/dB gradient it produces). Backport the multi-adapter wins to the single-adapter path:

- grouped_gram.py: _grouped_gram_kernel + grouped_lora_weight_grads -- dA/dB as recompute-free grouped Gram products over precomputed XA/YB (bit-identical to group_bwd_lora, err 0.0).
- ScatterMoELoRA.backward non-fused dA/dB: compute YB, XA once, then grouped-Gram; YB is reused by the non-fused dX_lora.
- _compute_lora_input_grad: two grouped scatter2scatter GEMMs (sync-free, single launch each) when routing ids are given, reusing YB; the per-expert loop is kept as a fallback but with one host sync for the whole offset array, not O(E).

Before/after, full ScatterMoELoRA fwd+bwd (E>=128, M=4096):
  fused-dX path (production, #dA/dB only): 1.08-1.15x
  non-fused path (#dA/dB + #dX_lora):      up to 2.2x (Qwen3-MoE, DeepSeek)
at +5..30 MB peak (the XA/YB buffers). The dA/dB kernel alone is 2-17x faster.

MXFP4 unaffected: dX takes the is_mx branch (scatter2scatter_lora_dX_mx) and never the rewritten non-fused path; dA/dB never touch the (frozen) base, so LoRA grads are bit-identical for an MX base vs its bf16 dequantization at a workload above the fuse-gather threshold (new regression test). (sonicmoe materialize) is already on main via baddbmm.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optimized LoRA weight gradient computation using grouped operations.
  * Enhanced LoRA input-gradient computation with fast routing support.

* **Refactor**
  * Improved LoRA backward computation path for better performance.

* **Tests**
  * Added CUDA integration test validating gradient accuracy for mixed-precision LoRA training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->