### PR TITLE
docs: add AI Badgr cloud GPU launch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Other installation approaches are described [here](https://docs.axolotl.ai/docs/
 <details>
 
 - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
+- [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl) (`badgr run template axolotl --max-cost 20 --max-runtime 120`)
 - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=github&utm_medium=developer_community&utm_campaign=template_launch_axolotl&utm_content=readme)
 - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
 - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Other installation approaches are described [here](https://docs.axolotl.ai/docs/
 <details>
 
 - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
-- [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl) (`badgr run template axolotl --max-cost 20 --max-runtime 120`)
+- [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
 - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=github&utm_medium=developer_community&utm_campaign=template_launch_axolotl&utm_content=readme)
 - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
 - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ Other installation approaches are described [here](https://docs.axolotl.ai/docs/
 <details>
 
 - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
-- [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
 - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=github&utm_medium=developer_community&utm_campaign=template_launch_axolotl&utm_content=readme)
 - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
 - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)
 - [Novita](https://novita.ai/gpus-console?templateId=311)
 - [JarvisLabs.ai](https://jarvislabs.ai/templates/axolotl)
 - [Latitude.sh](https://latitude.sh/blueprint/989e0e79-3bf6-41ea-a46b-1f246e309d5c)
+- [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
 
 </details>
 

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -95,13 +95,13 @@ For providers supporting Docker:
 - Use `axolotlai/axolotl-cloud-uv:main-latest`
 - Available on:
     - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
-    - [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
     - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=axolotl&utm_medium=partner&utm_campaign=template_launch_july2025&utm_content=docs_link)
     - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
     - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)
     - [Novita](https://novita.ai/gpus-console?templateId=311)
     - [JarvisLabs.ai](https://jarvislabs.ai/templates/axolotl)
     - [Latitude.sh](https://latitude.sh/blueprint/989e0e79-3bf6-41ea-a46b-1f246e309d5c)
+    - [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
 
 ### Google Colab {#sec-colab}
 

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -95,6 +95,7 @@ For providers supporting Docker:
 - Use `axolotlai/axolotl-cloud-uv:main-latest`
 - Available on:
     - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
+    - [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl) (`badgr run template axolotl --max-cost 20 --max-runtime 120`)
     - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=axolotl&utm_medium=partner&utm_campaign=template_launch_july2025&utm_content=docs_link)
     - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
     - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -95,7 +95,7 @@ For providers supporting Docker:
 - Use `axolotlai/axolotl-cloud-uv:main-latest`
 - Available on:
     - [RunPod](https://runpod.io/gsc?template=v2ickqhz9s&ref=6i7fkpdz)
-    - [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl) (`badgr run template axolotl --max-cost 20 --max-runtime 120`)
+    - [AI Badgr](https://aibadgr.com/gpu/launch?template=axolotl)
     - [Vast.ai](https://cloud.vast.ai?ref_id=62897&template_id=bdd4a49fa8bce926defc99471864cace&utm_source=axolotl&utm_medium=partner&utm_campaign=template_launch_july2025&utm_content=docs_link)
     - [PRIME Intellect](https://app.primeintellect.ai/dashboard/create-cluster?image=axolotl&location=Cheapest&security=Cheapest&show_spot=true)
     - [Modal](https://www.modal.com?utm_source=github&utm_medium=github&utm_campaign=axolotl)


### PR DESCRIPTION
# Description

Adds AI Badgr as an optional cloud GPU launch option in the README provider list.

This links users to a prefilled Axolotl GPU launch template:

https://aibadgr.com/gpu/launch?template=axolotl

The template gives users a copy-paste command for running Axolotl through AI Badgr with routed GPU capacity, cost caps, logs, teardown, and receipts.

## Motivation and Context

Axolotl already supports cloud GPU deployment patterns. This PR adds AI Badgr as another optional launch path for users who want a prefilled GPU workload command with spend controls.

It does not replace existing RunPod, Vast.ai, Modal, or local setup instructions.

## How has this been tested?

Docs-only change.

I verified the AI Badgr launch URL resolves to the Axolotl template and provides the expected `badgr run template axolotl` command.

## AI Usage Disclaimer

no.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AI Badgr as a supported Cloud Provider option in documentation.
  * Included AI Badgr with Docker GPU launch capability in the Cloud GPU Providers list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->