### PR TITLE
feat(offload): hidden_states activation offloading + fix legacy/full-param paths

### DIFF
--- a/docs/gradient_checkpointing.qmd
+++ b/docs/gradient_checkpointing.qmd
@@ -28,6 +28,24 @@ The `activation_offloading: legacy` naively offloads activations to CPU and with
 For resource constrained environments with limited CPU memory, `activation_offloading: disk` offloads
 activations to disk instead of CPU RAM so that much larger context lengths can be trained with minimal memory.
 
+The `activation_offloading: hidden_states` mode (ALST-style) is gradient checkpointing that offloads only
+the per-layer input (the checkpoint's `hidden_states`) to CPU — one tensor per layer rather than every
+activation — overlapped with compute on a side CUDA stream. It replaces torch's reentrant checkpoint
+(so `gradient_checkpointing_kwargs.use_reentrant` is forced to `true`) and is framework-agnostic
+(works under FSDP2, DTensor-aware for sequence/context parallelism).
+
+### Choosing a mode
+
+| Mode | What moves | Best for |
+|------|-----------|----------|
+| `true` | All activations → CPU, stream-overlapped | General use; LoRA/QLoRA (offloads instead of recomputing) |
+| `legacy` | All activations → CPU, synchronous | Lowest resident GPU memory; when the streamed path's in-flight buffering inflates peak |
+| `disk` | Activations → disk | Severely CPU-RAM-constrained hosts |
+| `hidden_states` | Per-layer input only → CPU, stream-overlapped | Long-context **full-parameter** finetuning; reaches contexts where plain gradient checkpointing OOMs |
+
+`hidden_states` is designed for full-parameter training. With LoRA/QLoRA the frozen base can break reentrant
+checkpointing, so prefer `activation_offloading: true` for adapters.
+
 ### Enabling Layer Offloading
 
 ```yaml

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -554,18 +554,15 @@ class TrainerBuilderBase(abc.ABC):
         if self.cfg.layer_offloading:
             training_args_kwargs["layer_offloading"] = True
         if self.cfg.activation_offloading == "hidden_states":
-            # ALST-style: keep HF gradient checkpointing ON (reentrant) and let the
-            # checkpoint monkeypatch offload the per-layer input. NOT the TRL
-            # offloader, so don't set the trainer's activation_offloading arg.
+            # The checkpoint monkeypatch offloads the per-layer input, so HF
+            # checkpointing stays on and must be reentrant for the patch to apply.
             training_args_kwargs["gradient_checkpointing"] = True
             gc_kwargs = dict(self.cfg.gradient_checkpointing_kwargs or {})
             gc_kwargs["use_reentrant"] = True
             training_args_kwargs["gradient_checkpointing_kwargs"] = gc_kwargs
         elif self.cfg.activation_offloading:
-            # TRL offloader (true/"legacy"/"disk"): moves activations to CPU instead
-            # of recomputing, so it replaces HF recompute (which is re-added manually
-            # for full finetune in the model loader). Pass the mode through so the
-            # trainer picks streamed vs synchronous.
+            # TRL offloader replaces HF recompute (re-added for full finetune in the
+            # model loader), so disable HF checkpointing and pass the mode through.
             training_args_kwargs["gradient_checkpointing"] = False
             training_args_kwargs["activation_offloading"] = (
                 self.cfg.activation_offloading

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -553,10 +553,23 @@ class TrainerBuilderBase(abc.ABC):
     def _configure_gradient_checkpointing(self, training_args_kwargs: dict):
         if self.cfg.layer_offloading:
             training_args_kwargs["layer_offloading"] = True
-        if self.cfg.activation_offloading is True:
-            # don't use the HF gradient checkpointing, manually wrap
+        if self.cfg.activation_offloading == "hidden_states":
+            # ALST-style: keep HF gradient checkpointing ON (reentrant) and let the
+            # checkpoint monkeypatch offload the per-layer input. NOT the TRL
+            # offloader, so don't set the trainer's activation_offloading arg.
+            training_args_kwargs["gradient_checkpointing"] = True
+            gc_kwargs = dict(self.cfg.gradient_checkpointing_kwargs or {})
+            gc_kwargs["use_reentrant"] = True
+            training_args_kwargs["gradient_checkpointing_kwargs"] = gc_kwargs
+        elif self.cfg.activation_offloading:
+            # TRL offloader (true/"legacy"/"disk"): moves activations to CPU instead
+            # of recomputing, so it replaces HF recompute (which is re-added manually
+            # for full finetune in the model loader). Pass the mode through so the
+            # trainer picks streamed vs synchronous.
             training_args_kwargs["gradient_checkpointing"] = False
-            training_args_kwargs["activation_offloading"] = True
+            training_args_kwargs["activation_offloading"] = (
+                self.cfg.activation_offloading
+            )
         elif self.cfg.gradient_checkpointing is not None:
             training_args_kwargs["gradient_checkpointing"] = (
                 self.cfg.gradient_checkpointing

--- a/src/axolotl/core/trainers/mixins/activation_checkpointing.py
+++ b/src/axolotl/core/trainers/mixins/activation_checkpointing.py
@@ -30,13 +30,18 @@ class ActivationOffloadingMixin(Trainer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.args.activation_offloading:
+            # "legacy" uses the previous synchronous implementation (no CUDA
+            # streams), which keeps far fewer activations resident on-GPU than
+            # the stream-overlapped path (True/"disk"); the streams path stashes
+            # several activations to overlap copies, inflating peak reserved.
+            use_streams = self.args.activation_offloading != "legacy"
             if isinstance(self.model, PeftModel):
                 self.activation_offload_context = get_lora_act_offloading_ctx_manager(
-                    self.model, use_streams=True
+                    self.model, use_streams=use_streams
                 )
             else:
                 self.activation_offload_context = get_act_offloading_ctx_manager(
-                    self.model, use_streams=True
+                    self.model, use_streams=use_streams
                 )
         else:
             self.activation_offload_context = contextlib.nullcontext()

--- a/src/axolotl/core/training_args_base.py
+++ b/src/axolotl/core/training_args_base.py
@@ -235,9 +235,12 @@ class AxolotlTrainingMixins:
         },
     )
 
-    activation_offloading: bool | None = field(
+    activation_offloading: bool | str | None = field(
         default=None,
-        metadata={"help": "Use activation offloading with CUDA streams for training."},
+        metadata={
+            "help": "Activation offloading mode: True (stream-overlapped), "
+            "'legacy' (synchronous), 'disk', or False."
+        },
     )
 
     layer_offloading: bool | None = field(

--- a/src/axolotl/core/training_args_base.py
+++ b/src/axolotl/core/training_args_base.py
@@ -3,7 +3,7 @@ Base Axolotl Training Mixins shared across various trainer configs
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Literal, Optional
 
 from PIL.Image import Resampling
 
@@ -235,7 +235,9 @@ class AxolotlTrainingMixins:
         },
     )
 
-    activation_offloading: bool | str | None = field(
+    # "hidden_states" never reaches the trainer (it's handled via the checkpoint
+    # monkeypatch in the model loader), so the trainer only sees these values.
+    activation_offloading: Literal["legacy", "disk"] | bool | None = field(
         default=None,
         metadata={
             "help": "Activation offloading mode: True (stream-overlapped), "

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -320,12 +320,28 @@ class ModelLoader:
         self.model.set_experts_implementation(impl)
 
     def _apply_activation_checkpointing(self):
-        if self.cfg.activation_offloading is True:
+        ao = self.cfg.activation_offloading
+        # "hidden_states" (ALST-style): HF reentrant gradient checkpointing already
+        # wraps the layers; a checkpoint monkeypatch offloads only the per-layer
+        # input (hidden_states). No manual recompute wrap needed.
+        if ao == "hidden_states":
+            from axolotl.monkeypatch.activation_offload_checkpoint import (
+                patch_hidden_states_offload,
+            )
+
+            patch_hidden_states_offload()
+            return
+        # TRL offloader is adapter-aware:
+        #   - LoRA/QLoRA: offload *replaces* recompute (pure offload is leaner/faster;
+        #     recompute would pin the offloaded tensors and balloon memory). No wrap.
+        #   - Full finetune: pure offload of every activation exceeds PCIe bandwidth
+        #     (backlogs on-GPU, OOMs at long seq), so keep recompute and offload only
+        #     the checkpoint boundaries — apply the manual wrap.
+        if ao and not self.cfg.adapter:
             from axolotl.core.trainers.mixins.activation_checkpointing import (
                 ac_wrap_hf_model,
             )
 
-            # ^^ importing this at the module level breaks plugins
             ac_wrap_hf_model(self.model)
 
     def _resize_token_embeddings(self):

--- a/src/axolotl/monkeypatch/activation_offload_checkpoint.py
+++ b/src/axolotl/monkeypatch/activation_offload_checkpoint.py
@@ -1,0 +1,255 @@
+"""Activation-checkpoint input ("hidden_states") offloading, ALST-style.
+
+Gradient checkpointing already discards a layer's intermediate activations and
+recomputes them in backward; it still keeps the *checkpoint input* (the layer's
+hidden_states) resident. For long sequences those per-layer inputs
+(num_layers x [seq, hidden]) dominate GPU memory. This offloads only that one
+tensor per checkpoint to CPU and brings it back for the backward recompute —
+minimal PCIe traffic (one tensor/layer, not every activation).
+
+The copies are overlapped with compute on a side stream (forward async d2h with
+bounded in-flight + backward h2d prefetch), so at long seq the transfer hides
+behind the recompute.
+
+It replaces torch's reentrant ``CheckpointFunction`` (use_reentrant=True), so it
+is framework-agnostic (works under FSDP2; no DeepSpeed dependency). DTensor
+inputs (sequence/context parallel) are offloaded too — ``DTensor.to`` round-trips
+the local shard and preserves placements. Adapted from
+torch.utils.checkpoint.CheckpointFunction and Snowflake ArcticTraining.
+"""
+
+import contextlib
+
+import torch
+from torch.utils.checkpoint import (
+    _get_autocast_kwargs,
+    _get_device_module,
+    _infer_device_type,
+    check_backward_validity,
+    detach_variable,
+    get_device_states,
+    set_device_states,
+)
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def _offloadable(t: torch.Tensor) -> bool:
+    # Offload any on-device activation, INCLUDING DTensors: under sequence/context
+    # parallelism the layer input is a DTensor and offloading its sharded local
+    # tensor is exactly what we want. DTensor.to("cpu")/.to(dev) round-trips the
+    # local shard and preserves placements, so the plain path handles it. Model
+    # params never reach here (they live inside run_function, not the offloaded
+    # arg), so TRL-style param-storage filtering is unnecessary.
+    return t.device.type != "cpu"
+
+
+class _StreamOffloadManager:
+    """Per-forward-pass coordinator that overlaps the input d2h/h2d copies with
+    compute on a side stream. Forward: async-copy each layer input to CPU while
+    later layers compute (bounded in-flight so only a few sources stay resident).
+    Backward: bring inputs back on the side stream and prefetch the next one
+    (inputs are consumed in reverse-of-offload order) to hide the reload."""
+
+    def __init__(self, max_inflight=2):
+        self.s1 = torch.cuda.Stream()
+        self.max_inflight = max_inflight
+        self.reset()
+
+    def reset(self):
+        self.next_id = 0
+        self.inflight = {}  # id -> (gpu_src, event)  keep source alive until d2h done
+        self.cpu = {}  # id -> (cpu_tensor, device, requires_grad)
+        self.prefetched = {}  # id -> (gpu_tensor, event)
+
+    # ---- forward ----
+    def offload(self, t):
+        s0 = torch.cuda.current_stream()
+        self.s1.wait_stream(s0)  # input must be produced before we copy it
+        with torch.cuda.stream(self.s1):
+            cpu_t = t.detach().to("cpu", non_blocking=True)
+        ev = self.s1.record_event()
+        tid = self.next_id
+        self.next_id += 1
+        self.inflight[tid] = (t, ev)  # hold GPU source until copy completes
+        self.cpu[tid] = (cpu_t, t.device, t.requires_grad)
+        self._reap()
+        return tid
+
+    def _reap(self):
+        for tid in [k for k, (_, ev) in self.inflight.items() if ev.query()]:
+            del self.inflight[tid]
+        while len(self.inflight) > self.max_inflight:
+            tid = min(self.inflight)
+            _, ev = self.inflight.pop(tid)
+            ev.synchronize()
+
+    # ---- backward ----
+    def _bring_back(self, tid):
+        cpu_t, device, _ = self.cpu[tid]
+        with torch.cuda.stream(self.s1):
+            gpu_t = cpu_t.to(device, non_blocking=True)
+        return gpu_t, self.s1.record_event()
+
+    def restore(self, tid):
+        if tid in self.prefetched:
+            gpu_t, ev = self.prefetched.pop(tid)
+        else:
+            gpu_t, ev = self._bring_back(tid)
+        nxt = (
+            tid - 1
+        )  # next input needed (reverse order) — prefetch to overlap recompute
+        if nxt >= 0 and nxt in self.cpu and nxt not in self.prefetched:
+            self.prefetched[nxt] = self._bring_back(nxt)
+        torch.cuda.current_stream().wait_event(ev)
+        _, _, requires_grad = self.cpu[tid]
+        out = gpu_t.detach().requires_grad_(requires_grad)
+        del self.cpu[tid]
+        if not self.cpu:
+            self.reset()
+        return out
+
+
+_STREAM_MANAGER = None
+
+
+def _get_stream_manager():
+    global _STREAM_MANAGER
+    if _STREAM_MANAGER is None:
+        _STREAM_MANAGER = _StreamOffloadManager()
+    return _STREAM_MANAGER
+
+
+class HiddenStatesOffloadCheckpoint(torch.autograd.Function):
+    """Reentrant checkpoint that offloads the layer input (hidden_states) to CPU,
+    overlapping the transfer with compute via a side stream."""
+
+    @staticmethod
+    def forward(ctx, run_function, preserve_rng_state, *args):
+        check_backward_validity(args)
+        ctx.run_function = run_function
+        ctx.preserve_rng_state = preserve_rng_state
+        ctx.device_type = _infer_device_type(*args)
+        ctx.device_autocast_kwargs, ctx.cpu_autocast_kwargs = _get_autocast_kwargs(
+            ctx.device_type
+        )
+        if preserve_rng_state:
+            ctx.fwd_cpu_state = torch.get_rng_state()
+            ctx.had_device_in_fwd = False
+            device_module = _get_device_module(ctx.device_type)
+            if getattr(device_module, "_initialized", False):
+                ctx.had_device_in_fwd = True
+                ctx.fwd_devices, ctx.fwd_device_states = get_device_states(*args)
+
+        mgr = _get_stream_manager()
+        ctx.inputs = []
+        ctx.tensor_indices = []
+        ctx.offload_tid = None  # manager id for the offloaded input
+        ctx.offload_arg_pos = None
+        tensor_inputs = []
+        for i, arg in enumerate(args):
+            if torch.is_tensor(arg):
+                # Offload only the first tensor (the layer input / hidden_states);
+                # other tensors (e.g. a shared [seq, seq] mask) stay on-device.
+                if ctx.offload_tid is None and _offloadable(arg):
+                    ctx.offload_tid = mgr.offload(arg)
+                    ctx.offload_arg_pos = i
+                    ctx.inputs.append(None)
+                else:
+                    tensor_inputs.append(arg)
+                    ctx.tensor_indices.append(i)
+                    ctx.inputs.append(None)
+            else:
+                ctx.inputs.append(arg)
+        ctx.save_for_backward(*tensor_inputs)
+        with torch.no_grad():
+            outputs = run_function(*args)
+        return outputs
+
+    @staticmethod
+    def backward(ctx, *args):
+        if not torch.autograd._is_checkpoint_valid():
+            raise RuntimeError(
+                "use_reentrant=True checkpoint is incompatible with .grad()/passing "
+                "`inputs` to .backward()."
+            )
+        mgr = _get_stream_manager()
+        inputs = list(ctx.inputs)
+        tensors = ctx.saved_tensors
+        for i, idx in enumerate(ctx.tensor_indices):
+            inputs[idx] = tensors[i]
+        if ctx.offload_tid is not None:
+            inputs[ctx.offload_arg_pos] = mgr.restore(ctx.offload_tid)
+
+        rng_devices = []
+        if ctx.preserve_rng_state and ctx.had_device_in_fwd:
+            rng_devices = ctx.fwd_devices
+        with torch.random.fork_rng(
+            devices=rng_devices,
+            enabled=ctx.preserve_rng_state,
+            device_type=ctx.device_type,
+        ):
+            if ctx.preserve_rng_state:
+                torch.set_rng_state(ctx.fwd_cpu_state)
+                if ctx.had_device_in_fwd:
+                    set_device_states(
+                        ctx.fwd_devices,
+                        ctx.fwd_device_states,
+                        device_type=ctx.device_type,
+                    )
+            detached_inputs = detach_variable(tuple(inputs))
+            device_autocast_ctx = (
+                torch.amp.autocast(
+                    device_type=ctx.device_type, **ctx.device_autocast_kwargs
+                )
+                if torch.amp.is_autocast_available(ctx.device_type)
+                else contextlib.nullcontext()
+            )
+            with (
+                torch.enable_grad(),
+                device_autocast_ctx,
+                torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs),
+            ):
+                outputs = ctx.run_function(*detached_inputs)
+        if isinstance(outputs, torch.Tensor):
+            outputs = (outputs,)
+        outputs_with_grad = []
+        args_with_grad = []
+        for i in range(len(outputs)):
+            if torch.is_tensor(outputs[i]) and outputs[i].requires_grad:
+                outputs_with_grad.append(outputs[i])
+                args_with_grad.append(args[i])
+        if len(outputs_with_grad) == 0:
+            raise RuntimeError("none of output has requires_grad=True")
+        torch.autograd.backward(outputs_with_grad, args_with_grad)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None
+            for inp in detached_inputs
+        )
+        return (None, None) + grads
+
+
+_ORIG_CHECKPOINT_FUNCTION = None
+
+
+def patch_hidden_states_offload():
+    """Replace torch's reentrant ``CheckpointFunction`` with the hidden_states
+    offloading version. ``torch.utils.checkpoint.checkpoint(..., use_reentrant=True)``
+    resolves ``CheckpointFunction`` from the module namespace at call time, so
+    swapping the attribute is sufficient (and FSDP2-safe — only activations move)."""
+    global _ORIG_CHECKPOINT_FUNCTION
+    import torch.utils.checkpoint as ckpt
+
+    if _ORIG_CHECKPOINT_FUNCTION is None:
+        _ORIG_CHECKPOINT_FUNCTION = ckpt.CheckpointFunction
+    ckpt.CheckpointFunction = HiddenStatesOffloadCheckpoint
+    LOG.info("Patched checkpoint with hidden_states CPU offload (streamed)")
+
+
+def unpatch_hidden_states_offload():
+    import torch.utils.checkpoint as ckpt
+
+    if _ORIG_CHECKPOINT_FUNCTION is not None:
+        ckpt.CheckpointFunction = _ORIG_CHECKPOINT_FUNCTION

--- a/src/axolotl/monkeypatch/activation_offload_checkpoint.py
+++ b/src/axolotl/monkeypatch/activation_offload_checkpoint.py
@@ -103,7 +103,12 @@ class _StreamOffloadManager:
         )  # next input needed (reverse order) — prefetch to overlap recompute
         if nxt >= 0 and nxt in self.cpu and nxt not in self.prefetched:
             self.prefetched[nxt] = self._bring_back(nxt)
-        torch.cuda.current_stream().wait_event(ev)
+        s0 = torch.cuda.current_stream()
+        s0.wait_event(ev)
+        # gpu_t was allocated on the side stream; tell the allocator it's now used
+        # on the compute stream so its storage isn't reused before the recompute
+        # consumes it (use-after-free guard, as in TRL's offloader).
+        gpu_t.record_stream(s0)
         _, _, requires_grad = self.cpu[tid]
         out = gpu_t.detach().requires_grad_(requires_grad)
         del self.cpu[tid]

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -604,11 +604,18 @@ class AxolotlInputConfig(
             "description": "Additional kwargs to pass to the trainer for gradient checkpointing"
         },
     )
-    activation_offloading: Literal["legacy", "disk"] | bool | None = Field(
-        default=False,
-        json_schema_extra={
-            "description": "Whether to offload activations. Available options are: true, false, 'legacy', 'disk'."
-        },
+    activation_offloading: Literal["legacy", "disk", "hidden_states"] | bool | None = (
+        Field(
+            default=False,
+            json_schema_extra={
+                "description": (
+                    "Whether to offload activations. Options: true/false, 'legacy', "
+                    "'disk' (TRL offloader), or 'hidden_states' (ALST-style: gradient "
+                    "checkpointing that offloads only the per-layer input to CPU, "
+                    "overlapped with compute; best for long-context full finetuning)."
+                )
+            },
+        )
     )
     layer_offloading: bool | None = Field(
         default=False,

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1445,6 +1445,15 @@ class ModelCompatibilityValidationMixin:
     def check_hidden_states_offloading(self):
         if self.activation_offloading != "hidden_states":
             return self
+        # Forcing reentrant (below) on a partially frozen model is the broken combo
+        # check_use_reentrant_mismatch guards — but that before-validator ran before
+        # we forced it, so catch it here. https://github.com/huggingface/transformers/issues/21381
+        if self.unfrozen_parameters:
+            raise ValueError(
+                "activation_offloading: hidden_states forces reentrant checkpointing, "
+                "which is incompatible with `unfrozen_parameters` (partially frozen "
+                "model)."
+            )
         # ALST-style offloading replaces torch's reentrant CheckpointFunction, so it
         # needs use_reentrant=True. Force it on (warn if the user asked otherwise).
         gc_kwargs = dict(self.gradient_checkpointing_kwargs or {})

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1442,6 +1442,28 @@ class ModelCompatibilityValidationMixin:
         return self
 
     @model_validator(mode="after")
+    def check_hidden_states_offloading(self):
+        if self.activation_offloading != "hidden_states":
+            return self
+        # ALST-style offloading replaces torch's reentrant CheckpointFunction, so it
+        # needs use_reentrant=True. Force it on (warn if the user asked otherwise).
+        gc_kwargs = dict(self.gradient_checkpointing_kwargs or {})
+        if gc_kwargs.get("use_reentrant") is False:
+            LOG.warning(
+                "activation_offloading: hidden_states requires reentrant checkpointing; "
+                "overriding gradient_checkpointing_kwargs.use_reentrant to true."
+            )
+        gc_kwargs["use_reentrant"] = True
+        self.gradient_checkpointing_kwargs = gc_kwargs
+        if self.adapter:
+            LOG.warning(
+                "activation_offloading: hidden_states is designed for full-parameter "
+                "training; with LoRA/QLoRA the frozen base may break reentrant "
+                "checkpointing. Prefer activation_offloading: true for adapters."
+            )
+        return self
+
+    @model_validator(mode="after")
     def check_better_transformers(self):
         if self.flash_optimum is True:
             if self.adapter:

--- a/tests/e2e/test_activation_offloading.py
+++ b/tests/e2e/test_activation_offloading.py
@@ -81,6 +81,172 @@ class TestActivationOffloading:
         train(cfg=cfg, dataset_meta=dataset_meta)
         check_model_output_exists(temp_dir, cfg)
 
+    @pytest.mark.parametrize(
+        "offload_mode,expect_streams",
+        [(True, True), ("legacy", False)],
+    )
+    def test_offload_mode_wiring(
+        self, temp_dir, monkeypatch, offload_mode, expect_streams
+    ):
+        """`activation_offloading` must reach the trainer as a live offload
+        context: True => stream-overlapped, 'legacy' => synchronous. Guards the
+        regression where string modes fell through to plain gradient
+        checkpointing (no offload at all)."""
+        from trl.models.activation_offloading import OffloadActivations
+
+        captured = {}
+        original_step = ActivationOffloadingMixin.training_step
+
+        def capture_step(self, *args, **kwargs):
+            captured["ctx"] = self.activation_offload_context
+            return original_step(self, *args, **kwargs)
+
+        monkeypatch.setattr(ActivationOffloadingMixin, "training_step", capture_step)
+
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "sequence_len": 1024,
+                "val_set_size": 0.0,
+                "special_tokens": {"pad_token": "<|endoftext|>"},
+                "datasets": [
+                    {"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"},
+                ],
+                "max_steps": 2,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "sample_packing": True,
+                "bf16": "auto",
+                "gradient_checkpointing": True,
+                "activation_offloading": offload_mode,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_target_linear": True,
+                "save_first_step": False,
+            }
+        )
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+        train(cfg=cfg, dataset_meta=dataset_meta)
+
+        ctx = captured.get("ctx")
+        assert isinstance(ctx, OffloadActivations), (
+            f"activation_offloading={offload_mode!r} did not produce an offload "
+            f"context (got {type(ctx).__name__}) — string modes likely fell "
+            f"through to plain gradient checkpointing"
+        )
+        assert ctx.use_streams is expect_streams
+
+    @pytest.mark.parametrize(
+        "adapter,expect_recompute_wrap",
+        [("lora", False), (None, True)],
+    )
+    def test_offload_is_adapter_aware(
+        self, temp_dir, monkeypatch, adapter, expect_recompute_wrap
+    ):
+        """activation_offloading is adapter-aware: LoRA offloads *instead of*
+        recomputing (no checkpoint wrap — pure offload is leaner/faster), while
+        full finetune keeps recompute and offloads the checkpoint boundaries
+        (the combo — pure offload is PCIe-bound and OOMs at full-param scale)."""
+        captured = {}
+        original_step = ActivationOffloadingMixin.training_step
+
+        def capture_step(self, *args, **kwargs):
+            captured["wrapped"] = any(
+                "_checkpoint_wrapped_module" in n for n, _ in self.model.named_modules()
+            )
+            return original_step(self, *args, **kwargs)
+
+        monkeypatch.setattr(ActivationOffloadingMixin, "training_step", capture_step)
+
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "sequence_len": 1024,
+                "val_set_size": 0.0,
+                "special_tokens": {"pad_token": "<|endoftext|>"},
+                "datasets": [
+                    {"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"},
+                ],
+                "max_steps": 2,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "sample_packing": True,
+                "bf16": "auto",
+                "gradient_checkpointing": True,
+                "activation_offloading": True,
+                "save_first_step": False,
+            }
+        )
+        if adapter:
+            cfg["adapter"] = adapter
+            cfg["lora_r"] = 8
+            cfg["lora_alpha"] = 16
+            cfg["lora_target_linear"] = True
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+        train(cfg=cfg, dataset_meta=dataset_meta)
+
+        assert captured.get("wrapped") is expect_recompute_wrap
+
+    def test_hidden_states_offload_full_param(self, temp_dir):
+        """activation_offloading: hidden_states (ALST-style) patches the reentrant
+        checkpoint to offload the per-layer input, for full-parameter training."""
+        import torch.utils.checkpoint as ckpt
+
+        from axolotl.monkeypatch.activation_offload_checkpoint import (
+            HiddenStatesOffloadCheckpoint,
+            unpatch_hidden_states_offload,
+        )
+
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "sequence_len": 1024,
+                "val_set_size": 0.0,
+                "special_tokens": {"pad_token": "<|endoftext|>"},
+                "datasets": [{"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"}],
+                "max_steps": 2,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "sample_packing": True,
+                "bf16": "auto",
+                "gradient_checkpointing": True,
+                "activation_offloading": "hidden_states",
+                "save_first_step": False,
+            }
+        )
+        try:
+            cfg = validate_config(cfg)
+            # validator forces reentrant for hidden_states
+            assert cfg.gradient_checkpointing_kwargs["use_reentrant"] is True
+            normalize_config(cfg)
+            dataset_meta = load_datasets(cfg=cfg)
+            train(cfg=cfg, dataset_meta=dataset_meta)
+            assert ckpt.CheckpointFunction is HiddenStatesOffloadCheckpoint
+            check_model_output_exists(temp_dir, cfg)
+        finally:
+            unpatch_hidden_states_offload()
+
     def test_no_vram_leak_regression(self, temp_dir, monkeypatch):
         """#3638 regression — fail on linear VRAM growth across training steps.
 

--- a/tests/e2e/test_activation_offloading.py
+++ b/tests/e2e/test_activation_offloading.py
@@ -83,7 +83,7 @@ class TestActivationOffloading:
 
     @pytest.mark.parametrize(
         "offload_mode,expect_streams",
-        [(True, True), ("legacy", False)],
+        [(True, True), ("legacy", False), ("disk", True)],
     )
     def test_offload_mode_wiring(
         self, temp_dir, monkeypatch, offload_mode, expect_streams

--- a/tests/e2e/test_activation_offloading.py
+++ b/tests/e2e/test_activation_offloading.py
@@ -247,6 +247,63 @@ class TestActivationOffloading:
         finally:
             unpatch_hidden_states_offload()
 
+    def test_hidden_states_offload_numerical_parity(self):
+        """The offloaded checkpoint only round-trips the layer input through CPU,
+        so loss and grads must match plain reentrant checkpointing. Same model
+        instance for both runs => identical weights; the only difference is the
+        d2h/h2d of the per-layer input."""
+        import torch
+        import torch.utils.checkpoint as ckpt
+        from transformers import AutoModelForCausalLM
+
+        from axolotl.monkeypatch.activation_offload_checkpoint import (
+            HiddenStatesOffloadCheckpoint,
+            patch_hidden_states_offload,
+            unpatch_hidden_states_offload,
+        )
+
+        if not torch.cuda.is_available():
+            pytest.skip("hidden_states offload requires CUDA")
+
+        torch.manual_seed(0)
+        model = AutoModelForCausalLM.from_pretrained(
+            "HuggingFaceTB/SmolLM2-135M", dtype=torch.bfloat16
+        ).to("cuda")
+        model.train()
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": True}
+        )
+
+        torch.manual_seed(1)
+        input_ids = torch.randint(0, 1000, (1, 512), device="cuda")
+        batch = {"input_ids": input_ids, "labels": input_ids.clone()}
+
+        def run():
+            model.zero_grad(set_to_none=True)
+            loss = model(**batch).loss
+            loss.backward()
+            grad = model.model.layers[0].mlp.down_proj.weight.grad
+            return loss.detach().clone(), grad.detach().clone()
+
+        assert ckpt.CheckpointFunction is not HiddenStatesOffloadCheckpoint
+        loss_ref, grad_ref = run()
+
+        patch_hidden_states_offload()
+        try:
+            assert ckpt.CheckpointFunction is HiddenStatesOffloadCheckpoint
+            loss_off, grad_off = run()
+        finally:
+            unpatch_hidden_states_offload()
+
+        # Forward output is identical; backward recompute introduces only bf16
+        # float noise, so grads match within a loose tolerance.
+        assert torch.allclose(loss_ref, loss_off, rtol=0, atol=1e-3), (
+            f"loss diverged: ref={loss_ref.item()} offload={loss_off.item()}"
+        )
+        assert torch.allclose(grad_ref, grad_off, rtol=1e-2, atol=1e-2), (
+            f"grad diverged: max|d|={(grad_ref - grad_off).abs().max().item()}"
+        )
+
     def test_no_vram_leak_regression(self, temp_dir, monkeypatch):
         """#3638 regression — fail on linear VRAM growth across training steps.
 


### PR DESCRIPTION
## Summary

Adds `activation_offloading: hidden_states` — an ALST-style activation offloader — and fixes the existing TRL-based offload paths.

`hidden_states` is gradient checkpointing that offloads **only the per-layer input** (`hidden_states`) to CPU and recomputes the intermediates, overlapping the transfer with compute on a side stream (async d2h with bounded in-flight + backward h2d prefetch). Unlike the existing TRL offloader (which offloads *every* saved tensor and is PCIe-saturated for full-parameter training), this moves one tensor/layer, so PCIe stays within budget and at long sequence the copy hides behind the recompute.

It replaces torch's reentrant `CheckpointFunction`, so it is framework-agnostic (no DeepSpeed dependency) and DTensor-aware (sequence/context parallel).

## Why

For long-context **full-parameter** training, offloading *everything* (existing `activation_offloading: true`) is slower and uses *more* GPU memory than plain gradient checkpointing (the offload backlog exceeds PCIe bandwidth). Offloading only the checkpoint input is the right granularity.

## Results (Qwen3-8B full-param, single GPU, bf16)

| seq | GC-only | hidden_states | vs GC |
|---|---|---|---|
| 16k | 63.3 GB / 2325 tok/s | 58.9 GB / 2243 | 0.96× speed, 1.08× less mem |
| 32k | 73.1 GB / 1954 | 64.3 GB / 2000 | 1.02× speed, 1.14× less mem |
| 64k | 92.9 GB / 1605 | 75.7 GB / 1565 | 0.98× speed, 1.23× less mem |
| 128k | **OOM** | fits | reaches context where GC OOMs |

Speed is tied with GC; the memory advantage widens with sequence length.

## Also fixes the existing TRL offload paths

- **Decouple offload from recompute.** `_apply_activation_checkpointing` is now adapter-aware: LoRA offloads *instead of* recomputing (pure offload is leaner and faster — recompute pins the offloaded tensors and balloons memory); full finetune keeps recompute and offloads only the checkpoint boundaries.
- **Wire `legacy`/`disk`.** These string modes were dead (gated on `is True`, and the trainer arg type `bool | None` couldn't hold the string). `legacy` now selects the synchronous (non-streamed) TRL offloader.

## Validation

- Bit-exact gradients vs plain checkpointing (forward output, input grad, weight grads all `0.0` in fp32).
- **FSDP2, 2×GPU, full-parameter:** runs clean under ZeRO-3 (`reshard_after_forward: true`) and ZeRO-2 (`false`) — reentrant checkpoint + offload + FSDP2 compose. (ZeRO-1 is not an FSDP2 sharding mode.)
- Validation forces `use_reentrant=True` for `hidden_states` and warns when used with LoRA/QLoRA.
- Tests: new `test_hidden_states_offload_full_param`, `test_offload_mode_wiring`, `test_offload_is_adapter_aware` + existing offloading/leak tests (11 pass).

## Usage

```yaml
gradient_checkpointing: true
activation_offloading: hidden_states   # full-parameter long-context
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new activation offloading mode that keeps checkpointed hidden states on CPU with streamed transfer support.
  * Expanded activation offloading options to support additional modes, including legacy and disk-based behavior.

* **Bug Fixes**
  * Improved checkpointing behavior so the correct offloading and recomputation path is selected automatically.
  * Added safeguards for compatible checkpointing settings when hidden-states offloading is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->