### PR TITLE
BUG: fix qwen chat3.5 

### DIFF
--- a/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
+++ b/src/axolotl/utils/chat_templates/templates/qwen3_5.jinja
@@ -81,12 +81,13 @@
         {%- if message['content'] is string %}
             {%- set content = message.content %}
         {%- else %}
-            {%- set content = '' %}
+            {%- set content_ns = namespace(text='') %}
             {%- for item in message['content'] %}
                 {%- if 'text' in item %}
-                    {%- set content = content + item['text'] %}
+                    {%- set content_ns.text = content_ns.text + item['text'] %}
                 {%- endif %}
             {%- endfor %}
+            {%- set content = content_ns.text %}
         {%- endif %}
         {%- set reasoning_content = '' %}
         {%- if message.reasoning_content is defined and message.reasoning_content is not none %}


### PR DESCRIPTION

# Description
Fine-tuning Qwen3.5 vision models with chat_template: qwen3_5 on datasets whose assistant turns use list/parts content (e.g. HuggingFaceH4/llava-instruct-mix-vsft, OpenAI-style
  [{"type":"text","text":...}]) produces a model that returns empty replies after merge. 

## Motivation and Context
 Fixes #3600. 

## How has this been tested?

repro fixed 

## AI Usage Disclaimer
claude helped with dignose 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of assistant messages in chat templates to ensure proper text concatenation and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->