### PR TITLE
fix(chat_templates): extract reasoning_content before reassigning content in qwen3_5 template

### DIFF
--- a/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
+++ b/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
@@ -93,8 +93,8 @@
             {%- set reasoning_content = message.reasoning_content %}
         {%- else %}
             {%- if '</think>' in content %}
-                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
                 {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
             {%- endif %}
         {%- endif %}
         {%- if loop.index0 > ns.last_query_index %}


### PR DESCRIPTION
## Summary

Fixes #3724.

The bundled `qwen3_5.jinja` template parses inline `<think>...</think>` reasoning incorrectly for assistant messages. In the `else` branch that handles inline reasoning, the two `{%- set %}` statements were in the wrong order relative to the official Qwen3.5 template: `content` was mutated **before** `reasoning_content` was extracted from it.

Both assignments read `content`, so they are order-dependent:

```jinja
{%- set content = content.split('</think>')[-1].lstrip('\n') %}
{%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
```

After the first line, `content` no longer contains `</think>` (or `<think>`), so the second line's `content.split('</think>')[0].split('<think>')[-1]` just returns the already-truncated answer. The result: the reasoning trace is silently dropped and the answer is duplicated into the `<think>` block of the rendered prompt.

## Fix

Swap the two statements so `reasoning_content` is extracted from the original `content` **before** `content` is reassigned, matching the [official Qwen3.5 template](https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/chat_template.jinja#L94-L97):

```jinja
{%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
{%- set content = content.split('</think>')[-1].lstrip('\n') %}
```

## Test plan

- [ ] Render an assistant turn whose `content` contains an inline `<think>...</think>` block (and no separate `message.reasoning_content` field) and confirm the reasoning text lands in the `<think>` block and the answer follows after `</think>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing and display of reasoning content in model responses to ensure accurate extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->