### PR TITLE
FIX loss diff for streaming n non streaming 

### DIFF
--- a/src/axolotl/prompt_strategies/pretrain.py
+++ b/src/axolotl/prompt_strategies/pretrain.py
@@ -30,13 +30,16 @@ class PretrainTokenizationStrategy(PromptTokenizingStrategy):
     def _tokenize(
         self, prompt: str, add_eos_token: bool = True, strip_bos_token: bool = False
     ) -> BatchEncoding:
+        # keep the overlap below the window size so small sequence_len values don't
+        # violate the tokenizer's `stride < effective max_length` constraint
+        stride = min(256, (self.max_length - 1) // 2)
         res = self.tokenizer(
             prompt,
             truncation=True,
             max_length=self.max_length - 1,
             add_special_tokens=True,
             return_overflowing_tokens=True,
-            stride=256,
+            stride=stride,
         )
         res["input_ids"] = [
             seq + [self.tokenizer.eos_token_id] for seq in res["input_ids"]
@@ -56,6 +59,8 @@ def load(tokenizer, cfg):
         cfg.train_on_inputs,
         cfg.sequence_len,
         text_column=cfg.pretraining_dataset[0]["text_column"] or "text",
-        max_length=cfg.sequence_len * 64,
+        # windows; larger values produce windows that the downstream
+        # `filter_sequences_by_length` drops wholesale
+        max_length=cfg.sequence_len,
     )
     return strat

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,9 @@ import unittest
 
 from transformers import LlamaTokenizer
 
+from axolotl.prompt_strategies.pretrain import load as load_pretrain
 from axolotl.utils.data import encode_streaming, md5
+from axolotl.utils.dict import DictDefault
 from axolotl.utils.trainer import filter_sequences_by_length
 
 from tests.hf_offline_utils import enable_hf_offline
@@ -57,6 +59,61 @@ class TestEncodePretraining(unittest.TestCase):
         self.assertEqual(result["input_ids"][0][7], self.tokenizer.bos_token_id)
         self.assertEqual(result["input_ids"][0][13], self.tokenizer.eos_token_id)
         self.assertEqual(result["input_ids"][0][14], self.tokenizer.pad_token_id)
+
+    def _pretrain_strategy(self, sequence_len):
+        cfg = DictDefault(
+            {
+                "train_on_inputs": False,
+                "sequence_len": sequence_len,
+                "pretraining_dataset": [{"text_column": "text"}],
+            }
+        )
+        return load_pretrain(self.tokenizer, cfg)
+
+    def test_long_document_is_chunked_not_dropped(self):
+        """Long docs must be chunked into windows that survive the length filter (#3441)."""
+        for sequence_len in (256, 512, 2048):
+            with self.subTest(sequence_len=sequence_len):
+                strat = self._pretrain_strategy(sequence_len)
+                long_doc = " ".join(f"token{i}" for i in range(4 * sequence_len))
+                windows = strat._tokenize(long_doc)["input_ids"]
+
+                # the document spans more than one window (i.e. it was chunked)
+                self.assertGreater(len(windows), 1)
+
+                for window in windows:
+                    # every window survives the downstream length filter ...
+                    self.assertLessEqual(len(window), sequence_len)
+                    self.assertTrue(
+                        filter_sequences_by_length(
+                            {"input_ids": window}, sequence_len=sequence_len
+                        )
+                    )
+                    # ... and ends with EOS
+                    self.assertEqual(window[-1], self.tokenizer.eos_token_id)
+
+    def test_no_tokens_dropped_for_oversized_docs(self):
+        """A doc longer than sequence_len must not be dropped entirely (#3441)."""
+        sequence_len = 256
+        strat = self._pretrain_strategy(sequence_len)
+        long_doc = " ".join(f"token{i}" for i in range(2000))
+        windows = strat._tokenize(long_doc)["input_ids"]
+
+        kept = [
+            w
+            for w in windows
+            if filter_sequences_by_length({"input_ids": w}, sequence_len=sequence_len)
+        ]
+        self.assertTrue(kept, "all windows were dropped — oversized doc lost entirely")
+        self.assertEqual(len(kept), len(windows))
+
+    def test_stride_below_window_size(self):
+        """Tokenization must not raise from a stride >= effective max length."""
+        for sequence_len in (256, 2048):
+            with self.subTest(sequence_len=sequence_len):
+                strat = self._pretrain_strategy(sequence_len)
+                # would raise ValueError from the tokenizer if stride were too large
+                strat._tokenize(" ".join(f"token{i}" for i in range(sequence_len * 3)))
 
     def test_md5(self):
         self.assertEqual(md5("hello world"), "5eb63bbbe01eeed093cb22bb8f5acdc3")


### PR DESCRIPTION

# Description
pretrain (streaming) drops every document longer than sequence_len via `filter_sequences_by_length`


completion (non-streaming) splits long docs into sequence_len chunks and keeps all tokens.

## fix 
pretrain strategy chunk long documents instead of dropping them.

## Motivation and Context
#3341


## How has this been tested?
unit test enough 

## AI Usage Disclaimer

dignose claude 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tokenization stride calculation for pretraining to ensure proper overlap behavior with longer sequences
  * Fixed sequence length parameter configuration to use specified value directly instead of scaled multiplier

* **Tests**
  * Added test coverage for long document handling and edge cases in pretraining tokenization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->