### PR TITLE
Fix GPT-OSS 20B LoRA example config by disabling use_kernels to prevent kernelize error.

### DIFF
--- a/examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml
+++ b/examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml
@@ -1,5 +1,5 @@
 base_model: openai/gpt-oss-20b
-use_kernels: true
+use_kernels: false
 model_quantization_config: Mxfp4Config
 model_quantization_config_kwargs:
   dequantize: true


### PR DESCRIPTION
Fixes #3720.

### What changed
Fix GPT-OSS 20B LoRA example config by disabling use_kernels to prevent kernelize error.

### Why
The error occurs because `use_kernels: true` triggers a transformers kernelize path that incorrectly treats `apply_rotary_pos_emb` as a Module subclass. The comment on the issue confirms this requires hopper architecture. Other GPT-OSS 20B configs already set `use_kernels: false`, so this brings the LoRA config in line with the working examples.

### Verification
- yaml parse passed

### Not run
- Repository runtime tests were not run outside the configured static/sandbox policy.

### Changed files
- `examples/gpt-oss/gpt-oss-20b-sft-lora-singlegpu.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPT-OSS 20B SFT LoRA single GPU example configuration to disable kernel optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->