### PR TITLE
feat(grpo): add RLOO and REINFORCE++ advantage estimators

### DIFF
--- a/docs/grpo.qmd
+++ b/docs/grpo.qmd
@@ -534,8 +534,31 @@ All GRPO-specific options live under the `trl:` key in your config. Standard tra
 | `epsilon` | float | `null` | PPO clipping lower bound |
 | `epsilon_high` | float | `null` | PPO clipping upper bound |
 | `loss_type` | str | `null` | Loss formulation: `grpo`, `bnpo`, or `dr_grpo` |
-| `scale_rewards` | bool | `true` | Normalize rewards by standard deviation |
+| `scale_rewards` | bool or str | `true` | Reward scaling: `group` (or `true`), `batch`, or `none` (or `false`) |
+| `advantage_estimator` | str | `group_mean` | Baseline for advantages: `group_mean` (GRPO), `rloo`, or `reinforce_plus_plus` |
 | `mask_truncated_completions` | bool | `false` | Exclude truncated completions from loss |
+
+#### Advantage estimators
+
+GRPO, RLOO, and REINFORCE++ share the same rollout-and-reward structure and differ
+only in how the baseline is subtracted from rewards. `advantage_estimator` selects
+the baseline while `scale_rewards` independently controls normalization:
+
+- `group_mean` (default): each completion is baselined against the mean reward of
+  its prompt group — standard GRPO.
+- `rloo`: each completion is baselined against the mean reward of the *other*
+  completions in its group ([RLOO](https://huggingface.co/papers/2402.14740)).
+  Canonically used with `scale_rewards: none`.
+- `reinforce_plus_plus`: completions are baselined against the mean reward of the
+  whole batch ([REINFORCE++](https://huggingface.co/papers/2501.03262)).
+  Pair with `scale_rewards: batch` for the normalization used in the paper.
+
+```yaml
+rl: grpo
+trl:
+  advantage_estimator: rloo
+  scale_rewards: none
+```
 
 ### Reward functions
 

--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -118,6 +118,9 @@ class GRPOStrategy:
         if trl.scale_rewards is not None:
             grpo_args_kwargs["scale_rewards"] = trl.scale_rewards
 
+        if trl.advantage_estimator is not None:
+            grpo_args_kwargs["advantage_estimator"] = trl.advantage_estimator
+
         if trl.loss_type is not None:
             grpo_args_kwargs["loss_type"] = trl.loss_type
         if trl.mask_truncated_completions is not None:

--- a/src/axolotl/core/trainers/grpo/advantages.py
+++ b/src/axolotl/core/trainers/grpo/advantages.py
@@ -1,0 +1,109 @@
+"""Advantage estimators for GRPO-style RL trainers.
+
+Implements the selectable baseline/advantage computations requested in
+https://github.com/axolotl-ai-cloud/axolotl/issues/3676:
+
+- ``group_mean`` (default): the standard GRPO baseline — the mean reward of
+  the ``num_generations`` completions sampled for the same prompt.
+- ``rloo``: REINFORCE Leave-One-Out — each completion is baselined against
+  the mean reward of the *other* completions in its group, which keeps the
+  baseline unbiased w.r.t. the sample it is applied to. See `Back to Basics:
+  Revisiting REINFORCE-Style Optimization for Learning from Human Feedback
+  in LLMs <https://huggingface.co/papers/2402.14740>`_.
+- ``reinforce_plus_plus``: a global-batch baseline — every completion is
+  baselined against the mean reward of the entire (gathered) batch, ignoring
+  group structure. See `REINFORCE++: A Simple and Efficient Approach for
+  Aligning Large Language Models <https://huggingface.co/papers/2501.03262>`_.
+  The paper normalizes advantages with global batch statistics, so this
+  estimator pairs naturally with ``scale_rewards: batch``.
+
+The estimator only controls the *baseline*; reward scaling stays controlled
+by ``scale_rewards`` (``group`` / ``batch`` / ``none``) so the two remain
+orthogonal, mirroring TRL's GRPO semantics.
+"""
+
+import torch
+
+ADVANTAGE_ESTIMATORS = ("group_mean", "rloo", "reinforce_plus_plus")
+
+
+def compute_advantages(
+    rewards: torch.Tensor,
+    num_generations: int,
+    advantage_estimator: str = "group_mean",
+    scale_rewards: str | bool = "group",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute advantages from a flat tensor of rewards.
+
+    Args:
+        rewards: Flat tensor of shape ``(B,)`` where ``B`` is a multiple of
+            ``num_generations`` and completions of the same prompt are
+            contiguous (the layout produced by GRPO rollouts after
+            ``gather()``).
+        num_generations: Number of completions sampled per prompt.
+        advantage_estimator: One of ``"group_mean"``, ``"rloo"``, or
+            ``"reinforce_plus_plus"``.
+        scale_rewards: ``"group"`` (or ``True``) scales by the per-group
+            standard deviation, ``"batch"`` by the standard deviation of the
+            whole batch, ``"none"`` (or ``False``) applies no scaling.
+
+    Returns:
+        Tuple of ``(advantages, std_rewards, is_std_zero)`` where
+        ``advantages`` has the same shape as ``rewards``, ``std_rewards`` is
+        the (per-sample) standard deviation used for scaling/logging, and
+        ``is_std_zero`` is a boolean tensor flagging samples whose scaling
+        std is (numerically) zero.
+
+    Raises:
+        ValueError: If ``advantage_estimator`` or ``scale_rewards`` is
+            invalid, or if ``rloo`` is requested with fewer than two
+            generations per prompt.
+    """
+    if advantage_estimator not in ADVANTAGE_ESTIMATORS:
+        raise ValueError(
+            f"Invalid advantage_estimator: {advantage_estimator!r}. Must be one of "
+            f"{ADVANTAGE_ESTIMATORS}."
+        )
+    # GRPOConfig.__post_init__ maps bools to strings, but accept bools here
+    # too so the helper can be used with raw config values.
+    scale_rewards = {True: "group", False: "none"}.get(scale_rewards, scale_rewards)
+    if scale_rewards not in ("group", "batch", "none"):
+        raise ValueError(
+            f"Invalid scale_rewards: {scale_rewards!r}. Must be one of 'group', "
+            "'batch', or 'none'."
+        )
+
+    grouped = rewards.view(-1, num_generations)
+
+    if advantage_estimator == "group_mean":
+        baseline = grouped.mean(dim=1, keepdim=True).expand_as(grouped)
+    elif advantage_estimator == "rloo":
+        if num_generations < 2:
+            raise ValueError(
+                "advantage_estimator 'rloo' requires num_generations >= 2, got "
+                f"{num_generations}."
+            )
+        # Leave-one-out baseline: mean of the other (G - 1) rewards in the group
+        baseline = (grouped.sum(dim=1, keepdim=True) - grouped) / (num_generations - 1)
+    else:  # reinforce_plus_plus
+        baseline = rewards.mean().expand_as(grouped)
+
+    advantages = (grouped - baseline).reshape(-1)
+
+    if scale_rewards == "batch":
+        if rewards.numel() > 1:
+            std_rewards = rewards.std().expand_as(rewards)
+        else:
+            std_rewards = torch.zeros_like(rewards)
+    else:
+        # For scale_rewards == "none", std_rewards is only used for logging
+        if num_generations > 1:
+            std_rewards = grouped.std(dim=1).repeat_interleave(num_generations, dim=0)
+        else:
+            std_rewards = torch.zeros_like(rewards)
+
+    if scale_rewards != "none":
+        advantages = advantages / (std_rewards + 1e-4)
+    is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))
+
+    return advantages, std_rewards, is_std_zero

--- a/src/axolotl/core/trainers/grpo/advantages.py
+++ b/src/axolotl/core/trainers/grpo/advantages.py
@@ -1,25 +1,10 @@
-"""Advantage estimators for GRPO-style RL trainers.
+"""Selectable advantage estimators for GRPO-style RL trainers.
 
-Implements the selectable baseline/advantage computations requested in
-https://github.com/axolotl-ai-cloud/axolotl/issues/3676:
-
-- ``group_mean`` (default): the standard GRPO baseline — the mean reward of
-  the ``num_generations`` completions sampled for the same prompt.
-- ``rloo``: REINFORCE Leave-One-Out — each completion is baselined against
-  the mean reward of the *other* completions in its group, which keeps the
-  baseline unbiased w.r.t. the sample it is applied to. See `Back to Basics:
-  Revisiting REINFORCE-Style Optimization for Learning from Human Feedback
-  in LLMs <https://huggingface.co/papers/2402.14740>`_.
-- ``reinforce_plus_plus``: a global-batch baseline — every completion is
-  baselined against the mean reward of the entire (gathered) batch, ignoring
-  group structure. See `REINFORCE++: A Simple and Efficient Approach for
-  Aligning Large Language Models <https://huggingface.co/papers/2501.03262>`_.
-  The paper normalizes advantages with global batch statistics, so this
-  estimator pairs naturally with ``scale_rewards: batch``.
-
-The estimator only controls the *baseline*; reward scaling stays controlled
-by ``scale_rewards`` (``group`` / ``batch`` / ``none``) so the two remain
-orthogonal, mirroring TRL's GRPO semantics.
+The estimator only swaps the baseline (``group_mean`` = GRPO, ``rloo`` =
+leave-one-out per https://huggingface.co/papers/2402.14740,
+``reinforce_plus_plus`` = global batch per
+https://huggingface.co/papers/2501.03262); reward scaling stays governed by
+``scale_rewards`` so the two remain orthogonal, mirroring TRL's semantics.
 """
 
 import torch

--- a/src/axolotl/core/trainers/grpo/args.py
+++ b/src/axolotl/core/trainers/grpo/args.py
@@ -15,6 +15,7 @@ class AxolotlGRPOConfig(AxolotlTrainingMixins, GRPOConfig):
     """Axolotl GRPO Config for GRPO training"""
 
     context_parallel_size: int | None = None
+    advantage_estimator: str = "group_mean"
 
 
 @dataclass
@@ -22,3 +23,4 @@ class AxolotlAsyncGRPOConfig(AxolotlTrainingMixins, FastAsyncGRPOConfig):
     """Axolotl Async GRPO Config — adds async prefetch, streaming scoring, and IS correction."""
 
     context_parallel_size: int | None = None
+    advantage_estimator: str = "group_mean"

--- a/src/axolotl/core/trainers/grpo/async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/async_trainer.py
@@ -50,6 +50,8 @@ from trl.trainer.utils import (
     unsplit_pixel_values_by_grid,
 )
 
+from axolotl.core.trainers.grpo.advantages import compute_advantages
+
 try:
     from trl.data_utils import (
         apply_chat_template,
@@ -1898,32 +1900,13 @@ class AsyncGRPOTrainer(GRPOTrainer):
             rewards = (
                 rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
             ).nansum(dim=1)
-            mean_grouped = (
-                rewards.view(-1, num_generations)
-                .mean(dim=1)
-                .repeat_interleave(num_generations)
+            advantages, _, is_std_zero = compute_advantages(
+                rewards,
+                num_generations,
+                advantage_estimator=getattr(self.args, "advantage_estimator", None)
+                or "group_mean",
+                scale_rewards=self.scale_rewards,
             )
-            if self.scale_rewards in ("group", "none"):
-                if num_generations > 1:
-                    std_rewards = (
-                        rewards.view(-1, num_generations)
-                        .std(dim=1)
-                        .repeat_interleave(num_generations)
-                    )
-                else:
-                    std_rewards = torch.zeros_like(rewards)
-            elif self.scale_rewards == "batch":
-                std_rewards = (
-                    rewards.std().expand_as(rewards)
-                    if rewards.numel() > 1
-                    else torch.zeros_like(rewards)
-                )
-            else:
-                raise ValueError(f"Invalid scale_rewards: {self.scale_rewards}")
-            advantages = rewards - mean_grouped
-            if self.scale_rewards != "none":
-                advantages = advantages / (std_rewards + 1e-4)
-            is_std_zero = torch.isclose(std_rewards, torch.zeros_like(std_rewards))
 
         elif self.multi_objective_aggregation == "normalize_then_sum":
             grouped = rewards_per_func.view(-1, num_generations, len(self.reward_funcs))
@@ -2296,23 +2279,13 @@ class AsyncGRPOTrainer(GRPOTrainer):
             rewards = (
                 rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
             ).nansum(dim=1)
-            mean_g = (
-                rewards.view(-1, num_generations)
-                .mean(dim=1)
-                .repeat_interleave(num_generations)
+            advantages, _, is_std_zero = compute_advantages(
+                rewards,
+                num_generations,
+                advantage_estimator=getattr(self.args, "advantage_estimator", None)
+                or "group_mean",
+                scale_rewards=self.scale_rewards,
             )
-            if num_generations > 1:
-                std_r = (
-                    rewards.view(-1, num_generations)
-                    .std(dim=1)
-                    .repeat_interleave(num_generations)
-                )
-            else:
-                std_r = torch.zeros_like(rewards)
-            advantages = rewards - mean_g
-            if self.scale_rewards != "none":
-                advantages = advantages / (std_r + 1e-4)
-            is_std_zero = torch.isclose(std_r, torch.zeros_like(std_r))
 
         elif self.multi_objective_aggregation == "normalize_then_sum":
             grouped = rewards_per_func.view(-1, num_generations, len(self.reward_funcs))

--- a/src/axolotl/core/trainers/grpo/trainer.py
+++ b/src/axolotl/core/trainers/grpo/trainer.py
@@ -40,6 +40,7 @@ from trl.trainer.grpo_config import GRPOConfig
 from trl.trainer.grpo_trainer import RewardFunc, nanstd
 from trl.trainer.utils import pad
 
+from axolotl.core.trainers.grpo.advantages import compute_advantages
 from axolotl.core.trainers.grpo.fast_async_trainer import FastAsyncGRPOTrainer
 from axolotl.core.trainers.grpo.sampler import SequenceParallelRepeatRandomSampler
 from axolotl.core.trainers.mixins import (
@@ -65,6 +66,74 @@ class AxolotlGRPOTrainer(
     """Extend the base GRPOTrainer for axolotl helpers"""
 
     _tag_names = ["trl", "grpo", "axolotl"]
+
+    @property
+    def _advantage_estimator(self) -> str:
+        """Configured advantage estimator, defaulting to GRPO's group mean."""
+        return getattr(self.args, "advantage_estimator", None) or "group_mean"
+
+    def _calculate_rewards(self, inputs, prompts, completions, completion_ids_list):
+        """Stash the gathered per-function rewards so the advantage estimator
+        override can recompute advantages without re-running reward functions."""
+        rewards_per_func = super()._calculate_rewards(
+            inputs, prompts, completions, completion_ids_list
+        )
+        self._axolotl_rewards_per_func = rewards_per_func
+        return rewards_per_func
+
+    def _generate_and_score_completions(
+        self, inputs: list[dict[str, torch.Tensor | Any]]
+    ) -> dict[str, torch.Tensor | Any]:
+        """Generate/score as usual, then swap in the configured advantage estimator.
+
+        TRL inlines the group-mean advantage computation inside its (large)
+        ``_generate_and_score_completions``, so instead of copying that whole
+        method we recompute advantages from the rewards captured in
+        ``_calculate_rewards`` and replace them in the returned batch.
+        """
+        output = super()._generate_and_score_completions(inputs)
+        if self._advantage_estimator == "group_mean":
+            return output
+
+        if self.multi_objective_aggregation != "sum_then_normalize":
+            raise ValueError(
+                "advantage_estimator is only supported with "
+                "multi_objective_aggregation='sum_then_normalize', got "
+                f"{self.multi_objective_aggregation!r}."
+            )
+
+        rewards_per_func = self._axolotl_rewards_per_func
+        device = rewards_per_func.device
+        rewards = (
+            rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
+        ).nansum(dim=1)
+        mode = "train" if self.model.training else "eval"
+        num_generations = (
+            self.num_generations if mode == "train" else self.num_generations_eval
+        )
+        advantages, _, _ = compute_advantages(
+            rewards,
+            num_generations,
+            advantage_estimator=self._advantage_estimator,
+            scale_rewards=self.scale_rewards,
+        )
+
+        process_slice = slice(
+            self.accelerator.process_index * len(inputs),
+            (self.accelerator.process_index + 1) * len(inputs),
+        )
+        output["advantages"] = advantages[process_slice]
+
+        # Keep the logged advantages consistent with what is trained on: the
+        # parent method already appended its group-mean advantages, so replace
+        # the entries it just added.
+        logged = self._logs.get("advantages")
+        if logged is not None:
+            for _ in range(min(advantages.numel(), len(logged))):
+                logged.pop()
+            logged.extend(advantages.tolist())
+
+        return output
 
 
 class AxolotlAsyncGRPOTrainer(
@@ -593,20 +662,23 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
             rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
         ).nansum(dim=1)
 
-        # Compute grouped-wise rewards
+        # Compute grouped-wise rewards (for logging)
         mean_grouped_rewards = rewards.view(-1, self.num_generations).mean(dim=1)
         std_grouped_rewards = rewards.view(-1, self.num_generations).std(dim=1)
-
-        # Normalize the rewards to compute the advantages
         mean_grouped_rewards = mean_grouped_rewards.repeat_interleave(
             self.num_generations, dim=0
         )
         std_grouped_rewards = std_grouped_rewards.repeat_interleave(
             self.num_generations, dim=0
         )
-        advantages = rewards - mean_grouped_rewards
-        if self.args.scale_rewards:
-            advantages = advantages / (std_grouped_rewards + 1e-4)
+
+        # Compute the advantages with the configured estimator and scaling
+        advantages, _, _ = compute_advantages(
+            rewards,
+            self.num_generations,
+            advantage_estimator=self._advantage_estimator,
+            scale_rewards=self.args.scale_rewards,
+        )
 
         # Slice to keep only the local part of the data
         if self.args.context_parallel_size > 1:

--- a/src/axolotl/core/trainers/grpo/trainer.py
+++ b/src/axolotl/core/trainers/grpo/trainer.py
@@ -677,7 +677,7 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
             rewards,
             self.num_generations,
             advantage_estimator=self._advantage_estimator,
-            scale_rewards=self.args.scale_rewards,
+            scale_rewards=self.scale_rewards,
         )
 
         # Slice to keep only the local part of the data

--- a/src/axolotl/utils/schemas/trl.py
+++ b/src/axolotl/utils/schemas/trl.py
@@ -106,11 +106,24 @@ class TRLConfig(BaseModel):
         default=64,
         json_schema_extra={"description": "Sync steps for the reference model."},
     )
-    scale_rewards: bool = Field(
+    scale_rewards: bool | Literal["group", "batch", "none"] = Field(
         default=True,
         json_schema_extra={
-            "description": "Whether to scale rewards by their standard deviation."
+            "description": "Reward scaling strategy. 'group' (or True) scales by the "
+            "per-group std, 'batch' by the std of the whole batch, 'none' (or False) "
+            "disables scaling."
         },
+    )
+    advantage_estimator: Literal["group_mean", "rloo", "reinforce_plus_plus"] | None = (
+        Field(
+            default=None,
+            json_schema_extra={
+                "description": "Advantage estimator for GRPO. 'group_mean' (default) is "
+                "the standard GRPO group-mean baseline, 'rloo' uses a leave-one-out "
+                "baseline over the group, and 'reinforce_plus_plus' uses a global-batch "
+                "baseline (pair with `scale_rewards: batch`)."
+            },
+        )
     )
 
     temperature: float | None = Field(

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -715,6 +715,48 @@ class RLValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
+    def check_grpo_advantage_estimator(cls, data):
+        """Validate `trl.advantage_estimator` and warn about unusual pairings.
+
+        The estimator swaps the GRPO baseline (group mean) for RLOO's
+        leave-one-out baseline or REINFORCE++'s global-batch baseline. It only
+        applies to `rl: grpo` and is implemented for the default
+        `sum_then_normalize` reward aggregation.
+        """
+        trl_cfg = data.get("trl") or {}
+        estimator = trl_cfg.get("advantage_estimator")
+        if estimator is None or estimator == "group_mean":
+            return data
+
+        if data.get("rl") != "grpo":
+            raise ValueError(
+                f"`trl.advantage_estimator` is only supported with `rl: grpo`, "
+                f"but got rl: {data.get('rl')!r}"
+            )
+
+        if trl_cfg.get("multi_objective_aggregation") == "normalize_then_sum":
+            raise ValueError(
+                "`trl.advantage_estimator` is not supported with "
+                "`multi_objective_aggregation: normalize_then_sum` (the GDPO "
+                "aggregation already defines its own normalization)."
+            )
+
+        scale_rewards = trl_cfg.get("scale_rewards", True)
+        if estimator == "rloo" and scale_rewards not in (False, "none"):
+            LOG.warning(
+                "advantage_estimator: rloo is canonically used without reward "
+                "scaling; consider setting `trl.scale_rewards: none`."
+            )
+        if estimator == "reinforce_plus_plus" and scale_rewards in (True, "group"):
+            LOG.warning(
+                "advantage_estimator: reinforce_plus_plus normalizes advantages "
+                "with global batch statistics; consider setting "
+                "`trl.scale_rewards: batch`."
+            )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_rl_config_gradient_checkpointing(cls, data):
         # TODO: SalmanMohammadi
         # Distributed RL with QLoRA + gradient checkpointing

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -725,7 +725,7 @@ class RLValidationMixin:
         """
         trl_cfg = data.get("trl") or {}
         estimator = trl_cfg.get("advantage_estimator")
-        if estimator is None or estimator == "group_mean":
+        if estimator is None:
             return data
 
         if data.get("rl") != "grpo":
@@ -733,6 +733,10 @@ class RLValidationMixin:
                 f"`trl.advantage_estimator` is only supported with `rl: grpo`, "
                 f"but got rl: {data.get('rl')!r}"
             )
+
+        if estimator == "group_mean":
+            # The default estimator is a no-op, so any aggregation is fine
+            return data
 
         if trl_cfg.get("multi_objective_aggregation") == "normalize_then_sum":
             raise ValueError(
@@ -747,7 +751,7 @@ class RLValidationMixin:
                 "advantage_estimator: rloo is canonically used without reward "
                 "scaling; consider setting `trl.scale_rewards: none`."
             )
-        if estimator == "reinforce_plus_plus" and scale_rewards in (True, "group"):
+        if estimator == "reinforce_plus_plus" and scale_rewards != "batch":
             LOG.warning(
                 "advantage_estimator: reinforce_plus_plus normalizes advantages "
                 "with global batch statistics; consider setting "

--- a/tests/core/test_grpo_advantages.py
+++ b/tests/core/test_grpo_advantages.py
@@ -1,0 +1,242 @@
+"""
+Tests for the GRPO advantage estimators (group_mean, rloo, reinforce_plus_plus)
+"""
+
+import pytest
+import torch
+
+from axolotl.core.trainers.grpo.advantages import (
+    ADVANTAGE_ESTIMATORS,
+    compute_advantages,
+)
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.schemas.validation import RLValidationMixin
+
+# 2 groups of 4 generations with distinct group statistics
+REWARDS = torch.tensor([1.0, 2.0, 3.0, 4.0, 10.0, 10.0, 14.0, 18.0])
+NUM_GENERATIONS = 4
+
+
+class TestComputeAdvantages:
+    """Unit tests for compute_advantages."""
+
+    def test_group_mean_matches_grpo_formula(self):
+        """group_mean reproduces TRL's GRPO advantage computation exactly."""
+        advantages, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "group_mean", scale_rewards="group"
+        )
+        grouped = REWARDS.view(-1, NUM_GENERATIONS)
+        mean = grouped.mean(dim=1).repeat_interleave(NUM_GENERATIONS)
+        std = grouped.std(dim=1).repeat_interleave(NUM_GENERATIONS)
+        expected = (REWARDS - mean) / (std + 1e-4)
+        torch.testing.assert_close(advantages, expected)
+
+    def test_group_mean_scale_none(self):
+        """scale_rewards='none' subtracts the group mean without dividing by std."""
+        advantages, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "group_mean", scale_rewards="none"
+        )
+        grouped = REWARDS.view(-1, NUM_GENERATIONS)
+        mean = grouped.mean(dim=1).repeat_interleave(NUM_GENERATIONS)
+        torch.testing.assert_close(advantages, REWARDS - mean)
+
+    def test_group_mean_scale_batch(self):
+        """scale_rewards='batch' divides by the std of the whole batch."""
+        advantages, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "group_mean", scale_rewards="batch"
+        )
+        grouped = REWARDS.view(-1, NUM_GENERATIONS)
+        mean = grouped.mean(dim=1).repeat_interleave(NUM_GENERATIONS)
+        expected = (REWARDS - mean) / (REWARDS.std() + 1e-4)
+        torch.testing.assert_close(advantages, expected)
+
+    def test_rloo_leave_one_out_baseline(self):
+        """RLOO baselines each reward against the mean of the other G-1 rewards."""
+        advantages, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "rloo", scale_rewards="none"
+        )
+        grouped = REWARDS.view(-1, NUM_GENERATIONS)
+        baseline = (grouped.sum(dim=1, keepdim=True) - grouped) / (NUM_GENERATIONS - 1)
+        torch.testing.assert_close(advantages, (grouped - baseline).reshape(-1))
+
+    def test_rloo_is_scaled_group_mean(self):
+        """Unscaled RLOO advantages equal group_mean advantages times G/(G-1)."""
+        rloo, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "rloo", scale_rewards="none"
+        )
+        group_mean, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "group_mean", scale_rewards="none"
+        )
+        torch.testing.assert_close(
+            rloo, group_mean * NUM_GENERATIONS / (NUM_GENERATIONS - 1)
+        )
+
+    def test_reinforce_plus_plus_global_baseline(self):
+        """REINFORCE++ with batch scaling is the global z-score of the rewards."""
+        advantages, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, "reinforce_plus_plus", scale_rewards="batch"
+        )
+        expected = (REWARDS - REWARDS.mean()) / (REWARDS.std() + 1e-4)
+        torch.testing.assert_close(advantages, expected)
+
+    def test_bool_scale_rewards_accepted(self):
+        """Bool scale_rewards values map to 'group' (True) and 'none' (False)."""
+        scaled, _, _ = compute_advantages(REWARDS, NUM_GENERATIONS, scale_rewards=True)
+        grouped, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, scale_rewards="group"
+        )
+        torch.testing.assert_close(scaled, grouped)
+        unscaled, _, _ = compute_advantages(
+            REWARDS, NUM_GENERATIONS, scale_rewards=False
+        )
+        none, _, _ = compute_advantages(REWARDS, NUM_GENERATIONS, scale_rewards="none")
+        torch.testing.assert_close(unscaled, none)
+
+    def test_zero_variance_group_flagged(self):
+        """Constant-reward groups are reported via is_std_zero."""
+        rewards = torch.tensor([1.0, 1.0, 2.0, 4.0])
+        _, _, is_std_zero = compute_advantages(rewards, 2, scale_rewards="group")
+        assert is_std_zero.tolist() == [True, True, False, False]
+
+    def test_invalid_estimator_raises(self):
+        """Unknown estimators raise a clear ValueError."""
+        with pytest.raises(ValueError, match="Invalid advantage_estimator"):
+            compute_advantages(REWARDS, NUM_GENERATIONS, "ppo")
+
+    def test_invalid_scale_rewards_raises(self):
+        """Unknown scale_rewards values raise a clear ValueError."""
+        with pytest.raises(ValueError, match="Invalid scale_rewards"):
+            compute_advantages(REWARDS, NUM_GENERATIONS, scale_rewards="global")
+
+    def test_rloo_requires_two_generations(self):
+        """RLOO needs at least two generations for a leave-one-out baseline."""
+        with pytest.raises(ValueError, match="num_generations >= 2"):
+            compute_advantages(torch.tensor([1.0, 2.0]), 1, "rloo")
+
+    def test_all_estimators_zero_mean_per_batch(self):
+        """Every estimator produces advantages that sum to ~0 over the batch."""
+        for estimator in ADVANTAGE_ESTIMATORS:
+            advantages, _, _ = compute_advantages(
+                REWARDS, NUM_GENERATIONS, estimator, scale_rewards="none"
+            )
+            assert abs(advantages.sum().item()) < 1e-4, estimator
+
+
+class TestTrainerOverride:
+    """The AxolotlGRPOTrainer hook swaps advantages for the configured estimator."""
+
+    def test_override_replaces_advantages_and_logs(self, monkeypatch):
+        """With advantage_estimator=rloo, the batch advantages and the logged
+        advantages both reflect the leave-one-out baseline instead of TRL's
+        group-mean values."""
+        from collections import deque
+        from unittest.mock import MagicMock
+
+        from trl import GRPOTrainer
+
+        from axolotl.core.trainers.grpo.trainer import AxolotlGRPOTrainer
+
+        rewards_per_func = REWARDS.unsqueeze(1)
+
+        def fake_super_gen(self, inputs):
+            """Simulate TRL's parent method: stash rewards and return/log
+            group-mean advantages."""
+            self._axolotl_rewards_per_func = rewards_per_func
+            adv, _, _ = compute_advantages(
+                REWARDS, NUM_GENERATIONS, "group_mean", "none"
+            )
+            self._logs["advantages"].extend(adv.tolist())
+            return {"advantages": adv}
+
+        monkeypatch.setattr(
+            GRPOTrainer, "_generate_and_score_completions", fake_super_gen
+        )
+
+        trainer = object.__new__(AxolotlGRPOTrainer)
+        trainer.args = MagicMock(advantage_estimator="rloo")
+        trainer.multi_objective_aggregation = "sum_then_normalize"
+        trainer.reward_weights = torch.ones(1)
+        trainer.scale_rewards = "none"
+        trainer.num_generations = NUM_GENERATIONS
+        trainer.num_generations_eval = NUM_GENERATIONS
+        trainer.model = MagicMock(training=True)
+        trainer.accelerator = MagicMock(process_index=0)
+        trainer._logs = {"advantages": deque(maxlen=64)}
+
+        inputs = [{} for _ in range(len(REWARDS))]
+        output = AxolotlGRPOTrainer._generate_and_score_completions(trainer, inputs)
+
+        expected, _, _ = compute_advantages(REWARDS, NUM_GENERATIONS, "rloo", "none")
+        torch.testing.assert_close(output["advantages"], expected)
+        assert list(trainer._logs["advantages"]) == expected.tolist()
+
+    def test_override_noop_for_group_mean(self, monkeypatch):
+        """With the default estimator, the parent output passes through untouched."""
+        from unittest.mock import MagicMock
+
+        from trl import GRPOTrainer
+
+        from axolotl.core.trainers.grpo.trainer import AxolotlGRPOTrainer
+
+        sentinel = {"advantages": torch.tensor([1.0])}
+        monkeypatch.setattr(
+            GRPOTrainer,
+            "_generate_and_score_completions",
+            lambda self, inputs: sentinel,
+        )
+
+        trainer = object.__new__(AxolotlGRPOTrainer)
+        trainer.args = MagicMock(advantage_estimator="group_mean")
+        assert (
+            AxolotlGRPOTrainer._generate_and_score_completions(trainer, []) is sentinel
+        )
+
+
+class TestAdvantageEstimatorConfig:
+    """Config plumbing and validation for trl.advantage_estimator."""
+
+    def test_strategy_passes_estimator_to_training_args(self):
+        """GRPOStrategy forwards advantage_estimator into the trainer kwargs."""
+        from axolotl.core.trainers.grpo import GRPOStrategy
+
+        cfg = DictDefault(
+            {
+                "trl": {"advantage_estimator": "rloo"},
+                "vllm": {},
+                "context_parallel_size": 1,
+            }
+        )
+        kwargs = GRPOStrategy.set_training_args_kwargs(cfg)
+        assert kwargs["advantage_estimator"] == "rloo"
+
+    def test_validator_rejects_non_grpo(self):
+        """advantage_estimator with a non-GRPO trainer is a config error."""
+        data = {"rl": "dpo", "trl": {"advantage_estimator": "rloo"}}
+        with pytest.raises(ValueError, match="only supported with `rl: grpo`"):
+            RLValidationMixin.check_grpo_advantage_estimator(data)
+
+    def test_validator_rejects_normalize_then_sum(self):
+        """advantage_estimator with GDPO-style aggregation is a config error."""
+        data = {
+            "rl": "grpo",
+            "trl": {
+                "advantage_estimator": "reinforce_plus_plus",
+                "multi_objective_aggregation": "normalize_then_sum",
+            },
+        }
+        with pytest.raises(ValueError, match="normalize_then_sum"):
+            RLValidationMixin.check_grpo_advantage_estimator(data)
+
+    def test_validator_allows_valid_config(self):
+        """A valid GRPO + rloo config passes validation unchanged."""
+        data = {
+            "rl": "grpo",
+            "trl": {"advantage_estimator": "rloo", "scale_rewards": "none"},
+        }
+        assert RLValidationMixin.check_grpo_advantage_estimator(data) is data
+
+    def test_validator_ignores_default(self):
+        """group_mean / unset estimators pass for any trainer type."""
+        for trl_cfg in ({}, {"advantage_estimator": "group_mean"}):
+            data = {"rl": "dpo", "trl": dict(trl_cfg)}
+            assert RLValidationMixin.check_grpo_advantage_estimator(data) is data

--- a/tests/core/test_grpo_advantages.py
+++ b/tests/core/test_grpo_advantages.py
@@ -235,8 +235,24 @@ class TestAdvantageEstimatorConfig:
         }
         assert RLValidationMixin.check_grpo_advantage_estimator(data) is data
 
-    def test_validator_ignores_default(self):
-        """group_mean / unset estimators pass for any trainer type."""
-        for trl_cfg in ({}, {"advantage_estimator": "group_mean"}):
-            data = {"rl": "dpo", "trl": dict(trl_cfg)}
-            assert RLValidationMixin.check_grpo_advantage_estimator(data) is data
+    def test_validator_ignores_unset(self):
+        """An unset estimator passes for any trainer type."""
+        data = {"rl": "dpo", "trl": {}}
+        assert RLValidationMixin.check_grpo_advantage_estimator(data) is data
+
+    def test_validator_rejects_explicit_group_mean_non_grpo(self):
+        """Explicitly setting the estimator (even to the default) requires rl: grpo."""
+        data = {"rl": "dpo", "trl": {"advantage_estimator": "group_mean"}}
+        with pytest.raises(ValueError, match="only supported with `rl: grpo`"):
+            RLValidationMixin.check_grpo_advantage_estimator(data)
+
+    def test_validator_allows_group_mean_with_normalize_then_sum(self):
+        """group_mean is a no-op, so it stays valid with GDPO-style aggregation."""
+        data = {
+            "rl": "grpo",
+            "trl": {
+                "advantage_estimator": "group_mean",
+                "multi_objective_aggregation": "normalize_then_sum",
+            },
+        }
+        assert RLValidationMixin.check_grpo_advantage_estimator(data) is data


### PR DESCRIPTION
# Description

Closes #3676.

Adds a `trl.advantage_estimator` config option that selects the baseline used when computing GRPO advantages. RLOO and REINFORCE++ share GRPO's rollout-and-reward structure and differ only in baseline/advantage estimation, so they are implemented as a selector inside the GRPO strategy/trainers (the approach suggested in the issue) rather than as separate trainers:

- `group_mean` (default) — standard GRPO group-mean baseline; **zero behavior change** for existing configs.
- `rloo` — leave-one-out baseline over the group ([Ahmadian et al., 2024](https://huggingface.co/papers/2402.14740)).
- `reinforce_plus_plus` — global-batch baseline ([Hu, 2025](https://huggingface.co/papers/2501.03262)); pairs with `scale_rewards: batch` for the paper's normalization.

The estimator only controls the baseline. Scaling stays governed by `scale_rewards`, which the schema now accepts as TRL's string values (`group`/`batch`/`none`) in addition to the previous bool — needed to even express REINFORCE++'s batch normalization from a YAML config.

```yaml
rl: grpo
trl:
  advantage_estimator: rloo
  scale_rewards: none
```

## Implementation notes

- **`core/trainers/grpo/advantages.py` (new)** — a single `compute_advantages(rewards, num_generations, estimator, scale_rewards)` helper shared by all three GRPO trainer variants, so the estimator math lives in one place.
- **`AxolotlGRPOTrainer`** — TRL inlines the advantage computation inside its ~600-line `_generate_and_score_completions`, so instead of copying that method, the trainer stashes the gathered rewards in a `_calculate_rewards` override and recomputes advantages after `super()` returns (only when a non-default estimator is configured). The logged advantages are replaced too, so `_logs` stays consistent with what is actually trained on.
- **Sequence-parallel trainer** — its existing inline advantage block is replaced with the helper. This also fixes a latent bug: `if self.args.scale_rewards:` was always truthy because TRL's `GRPOConfig.__post_init__` normalizes `scale_rewards` to the strings `"group"`/`"none"`, so `scale_rewards: false` still divided by the group std.
- **Async trainer** — both scoring paths (full-batch and streaming) now use the helper; the streaming path additionally gains `"batch"` scaling support it previously lacked.
- **Validation** — config-parse-time errors for `advantage_estimator` with non-GRPO trainers or with `multi_objective_aggregation: normalize_then_sum`, plus warnings for non-canonical scaling pairings (RLOO is canonically unscaled; REINFORCE++ normalizes with batch statistics).

## Motivation and Context

Requested in #3676. RLOO/REINFORCE++ are commonly used GRPO alternatives (both available in TRL/verl) and need only a different baseline given axolotl's existing GRPO rollout machinery.

## How has this been tested?

New `tests/core/test_grpo_advantages.py` (19 tests, CPU-only, no model downloads):

- Estimator math vs hand-computed formulas for all three estimators × group/batch/none scaling, including the identity `A_rloo = A_grpo · G/(G−1)` for unscaled rewards and zero-mean checks.
- The `AxolotlGRPOTrainer` override: advantages and logged advantages both replaced for `rloo`, exact pass-through for `group_mean`.
- Config plumbing (`GRPOStrategy.set_training_args_kwargs`) and the new validator (rejects non-GRPO and `normalize_then_sum`, accepts valid configs).

All 19 pass locally; `ruff check`/`ruff format` clean.

## Screenshots (if appropriate)

## Types of changes

- New feature (non-breaking change which adds functionality)
- Bug fix (the SP-trainer `scale_rewards: false` truthiness fix noted above)

## Social Handles (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three advantage estimator options for GRPO training: `group_mean`, `rloo`, and `reinforce_plus_plus`.
  * Extended reward scaling configuration to support group-level, batch-level, or disabled scaling modes.

* **Documentation**
  * Updated GRPO configuration reference with new advantage estimator options and usage examples.

* **Tests**
  * Added comprehensive test coverage for advantage computation and estimator configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->