### PR TITLE
fix: fail early for CI if meet CUDA error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,35 @@ if not hasattr(_transformers_utils, "is_flash_attn_greater_or_equal_2_10"):
     )
 
 
+# A device-side assert / illegal access poisons the process-wide CUDA context, so
+# every later GPU test errors at setup. Abort the session instead of cascading.
+_CUDA_FATAL_MARKERS = (
+    "device-side assert triggered",
+    "an illegal memory access was encountered",
+    "misaligned address",
+)
+_cuda_context_poisoned = False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
+    outcome = yield
+    report = outcome.get_result()
+    global _cuda_context_poisoned  # pylint: disable=global-statement
+    if report.failed and call.excinfo is not None:
+        if any(marker in str(call.excinfo.value) for marker in _CUDA_FATAL_MARKERS):
+            _cuda_context_poisoned = True
+
+
+def pytest_runtest_setup(item):  # pylint: disable=unused-argument
+    if _cuda_context_poisoned:
+        pytest.exit(
+            "CUDA context corrupted by an earlier test (device-side assert); "
+            "aborting to avoid cascading setup errors. Re-run the job.",
+            returncode=1,
+        )
+
+
 def retry_on_request_exceptions(max_retries=3, delay=1):
     def decorator(func):
         @functools.wraps(func)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,13 +73,13 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
             _cuda_context_poisoned = True
 
 
-def pytest_runtest_setup(item):  # pylint: disable=unused-argument
+def pytest_runtest_setup(item):
     if _cuda_context_poisoned:
-        pytest.exit(
-            "CUDA context corrupted by an earlier test (device-side assert); "
-            "aborting to avoid cascading setup errors. Re-run the job.",
-            returncode=1,
+        item.session.shouldstop = (
+            "CUDA context corrupted by an earlier test; aborting to avoid "
+            "cascading setup errors. Re-run the job."
         )
+        pytest.skip("CUDA context corrupted by an earlier test; aborting suite.")
 
 
 def retry_on_request_exceptions(max_retries=3, delay=1):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

I'm seeing a few failures, in main, in unrelated PRs (for ex https://github.com/axolotl-ai-cloud/axolotl/actions/runs/27540583170/job/81407934320?pr=3736) , where the modal gpu docker e2e fails due to some device flakiness. This change makes those failures fail fast, so we can restart them at our own time and save cost instead of stuck in error loop.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

Claude

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU test execution: automatic detection of fatal CUDA errors with early test termination to prevent cascading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->