### PR TITLE
fix(diffusion): exclude padding from bidirectional attention mask

### DIFF
--- a/src/axolotl/integrations/diffusion/utils.py
+++ b/src/axolotl/integrations/diffusion/utils.py
@@ -129,13 +129,17 @@ def create_bidirectional_attention_mask(
 ) -> torch.Tensor:
     """
     Create bidirectional attention mask to override default causal masking.
-    Handles sample-packed sequences where different samples are identified
-    by different attention mask values.
+
+    When an ``attention_mask`` is provided it is always honored, whether it is a
+    binary padding mask (non-packed batches) or per-sample segment ids (packed
+    batches): a query may attend to a key only if they share the same non-zero
+    value. Passing the 4D mask to the model replaces its own padding handling,
+    so padding must be excluded here or real tokens would attend to padding.
 
     Args:
         input_ids: Input token ids [batch_size, seq_len]
         attention_mask: Attention mask [batch_size, seq_len]
-        sample_packing: Whether sample packing is enabled
+        sample_packing: Unused; segment-vs-padding masks are handled uniformly.
 
     Returns:
         bidirectional_mask: 4D attention mask [batch_size, 1, seq_len, seq_len]
@@ -143,16 +147,18 @@ def create_bidirectional_attention_mask(
     batch_size, seq_len = input_ids.shape
     device = input_ids.device
 
-    if attention_mask is None or not sample_packing:
+    # Without an attention mask every position is valid -> full all-to-all.
+    if attention_mask is None:
         return torch.ones(
             batch_size, 1, seq_len, seq_len, dtype=torch.bool, device=device
         )
 
-    # Handle sample packing: tokens can only attend within their sample
     mask_i = attention_mask.unsqueeze(2)  # [batch_size, seq_len, 1]
     mask_j = attention_mask.unsqueeze(1)  # [batch_size, 1, seq_len]
 
-    # Tokens can attend to each other if they have the same non-zero sample ID
+    # Tokens attend to each other only if they share the same non-zero id. For
+    # a binary padding mask this keeps valid<->valid and drops padding; for
+    # packed segment ids it additionally blocks cross-sample attention.
     bidirectional_mask = (mask_i == mask_j) & (mask_i > 0)
 
     # Add head dimension: [batch_size, 1, seq_len, seq_len]

--- a/tests/integrations/test_diffusion.py
+++ b/tests/integrations/test_diffusion.py
@@ -128,6 +128,27 @@ class TestDiffusionTrainer:
         assert mask.shape == expected_shape
         assert mask.all()
 
+    def test_bidirectional_attention_mask_excludes_padding(
+        self, diffusion_trainer_instance
+    ):
+        """With a binary padding mask (non-packed batch), real tokens must not
+        attend to padding and padding must not attend to real tokens."""
+        input_ids = torch.tensor([[1, 10, 20, 0]], dtype=torch.long)
+        attention_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.long)
+
+        # sample_packing=False mirrors the trainer's default call path
+        mask = create_bidirectional_attention_mask(
+            input_ids, attention_mask, sample_packing=False
+        )
+
+        assert mask.shape == (1, 1, 4, 4)
+        # Real tokens (0..2) attend to each other
+        assert mask[0, 0, 0, 1].item()
+        assert mask[0, 0, 2, 0].item()
+        # No attention to or from the padding position (index 3)
+        assert not mask[0, 0, :, 3].any().item()
+        assert not mask[0, 0, 3, :].any().item()
+
     def test_bidirectional_attention_mask_with_packing(
         self, diffusion_trainer_instance
     ):


### PR DESCRIPTION
# Description

Fixes a correctness bug in the diffusion LM integration: in non-packed (padded) batches, real tokens attended to padding positions in the bidirectional attention mask, corrupting their representations and the training loss.

`create_bidirectional_attention_mask` short-circuited to an all-to-all mask whenever `sample_packing` was `False`:

```python
if attention_mask is None or not sample_packing:
    return torch.ones(batch_size, 1, seq_len, seq_len, dtype=torch.bool, device=device)
```

The returned 4D mask is passed to the model as `attention_mask`, which **replaces** the model's own padding handling. So with `sample_packing: false` (the default) and a padded batch, padding tokens were fully attended to by every real token in both directions. For a bidirectional (diffusion) model this contaminates the hidden states of all real tokens and therefore the loss/gradients.

## Why training was affected but generation wasn't

The two call sites disagreed:

- **Training** (`DiffusionTrainer._compute_diffusion_loss`) passes `sample_packing=self.axolotl_cfg.sample_packing` — `False` by default, so the buggy branch fired on every padded batch.
- **Generation** (`generation.py`) already worked around it by passing `sample_packing=(attention_mask is not None)`, i.e. it forced the masked path whenever a mask existed.

So generation effectively had the correct behavior; training did not.

## Fix

Honor the `attention_mask` whenever it is provided, regardless of `sample_packing`. The existing rule

```python
(mask_i == mask_j) & (mask_i > 0)
```

already produces the correct mask for **both** cases:

- binary padding mask (`[1,1,1,0]`) → valid↔valid only, padding excluded;
- packed segment ids (`[1,1,2,2]`) → same-sample only, cross-sample blocked.

Only the early-return guard needed to change (`not sample_packing` removed). No behavior change for the `attention_mask is None` path (still full all-to-all) or for the existing packed path.

## How has this been tested?

`tests/integrations/test_diffusion.py`:

- New `test_bidirectional_attention_mask_excludes_padding` — non-packed batch with a binary padding mask asserts no attention to/from the padding position.
- Existing `test_bidirectional_attention_mask_no_packing` (no mask → all-ones) and `..._with_packing` (segment ids) still pass.

Full file: 13 passed locally. `ruff check`/`ruff format` clean.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attention mask behavior to consistently exclude padding tokens during diffusion model training. The system now reliably prevents padding tokens from interfering with attention calculations, improving training consistency.

* **Tests**
  * Added test coverage verifying proper exclusion of padding tokens in attention mask operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->