### PR TITLE
Feat/liger 0.8.0 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "bitsandbytes==0.49.1 ; sys_platform != 'darwin'",
     "triton>=3.4.0 ; sys_platform != 'darwin'",
     "xformers>=0.0.33.post2 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
-    "liger-kernel==0.7.0 ; sys_platform != 'darwin'",
+    "liger-kernel==0.8.0 ; sys_platform != 'darwin'",
     "torchao==0.17.0 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
 
     # Architecture-specific

--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -250,8 +250,7 @@ class LigerPlugin(BasePlugin):
                 _OrigGemma4RMSNorm = modeling_gemma4.Gemma4RMSNorm
 
                 class _LigerGemma4RMSNorm(LigerRMSNorm):
-                    """LigerRMSNorm for Gemma4: offset=0 (not 1 like Gemma3), in_place=False
-                    for gradient-checkpointing safety, with_scale support."""
+                    """LigerRMSNorm for Gemma4: offset=0, in_place=False (grad-ckpt safe), with_scale support."""
 
                     def __new__(cls, dim, eps=1e-6, with_scale=True):
                         if not with_scale:

--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -20,7 +20,8 @@ class LigerPlugin(BasePlugin):
         return "axolotl.integrations.liger.LigerArgs"
 
     def pre_model_load(self, cfg):
-        # shim: liger-kernel 0.7.0 imports ORPOTrainer from old trl path
+        # shim: liger-kernel imports ORPOTrainer from the old trl.trainer path,
+        # which modern trl has moved to trl.experimental.orpo
         import trl.trainer
         from trl.experimental.orpo import ORPOTrainer
 
@@ -81,7 +82,18 @@ class LigerPlugin(BasePlugin):
 
             LigerFusedLinearCrossEntropyLoss.__init__ = patched_init
 
-        if cfg.model_config_type in MODEL_TYPE_TO_APPLY_LIGER_FN:
+        # liger-kernel 0.8.0 added native dispatch entries for these model types,
+        # but the axolotl branches below add handling those native paths lack:
+        # fused gated-RMSNorm (Qwen3_5RMSNormGated / Qwen3_5MoeRMSNormGated, used by
+        # the linear-attention layers) for qwen3_5 / qwen3_5_moe, and checkpoint-safe
+        # (in_place=False) RMSNorm/GEGLU for gemma4_text. Keep routing them to the
+        # axolotl branches instead of the generic native dispatch.
+        axolotl_override_liger_fn = {"qwen3_5", "qwen3_5_moe", "gemma4_text"}
+
+        if (
+            cfg.model_config_type in MODEL_TYPE_TO_APPLY_LIGER_FN
+            and cfg.model_config_type not in axolotl_override_liger_fn
+        ):
             apply_liger_fn = MODEL_TYPE_TO_APPLY_LIGER_FN[cfg.model_config_type]
             liger_fn_sig = inspect.signature(apply_liger_fn)
             kwargs = {}

--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -82,7 +82,7 @@ class LigerPlugin(BasePlugin):
             LigerFusedLinearCrossEntropyLoss.__init__ = patched_init
 
         # liger 0.8.0 natively dispatches these, but axolotl's branches add kernels native lacks
-        axolotl_override_liger_fn = {"qwen3_5", "qwen3_5_moe", "gemma4_text"}
+        axolotl_override_liger_fn = {"qwen3_5", "qwen3_5_moe"}
 
         if (
             cfg.model_config_type in MODEL_TYPE_TO_APPLY_LIGER_FN
@@ -241,9 +241,8 @@ class LigerPlugin(BasePlugin):
                 rms_norm=cfg.liger_rms_norm,
                 swiglu=cfg.liger_glu_activation,
             )
-        elif cfg.model_config_type in ("gemma4", "gemma4_text"):
-            # Gemma4: offset=0 (NOT 1 like Gemma3), in_place=False required for
-            # gradient checkpointing compatibility, RoPE incompatible (separate q/k).
+        elif cfg.model_config_type == "gemma4":
+            # multimodal gemma4 only; gemma4_text uses liger 0.8.0 native dispatch (incl. FLCE)
             from liger_kernel.transformers.geglu import LigerGEGLUMLP
             from transformers.models.gemma4 import modeling_gemma4
 
@@ -251,7 +250,8 @@ class LigerPlugin(BasePlugin):
                 _OrigGemma4RMSNorm = modeling_gemma4.Gemma4RMSNorm
 
                 class _LigerGemma4RMSNorm(LigerRMSNorm):
-                    """LigerRMSNorm for Gemma4 with in_place=False and with_scale support."""
+                    """LigerRMSNorm for Gemma4: offset=0 (not 1 like Gemma3), in_place=False
+                    for gradient-checkpointing safety, with_scale support."""
 
                     def __new__(cls, dim, eps=1e-6, with_scale=True):
                         if not with_scale:
@@ -284,7 +284,8 @@ class LigerPlugin(BasePlugin):
                 modeling_gemma4.nn.CrossEntropyLoss = LigerCrossEntropyLoss
             if cfg.liger_fused_linear_cross_entropy:
                 LOG.warning(
-                    "Liger fused linear cross entropy is not compatible with Gemma4. Skipping."
+                    "Liger fused linear cross entropy is not supported for multimodal gemma4. "
+                    "Skipping (the gemma4_text language model gets FLCE via liger's native path)."
                 )
             LOG.info(
                 f"Applied Liger kernels for gemma4: "

--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -284,8 +284,9 @@ class LigerPlugin(BasePlugin):
                 modeling_gemma4.nn.CrossEntropyLoss = LigerCrossEntropyLoss
             if cfg.liger_fused_linear_cross_entropy:
                 LOG.warning(
-                    "Liger fused linear cross entropy is not supported for multimodal gemma4. "
-                    "Skipping (the gemma4_text language model gets FLCE via liger's native path)."
+                    "Liger fused linear cross entropy for multimodal gemma4 is not in "
+                    "liger-kernel 0.8.0 (added upstream in PR #1203, post-0.8.0). Skipping; "
+                    "the gemma4_text language model gets FLCE via liger's native path."
                 )
             LOG.info(
                 f"Applied Liger kernels for gemma4: "

--- a/src/axolotl/integrations/liger/plugin.py
+++ b/src/axolotl/integrations/liger/plugin.py
@@ -20,8 +20,7 @@ class LigerPlugin(BasePlugin):
         return "axolotl.integrations.liger.LigerArgs"
 
     def pre_model_load(self, cfg):
-        # shim: liger-kernel imports ORPOTrainer from the old trl.trainer path,
-        # which modern trl has moved to trl.experimental.orpo
+        # shim: liger imports ORPOTrainer from old trl.trainer (now trl.experimental.orpo)
         import trl.trainer
         from trl.experimental.orpo import ORPOTrainer
 
@@ -82,12 +81,7 @@ class LigerPlugin(BasePlugin):
 
             LigerFusedLinearCrossEntropyLoss.__init__ = patched_init
 
-        # liger-kernel 0.8.0 added native dispatch entries for these model types,
-        # but the axolotl branches below add handling those native paths lack:
-        # fused gated-RMSNorm (Qwen3_5RMSNormGated / Qwen3_5MoeRMSNormGated, used by
-        # the linear-attention layers) for qwen3_5 / qwen3_5_moe, and checkpoint-safe
-        # (in_place=False) RMSNorm/GEGLU for gemma4_text. Keep routing them to the
-        # axolotl branches instead of the generic native dispatch.
+        # liger 0.8.0 natively dispatches these, but axolotl's branches add kernels native lacks
         axolotl_override_liger_fn = {"qwen3_5", "qwen3_5_moe", "gemma4_text"}
 
         if (


### PR DESCRIPTION
## Description

Bumps `liger-kernel` from **0.7.0 → 0.8.0** and aligns axolotl's Liger integration with the new release. liger 0.8.0 added native auto-patch entries to `MODEL_TYPE_TO_APPLY_LIGER_FN` for `qwen3_5`, `qwen3_5_text`, `qwen3_5_moe`, `qwen3_5_moe_text`, `gemma4_text`, `ministral`, and `nemotron`. `LigerPlugin.pre_model_load` consults that registry before its own model-specific branches, so this PR guards the cases where axolotl's handling must win and lets native dispatch take over where it is now equal or better. Two files: the pin in `pyproject.toml` and the dispatch logic in `plugin.py`.

## Motivation and Context

The plugin checks `MODEL_TYPE_TO_APPLY_LIGER_FN` **before** its own branches, so a plain version bump silently changes behavior for the newly-added keys:

- `qwen3_5` / `qwen3_5_moe` would fall through to native dispatch, which **does not patch the gated RMSNorm** (`Qwen3_5RMSNormGated` / `Qwen3_5MoeRMSNormGated`, used by the linear-attention layers). That drops axolotl's fused `FusedRMSNormGated` kernel. An `axolotl_override_liger_fn = {"qwen3_5", "qwen3_5_moe"}` set keeps these on axolotl's branches.
- `gemma4_text` is now **better** served by native: `apply_liger_kernel_to_gemma4_text` supports fused-linear-cross-entropy (which axolotl's custom gemma4 branch skipped) and uses the more-correct `casting_mode="gemma"` fp32 RMSNorm with `with_scale=False` v_norm handling. It is dropped from the override set so it adopts native dispatch and gains FLCE.
- Multimodal `gemma4` has no native entry in 0.8.0 (`apply_liger_kernel_to_gemma4` for `Gemma4ForConditionalGeneration` was added upstream **after** the 0.8.0 tag in linkedin/Liger-Kernel#1203), so it stays on axolotl's branch; its FLCE warning now points to the text path.
- Genuinely-new types (`qwen3_5_text`, `qwen3_5_moe_text`, `qwen3_next`, `ministral`, `nemotron`) correctly adopt native dispatch — new model coverage, no axolotl code needed.

The ORPO trl-compat shim is retained (liger 0.8.0 still imports `ORPOTrainer` from the old `trl.trainer` path, which modern trl moved to `trl.experimental.orpo`). All Liger symbols axolotl imports remain present in 0.8.0 with backward-compatible signatures (new keyword args only).

## How has this been tested?

Run against the repo-pinned dependency versions (`transformers==5.9.0`, `trl==1.5.1`, `accelerate==1.13.0`, `liger-kernel==0.8.0`):

- **Unit**: `tests/integrations/test_liger.py`, `test_kd_liger.py`, `test_liger_qwen_vl_rope_default.py` → 14 passed, 0 failed (GPU-gated `test_qwen3_5_fused_attn.py` skips as expected).
- **Imports/regression**: every `liger_kernel` import across `src/` resolves under 0.8.0; the trl ORPO shim (`trl.experimental.orpo`) is valid under trl 1.5.1; transformers 5.9.0's `Qwen3_5RMSNormGated` / `Qwen3_5MoeRMSNormGated` and `gemma4` modules resolve; signatures axolotl depends on (`use_token_scaling`, FLCE forward/backward ops, `LigerForCausalLMLoss`, `LigerRMSNorm`) all present.
- **GPU (RTX 5090, torch 2.11.0+cu130)**: Qwen3.5-0.8B with `liger_rms_norm_gated: true` routes through the `qwen3_5` override branch with `FusedRMSNormGated` swapped into `Qwen3_5RMSNormGated` and the custom `lce_forward` active — 6 steps, finite losses, exit 0 (validated under transformers 5.9.0; earlier also under 5.5.4 on torch 2.9.1/2.11.0). llama (SmolLM2-135M) baseline uses native dispatch, finite losses. Tiny `Gemma4ForCausalLM` native FLCE forward → finite loss, `out.logits is None` (fused path, no logit materialization), finite grads.
- **Environment**: Python 3.12, transformers==5.9.0, trl==1.5.1, accelerate==1.13.0, peft 0.19.1, torch 2.11.0+cu130, liger-kernel==0.8.0, local venv.

## AI Usage Disclaimer

Opus 4.8 assisted with the liger 0.7.0 → 0.8.0 API diff analysis, the dispatch-override fix, and GPU validation.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated liger-kernel dependency to version 0.8.0 for non-Darwin platforms.
  * Adjusted plugin compatibility for latest dependency version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->