### PR TITLE
perf(scattermoe): Blackwell sm120 MoE-LoRA — EP sentinel-skip, fused MXFP4, sonicmoe fallback

### DIFF
--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -82,7 +82,27 @@ def _scattermoe_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
 
 
 def _sonicmoe_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
-    raise NotImplementedError("Sonicmoe + EP is not yet properly implemented.")
+    # The sonic-moe CUTLASS kernel can't run on sm_120 (Blackwell); for standard-layout
+    # experts there, use the vendored scattermoe EP path (sentinel-skip + fused MXFP4),
+    # which runs on sm_120 and gives sonicmoe + LoRA + EP. Elsewhere sonicmoe+EP is not
+    # yet wired (needs the upstream EP-sentinel kernel).
+    from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (
+        scattermoe_experts_forward_ep,
+        scattermoe_supports_layout,
+    )
+    from axolotl.integrations.kernels.libs.sonicmoe.experts import (
+        _sonicmoe_kernel_supported,
+    )
+
+    if not _sonicmoe_kernel_supported() and scattermoe_supports_layout(experts):
+        return scattermoe_experts_forward_ep(
+            experts, recv_x, recv_topk_idx, recv_topk_weights
+        )
+    raise NotImplementedError(
+        "Sonicmoe + EP is not yet implemented on this device/layout. On sm_120 with a "
+        "standard expert layout it falls back to the scattermoe EP path automatically; "
+        "otherwise use use_scattermoe."
+    )
 
 
 _LOCAL_KERNELS = {

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -51,19 +51,34 @@ def _maybe_install_decorator_attrs(experts):
         experts.is_transposed = False
 
 
+def _mask_sentinels(recv_topk_idx, recv_topk_weights):
+    """Map ``-1`` remote sentinels to expert 0 / weight 0 for kernels that index by
+    expert id and don't filter (grouped_mm). The zero weight nulls their contribution."""
+    safe_idx = torch.where(
+        recv_topk_idx >= 0, recv_topk_idx, torch.zeros_like(recv_topk_idx)
+    )
+    valid = (recv_topk_idx >= 0).to(recv_topk_weights.dtype)
+    return safe_idx, recv_topk_weights * valid
+
+
 def _grouped_mm_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
     from transformers.integrations.moe import grouped_mm_experts_forward
 
     _maybe_install_decorator_attrs(experts)
-    return grouped_mm_experts_forward(experts, recv_x, recv_topk_idx, recv_topk_weights)
+    safe_idx, safe_w = _mask_sentinels(recv_topk_idx, recv_topk_weights)
+    return grouped_mm_experts_forward(experts, recv_x, safe_idx, safe_w)
 
 
 def _scattermoe_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
+    # scattermoe skips sentinel rows natively (only valid rows hit the grouped GEMM
+    # + per-row LoRA) -- pass the raw -1-tagged routing, not the masked version.
     from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (
-        scattermoe_experts_forward,
+        scattermoe_experts_forward_ep,
     )
 
-    return scattermoe_experts_forward(experts, recv_x, recv_topk_idx, recv_topk_weights)
+    return scattermoe_experts_forward_ep(
+        experts, recv_x, recv_topk_idx, recv_topk_weights
+    )
 
 
 def _sonicmoe_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
@@ -160,9 +175,10 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
     """Shared dispatch -> local-experts -> combine pipeline.
 
     Inputs come in with **global** routing indices (we do not run
-    `transformers.RouterParallel`; see DEEP_EP.md §2.4 for why). Sentinels are
-    `-1` for slots routed to remote experts; we mask them to a valid local id
-    with weight=0 so the local kernel can index safely.
+    `transformers.RouterParallel`; see DEEP_EP.md §2.4 for why). Dispatch returns
+    local expert ids in `[0, E_local)` with `-1` for slots routed to remote experts;
+    the `-1` sentinels are passed through to the local kernel, which decides whether
+    to skip them (eager/scattermoe) or mask them (grouped_mm).
     """
     if hidden_states.dtype != torch.bfloat16:
         original_dtype = hidden_states.dtype
@@ -191,14 +207,11 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
         is_in_rank,
     )
 
-    # Mask -1 sentinels for kernels that don't filter.
-    safe_idx = torch.where(
-        recv_topk_idx >= 0, recv_topk_idx, torch.zeros_like(recv_topk_idx)
+    # Pass the raw -1-tagged routing through; each local kernel handles sentinels
+    # its own way (eager/scattermoe skip them, grouped_mm masks internally).
+    local_out = _LOCAL_KERNELS[kernel_name](
+        self, recv_x, recv_topk_idx, recv_topk_weights
     )
-    valid_mask = (recv_topk_idx >= 0).to(recv_topk_weights.dtype)
-    safe_w = recv_topk_weights * valid_mask
-
-    local_out = _LOCAL_KERNELS[kernel_name](self, recv_x, safe_idx, safe_w)
 
     combined = _DeepEPCombine.apply(local_out, handle_holder)
 

--- a/src/axolotl/integrations/kernels/README.md
+++ b/src/axolotl/integrations/kernels/README.md
@@ -84,9 +84,13 @@ Any model whose `Experts` class is decorated with `@use_experts_implementation` 
 | `ernie4_5_moe`    |    Yes    |   Yes    |
 | `hunyuan_v1_moe`  |    Yes    |   Yes    |
 | `gemma4_text`     |    Yes    |   Yes    |
-| `gpt_oss`         |    No     |   Yes    |
+| `gpt_oss`         |    Yes    |   Yes    |
 
-`gpt_oss` carries the decorator with `is_concatenated=False, is_transposed=True, has_bias=True` and uses a sigmoid-GLU activation with clamping. The SonicMoE forward reads these flags off `self` and dispatches accordingly. The ScatterMoE forward assumes the standard `[E, 2*I, H]` concat layout and SiLU-GLU without bias, so it does not yet support `gpt_oss`.
+`gpt_oss` carries the decorator with `is_concatenated=False, is_transposed=True, has_bias=True` and uses a sigmoid-GLU activation with clamping. Both forwards read these flags off `self` and dispatch accordingly: the ScatterMoE forward handles the transposed/interleaved/biased layout and clamped sigmoid-GLU via its Triton path (no weight transpose, interleaved gate/up, per-expert bias folded into the grouped GEMM); the SonicMoE forward uses the upstream CUTLASS kernel.
+
+### Blackwell (sm_120) note
+
+The SonicMoE CUTLASS kernel (`kernels-community/sonic-moe`) does not currently run on consumer Blackwell (sm_120) — its bundled quack `GemmSm120` predates the `concat_layout` arg the dispatcher passes. On sm_120, `use_sonicmoe` with a standard-layout model transparently falls back to the ScatterMoE Triton path, which runs there. `gpt_oss` on sm_120 should use `use_scattermoe` directly (bf16 base; MXFP4 weights dequantize on the fly as with other MXFP4 models — fused MXFP4 for `gpt_oss` is not yet wired).
 
 ## Feature comparison
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -91,6 +91,7 @@ def _parallel_linear_maybe_lora(
     grouped_in,
     grouped_out,
     gates=None,
+    expert_biases=None,
 ):
     """Call parallel_linear or parallel_linear_lora depending on whether LoRA is active."""
     if lora_tuple is not None:
@@ -105,6 +106,7 @@ def _parallel_linear_maybe_lora(
             lora_A,
             lora_B,
             scaling,
+            expert_biases=expert_biases,
             grouped_in=grouped_in,
             grouped_out=grouped_out,
             gates=gates,
@@ -116,29 +118,118 @@ def _parallel_linear_maybe_lora(
         sorted_expert_idxs,
         sorted_scattered_idxs,
         expert_offsets,
+        expert_biases=expert_biases,
         grouped_in=grouped_in,
         grouped_out=grouped_out,
         gates=gates,
     )
 
 
-def _check_supported_layout(self):
-    """Reject expert layouts the fixed transpose/chunk below would miscompute."""
-    # Assumes the standard expert layout: gate_up concatenated as [E, 2I, H],
-    # gated SwiGLU, no expert bias. gpt_oss-style experts (interleaved gate/up,
-    # transposed [E, H, 2I], expert bias) would be silently miscomputed by the
-    # fixed transpose/chunk below, so reject rather than corrupt training.
-    if (
+def scattermoe_supports_layout(self) -> bool:
+    """True iff this experts module uses the standard layout scattermoe handles:
+    gate_up concatenated as [E, 2I, H], gated SwiGLU, no expert bias. gpt_oss-style
+    experts (interleaved gate/up, transposed [E, H, 2I], expert bias) return False."""
+    return not (
         getattr(self, "is_transposed", False)
         or not getattr(self, "is_concatenated", True)
         or getattr(self, "has_bias", False)
         or not getattr(self, "has_gate", True)
-    ):
+    )
+
+
+def _check_supported_layout(self):
+    """Reject expert layouts the fixed transpose/chunk below would miscompute."""
+    # gpt_oss-style experts (interleaved gate/up, transposed [E, H, 2I], expert
+    # bias) would be silently miscomputed by the fixed transpose/chunk below, so
+    # reject rather than corrupt training.
+    if not scattermoe_supports_layout(self):
         raise NotImplementedError(
             "scattermoe supports only concatenated, non-transposed, gated, biasless "
             "experts (qwen/mixtral/deepseek/glm/...). This model's experts use an "
             "unsupported layout; use use_sonicmoe or a built-in experts_implementation."
         )
+
+
+def _is_gptoss_layout(self) -> bool:
+    """gpt_oss expert layout: transposed [E, H, 2I] weights, interleaved gate/up,
+    per-expert bias, clamped sigmoid-GLU. Handled by the Triton path below."""
+    return (
+        getattr(self, "is_transposed", False)
+        and not getattr(self, "is_concatenated", True)
+        and getattr(self, "has_bias", False)
+        and getattr(self, "has_gate", True)
+        and hasattr(self, "gate_up_proj_bias")
+        and hasattr(self, "down_proj_bias")
+    )
+
+
+def _gptoss_glu(gate_up: torch.Tensor, alpha: float, limit: float) -> torch.Tensor:
+    """gpt_oss clamped sigmoid-GLU over interleaved gate/up columns (matches
+    ``GptOssExperts._apply_gate``)."""
+    gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    glu = gate * torch.sigmoid(gate * alpha)
+    return (up + 1) * glu
+
+
+def _scattermoe_gptoss_forward(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """ScatterMoE forward for gpt_oss-style experts (transposed/interleaved/biased).
+
+    gpt_oss stores weights already in ``[E, in, out]`` form, so no transpose; gate/up
+    are interleaved (``[..., ::2]`` / ``[..., 1::2]``); per-expert bias is folded into
+    the grouped GEMM; the activation is the clamped sigmoid-GLU. LoRA fuses exactly as
+    in the standard path (in/out dims match), and the down bias is added per row before
+    the routing-weight combine.
+    """
+    K = top_k_index.shape[1]
+    routing_weights = top_k_weights.to(hidden_states.dtype)
+    sorted_expert_idxs, sorted_scattered_idxs, expert_offsets = flatten_sort_count(
+        top_k_index, num_experts=self.num_experts
+    )
+
+    gate_up_weight = _get_base_param(self.gate_up_proj)  # [E, H, 2I], already [E,in,out]
+    down_weight = _get_base_param(self.down_proj)  # [E, I, H]
+    gate_up_bias = _get_base_param(self.gate_up_proj_bias)  # [E, 2I]
+    down_bias = _get_base_param(self.down_proj_bias)  # [E, H]
+
+    gup_lora, down_lora = None, None
+    if _has_peft_wrapper(self):
+        _, gup_lora, down_lora = _unwrap_experts_lora(self)
+
+    gate_up = _parallel_linear_maybe_lora(
+        hidden_states,
+        gate_up_weight,
+        K,
+        sorted_expert_idxs,
+        sorted_scattered_idxs,
+        expert_offsets,
+        gup_lora,
+        grouped_in=False,
+        grouped_out=True,
+        expert_biases=gate_up_bias,
+    )
+    h = _gptoss_glu(gate_up, getattr(self, "alpha", 1.702), getattr(self, "limit", 7.0))
+
+    output = _parallel_linear_maybe_lora(
+        h,
+        down_weight,
+        1,
+        sorted_expert_idxs,
+        sorted_scattered_idxs,
+        expert_offsets,
+        down_lora,
+        grouped_in=True,
+        grouped_out=False,
+        gates=routing_weights,
+        expert_biases=down_bias,
+    )
+    return output
 
 
 def scattermoe_experts_forward(
@@ -148,7 +239,12 @@ def scattermoe_experts_forward(
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
     """ScatterMoE experts forward with fused-LoRA support."""
-    _check_supported_layout(self)
+    if not scattermoe_supports_layout(self):
+        if _is_gptoss_layout(self):
+            return _scattermoe_gptoss_forward(
+                self, hidden_states, top_k_index, top_k_weights
+            )
+        _check_supported_layout(self)  # raises for any other unsupported layout
 
     K = top_k_index.shape[1]
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -122,13 +122,8 @@ def _parallel_linear_maybe_lora(
     )
 
 
-def scattermoe_experts_forward(
-    self,
-    hidden_states: torch.Tensor,
-    top_k_index: torch.Tensor,
-    top_k_weights: torch.Tensor,
-) -> torch.Tensor:
-    """ScatterMoE experts forward with fused-LoRA support."""
+def _check_supported_layout(self):
+    """Reject expert layouts the fixed transpose/chunk below would miscompute."""
     # Assumes the standard expert layout: gate_up concatenated as [E, 2I, H],
     # gated SwiGLU, no expert bias. gpt_oss-style experts (interleaved gate/up,
     # transposed [E, H, 2I], expert bias) would be silently miscomputed by the
@@ -144,6 +139,16 @@ def scattermoe_experts_forward(
             "experts (qwen/mixtral/deepseek/glm/...). This model's experts use an "
             "unsupported layout; use use_sonicmoe or a built-in experts_implementation."
         )
+
+
+def scattermoe_experts_forward(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """ScatterMoE experts forward with fused-LoRA support."""
+    _check_supported_layout(self)
 
     K = top_k_index.shape[1]
 
@@ -190,6 +195,91 @@ def scattermoe_experts_forward(
         gates=routing_weights,
     )
 
+    return output
+
+
+def scattermoe_experts_forward_ep(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """ScatterMoE experts forward for the DeepEP local path, skipping EP sentinels.
+
+    After DeepEP dispatch ``top_k_index`` holds local expert ids in ``[0, E_local)``
+    for slots this rank owns and ``-1`` for slots routed to remote ranks. Rather than
+    map sentinels to expert 0 / weight 0 and run the full grouped GEMM over all
+    ``N*K`` rows (compute-and-mask), drop the sentinel rows so only the valid routed
+    rows hit the GEMM + per-row LoRA. Output matches the masked path since sentinel
+    slots carry weight 0.
+
+    Runs both projections fully grouped (the sentinel-compacted routing breaks the
+    ``L_scattered == X.rows * k`` fan-out contract of the scattered path), with the
+    weighted token-combine done via ``index_add_``.
+    """
+    _check_supported_layout(self)
+
+    N = hidden_states.size(0)
+    K = top_k_index.shape[1]
+    E_local = self.num_experts
+
+    idx_flat = top_k_index.reshape(-1)
+    valid = idx_flat >= 0
+    e_v = idx_flat[valid].to(torch.long)
+    if e_v.numel() == 0:
+        return torch.zeros_like(hidden_states)
+
+    tok = torch.arange(N, device=hidden_states.device).repeat_interleave(K)
+    tok_v = tok[valid]
+    w_v = top_k_weights.reshape(-1)[valid].to(hidden_states.dtype)
+
+    # Sort valid rows by expert so each expert's rows are contiguous (grouped layout).
+    se, order = torch.sort(e_v)
+    tok_sorted = tok_v[order].to(torch.int32)
+    w_sorted = w_v[order]
+    expert_offsets = torch.bincount(e_v, minlength=E_local).cumsum(-1)
+    M = se.size(0)
+    ss = torch.arange(M, device=hidden_states.device, dtype=torch.int32)
+
+    gate_up_weight = _get_base_param(self.gate_up_proj).transpose(2, 1)
+    down_weight = _get_base_param(self.down_proj).transpose(2, 1)
+
+    gup_lora, down_lora = None, None
+    if _has_peft_wrapper(self):
+        _, gup_lora, down_lora = _unwrap_experts_lora(self)
+
+    # Pre-gather token rows into expert-grouped order; both projections run grouped.
+    grouped_x = hidden_states.index_select(0, tok_sorted.to(torch.long))
+
+    gates_h = _parallel_linear_maybe_lora(
+        grouped_x,
+        gate_up_weight,
+        1,
+        se,
+        ss,
+        expert_offsets,
+        gup_lora,
+        grouped_in=True,
+        grouped_out=True,
+    )
+    gates, h = gates_h.chunk(2, dim=-1)
+    h = self.act_fn(gates) * h
+
+    down_out = _parallel_linear_maybe_lora(
+        h,
+        down_weight,
+        1,
+        se,
+        ss,
+        expert_offsets,
+        down_lora,
+        grouped_in=True,
+        grouped_out=True,
+    )
+    down_out = down_out * w_sorted.unsqueeze(-1)
+
+    output = hidden_states.new_zeros((N, down_out.size(-1)))
+    output.index_add_(0, tok_sorted.to(torch.long), down_out)
     return output
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -133,8 +133,14 @@ def _parallel_linear_maybe_lora(
 
 
 def _prepare_weights_and_lora(
-    gu_param, dn_param, sorted_expert_idxs, expert_offsets, num_experts,
-    gup_lora, down_lora, dtype,
+    gu_param,
+    dn_param,
+    sorted_expert_idxs,
+    expert_offsets,
+    num_experts,
+    gup_lora,
+    down_lora,
+    dtype,
 ):
     """Resolve the gate_up / down weights (+ routing + LoRA) for the grouped GEMM.
 
@@ -154,15 +160,28 @@ def _prepare_weights_and_lora(
         )
         gate_up_weight = selective_mx_weights_fwd(gu_param, active)
         down_weight = selective_mx_weights_fwd(dn_param, active)
-        gup_lora = (*selective_lora_weights(gup_lora[0], gup_lora[1], active, num_experts), gup_lora[2])
-        down_lora = (*selective_lora_weights(down_lora[0], down_lora[1], active, num_experts), down_lora[2])
+        gup_lora = (
+            *selective_lora_weights(gup_lora[0], gup_lora[1], active, num_experts),
+            gup_lora[2],
+        )
+        down_lora = (
+            *selective_lora_weights(down_lora[0], down_lora[1], active, num_experts),
+            down_lora[2],
+        )
     elif is_mxfp4_param(gu_param):
         gate_up_weight = gu_param.dequantize(dtype).transpose(2, 1)
         down_weight = dn_param.dequantize(dtype).transpose(2, 1)
     else:
         gate_up_weight = gu_param.transpose(2, 1)  # bf16 [E, out, in] -> [E, in, out]
         down_weight = dn_param.transpose(2, 1)
-    return gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets, gup_lora, down_lora
+    return (
+        gate_up_weight,
+        down_weight,
+        sorted_expert_idxs,
+        expert_offsets,
+        gup_lora,
+        down_lora,
+    )
 
 
 def scattermoe_supports_layout(self) -> bool:
@@ -233,7 +252,9 @@ def _scattermoe_gptoss_forward(
         top_k_index, num_experts=self.num_experts
     )
 
-    gate_up_weight = _get_base_param(self.gate_up_proj)  # [E, H, 2I], already [E,in,out]
+    gate_up_weight = _get_base_param(
+        self.gate_up_proj
+    )  # [E, H, 2I], already [E,in,out]
     down_weight = _get_base_param(self.down_proj)  # [E, I, H]
     gate_up_bias = _get_base_param(self.gate_up_proj_bias)  # [E, 2I]
     down_bias = _get_base_param(self.down_proj_bias)  # [E, H]
@@ -299,13 +320,21 @@ def scattermoe_experts_forward(
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
 
     (
-        gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
-        gup_lora, down_lora,
+        gate_up_weight,
+        down_weight,
+        sorted_expert_idxs,
+        expert_offsets,
+        gup_lora,
+        down_lora,
     ) = _prepare_weights_and_lora(
         _get_base_param(self.gate_up_proj),
         _get_base_param(self.down_proj),
-        sorted_expert_idxs, expert_offsets, self.num_experts,
-        gup_lora, down_lora, hidden_states.dtype,
+        sorted_expert_idxs,
+        expert_offsets,
+        self.num_experts,
+        gup_lora,
+        down_lora,
+        hidden_states.dtype,
     )
 
     # Gate-up projection (with optional LoRA)
@@ -391,7 +420,12 @@ def scattermoe_experts_forward_ep(
         _prepare_weights_and_lora(
             _get_base_param(self.gate_up_proj),
             _get_base_param(self.down_proj),
-            se, expert_offsets, E_local, gup_lora, down_lora, hidden_states.dtype,
+            se,
+            expert_offsets,
+            E_local,
+            gup_lora,
+            down_lora,
+            hidden_states.dtype,
         )
     )
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -6,8 +6,15 @@ ScatterMoE Triton call via ``parallel_linear_lora``.
 
 import torch
 
+from .mx_weights import selective_mx_weights_fwd
 from .parallel_experts import flatten_sort_count, parallel_linear
 from .parallel_linear_lora import get_lora_params_from_wrapper, parallel_linear_lora
+from .selective_dequant import (
+    get_active_experts,
+    is_mxfp4_param,
+    remap_expert_indices,
+    selective_lora_weights,
+)
 
 
 def _has_peft_wrapper(module):
@@ -253,14 +260,39 @@ def scattermoe_experts_forward(
         top_k_index, num_experts=self.num_experts
     )
 
-    # Get base weights (unwrap PEFT if needed)
-    gate_up_weight = _get_base_param(self.gate_up_proj).transpose(2, 1)
-    down_weight = _get_base_param(self.down_proj).transpose(2, 1)
-
     # Extract LoRA params if PEFT is active
     gup_lora, down_lora = None, None
     if _has_peft_wrapper(self):
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
+
+    gu_param = _get_base_param(self.gate_up_proj)
+    dn_param = _get_base_param(self.down_proj)
+
+    # Fused MXFP4: keep the frozen base weights packed (dequant happens inside the
+    # kernel's K-loop) instead of materializing bf16. Only the LoRA path has an
+    # MX-aware kernel, so this needs LoRA on both projections; otherwise fall through
+    # to the dequant-on-cast path below.
+    if (
+        is_mxfp4_param(gu_param)
+        and gup_lora is not None
+        and down_lora is not None
+    ):
+        active = get_active_experts(sorted_expert_idxs, self.num_experts)
+        sorted_expert_idxs, expert_offsets = remap_expert_indices(
+            sorted_expert_idxs, expert_offsets, active, self.num_experts
+        )
+        gate_up_weight = selective_mx_weights_fwd(gu_param, active)
+        down_weight = selective_mx_weights_fwd(dn_param, active)
+        gup_lora = (*selective_lora_weights(gup_lora[0], gup_lora[1], active, self.num_experts), gup_lora[2])
+        down_lora = (*selective_lora_weights(down_lora[0], down_lora[1], active, self.num_experts), down_lora[2])
+    elif is_mxfp4_param(gu_param):
+        # MXFP4 base without LoRA: the fused kernel is LoRA-only and MXTensor has no
+        # transpose, so dequantize to bf16 here (frozen-base inference path).
+        gate_up_weight = gu_param.dequantize(hidden_states.dtype).transpose(2, 1)
+        down_weight = dn_param.dequantize(hidden_states.dtype).transpose(2, 1)
+    else:
+        gate_up_weight = gu_param.transpose(2, 1)  # bf16 [E, out, in] -> [E, in, out]
+        down_weight = dn_param.transpose(2, 1)
 
     # Gate-up projection (with optional LoRA)
     gates_h = _parallel_linear_maybe_lora(

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -132,6 +132,39 @@ def _parallel_linear_maybe_lora(
     )
 
 
+def _prepare_weights_and_lora(
+    gu_param, dn_param, sorted_expert_idxs, expert_offsets, num_experts,
+    gup_lora, down_lora, dtype,
+):
+    """Resolve the gate_up / down weights (+ routing + LoRA) for the grouped GEMM.
+
+    For an MXFP4 base with LoRA on both projections, keep the weights packed (4-bit)
+    and route through the fused MX kernel: select the active experts and remap the
+    routing / LoRA to that compact set (dequant happens inside the kernel K-loop).
+    Otherwise return bf16 ``[E, in, out]`` weights (dequantizing MXFP4 explicitly when
+    LoRA is absent, since the fused kernel is LoRA-only and MXTensor has no transpose).
+
+    Returns ``(gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
+    gup_lora, down_lora)``.
+    """
+    if is_mxfp4_param(gu_param) and gup_lora is not None and down_lora is not None:
+        active = get_active_experts(sorted_expert_idxs, num_experts)
+        sorted_expert_idxs, expert_offsets = remap_expert_indices(
+            sorted_expert_idxs, expert_offsets, active, num_experts
+        )
+        gate_up_weight = selective_mx_weights_fwd(gu_param, active)
+        down_weight = selective_mx_weights_fwd(dn_param, active)
+        gup_lora = (*selective_lora_weights(gup_lora[0], gup_lora[1], active, num_experts), gup_lora[2])
+        down_lora = (*selective_lora_weights(down_lora[0], down_lora[1], active, num_experts), down_lora[2])
+    elif is_mxfp4_param(gu_param):
+        gate_up_weight = gu_param.dequantize(dtype).transpose(2, 1)
+        down_weight = dn_param.dequantize(dtype).transpose(2, 1)
+    else:
+        gate_up_weight = gu_param.transpose(2, 1)  # bf16 [E, out, in] -> [E, in, out]
+        down_weight = dn_param.transpose(2, 1)
+    return gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets, gup_lora, down_lora
+
+
 def scattermoe_supports_layout(self) -> bool:
     """True iff this experts module uses the standard layout scattermoe handles:
     gate_up concatenated as [E, 2I, H], gated SwiGLU, no expert bias. gpt_oss-style
@@ -265,34 +298,15 @@ def scattermoe_experts_forward(
     if _has_peft_wrapper(self):
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
 
-    gu_param = _get_base_param(self.gate_up_proj)
-    dn_param = _get_base_param(self.down_proj)
-
-    # Fused MXFP4: keep the frozen base weights packed (dequant happens inside the
-    # kernel's K-loop) instead of materializing bf16. Only the LoRA path has an
-    # MX-aware kernel, so this needs LoRA on both projections; otherwise fall through
-    # to the dequant-on-cast path below.
-    if (
-        is_mxfp4_param(gu_param)
-        and gup_lora is not None
-        and down_lora is not None
-    ):
-        active = get_active_experts(sorted_expert_idxs, self.num_experts)
-        sorted_expert_idxs, expert_offsets = remap_expert_indices(
-            sorted_expert_idxs, expert_offsets, active, self.num_experts
-        )
-        gate_up_weight = selective_mx_weights_fwd(gu_param, active)
-        down_weight = selective_mx_weights_fwd(dn_param, active)
-        gup_lora = (*selective_lora_weights(gup_lora[0], gup_lora[1], active, self.num_experts), gup_lora[2])
-        down_lora = (*selective_lora_weights(down_lora[0], down_lora[1], active, self.num_experts), down_lora[2])
-    elif is_mxfp4_param(gu_param):
-        # MXFP4 base without LoRA: the fused kernel is LoRA-only and MXTensor has no
-        # transpose, so dequantize to bf16 here (frozen-base inference path).
-        gate_up_weight = gu_param.dequantize(hidden_states.dtype).transpose(2, 1)
-        down_weight = dn_param.dequantize(hidden_states.dtype).transpose(2, 1)
-    else:
-        gate_up_weight = gu_param.transpose(2, 1)  # bf16 [E, out, in] -> [E, in, out]
-        down_weight = dn_param.transpose(2, 1)
+    (
+        gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
+        gup_lora, down_lora,
+    ) = _prepare_weights_and_lora(
+        _get_base_param(self.gate_up_proj),
+        _get_base_param(self.down_proj),
+        sorted_expert_idxs, expert_offsets, self.num_experts,
+        gup_lora, down_lora, hidden_states.dtype,
+    )
 
     # Gate-up projection (with optional LoRA)
     gates_h = _parallel_linear_maybe_lora(
@@ -369,12 +383,17 @@ def scattermoe_experts_forward_ep(
     M = se.size(0)
     ss = torch.arange(M, device=hidden_states.device, dtype=torch.int32)
 
-    gate_up_weight = _get_base_param(self.gate_up_proj).transpose(2, 1)
-    down_weight = _get_base_param(self.down_proj).transpose(2, 1)
-
     gup_lora, down_lora = None, None
     if _has_peft_wrapper(self):
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
+
+    gate_up_weight, down_weight, se, expert_offsets, gup_lora, down_lora = (
+        _prepare_weights_and_lora(
+            _get_base_param(self.gate_up_proj),
+            _get_base_param(self.down_proj),
+            se, expert_offsets, E_local, gup_lora, down_lora, hidden_states.dtype,
+        )
+    )
 
     # Pre-gather token rows into expert-grouped order; both projections run grouped.
     grouped_x = hidden_states.index_select(0, tok_sorted.to(torch.long))

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -6,12 +6,13 @@ ScatterMoE Triton call via ``parallel_linear_lora``.
 
 import torch
 
-from .mx_weights import selective_mx_weights_fwd
+from .mx_weights import selective_mx_weights_fwd, selective_nvfp4_weights_fwd
 from .parallel_experts import flatten_sort_count, parallel_linear
 from .parallel_linear_lora import get_lora_params_from_wrapper, parallel_linear_lora
 from .selective_dequant import (
     get_active_experts,
     is_mxfp4_param,
+    is_nvfp4_param,
     remap_expert_indices,
     selective_lora_weights,
 )
@@ -144,22 +145,25 @@ def _prepare_weights_and_lora(
 ):
     """Resolve the gate_up / down weights (+ routing + LoRA) for the grouped GEMM.
 
-    For an MXFP4 base with LoRA on both projections, keep the weights packed (4-bit)
-    and route through the fused MX kernel: select the active experts and remap the
-    routing / LoRA to that compact set (dequant happens inside the kernel K-loop).
-    Otherwise return bf16 ``[E, in, out]`` weights (dequantizing MXFP4 explicitly when
-    LoRA is absent, since the fused kernel is LoRA-only and MXTensor has no transpose).
+    For an MXFP4 or NVFP4 base with LoRA on both projections, keep the weights packed
+    (4-bit) and route through the fused kernel: select the active experts and remap the
+    routing / LoRA to that compact set (dequant happens inside the kernel K-loop; NVFP4
+    reuses the MXWeights container with linear E4M3 block scales). Otherwise return bf16
+    ``[E, in, out]`` weights (dequantizing FP4 explicitly when LoRA is absent, since the
+    fused kernel is LoRA-only and the FP4 tensors have no transpose).
 
     Returns ``(gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
     gup_lora, down_lora)``.
     """
-    if is_mxfp4_param(gu_param) and gup_lora is not None and down_lora is not None:
+    is_mx, is_nv = is_mxfp4_param(gu_param), is_nvfp4_param(gu_param)
+    if (is_mx or is_nv) and gup_lora is not None and down_lora is not None:
+        select = selective_mx_weights_fwd if is_mx else selective_nvfp4_weights_fwd
         active = get_active_experts(sorted_expert_idxs, num_experts)
         sorted_expert_idxs, expert_offsets = remap_expert_indices(
             sorted_expert_idxs, expert_offsets, active, num_experts
         )
-        gate_up_weight = selective_mx_weights_fwd(gu_param, active)
-        down_weight = selective_mx_weights_fwd(dn_param, active)
+        gate_up_weight = select(gu_param, active)
+        down_weight = select(dn_param, active)
         gup_lora = (
             *selective_lora_weights(gup_lora[0], gup_lora[1], active, num_experts),
             gup_lora[2],
@@ -168,7 +172,9 @@ def _prepare_weights_and_lora(
             *selective_lora_weights(down_lora[0], down_lora[1], active, num_experts),
             down_lora[2],
         )
-    elif is_mxfp4_param(gu_param):
+    elif is_mx or is_nv:
+        # quantized base without LoRA: the fused kernel is LoRA-only and the FP4
+        # tensors have no transpose, so dequantize to bf16 here.
         gate_up_weight = gu_param.dequantize(dtype).transpose(2, 1)
         down_weight = dn_param.dequantize(dtype).transpose(2, 1)
     else:

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -2403,6 +2403,7 @@ def _compute_expert_block_lora_mxfp4(
     BLOCK_N: tl.constexpr,
     BLOCK_R: tl.constexpr,
     MX_BLOCK_SIZE: tl.constexpr,
+    SCALE_LINEAR: tl.constexpr,
     scaling,
     allow_tf32: tl.constexpr,
 ):
@@ -2469,8 +2470,13 @@ def _compute_expert_block_lora_mxfp4(
         packed = tl.load(Wp_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
         nibble = tl.where(K_is_high[None, :], (packed >> 4) & 0xF, packed & 0xF)
         codebook_val = tl.load(Codebook_ptr + nibble)  # [BLOCK_N, BLOCK_K] fp32
-        scale_byte = tl.load(Ws_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
-        scale_fp = tl.exp2((scale_byte - 127).to(tl.float32))
+        if SCALE_LINEAR:
+            # NVFP4: scale is a linear fp multiplier (E4M3 block scale * per-tensor)
+            scale_fp = tl.load(Ws_blk_ptrs, mask=w_mask, other=0.0).to(tl.float32)
+        else:
+            # MXFP4: E8M0 scale, decode as 2^(byte-127)
+            scale_byte = tl.load(Ws_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
+            scale_fp = tl.exp2((scale_byte - 127).to(tl.float32))
         w_dq_nk = (codebook_val * scale_fp).to(INPUT_DTYPE)  # [BLOCK_N, BLOCK_K]
         w_tile = tl.trans(w_dq_nk)  # [BLOCK_K, BLOCK_N]
 
@@ -2644,6 +2650,7 @@ def _scatter2scatter_lora_mx(
     BLOCK_K: tl.constexpr,
     BLOCK_R: tl.constexpr,
     MX_BLOCK_SIZE: tl.constexpr,
+    SCALE_LINEAR: tl.constexpr,
     ACC_TYPE: tl.constexpr,
     scaling,
     allow_tf32: tl.constexpr,
@@ -2653,7 +2660,7 @@ def _scatter2scatter_lora_mx(
     NO_N_MASK: tl.constexpr,
     INT64_INDICES: tl.constexpr = False,
 ):
-    """Fused scatter2scatter forward with MXFP4 base weights + LoRA."""
+    """Fused scatter2scatter forward with MXFP4/NVFP4 base weights + LoRA."""
     pid = tl.program_id(axis=0)
     N_BLOCK_COUNT = tl.cdiv(N, BLOCK_N)
     M_block_id = pid // N_BLOCK_COUNT
@@ -2717,6 +2724,7 @@ def _scatter2scatter_lora_mx(
             BLOCK_N,
             BLOCK_R,
             MX_BLOCK_SIZE,
+            SCALE_LINEAR,
             scaling,
             allow_tf32=allow_tf32,
         )
@@ -2829,7 +2837,8 @@ def scatter2scatter_lora_mx(
         E=E,
         ACTUAL_R=R,
         BLOCK_R=BLOCK_R,
-        MX_BLOCK_SIZE=_MX_BLOCK_SIZE,
+        MX_BLOCK_SIZE=W_mx.block_size,
+        SCALE_LINEAR=W_mx.scale_is_linear,
         ACC_TYPE=tl.float32,
         scaling=scaling,
         allow_tf32=ALLOW_TF32,
@@ -2879,6 +2888,7 @@ def _compute_expert_block_lora_dX_mxfp4(
     BLOCK_K: tl.constexpr,
     BLOCK_R: tl.constexpr,
     MX_BLOCK_SIZE: tl.constexpr,
+    SCALE_LINEAR: tl.constexpr,
     scaling,
     allow_tf32: tl.constexpr,
 ):
@@ -2950,8 +2960,11 @@ def _compute_expert_block_lora_dX_mxfp4(
         packed = tl.load(Wp_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
         nibble = tl.where(K_is_high[:, None], (packed >> 4) & 0xF, packed & 0xF)
         codebook_val = tl.load(Codebook_ptr + nibble)
-        scale_byte = tl.load(Ws_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
-        scale_fp = tl.exp2((scale_byte - 127).to(tl.float32))
+        if SCALE_LINEAR:
+            scale_fp = tl.load(Ws_blk_ptrs, mask=w_mask, other=0.0).to(tl.float32)
+        else:
+            scale_byte = tl.load(Ws_blk_ptrs, mask=w_mask, other=0).to(tl.int32)
+            scale_fp = tl.exp2((scale_byte - 127).to(tl.float32))
         w_dq = (codebook_val * scale_fp).to(INPUT_DTYPE)  # [BLOCK_K, BLOCK_N]
 
         # Base: acc += DY @ W^T  ([M, N] @ [N, K] -> [M, K])
@@ -3107,6 +3120,7 @@ def _scatter2scatter_lora_dX_mx(
     BLOCK_K: tl.constexpr,
     BLOCK_R: tl.constexpr,
     MX_BLOCK_SIZE: tl.constexpr,
+    SCALE_LINEAR: tl.constexpr,
     ACC_TYPE: tl.constexpr,
     scaling,
     allow_tf32: tl.constexpr,
@@ -3115,7 +3129,7 @@ def _scatter2scatter_lora_dX_mx(
     NO_N_MASK: tl.constexpr,
     INT64_INDICES: tl.constexpr = False,
 ):
-    """Fused MXFP4 dX kernel."""
+    """Fused MXFP4/NVFP4 dX kernel."""
     pid = tl.program_id(axis=0)
     K_BLOCK_COUNT = tl.cdiv(K, BLOCK_K)
     M_block_id = pid // K_BLOCK_COUNT
@@ -3179,6 +3193,7 @@ def _scatter2scatter_lora_dX_mx(
             BLOCK_K,
             BLOCK_R,
             MX_BLOCK_SIZE,
+            SCALE_LINEAR,
             scaling,
             allow_tf32=allow_tf32,
         )
@@ -3285,7 +3300,8 @@ def scatter2scatter_lora_dX_mx(
         E=E,
         ACTUAL_R=R,
         BLOCK_R=BLOCK_R,
-        MX_BLOCK_SIZE=_MX_BLOCK_SIZE,
+        MX_BLOCK_SIZE=W_mx.block_size,
+        SCALE_LINEAR=W_mx.scale_is_linear,
         ACC_TYPE=tl.float32,
         scaling=scaling,
         allow_tf32=ALLOW_TF32,

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/mx_weights.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/mx_weights.py
@@ -90,7 +90,12 @@ class MXWeights:
     layout:
         Which axis the block scaling runs along (see ``MXLayout``).
     block_size:
-        OCP MX block size; only ``32`` is supported by the kernels.
+        OCP block size: ``32`` for MXFP4 (E8M0 scales), ``16`` for NVFP4.
+    scale_is_linear:
+        ``False`` (default): scales are E8M0 (``uint8``), decoded in-kernel as
+        ``2^(byte-127)``. ``True``: scales are already a linear floating-point
+        multiplier (e.g. NVFP4's E4M3 block scale pre-multiplied by the per-tensor
+        scale), loaded and used directly with no exponent decode.
     """
 
     packed: torch.Tensor
@@ -101,14 +106,15 @@ class MXWeights:
     block_size: int = MX_BLOCK_SIZE
     num_experts: Optional[int] = None  # E_active; convenience field
     orig_dtype: torch.dtype = torch.bfloat16
+    scale_is_linear: bool = False
 
     def __post_init__(self) -> None:
-        assert self.block_size == MX_BLOCK_SIZE, (
-            f"only block_size={MX_BLOCK_SIZE} is supported, got {self.block_size}"
+        assert self.block_size in (16, 32), (
+            f"block_size must be 16 (NVFP4) or 32 (MXFP4), got {self.block_size}"
         )
-        # scales are E8M0 (float8_e8m0fnu) in torchao; viewed as uint8 here so
-        # the Triton kernel can load them with simple integer arithmetic.
-        if self.scales.dtype != torch.uint8:
+        if not self.scale_is_linear and self.scales.dtype != torch.uint8:
+            # E8M0 (float8_e8m0fnu) scales viewed as uint8 so the Triton kernel can
+            # load them with simple integer arithmetic. Linear scales stay floating.
             self.scales = self.scales.view(torch.uint8)
         assert self.packed.dtype == torch.uint8, (
             f"packed must be uint8, got {self.packed.dtype}"
@@ -218,4 +224,54 @@ def selective_mx_weights_fwd(mx_param, active_experts: torch.Tensor) -> MXWeight
         block_size=mx_param.block_size,
         num_experts=sub_qdata.size(0),
         orig_dtype=mx_param.orig_dtype,
+    )
+
+
+def _torchao_nvfp4tensor_cls():
+    """Return the torchao NVFP4Tensor class, or ``None`` if torchao is missing."""
+    try:
+        from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+    except ImportError:
+        return None
+    return NVFP4Tensor
+
+
+def selective_nvfp4_weights_fwd(nv_param, active_experts: torch.Tensor) -> MXWeights:
+    """Slice an NVFP4 expert parameter to the active set as an ``MXWeights`` with
+    ``scale_is_linear=True``.
+
+    NVFP4 shares the FP4 E2M1 element codebook with MXFP4 (same packed nibble layout)
+    but scales per 16-element block with an E4M3 (fp8) value, optionally times a
+    per-tensor fp32 scale. The dequant is ``codebook(nibble) * e4m3_block_scale *
+    per_tensor`` -- not a power-of-2 -- so the E4M3 block scale (folded with the
+    per-tensor scale) is decoded to a linear fp32 multiplier here and consumed
+    directly by the kernel (no in-kernel exponent decode). The packed buffer stays
+    4-bit; only the small ``[num_active, N, K/16]`` scale tensor is materialized.
+    """
+    NVFP4Tensor = _torchao_nvfp4tensor_cls()
+    if NVFP4Tensor is None:
+        raise ImportError("NVFP4 fused path requires torchao (install `torchao`).")
+    assert isinstance(nv_param, NVFP4Tensor), (
+        f"selective_nvfp4_weights_fwd expects an NVFP4Tensor, got {type(nv_param)}"
+    )
+    assert nv_param.block_size == 16, (
+        f"NVFP4 block_size must be 16, got {nv_param.block_size}"
+    )
+    sub_qdata = nv_param.qdata[active_experts].contiguous()  # [a, N, K/2] uint8
+    block_scale = nv_param.scale[active_experts].to(torch.float32)  # [a, N, K/16]
+    per_tensor = getattr(nv_param, "per_tensor_scale", None)
+    if per_tensor is not None:
+        block_scale = block_scale * per_tensor.to(torch.float32)
+    N = sub_qdata.size(1)
+    K = sub_qdata.size(2) * 2
+    return MXWeights(
+        packed=sub_qdata,
+        scales=block_scale.contiguous(),
+        K=K,
+        N=N,
+        layout=MXLayout.FWD,
+        block_size=16,
+        num_experts=sub_qdata.size(0),
+        orig_dtype=nv_param.orig_dtype,
+        scale_is_linear=True,
     )

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant.py
@@ -31,6 +31,7 @@ from .mx_weights import (
     _mx_qdata,
     _mx_scale,
     _torchao_mxtensor_cls,
+    _torchao_nvfp4tensor_cls,
 )
 
 
@@ -40,6 +41,12 @@ def is_mxfp4_param(param) -> bool:
     if MXTensor is None or not isinstance(param, MXTensor):
         return False
     return param.elem_dtype == torch.float4_e2m1fn_x2
+
+
+def is_nvfp4_param(param) -> bool:
+    """True iff ``param`` is a torchao NVFP4Tensor (FP4 E2M1, block-16 E4M3 scales)."""
+    NVFP4Tensor = _torchao_nvfp4tensor_cls()
+    return NVFP4Tensor is not None and isinstance(param, NVFP4Tensor)
 
 
 def get_active_experts(sorted_expert_idxs: torch.Tensor, E: int) -> torch.Tensor:

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -6,6 +6,8 @@ Wraps upstream ``_sonicmoe_wrapper`` and materializes expert LoRA via
 
 from __future__ import annotations
 
+import functools
+
 import torch
 
 from .lora import (
@@ -55,13 +57,38 @@ def _resolve_weights_and_lora(experts_module):
     return w1, b1, w2, b2, lora_w1, lora_w2
 
 
+@functools.lru_cache(maxsize=1)
+def _sonicmoe_kernel_supported() -> bool:
+    """The kernels-community/sonic-moe CUTLASS GEMM fails to compile on sm_120
+    (Blackwell): its bundled quack ``GemmSm120`` predates the ``concat_layout`` arg
+    the dispatcher passes. Gate it off there so standard-layout models fall back to
+    the vendored scattermoe Triton path. Drop this once a fixed sonic-moe ships."""
+    if not torch.cuda.is_available():
+        return True
+    return torch.cuda.get_device_capability()[0] < 12
+
+
 def sonicmoe_experts_forward_with_lora(
     self,
     hidden_states: torch.Tensor,
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
-    """Sonicmoe experts forward with PEFT LoRA materialization."""
+    """Sonicmoe experts forward with PEFT LoRA materialization.
+
+    On devices where the sonic-moe kernel can't run (sm_120), standard-layout
+    experts transparently use the vendored scattermoe Triton path instead.
+    """
+    from ..scattermoe_lora.experts import (
+        scattermoe_experts_forward,
+        scattermoe_supports_layout,
+    )
+
+    if not _sonicmoe_kernel_supported() and scattermoe_supports_layout(self):
+        return scattermoe_experts_forward(
+            self, hidden_states, top_k_index, top_k_weights
+        )
+
     from transformers.integrations.sonicmoe import _sonicmoe_wrapper
 
     if not getattr(self, "has_gate", True):

--- a/tests/integrations/kernels/scattermoe_lora/test_ep_sentinel_skip.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_ep_sentinel_skip.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""scattermoe DeepEP local path skips ``-1`` sentinels instead of compute-and-mask.
+
+Oracle: on the SAME experts module, ``scattermoe_experts_forward_ep`` (raw -1-tagged
+routing) must match ``scattermoe_experts_forward`` with sentinels mapped to expert 0 /
+weight 0 -- output, dX, and LoRA dA/dB. Sentinel slots carry weight 0 so both compute
+the same math; the skip path just omits the wasted rows (and the load-imbalanced
+expert-0 bucket the masked path creates).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
+from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (  # noqa: E402
+    scattermoe_experts_forward,
+    scattermoe_experts_forward_ep,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (  # noqa: E402
+    peft_lora_to_scattermoe,
+)
+
+DEV = "cuda"
+
+
+def _module(E, H, I, dt, rank, monkeypatch):
+    self = SimpleNamespace(
+        num_experts=E,
+        gate_up_proj=torch.randn(E, 2 * I, H, device=DEV, dtype=dt) * 0.02,
+        down_proj=torch.randn(E, H, I, device=DEV, dtype=dt) * 0.02,
+        act_fn=torch.nn.functional.silu,
+        is_transposed=False,
+        is_concatenated=True,
+        has_bias=False,
+        has_gate=True,
+    )
+    lora = None
+    if rank:
+        A1 = (torch.randn(rank * E, H, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+        B1 = (torch.randn(2 * I, rank * E, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+        A2 = (torch.randn(rank * E, I, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+        B2 = (torch.randn(H, rank * E, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+        gup = (*peft_lora_to_scattermoe(A1, B1, E, rank), 0.5)
+        dwn = (*peft_lora_to_scattermoe(A2, B2, E, rank), 0.5)
+        monkeypatch.setattr(ex, "_has_peft_wrapper", lambda m: True)
+        monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda m: (m, gup, dwn))
+        lora = (A1, B1, A2, B2)
+    return self, lora
+
+
+def _routing(N, K, E, ep, dt):
+    g = torch.Generator(device=DEV).manual_seed(0)
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    remote = torch.rand(N, K, device=DEV, generator=g) < (1 - 1.0 / ep)
+    remote[:, 0] = False  # >=1 valid slot per received token (DeepEP guarantee)
+    idx = torch.where(remote, torch.full_like(idx, -1), idx)
+    w = torch.rand(N, K, device=DEV, generator=g).to(dt)
+    return idx, w
+
+
+@pytest.mark.parametrize("dt", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("rank", [0, 16])
+@pytest.mark.parametrize("ep", [2, 4])
+def test_ep_skip_matches_masked(dt, rank, ep, monkeypatch):
+    E, H, I, N, K = 32, 512, 256, 512, 8
+    self, lora = _module(E, H, I, dt, rank, monkeypatch)
+    idx, w = _routing(N, K, E, ep, dt)
+    safe_idx = torch.where(idx >= 0, idx, torch.zeros_like(idx))
+    safe_w = w * (idx >= 0).to(dt)
+    grad = torch.randn(N, H, device=DEV, dtype=dt)
+
+    def run(fn, ii, ww):
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt,
+            generator=torch.Generator(DEV).manual_seed(1),
+        ).requires_grad_(True)
+        if lora:
+            for t in lora:
+                t.grad = None
+        fn(self, x, ii, ww).backward(grad)
+        return x.grad.clone(), [t.grad.clone() for t in lora] if lora else []
+
+    # forward equality
+    with torch.no_grad():
+        x = torch.randn(N, H, device=DEV, dtype=dt)
+        o_m = scattermoe_experts_forward(self, x, safe_idx, safe_w)
+        o_s = scattermoe_experts_forward_ep(self, x, idx, w)
+    tol = 1e-4 if dt == torch.float32 else 4e-2
+    assert torch.allclose(o_s, o_m, rtol=tol, atol=tol), (o_s - o_m).abs().max().item()
+
+    dx_m, gl_m = run(scattermoe_experts_forward, safe_idx, safe_w)
+    dx_s, gl_s = run(scattermoe_experts_forward_ep, idx, w)
+    assert torch.allclose(dx_s, dx_m, rtol=tol, atol=tol), (dx_s - dx_m).abs().max().item()
+    for a, b in zip(gl_s, gl_m):
+        assert torch.allclose(a, b, rtol=tol, atol=tol), (a - b).abs().max().item()
+
+
+def test_ep_skip_handles_all_sentinel_token():
+    """A row with every slot remote (-1) contributes nothing and must not crash."""
+    E, H, I, N, K = 8, 256, 128, 16, 4
+    self, _ = _module(E, H, I, torch.float32, 0, None)
+    idx = torch.full((N, K), -1, device=DEV, dtype=torch.long)
+    idx[1:, 0] = 0  # token 0 fully remote; others have one valid slot
+    w = torch.rand(N, K, device=DEV)
+    out = scattermoe_experts_forward_ep(self, torch.randn(N, H, device=DEV), idx, w)
+    assert out.shape == (N, H)
+    assert torch.equal(out[0], torch.zeros(H, device=DEV))

--- a/tests/integrations/kernels/scattermoe_lora/test_ep_sentinel_skip.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_ep_sentinel_skip.py
@@ -16,7 +16,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-torch = pytest.importorskip("torch")
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
 import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
@@ -31,11 +30,11 @@ from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (  # noqa: 
 DEV = "cuda"
 
 
-def _module(E, H, I, dt, rank, monkeypatch):
+def _module(E, H, IM, dt, rank, monkeypatch):
     self = SimpleNamespace(
         num_experts=E,
-        gate_up_proj=torch.randn(E, 2 * I, H, device=DEV, dtype=dt) * 0.02,
-        down_proj=torch.randn(E, H, I, device=DEV, dtype=dt) * 0.02,
+        gate_up_proj=torch.randn(E, 2 * IM, H, device=DEV, dtype=dt) * 0.02,
+        down_proj=torch.randn(E, H, IM, device=DEV, dtype=dt) * 0.02,
         act_fn=torch.nn.functional.silu,
         is_transposed=False,
         is_concatenated=True,
@@ -44,10 +43,18 @@ def _module(E, H, I, dt, rank, monkeypatch):
     )
     lora = None
     if rank:
-        A1 = (torch.randn(rank * E, H, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
-        B1 = (torch.randn(2 * I, rank * E, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
-        A2 = (torch.randn(rank * E, I, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
-        B2 = (torch.randn(H, rank * E, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+        A1 = (torch.randn(rank * E, H, device=DEV, dtype=dt) * 0.02).requires_grad_(
+            True
+        )
+        B1 = (
+            torch.randn(2 * IM, rank * E, device=DEV, dtype=dt) * 0.02
+        ).requires_grad_(True)
+        A2 = (torch.randn(rank * E, IM, device=DEV, dtype=dt) * 0.02).requires_grad_(
+            True
+        )
+        B2 = (torch.randn(H, rank * E, device=DEV, dtype=dt) * 0.02).requires_grad_(
+            True
+        )
         gup = (*peft_lora_to_scattermoe(A1, B1, E, rank), 0.5)
         dwn = (*peft_lora_to_scattermoe(A2, B2, E, rank), 0.5)
         monkeypatch.setattr(ex, "_has_peft_wrapper", lambda m: True)
@@ -70,8 +77,8 @@ def _routing(N, K, E, ep, dt):
 @pytest.mark.parametrize("rank", [0, 16])
 @pytest.mark.parametrize("ep", [2, 4])
 def test_ep_skip_matches_masked(dt, rank, ep, monkeypatch):
-    E, H, I, N, K = 32, 512, 256, 512, 8
-    self, lora = _module(E, H, I, dt, rank, monkeypatch)
+    E, H, IM, N, K = 32, 512, 256, 512, 8
+    self, lora = _module(E, H, IM, dt, rank, monkeypatch)
     idx, w = _routing(N, K, E, ep, dt)
     safe_idx = torch.where(idx >= 0, idx, torch.zeros_like(idx))
     safe_w = w * (idx >= 0).to(dt)
@@ -79,7 +86,10 @@ def test_ep_skip_matches_masked(dt, rank, ep, monkeypatch):
 
     def run(fn, ii, ww):
         x = torch.randn(
-            N, H, device=DEV, dtype=dt,
+            N,
+            H,
+            device=DEV,
+            dtype=dt,
             generator=torch.Generator(DEV).manual_seed(1),
         ).requires_grad_(True)
         if lora:
@@ -98,15 +108,17 @@ def test_ep_skip_matches_masked(dt, rank, ep, monkeypatch):
 
     dx_m, gl_m = run(scattermoe_experts_forward, safe_idx, safe_w)
     dx_s, gl_s = run(scattermoe_experts_forward_ep, idx, w)
-    assert torch.allclose(dx_s, dx_m, rtol=tol, atol=tol), (dx_s - dx_m).abs().max().item()
-    for a, b in zip(gl_s, gl_m):
+    assert torch.allclose(dx_s, dx_m, rtol=tol, atol=tol), (
+        (dx_s - dx_m).abs().max().item()
+    )
+    for a, b in zip(gl_s, gl_m, strict=True):
         assert torch.allclose(a, b, rtol=tol, atol=tol), (a - b).abs().max().item()
 
 
 def test_ep_skip_handles_all_sentinel_token():
     """A row with every slot remote (-1) contributes nothing and must not crash."""
-    E, H, I, N, K = 8, 256, 128, 16, 4
-    self, _ = _module(E, H, I, torch.float32, 0, None)
+    E, H, IM, N, K = 8, 256, 128, 16, 4
+    self, _ = _module(E, H, IM, torch.float32, 0, None)
     idx = torch.full((N, K), -1, device=DEV, dtype=torch.long)
     idx[1:, 0] = 0  # token 0 fully remote; others have one valid slot
     w = torch.rand(N, K, device=DEV)

--- a/tests/integrations/kernels/scattermoe_lora/test_gptoss_layout.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_gptoss_layout.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""scattermoe Triton path for gpt_oss-style experts (transposed [E,H,2I] weights,
+interleaved gate/up, per-expert bias, clamped sigmoid-GLU).
+
+Validated against an eager reference: output and every gradient must match. The LoRA
+fusion is the same ``scatter2scatter_lora`` the standard path uses, so the eager
+reference folds the kernel's delta ``ΔW_e = scaling * A_e^T @ W_B[e]`` into W_eff.
+TF32 is disabled so the fp32 comparison is tight (the kernel GEMMs otherwise use TF32).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
+import axolotl.integrations.kernels.libs.scattermoe_lora.kernels.lora_ops as _lo  # noqa: E402
+import axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops as _ops  # noqa: E402
+from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (  # noqa: E402
+    scattermoe_experts_forward,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (  # noqa: E402
+    peft_lora_B_to_scattermoe,
+    peft_lora_to_scattermoe,
+)
+
+DEV = "cuda"
+ALPHA, LIMIT = 1.702, 7.0
+E, H, I, N, K, R, SC = 8, 256, 128, 64, 4, 16, 0.5
+
+
+@pytest.fixture(autouse=True)
+def _no_tf32():
+    old = torch.backends.cuda.matmul.allow_tf32
+    torch.backends.cuda.matmul.allow_tf32 = False
+    a, b = _lo.ALLOW_TF32, _ops.ALLOW_TF32
+    _lo.ALLOW_TF32 = _ops.ALLOW_TF32 = False
+    yield
+    torch.backends.cuda.matmul.allow_tf32 = old
+    _lo.ALLOW_TF32, _ops.ALLOW_TF32 = a, b
+
+
+def _glu(gate_up):
+    gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+    gate = gate.clamp(max=LIMIT)
+    up = up.clamp(min=-LIMIT, max=LIMIT)
+    return (up + 1) * (gate * torch.sigmoid(gate * ALPHA))
+
+
+def _module(dt):
+    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+    return SimpleNamespace(
+        num_experts=E,
+        gate_up_proj=mk(E, H, 2 * I), gate_up_proj_bias=mk(E, 2 * I),
+        down_proj=mk(E, I, H), down_proj_bias=mk(E, H),
+        alpha=ALPHA, limit=LIMIT,
+        is_transposed=True, is_concatenated=False, has_bias=True, has_gate=True,
+    )
+
+
+def _eager(x, m, idx, w, weff=None):
+    gup, dp = (weff if weff else (m.gate_up_proj, m.down_proj))
+    fe = idx.reshape(-1)
+    xg = x.repeat_interleave(K, dim=0)
+    gate_up = torch.bmm(xg.unsqueeze(1), gup[fe]).squeeze(1) + m.gate_up_proj_bias[fe]
+    h = _glu(gate_up)
+    o = torch.bmm(h.unsqueeze(1), dp[fe]).squeeze(1) + m.down_proj_bias[fe]
+    o = o * w.reshape(-1, 1)
+    tok = torch.arange(x.size(0), device=DEV).repeat_interleave(K)
+    return torch.zeros(x.size(0), H, device=DEV, dtype=x.dtype).index_add_(0, tok, o)
+
+
+def _rel(a, b):
+    return (a - b).abs().max().item() / max(b.abs().max().item(), 1e-6)
+
+
+@pytest.mark.parametrize("dt", [torch.float32, torch.bfloat16])
+def test_gptoss_base_matches_eager(dt):
+    m = _module(dt)
+    g = torch.Generator(device=DEV).manual_seed(0)
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    w = torch.rand(N, K, device=DEV, generator=g).to(dt)
+    grad = torch.randn(N, H, device=DEV, dtype=dt)
+    ps = [m.gate_up_proj, m.gate_up_proj_bias, m.down_proj, m.down_proj_bias]
+
+    def run(eager):
+        for p in ps:
+            p.grad = None
+        x = torch.randn(N, H, device=DEV, dtype=dt,
+                        generator=torch.Generator(DEV).manual_seed(3)).requires_grad_(True)
+        out = _eager(x, m, idx, w) if eager else scattermoe_experts_forward(m, x, idx, w)
+        out.backward(grad)
+        return out.detach(), x.grad, [p.grad.clone() for p in ps]
+
+    ok, dxk, gk = run(False)
+    oe, dxe, ge = run(True)
+    tol = 2e-4 if dt == torch.float32 else 5e-2
+    assert _rel(ok, oe) < tol
+    assert _rel(dxk, dxe) < tol
+    for a, b in zip(gk, ge):
+        assert _rel(a, b) < tol
+
+
+@pytest.mark.parametrize("dt", [torch.float32, torch.bfloat16])
+def test_gptoss_lora_matches_eager(dt, monkeypatch):
+    g = torch.Generator(device=DEV).manual_seed(0)
+    base = SimpleNamespace(
+        num_experts=E,
+        gate_up_proj=torch.randn(E, H, 2 * I, device=DEV, dtype=dt, generator=g) * 0.02,
+        gate_up_proj_bias=torch.randn(E, 2 * I, device=DEV, dtype=dt, generator=g) * 0.02,
+        down_proj=torch.randn(E, I, H, device=DEV, dtype=dt, generator=g) * 0.02,
+        down_proj_bias=torch.randn(E, H, device=DEV, dtype=dt, generator=g) * 0.02,
+        alpha=ALPHA, limit=LIMIT,
+        is_transposed=True, is_concatenated=False, has_bias=True, has_gate=True,
+    )
+    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
+    pA1, pB1 = mk(R * E, H), mk(2 * I, R * E)
+    pA2, pB2 = mk(R * E, I), mk(H, R * E)
+    lora = [pA1, pB1, pA2, pB2]
+    gup_l = (*peft_lora_to_scattermoe(pA1, pB1, E, R), SC)
+    dwn_l = (*peft_lora_to_scattermoe(pA2, pB2, E, R), SC)
+    monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
+    monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, gup_l, dwn_l))
+
+    # eager W_eff: ΔW_e = scaling * A_e^T @ W_B[e], W_B = lora_B.T.reshape(E,R,out)
+    A1 = pA1.reshape(E, R, H); WB1 = peft_lora_B_to_scattermoe(pB1, E, R).t().reshape(E, R, 2 * I)
+    A2 = pA2.reshape(E, R, I); WB2 = peft_lora_B_to_scattermoe(pB2, E, R).t().reshape(E, R, H)
+    gup_eff = base.gate_up_proj + SC * torch.bmm(A1.transpose(1, 2), WB1)
+    dp_eff = base.down_proj + SC * torch.bmm(A2.transpose(1, 2), WB2)
+
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    w = torch.rand(N, K, device=DEV, generator=g).to(dt)
+    grad = torch.randn(N, H, device=DEV, dtype=dt)
+
+    def run(eager):
+        for t in lora:
+            t.grad = None
+        x = torch.randn(N, H, device=DEV, dtype=dt,
+                        generator=torch.Generator(DEV).manual_seed(3)).requires_grad_(True)
+        out = (_eager(x, base, idx, w, weff=(gup_eff, dp_eff)) if eager
+               else scattermoe_experts_forward(base, x, idx, w))
+        out.backward(grad)
+        return out.detach(), x.grad, [t.grad.clone() for t in lora]
+
+    ok, dxk, gk = run(False)
+    oe, dxe, ge = run(True)
+    tol = 3e-4 if dt == torch.float32 else 5e-2
+    assert _rel(ok, oe) < tol
+    assert _rel(dxk, dxe) < tol
+    for a, b in zip(gk, ge):
+        assert _rel(a, b) < tol
+        assert a.abs().sum() > 0  # LoRA grads actually populated

--- a/tests/integrations/kernels/scattermoe_lora/test_gptoss_layout.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_gptoss_layout.py
@@ -16,7 +16,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-torch = pytest.importorskip("torch")
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
 import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
@@ -32,7 +31,7 @@ from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (  # noqa: 
 
 DEV = "cuda"
 ALPHA, LIMIT = 1.702, 7.0
-E, H, I, N, K, R, SC = 8, 256, 128, 64, 4, 16, 0.5
+E, H, IM, N, K, R, SC = 8, 256, 128, 64, 4, 16, 0.5
 
 
 @pytest.fixture(autouse=True)
@@ -54,18 +53,26 @@ def _glu(gate_up):
 
 
 def _module(dt):
-    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+    def mk(*s):
+        return (torch.randn(*s, device=DEV, dtype=dt) * 0.02).requires_grad_(True)
+
     return SimpleNamespace(
         num_experts=E,
-        gate_up_proj=mk(E, H, 2 * I), gate_up_proj_bias=mk(E, 2 * I),
-        down_proj=mk(E, I, H), down_proj_bias=mk(E, H),
-        alpha=ALPHA, limit=LIMIT,
-        is_transposed=True, is_concatenated=False, has_bias=True, has_gate=True,
+        gate_up_proj=mk(E, H, 2 * IM),
+        gate_up_proj_bias=mk(E, 2 * IM),
+        down_proj=mk(E, IM, H),
+        down_proj_bias=mk(E, H),
+        alpha=ALPHA,
+        limit=LIMIT,
+        is_transposed=True,
+        is_concatenated=False,
+        has_bias=True,
+        has_gate=True,
     )
 
 
 def _eager(x, m, idx, w, weff=None):
-    gup, dp = (weff if weff else (m.gate_up_proj, m.down_proj))
+    gup, dp = weff if weff else (m.gate_up_proj, m.down_proj)
     fe = idx.reshape(-1)
     xg = x.repeat_interleave(K, dim=0)
     gate_up = torch.bmm(xg.unsqueeze(1), gup[fe]).squeeze(1) + m.gate_up_proj_bias[fe]
@@ -92,9 +99,12 @@ def test_gptoss_base_matches_eager(dt):
     def run(eager):
         for p in ps:
             p.grad = None
-        x = torch.randn(N, H, device=DEV, dtype=dt,
-                        generator=torch.Generator(DEV).manual_seed(3)).requires_grad_(True)
-        out = _eager(x, m, idx, w) if eager else scattermoe_experts_forward(m, x, idx, w)
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt, generator=torch.Generator(DEV).manual_seed(3)
+        ).requires_grad_(True)
+        out = (
+            _eager(x, m, idx, w) if eager else scattermoe_experts_forward(m, x, idx, w)
+        )
         out.backward(grad)
         return out.detach(), x.grad, [p.grad.clone() for p in ps]
 
@@ -103,7 +113,7 @@ def test_gptoss_base_matches_eager(dt):
     tol = 2e-4 if dt == torch.float32 else 5e-2
     assert _rel(ok, oe) < tol
     assert _rel(dxk, dxe) < tol
-    for a, b in zip(gk, ge):
+    for a, b in zip(gk, ge, strict=True):
         assert _rel(a, b) < tol
 
 
@@ -112,16 +122,27 @@ def test_gptoss_lora_matches_eager(dt, monkeypatch):
     g = torch.Generator(device=DEV).manual_seed(0)
     base = SimpleNamespace(
         num_experts=E,
-        gate_up_proj=torch.randn(E, H, 2 * I, device=DEV, dtype=dt, generator=g) * 0.02,
-        gate_up_proj_bias=torch.randn(E, 2 * I, device=DEV, dtype=dt, generator=g) * 0.02,
-        down_proj=torch.randn(E, I, H, device=DEV, dtype=dt, generator=g) * 0.02,
+        gate_up_proj=torch.randn(E, H, 2 * IM, device=DEV, dtype=dt, generator=g)
+        * 0.02,
+        gate_up_proj_bias=torch.randn(E, 2 * IM, device=DEV, dtype=dt, generator=g)
+        * 0.02,
+        down_proj=torch.randn(E, IM, H, device=DEV, dtype=dt, generator=g) * 0.02,
         down_proj_bias=torch.randn(E, H, device=DEV, dtype=dt, generator=g) * 0.02,
-        alpha=ALPHA, limit=LIMIT,
-        is_transposed=True, is_concatenated=False, has_bias=True, has_gate=True,
+        alpha=ALPHA,
+        limit=LIMIT,
+        is_transposed=True,
+        is_concatenated=False,
+        has_bias=True,
+        has_gate=True,
     )
-    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
-    pA1, pB1 = mk(R * E, H), mk(2 * I, R * E)
-    pA2, pB2 = mk(R * E, I), mk(H, R * E)
+
+    def mk(*s):
+        return (
+            torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05
+        ).requires_grad_(True)
+
+    pA1, pB1 = mk(R * E, H), mk(2 * IM, R * E)
+    pA2, pB2 = mk(R * E, IM), mk(H, R * E)
     lora = [pA1, pB1, pA2, pB2]
     gup_l = (*peft_lora_to_scattermoe(pA1, pB1, E, R), SC)
     dwn_l = (*peft_lora_to_scattermoe(pA2, pB2, E, R), SC)
@@ -129,8 +150,10 @@ def test_gptoss_lora_matches_eager(dt, monkeypatch):
     monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, gup_l, dwn_l))
 
     # eager W_eff: ΔW_e = scaling * A_e^T @ W_B[e], W_B = lora_B.T.reshape(E,R,out)
-    A1 = pA1.reshape(E, R, H); WB1 = peft_lora_B_to_scattermoe(pB1, E, R).t().reshape(E, R, 2 * I)
-    A2 = pA2.reshape(E, R, I); WB2 = peft_lora_B_to_scattermoe(pB2, E, R).t().reshape(E, R, H)
+    A1 = pA1.reshape(E, R, H)
+    WB1 = peft_lora_B_to_scattermoe(pB1, E, R).t().reshape(E, R, 2 * IM)
+    A2 = pA2.reshape(E, R, IM)
+    WB2 = peft_lora_B_to_scattermoe(pB2, E, R).t().reshape(E, R, H)
     gup_eff = base.gate_up_proj + SC * torch.bmm(A1.transpose(1, 2), WB1)
     dp_eff = base.down_proj + SC * torch.bmm(A2.transpose(1, 2), WB2)
 
@@ -141,10 +164,14 @@ def test_gptoss_lora_matches_eager(dt, monkeypatch):
     def run(eager):
         for t in lora:
             t.grad = None
-        x = torch.randn(N, H, device=DEV, dtype=dt,
-                        generator=torch.Generator(DEV).manual_seed(3)).requires_grad_(True)
-        out = (_eager(x, base, idx, w, weff=(gup_eff, dp_eff)) if eager
-               else scattermoe_experts_forward(base, x, idx, w))
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt, generator=torch.Generator(DEV).manual_seed(3)
+        ).requires_grad_(True)
+        out = (
+            _eager(x, base, idx, w, weff=(gup_eff, dp_eff))
+            if eager
+            else scattermoe_experts_forward(base, x, idx, w)
+        )
         out.backward(grad)
         return out.detach(), x.grad, [t.grad.clone() for t in lora]
 
@@ -153,6 +180,6 @@ def test_gptoss_lora_matches_eager(dt, monkeypatch):
     tol = 3e-4 if dt == torch.float32 else 5e-2
     assert _rel(ok, oe) < tol
     assert _rel(dxk, dxe) < tol
-    for a, b in zip(gk, ge):
+    for a, b in zip(gk, ge, strict=True):
         assert _rel(a, b) < tol
         assert a.abs().sum() > 0  # LoRA grads actually populated

--- a/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""scattermoe_experts_forward routes base MXFP4 + LoRA through the fused MX kernel
+(no bf16 dequant of the frozen base) and is bit-for-bit unaffected for non-MXFP4 models.
+
+The fused path keeps the packed 4-bit weights and dequantizes inside the kernel K-loop.
+Validated vs a reference = the same forward on the dequantized weights, within MX
+rounding tolerance, on output / dX / the active-expert slice of LoRA dA, dB.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+MXTensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.mx_tensor", reason="torchao required"
+).MXTensor
+
+import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
+from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (  # noqa: E402
+    scattermoe_experts_forward,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (  # noqa: E402
+    flatten_sort_count,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant import (  # noqa: E402
+    get_active_experts,
+)
+
+DEV = "cuda"
+E, H, I, N, K, R, SC = 8, 1024, 512, 512, 4, 16, 0.5
+
+
+def _module(gu, dn):
+    return SimpleNamespace(
+        num_experts=E, gate_up_proj=gu, down_proj=dn,
+        act_fn=torch.nn.functional.silu,
+        is_transposed=False, is_concatenated=True, has_bias=False, has_gate=True,
+    )
+
+
+def test_mxfp4_forward_uses_fused_kernel_matches_dequant(monkeypatch):
+    dt = torch.bfloat16
+    g = torch.Generator(device=DEV).manual_seed(0)
+    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+    gu_mx = mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1)
+    dn_mx = mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1)
+    gu_deq, dn_deq = gu_mx.dequantize(dt).contiguous(), dn_mx.dequantize(dt).contiguous()
+
+    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
+    A1, B1, A2, B2 = mk(R * E, H), mk(2 * I, R * E), mk(R * E, I), mk(H, R * E)
+    lora = [A1, B1, A2, B2]
+    monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
+    monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC)))
+
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    w = torch.rand(N, K, device=DEV, generator=g).to(dt)
+    sei, _, _ = flatten_sort_count(idx, E)
+    active = get_active_experts(sei, E)
+    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(-1)
+    grad = torch.randn(N, H, device=DEV, dtype=dt, generator=g)
+
+    def run(m):
+        for t in lora:
+            t.grad = None
+        x = torch.randn(N, H, device=DEV, dtype=dt,
+                        generator=torch.Generator(DEV).manual_seed(7)).requires_grad_(True)
+        scattermoe_experts_forward(m, x, idx, w).backward(grad)
+        return x.grad.detach(), [t.grad.clone() for t in lora]
+
+    dx_mx, gl_mx = run(_module(gu_mx, dn_mx))     # fused MX path
+    dx_bf, gl_bf = run(_module(gu_deq, dn_deq))   # bf16 dequant reference
+
+    rel = lambda a, b: (a - b).float().abs().max().item() / max(b.float().abs().max().item(), 1e-6)
+    assert rel(dx_mx, dx_bf) < 6e-2
+    for i, slc in ((0, row), (1, (slice(None), row)), (2, row), (3, (slice(None), row))):
+        assert rel(gl_mx[i][slc], gl_bf[i][slc]) < 6e-2, f"lora grad {i}"
+        assert torch.isfinite(gl_mx[i]).all()
+
+
+def test_mxfp4_without_lora_falls_back_to_dequant(monkeypatch):
+    """MXFP4 base with no LoRA must not hit the fused (LoRA-only) MX kernel."""
+    dt = torch.bfloat16
+    g = torch.Generator(device=DEV).manual_seed(0)
+    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+    m = _module(
+        mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1),
+        mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1),
+    )
+    monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: False)  # no LoRA
+    x = torch.randn(N, H, device=DEV, dtype=dt)
+    idx = torch.randint(0, E, (N, K), device=DEV)
+    w = torch.rand(N, K, device=DEV).to(dt)
+    out = scattermoe_experts_forward(m, x, idx, w)  # dequant-on-cast path, must not raise
+    assert out.shape == (N, H) and torch.isfinite(out).all()

--- a/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
@@ -83,6 +83,59 @@ def test_mxfp4_forward_uses_fused_kernel_matches_dequant(monkeypatch):
         assert torch.isfinite(gl_mx[i]).all()
 
 
+def test_mxfp4_ep_matches_dequant(monkeypatch):
+    """Fused MXFP4 through the EP (sentinel-skip) forward matches the bf16-dequant ref,
+    and _sonicmoe_local routes there on a device the sonic-moe kernel can't run."""
+    from axolotl.integrations.expert_parallel.experts_fn import _sonicmoe_local
+    from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (
+        scattermoe_experts_forward_ep,
+    )
+    from axolotl.integrations.kernels.libs.sonicmoe.experts import (
+        _sonicmoe_kernel_supported,
+    )
+
+    dt = torch.bfloat16
+    g = torch.Generator(device=DEV).manual_seed(0)
+    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+    gu_mx = mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1)
+    dn_mx = mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1)
+    gu_deq, dn_deq = gu_mx.dequantize(dt).contiguous(), dn_mx.dequantize(dt).contiguous()
+    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
+    A1, B1, A2, B2 = mk(R * E, H), mk(2 * I, R * E), mk(R * E, I), mk(H, R * E)
+    lora = [A1, B1, A2, B2]
+    monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
+    monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC)))
+
+    # routing with -1 remote sentinels (post-DeepEP-dispatch shape)
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    remote = torch.rand(N, K, device=DEV, generator=g) < 0.5
+    remote[:, 0] = False
+    idx = torch.where(remote, torch.full_like(idx, -1), idx)
+    w = torch.rand(N, K, device=DEV, generator=g).to(dt)
+    active = torch.unique(torch.sort(idx.reshape(-1)[idx.reshape(-1) >= 0]).values)
+    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(-1)
+    grad = torch.randn(N, H, device=DEV, dtype=dt, generator=g)
+
+    def run(m):
+        for t in lora:
+            t.grad = None
+        x = torch.randn(N, H, device=DEV, dtype=dt,
+                        generator=torch.Generator(DEV).manual_seed(7)).requires_grad_(True)
+        scattermoe_experts_forward_ep(m, x, idx, w).backward(grad)
+        return x.grad.detach(), [t.grad.clone() for t in lora]
+
+    dx_mx, gl_mx = run(_module(gu_mx, dn_mx))
+    dx_bf, gl_bf = run(_module(gu_deq, dn_deq))
+    rel = lambda a, b: (a - b).float().abs().max().item() / max(b.float().abs().max().item(), 1e-6)
+    assert rel(dx_mx, dx_bf) < 6e-2
+    for i, slc in ((0, row), (1, (slice(None), row)), (2, row), (3, (slice(None), row))):
+        assert rel(gl_mx[i][slc], gl_bf[i][slc]) < 6e-2, f"lora grad {i}"
+
+    if not _sonicmoe_kernel_supported():  # e.g. sm_120: sonicmoe+EP falls back to scattermoe
+        out = _sonicmoe_local(_module(gu_mx, dn_mx), torch.randn(N, H, device=DEV, dtype=dt), idx, w)
+        assert out.shape == (N, H) and torch.isfinite(out).all()
+
+
 def test_mxfp4_without_lora_falls_back_to_dequant(monkeypatch):
     """MXFP4 base with no LoRA must not hit the fused (LoRA-only) MX kernel."""
     dt = torch.bfloat16

--- a/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_mxfp4_experts_forward.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-torch = pytest.importorskip("torch")
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 MXTensor = pytest.importorskip(
     "torchao.prototype.mx_formats.mx_tensor", reason="torchao required"
@@ -33,52 +32,81 @@ from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant import 
 )
 
 DEV = "cuda"
-E, H, I, N, K, R, SC = 8, 1024, 512, 512, 4, 16, 0.5
+E, H, IM, N, K, R, SC = 8, 1024, 512, 512, 4, 16, 0.5
 
 
 def _module(gu, dn):
     return SimpleNamespace(
-        num_experts=E, gate_up_proj=gu, down_proj=dn,
+        num_experts=E,
+        gate_up_proj=gu,
+        down_proj=dn,
         act_fn=torch.nn.functional.silu,
-        is_transposed=False, is_concatenated=True, has_bias=False, has_gate=True,
+        is_transposed=False,
+        is_concatenated=True,
+        has_bias=False,
+        has_gate=True,
     )
 
 
 def test_mxfp4_forward_uses_fused_kernel_matches_dequant(monkeypatch):
     dt = torch.bfloat16
     g = torch.Generator(device=DEV).manual_seed(0)
-    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
-    gu_mx = mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1)
-    dn_mx = mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1)
-    gu_deq, dn_deq = gu_mx.dequantize(dt).contiguous(), dn_mx.dequantize(dt).contiguous()
 
-    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
-    A1, B1, A2, B2 = mk(R * E, H), mk(2 * I, R * E), mk(R * E, I), mk(H, R * E)
+    def mx(W):
+        return MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+
+    gu_mx = mx(torch.randn(E, 2 * IM, H, device=DEV, dtype=dt, generator=g) * 0.1)
+    dn_mx = mx(torch.randn(E, H, IM, device=DEV, dtype=dt, generator=g) * 0.1)
+    gu_deq, dn_deq = (
+        gu_mx.dequantize(dt).contiguous(),
+        dn_mx.dequantize(dt).contiguous(),
+    )
+
+    def mk(*s):
+        return (
+            torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05
+        ).requires_grad_(True)
+
+    A1, B1, A2, B2 = mk(R * E, H), mk(2 * IM, R * E), mk(R * E, IM), mk(H, R * E)
     lora = [A1, B1, A2, B2]
     monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
-    monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC)))
+    monkeypatch.setattr(
+        ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC))
+    )
 
     idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
     w = torch.rand(N, K, device=DEV, generator=g).to(dt)
     sei, _, _ = flatten_sort_count(idx, E)
     active = get_active_experts(sei, E)
-    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(-1)
+    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(
+        -1
+    )
     grad = torch.randn(N, H, device=DEV, dtype=dt, generator=g)
 
     def run(m):
         for t in lora:
             t.grad = None
-        x = torch.randn(N, H, device=DEV, dtype=dt,
-                        generator=torch.Generator(DEV).manual_seed(7)).requires_grad_(True)
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt, generator=torch.Generator(DEV).manual_seed(7)
+        ).requires_grad_(True)
         scattermoe_experts_forward(m, x, idx, w).backward(grad)
         return x.grad.detach(), [t.grad.clone() for t in lora]
 
-    dx_mx, gl_mx = run(_module(gu_mx, dn_mx))     # fused MX path
-    dx_bf, gl_bf = run(_module(gu_deq, dn_deq))   # bf16 dequant reference
+    dx_mx, gl_mx = run(_module(gu_mx, dn_mx))  # fused MX path
+    dx_bf, gl_bf = run(_module(gu_deq, dn_deq))  # bf16 dequant reference
 
-    rel = lambda a, b: (a - b).float().abs().max().item() / max(b.float().abs().max().item(), 1e-6)
+    def rel(a, b):
+        return (a - b).float().abs().max().item() / max(
+            b.float().abs().max().item(), 1e-6
+        )
+
     assert rel(dx_mx, dx_bf) < 6e-2
-    for i, slc in ((0, row), (1, (slice(None), row)), (2, row), (3, (slice(None), row))):
+    for i, slc in (
+        (0, row),
+        (1, (slice(None), row)),
+        (2, row),
+        (3, (slice(None), row)),
+    ):
         assert rel(gl_mx[i][slc], gl_bf[i][slc]) < 6e-2, f"lora grad {i}"
         assert torch.isfinite(gl_mx[i]).all()
 
@@ -96,15 +124,28 @@ def test_mxfp4_ep_matches_dequant(monkeypatch):
 
     dt = torch.bfloat16
     g = torch.Generator(device=DEV).manual_seed(0)
-    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
-    gu_mx = mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1)
-    dn_mx = mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1)
-    gu_deq, dn_deq = gu_mx.dequantize(dt).contiguous(), dn_mx.dequantize(dt).contiguous()
-    mk = lambda *s: (torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05).requires_grad_(True)
-    A1, B1, A2, B2 = mk(R * E, H), mk(2 * I, R * E), mk(R * E, I), mk(H, R * E)
+
+    def mx(W):
+        return MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+
+    gu_mx = mx(torch.randn(E, 2 * IM, H, device=DEV, dtype=dt, generator=g) * 0.1)
+    dn_mx = mx(torch.randn(E, H, IM, device=DEV, dtype=dt, generator=g) * 0.1)
+    gu_deq, dn_deq = (
+        gu_mx.dequantize(dt).contiguous(),
+        dn_mx.dequantize(dt).contiguous(),
+    )
+
+    def mk(*s):
+        return (
+            torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05
+        ).requires_grad_(True)
+
+    A1, B1, A2, B2 = mk(R * E, H), mk(2 * IM, R * E), mk(R * E, IM), mk(H, R * E)
     lora = [A1, B1, A2, B2]
     monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
-    monkeypatch.setattr(ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC)))
+    monkeypatch.setattr(
+        ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC))
+    )
 
     # routing with -1 remote sentinels (post-DeepEP-dispatch shape)
     idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
@@ -113,26 +154,43 @@ def test_mxfp4_ep_matches_dequant(monkeypatch):
     idx = torch.where(remote, torch.full_like(idx, -1), idx)
     w = torch.rand(N, K, device=DEV, generator=g).to(dt)
     active = torch.unique(torch.sort(idx.reshape(-1)[idx.reshape(-1) >= 0]).values)
-    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(-1)
+    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(
+        -1
+    )
     grad = torch.randn(N, H, device=DEV, dtype=dt, generator=g)
 
     def run(m):
         for t in lora:
             t.grad = None
-        x = torch.randn(N, H, device=DEV, dtype=dt,
-                        generator=torch.Generator(DEV).manual_seed(7)).requires_grad_(True)
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt, generator=torch.Generator(DEV).manual_seed(7)
+        ).requires_grad_(True)
         scattermoe_experts_forward_ep(m, x, idx, w).backward(grad)
         return x.grad.detach(), [t.grad.clone() for t in lora]
 
     dx_mx, gl_mx = run(_module(gu_mx, dn_mx))
     dx_bf, gl_bf = run(_module(gu_deq, dn_deq))
-    rel = lambda a, b: (a - b).float().abs().max().item() / max(b.float().abs().max().item(), 1e-6)
+
+    def rel(a, b):
+        return (a - b).float().abs().max().item() / max(
+            b.float().abs().max().item(), 1e-6
+        )
+
     assert rel(dx_mx, dx_bf) < 6e-2
-    for i, slc in ((0, row), (1, (slice(None), row)), (2, row), (3, (slice(None), row))):
+    for i, slc in (
+        (0, row),
+        (1, (slice(None), row)),
+        (2, row),
+        (3, (slice(None), row)),
+    ):
         assert rel(gl_mx[i][slc], gl_bf[i][slc]) < 6e-2, f"lora grad {i}"
 
-    if not _sonicmoe_kernel_supported():  # e.g. sm_120: sonicmoe+EP falls back to scattermoe
-        out = _sonicmoe_local(_module(gu_mx, dn_mx), torch.randn(N, H, device=DEV, dtype=dt), idx, w)
+    if (
+        not _sonicmoe_kernel_supported()
+    ):  # e.g. sm_120: sonicmoe+EP falls back to scattermoe
+        out = _sonicmoe_local(
+            _module(gu_mx, dn_mx), torch.randn(N, H, device=DEV, dtype=dt), idx, w
+        )
         assert out.shape == (N, H) and torch.isfinite(out).all()
 
 
@@ -140,14 +198,19 @@ def test_mxfp4_without_lora_falls_back_to_dequant(monkeypatch):
     """MXFP4 base with no LoRA must not hit the fused (LoRA-only) MX kernel."""
     dt = torch.bfloat16
     g = torch.Generator(device=DEV).manual_seed(0)
-    mx = lambda W: MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+
+    def mx(W):
+        return MXTensor.to_mx(W, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+
     m = _module(
-        mx(torch.randn(E, 2 * I, H, device=DEV, dtype=dt, generator=g) * 0.1),
-        mx(torch.randn(E, H, I, device=DEV, dtype=dt, generator=g) * 0.1),
+        mx(torch.randn(E, 2 * IM, H, device=DEV, dtype=dt, generator=g) * 0.1),
+        mx(torch.randn(E, H, IM, device=DEV, dtype=dt, generator=g) * 0.1),
     )
     monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: False)  # no LoRA
     x = torch.randn(N, H, device=DEV, dtype=dt)
     idx = torch.randint(0, E, (N, K), device=DEV)
     w = torch.rand(N, K, device=DEV).to(dt)
-    out = scattermoe_experts_forward(m, x, idx, w)  # dequant-on-cast path, must not raise
+    out = scattermoe_experts_forward(
+        m, x, idx, w
+    )  # dequant-on-cast path, must not raise
     assert out.shape == (N, H) and torch.isfinite(out).all()

--- a/tests/integrations/kernels/scattermoe_lora/test_nvfp4_experts_forward.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_nvfp4_experts_forward.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""scattermoe routes base NVFP4 + LoRA through the fused kernel (no bf16 dequant).
+
+NVFP4 shares the FP4 E2M1 packing with MXFP4 but scales per 16-element block with an
+E4M3 (fp8) value (times an optional per-tensor scale). It reuses the MXWeights container
+with ``scale_is_linear=True`` (the E4M3 block scale pre-folded with the per-tensor scale)
+and the same fused Triton kernel with a linear-scale branch + block-16. Validated vs a
+reference = the same forward on the dequantized weights, within NV rounding tolerance,
+through both the standard and EP (sentinel-skip) forwards.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+NVFP4Tensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.nvfp4_tensor", reason="torchao required"
+).NVFP4Tensor
+
+import axolotl.integrations.kernels.libs.scattermoe_lora.experts as ex  # noqa: E402
+from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (  # noqa: E402
+    scattermoe_experts_forward,
+    scattermoe_experts_forward_ep,
+)
+from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant import (  # noqa: E402
+    is_mxfp4_param,
+    is_nvfp4_param,
+)
+
+DEV = "cuda"
+E, H, IM, N, K, R, SC = 8, 1024, 512, 512, 4, 16, 0.5
+
+
+def _module(gu, dn):
+    return SimpleNamespace(
+        num_experts=E,
+        gate_up_proj=gu,
+        down_proj=dn,
+        act_fn=torch.nn.functional.silu,
+        is_transposed=False,
+        is_concatenated=True,
+        has_bias=False,
+        has_gate=True,
+    )
+
+
+def _rel(a, b):
+    return (a - b).float().abs().max().item() / max(b.float().abs().max().item(), 1e-6)
+
+
+def test_is_nvfp4_param_disjoint_from_mxfp4():
+    nv = NVFP4Tensor.to_nvfp4(
+        torch.randn(E, IM, H, device=DEV, dtype=torch.bfloat16), block_size=16
+    )
+    assert is_nvfp4_param(nv) and not is_mxfp4_param(nv)
+    assert not is_nvfp4_param(torch.randn(2, 2, device=DEV))  # plain tensor
+
+
+def _routing_std(g):
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    return idx, torch.rand(N, K, device=DEV, generator=g).to(torch.bfloat16)
+
+
+def _routing_ep(g):
+    idx = torch.randint(0, E, (N, K), device=DEV, generator=g)
+    remote = torch.rand(N, K, device=DEV, generator=g) < 0.5
+    remote[:, 0] = False  # >=1 valid slot per token (DeepEP guarantee)
+    idx = torch.where(remote, torch.full_like(idx, -1), idx)
+    return idx, torch.rand(N, K, device=DEV, generator=g).to(torch.bfloat16)
+
+
+@pytest.mark.parametrize(
+    "fwd,routing",
+    [
+        (scattermoe_experts_forward, _routing_std),
+        (scattermoe_experts_forward_ep, _routing_ep),
+    ],
+)
+def test_nvfp4_fused_matches_dequant(fwd, routing, monkeypatch):
+    dt = torch.bfloat16
+    g = torch.Generator(device=DEV).manual_seed(0)
+    gu_nv = NVFP4Tensor.to_nvfp4(
+        torch.randn(E, 2 * IM, H, device=DEV, dtype=dt, generator=g) * 0.1,
+        block_size=16,
+    )
+    dn_nv = NVFP4Tensor.to_nvfp4(
+        torch.randn(E, H, IM, device=DEV, dtype=dt, generator=g) * 0.1, block_size=16
+    )
+    gu_deq, dn_deq = (
+        gu_nv.dequantize(dt).contiguous(),
+        dn_nv.dequantize(dt).contiguous(),
+    )
+
+    def mk(*s):
+        return (
+            torch.randn(*s, device=DEV, dtype=dt, generator=g) * 0.05
+        ).requires_grad_(True)
+
+    A1, B1, A2, B2 = mk(R * E, H), mk(2 * IM, R * E), mk(R * E, IM), mk(H, R * E)
+    lora = [A1, B1, A2, B2]
+    monkeypatch.setattr(ex, "_has_peft_wrapper", lambda s: True)
+    monkeypatch.setattr(
+        ex, "_unwrap_experts_lora", lambda s: (s, (A1, B1, SC), (A2, B2, SC))
+    )
+
+    idx, w = routing(g)
+    valid = idx.reshape(-1) >= 0
+    active = torch.unique(torch.sort(idx.reshape(-1)[valid]).values)
+    row = (active.long()[:, None] * R + torch.arange(R, device=DEV)[None, :]).reshape(
+        -1
+    )
+    grad = torch.randn(N, H, device=DEV, dtype=dt, generator=g)
+
+    def run(m):
+        for t in lora:
+            t.grad = None
+        x = torch.randn(
+            N, H, device=DEV, dtype=dt, generator=torch.Generator(DEV).manual_seed(7)
+        ).requires_grad_(True)
+        fwd(m, x, idx, w).backward(grad)
+        return x.grad.detach(), [t.grad.clone() for t in lora]
+
+    dx_nv, gl_nv = run(_module(gu_nv, dn_nv))  # fused NVFP4 (no dequant)
+    dx_bf, gl_bf = run(_module(gu_deq, dn_deq))  # bf16 dequant reference
+    assert _rel(dx_nv, dx_bf) < 6e-2
+    for i, slc in (
+        (0, row),
+        (1, (slice(None), row)),
+        (2, row),
+        (3, (slice(None), row)),
+    ):
+        assert _rel(gl_nv[i][slc], gl_bf[i][slc]) < 6e-2, f"lora grad {i}"
+        assert torch.isfinite(gl_nv[i]).all()


### PR DESCRIPTION
Makes the vendored scattermoe Triton path the working MoE+LoRA story on Blackwell
(sm120), where the sonic-moe CUTLASS kernel can't compile (bundled quack `GemmSm120`
predates `concat_layout`). Four changes:

1. **EP sentinel-skip** — under DeepEP the local scattermoe kernel processed all
    `N*K` dispatched rows with remote slots masked to expert 0/weight 0 (compute-and-
    mask + a load-imbalanced expert-0 bucket). Now drops `-1` sentinel rows before the
    GEMMs. **2–10× fwd+bwd, 0.25–0.67× mem** at ep 2–8.

2. **gpt_oss layout** — scattermoe now handles transposed/interleaved/biased experts
    + clamped sigmoid-GLU, so gpt_oss MoE+LoRA runs on sm120 (**9.5–48× vs eager**).

3. **Fused MXFP4 (no dequant)** — `scatter2scatter_lora_mx` existed but was never
    wired into the live forward; base MXFP4 was dequantized to bf16 every step. Now
    routes MXFP4+LoRA through the fused kernel (dequant in the K-loop). **1.7–3.7×,
    16–24× less transient mem** vs the dequant path. Gated on `is_mxfp4_param`, so
    bf16/non-torchao models are unaffected.

4. **sonicmoe on sm120** — `use_sonicmoe` (standard layout) transparently falls back
    to scattermoe on sm120, and `_sonicmoe_local` routes there under EP — giving
    sonicmoe + LoRA + EP + fused MXFP4 on Blackwell.

All paths validated against eager/dequant references within tolerance (fp32 ~1e-6,
MX-tol for MXFP4). New regression tests: `test_ep_sentinel_skip.py`,
`test_gptoss_layout.py`, `test_mxfp4_experts_forward.py`. Existing EP suite green.

The real CUTLASS sonic-moe on sm120 needs a source build against quack 0.5.0 (probed;
a runtime monkeypatch cascades through `gemm_sm90`/`tile_scheduler` API drift) — out of
scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ScatterMoE support for GPT-OSS models (previously SonicMoE only)
  * Improved expert routing for distributed training with better sentinel handling

* **Bug Fixes**
  * Enhanced fallback mechanisms when SonicMoE kernels are unavailable on certain GPUs
  * Better handling of edge cases in expert selection and routing

* **Documentation**
  * Updated kernel support matrix with GPT-OSS layout information
  * Added guidance for Blackwell GPU kernel selection and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->