### PR TITLE
fix: KTO user_defined dataset transform crashes on every documented config

### DIFF
--- a/src/axolotl/prompt_strategies/base.py
+++ b/src/axolotl/prompt_strategies/base.py
@@ -29,6 +29,6 @@ def load(strategy, cfg, module_base=None, **kwargs):
         mod = importlib.import_module(strategy, module_base)
         func = getattr(mod, load_fn)
         return func(cfg, **kwargs)
-    except Exception:
-        LOG.warning(f"unable to load strategy {strategy}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOG.warning(f"unable to load strategy {strategy}: {exc}", exc_info=True)
         return None

--- a/src/axolotl/prompt_strategies/kto/user_defined.py
+++ b/src/axolotl/prompt_strategies/kto/user_defined.py
@@ -15,14 +15,14 @@ def default(cfg, dataset_idx=0, **kwargs):
     field_label = ds_cfg.get("field_label", "label")
     prompt_format = ds_cfg.get("prompt_format")
     if not prompt_format:
-        prompt_format = "{" + field_prompt + "}"
+        prompt_format = "{prompt}"
     completion_format = ds_cfg.get("completion_format")
     if not completion_format:
-        chosen_format = "{" + field_completion + "}"
+        completion_format = "{completion}"
 
     def transform_fn(sample):
         if (
-            "{" + field_system + "}" in prompt_format
+            "{system}" in prompt_format
             and field_system in sample
             and sample[field_system]
         ):
@@ -30,8 +30,10 @@ def default(cfg, dataset_idx=0, **kwargs):
                 system=sample[field_system], prompt=sample[field_prompt]
             )
         else:
-            sample["prompt"] = prompt_format.format(prompt=sample["prompt"])
-        sample["completion"] = chosen_format.format(chosen=sample[field_completion])
+            sample["prompt"] = prompt_format.format(prompt=sample[field_prompt])
+        sample["completion"] = completion_format.format(
+            completion=sample[field_completion]
+        )
         sample["label"] = sample[field_label]
         return sample
 

--- a/src/axolotl/utils/data/rl.py
+++ b/src/axolotl/utils/data/rl.py
@@ -328,6 +328,13 @@ def _load_split(cfg: DictDefault, split: Literal["train", "test"]) -> Dataset:
             else:
                 ds_transform_fn = load_dpo(_type, cfg, dataset_idx=i)
 
+            if ds_transform_fn is None:
+                raise ValueError(
+                    f"Failed to load dataset transform function for type {_type!r} "
+                    f"(rl: {cfg.rl}). See the warning logged above for the underlying "
+                    "error."
+                )
+
             map_kwargs: dict[str, Any] = {}
             if isinstance(ds_transform_fn, tuple):
                 ds_transform_fn, map_kwargs = ds_transform_fn

--- a/src/axolotl/utils/schemas/datasets.py
+++ b/src/axolotl/utils/schemas/datasets.py
@@ -280,7 +280,7 @@ class UserDefinedKTOType(BaseModel):
     field_system: str | None = None
     field_prompt: str | None = None
     field_completion: str | None = None
-    field_label: bool | None = None
+    field_label: str | None = None
     prompt_format: str | None = None
     completion_format: str | None = None
 

--- a/tests/prompt_strategies/test_kto_user_defined.py
+++ b/tests/prompt_strategies/test_kto_user_defined.py
@@ -1,0 +1,100 @@
+"""
+Tests for user-defined KTO dataset transform strategies
+"""
+
+import pytest
+
+from axolotl.prompt_strategies.kto import load as load_kto
+from axolotl.prompt_strategies.kto.user_defined import default
+from axolotl.utils.dict import DictDefault
+
+
+def make_cfg(type_cfg: dict) -> DictDefault:
+    return DictDefault({"datasets": [{"type": type_cfg}]})
+
+
+class TestKTOUserDefined:
+    """
+    Test user_defined.default KTO transforms
+    """
+
+    def test_documented_config(self):
+        # config from docs/rlhf.qmd, the same shape reported in issue #2757
+        cfg = make_cfg(
+            {
+                "field_prompt": "prompt",
+                "field_system": "system",
+                "field_completion": "completion",
+                "field_label": "label",
+                "prompt_format": "{prompt}",
+                "completion_format": "{completion}",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn({"prompt": "hello", "completion": "world", "label": True})
+        assert sample["prompt"] == "hello"
+        assert sample["completion"] == "world"
+        assert sample["label"] is True
+
+    def test_defaults_without_formats(self):
+        cfg = make_cfg({})
+        transform_fn = default(cfg)
+        sample = transform_fn(
+            {"prompt": "hello", "completion": "world", "label": False}
+        )
+        assert sample["prompt"] == "hello"
+        assert sample["completion"] == "world"
+        assert sample["label"] is False
+
+    def test_custom_field_names(self):
+        cfg = make_cfg(
+            {
+                "field_prompt": "question",
+                "field_completion": "answer",
+                "field_label": "is_good",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn({"question": "hello", "answer": "world", "is_good": True})
+        assert sample["prompt"] == "hello"
+        assert sample["completion"] == "world"
+        assert sample["label"] is True
+
+    def test_system_in_prompt_format(self):
+        cfg = make_cfg(
+            {
+                "prompt_format": "{system} {prompt}",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn(
+            {
+                "system": "be helpful",
+                "prompt": "hello",
+                "completion": "world",
+                "label": True,
+            }
+        )
+        assert sample["prompt"] == "be helpful hello"
+        assert sample["completion"] == "world"
+
+    def test_non_dict_type_raises(self):
+        cfg = make_cfg({})
+        cfg["datasets"][0]["type"] = "user_defined.default"
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            default(cfg)
+
+    def test_load_kto_user_defined_returns_callable(self):
+        # regression: load_kto previously swallowed errors and returned None,
+        # which crashed later with "TypeError: None is not a callable object"
+        cfg = make_cfg(
+            {
+                "field_prompt": "prompt",
+                "field_completion": "completion",
+                "field_label": "label",
+                "prompt_format": "{prompt}",
+                "completion_format": "{completion}",
+            }
+        )
+        transform_fn = load_kto("user_defined.default", cfg, dataset_idx=0)
+        assert callable(transform_fn)

--- a/tests/prompt_strategies/test_kto_user_defined.py
+++ b/tests/prompt_strategies/test_kto_user_defined.py
@@ -6,6 +6,7 @@ import pytest
 
 from axolotl.prompt_strategies.kto import load as load_kto
 from axolotl.prompt_strategies.kto.user_defined import default
+from axolotl.utils.config import validate_config
 from axolotl.utils.dict import DictDefault
 
 
@@ -94,8 +95,8 @@ class TestKTOUserDefined:
             default(cfg)
 
     def test_load_kto_user_defined_returns_callable(self):
-        """Regression: load_kto previously swallowed errors and returned None,
-        which crashed later with "TypeError: None is not a callable object"."""
+        """The loader path resolves user_defined.default to a callable
+        transform for the documented config."""
         cfg = make_cfg(
             {
                 "field_prompt": "prompt",
@@ -107,3 +108,33 @@ class TestKTOUserDefined:
         )
         transform_fn = load_kto("user_defined.default", cfg, dataset_idx=0)
         assert callable(transform_fn)
+
+    def test_documented_config_passes_validate_config(self):
+        """The documented config validates end-to-end: field_label is a column
+        name (str), which the schema previously rejected as a bool."""
+        cfg = DictDefault(
+            {
+                "base_model": "TinyLlama/TinyLlama-1.1B-Chat-v0.6",
+                "learning_rate": 0.000001,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "remove_unused_columns": False,
+                "rl": "kto",
+                "datasets": [
+                    {
+                        "path": "user/dataset",
+                        "split": "train",
+                        "type": {
+                            "field_prompt": "prompt",
+                            "field_system": "system",
+                            "field_completion": "completion",
+                            "field_label": "label",
+                            "prompt_format": "{prompt}",
+                            "completion_format": "{completion}",
+                        },
+                    }
+                ],
+            }
+        )
+        checked_cfg = validate_config(cfg)
+        assert checked_cfg["datasets"][0]["type"]["field_label"] == "label"

--- a/tests/prompt_strategies/test_kto_user_defined.py
+++ b/tests/prompt_strategies/test_kto_user_defined.py
@@ -10,6 +10,7 @@ from axolotl.utils.dict import DictDefault
 
 
 def make_cfg(type_cfg: dict) -> DictDefault:
+    """Build a minimal config with a single user-defined KTO dataset."""
     return DictDefault({"datasets": [{"type": type_cfg}]})
 
 
@@ -19,7 +20,8 @@ class TestKTOUserDefined:
     """
 
     def test_documented_config(self):
-        # config from docs/rlhf.qmd, the same shape reported in issue #2757
+        """Transform works with the exact config documented in docs/rlhf.qmd
+        (the same shape reported in issue #2757)."""
         cfg = make_cfg(
             {
                 "field_prompt": "prompt",
@@ -37,6 +39,8 @@ class TestKTOUserDefined:
         assert sample["label"] is True
 
     def test_defaults_without_formats(self):
+        """Transform falls back to canonical {prompt}/{completion} formats when
+        no explicit formats are configured."""
         cfg = make_cfg({})
         transform_fn = default(cfg)
         sample = transform_fn(
@@ -47,6 +51,8 @@ class TestKTOUserDefined:
         assert sample["label"] is False
 
     def test_custom_field_names(self):
+        """Transform reads from custom field_prompt/field_completion/field_label
+        columns and writes the canonical prompt/completion/label keys."""
         cfg = make_cfg(
             {
                 "field_prompt": "question",
@@ -61,6 +67,8 @@ class TestKTOUserDefined:
         assert sample["label"] is True
 
     def test_system_in_prompt_format(self):
+        """A {system} placeholder in prompt_format is filled from the system
+        field when present in the sample."""
         cfg = make_cfg(
             {
                 "prompt_format": "{system} {prompt}",
@@ -79,14 +87,15 @@ class TestKTOUserDefined:
         assert sample["completion"] == "world"
 
     def test_non_dict_type_raises(self):
+        """A non-dict dataset type raises a clear ValueError."""
         cfg = make_cfg({})
         cfg["datasets"][0]["type"] = "user_defined.default"
         with pytest.raises(ValueError, match="must be a dictionary"):
             default(cfg)
 
     def test_load_kto_user_defined_returns_callable(self):
-        # regression: load_kto previously swallowed errors and returned None,
-        # which crashed later with "TypeError: None is not a callable object"
+        """Regression: load_kto previously swallowed errors and returned None,
+        which crashed later with "TypeError: None is not a callable object"."""
         cfg = make_cfg(
             {
                 "field_prompt": "prompt",


### PR DESCRIPTION
# Description

Fixes #2757.

The `user_defined.default` KTO dataset strategy (`src/axolotl/prompt_strategies/kto/user_defined.py`) crashed in every configuration, including the exact config documented in `docs/rlhf.qmd`:

1. **`completion_format` provided** (the documented usage): the fallback branch assigned the default to a misnamed `chosen_format` variable, so the variable was never defined when a `completion_format` was given, and the transform raised `NameError: cannot access free variable 'chosen_format'`.
2. **`completion_format` omitted**: the generated default placeholder (`{completion}`) did not match the `.format()` keyword used (`chosen=`), raising `KeyError: 'completion'`.
3. **Custom `field_prompt`**: prompt formatting read the hardcoded `sample["prompt"]` instead of `sample[field_prompt]`, raising `KeyError` (the DPO equivalent already does this correctly).

The function only accidentally worked with `field_completion: chosen` and default `field_prompt`.

This PR also addresses the error-reporting chain that made #2757 hard to diagnose: `prompt_strategies/base.py` swallowed the underlying exception and returned `None`, which then crashed downstream in `utils/data/rl.py` with the unhelpful `TypeError: None is not a callable object` shown in the issue. Now:

- `base.load` logs the actual exception (with traceback) in its warning.
- `_load_split` raises a clear `ValueError` naming the dataset type when the transform fails to load, instead of crashing later in `inspect.signature(None)`.

## Changes

- `src/axolotl/prompt_strategies/kto/user_defined.py`: fix `completion_format` handling and use `sample[field_prompt]`; placeholders follow the documented canonical names (`{prompt}`, `{system}`, `{completion}`).
- `src/axolotl/prompt_strategies/base.py`: include the underlying exception in the strategy-load warning.
- `src/axolotl/utils/data/rl.py`: raise an actionable error when a dataset transform fails to load.
- `tests/prompt_strategies/test_kto_user_defined.py`: new unit tests covering the documented config from `docs/rlhf.qmd`, defaults, custom field names, system-in-prompt formatting, and the loader path.

## Verification

All three failure modes reproduce on `main`:

```
NameError: cannot access free variable 'chosen_format' where it is not associated with a value in enclosing scope
KeyError: 'completion'
KeyError: 'prompt'
```

With this PR, the new tests pass:

```
tests/prompt_strategies/test_kto_user_defined.py ......  [100%]
6 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging when loading strategies fails, now capturing full exception details and stack traces for easier troubleshooting.
  * Added validation to prevent silent failures when dataset transformations return incomplete results.

* **Changes**
  * Updated default prompt and completion format handling in KTO user-defined strategy.

* **Tests**
  * Added comprehensive test coverage for KTO user-defined strategy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->