### PR TITLE
feat: when validating OptimizationValidationMixin, fsdp_version shouldn't be flag as an warning

### DIFF
--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1085,7 +1085,7 @@ class OptimizationValidationMixin:
         if fsdp_config := data.get("fsdp_config"):
             should_fix = False
             for key, _ in fsdp_config.items():
-                if key.startswith("fsdp_"):
+                if key.startswith("fsdp_") and key != "fsdp_version":
                     should_fix = True
                     LOG.warning_once(
                         "Configuring FSDP fields with the `fsdp_` prefix is deprecated. "


### PR DESCRIPTION
With the following config.yaml

```yaml
fsdp_version: 2
fsdp_config:
  offload_params: false
  state_dict_type: FULL_STATE_DICT
  auto_wrap_policy: TRANSFORMER_BASED_WRAP
  transformer_layer_cls_to_wrap: LlamaDecoderLayer
  reshard_after_forward: true
```

We get the following WARNING
```
[2026-06-08 12:08:41,580] [WARNING] [axolotl.utils.schemas.validation] Configuring FSDP fields with the `fsdp_` prefix is deprecated. Please omit the `fsdp_` prefix from the any fields in `fsdp_config`.
```

Where 
```
key == "fsdp_version"
fsdp_config={'offload_params': False, 'state_dict_type': 'FULL_STATE_DICT', 'auto_wrap_policy': 'TRANSFORMER_BASED_WRAP', 'transformer_layer_cls_to_wrap': 'LlamaDecoderLayer', 'reshard_after_forward': True, 'fsdp_version': 2}
```

`fsdp_version` is part of [FSDPConfig](https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/utils/schemas/fsdp.py#L15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue where `fsdp_version` in FSDP configurations was incorrectly treated as deprecated and rewritten during configuration normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->