### PR TITLE
fix(offload): make activation_offloading: disk actually offload to disk

### DIFF
--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2060,7 +2060,7 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ("--activation-offloading",),
         None,
         None,
-        "Whether to offload activations. Options: true/false, 'legacy', 'disk' (TRL offloader), or 'hidden_states' (checkpoint input offload; non-reentrant by default, ALST-style when gradient_checkpointing_kwargs.use_reentrant is true).",
+        "Whether to offload activations. Options: true (TRL offloader, stream-overlapped), false, 'legacy' (TRL offloader, synchronous), 'disk' (offload activations to disk via the Disco gradient checkpointer), or 'hidden_states' (checkpoint input offload to CPU; non-reentrant by default, ALST-style when gradient_checkpointing_kwargs.use_reentrant is true).",
     ),
     (
         ("--layer-offloading/--no-layer-offloading",),

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -578,6 +578,16 @@ class TrainerBuilderBase(abc.ABC):
                 training_args_kwargs["activation_offloading"] = (
                     self.cfg.activation_offloading
                 )
+        elif self.cfg.activation_offloading == "disk":
+            # Disk offload uses the Disco checkpoint patch (installed by the patch
+            # manager); it needs HF gradient checkpointing enabled and is NOT the TRL
+            # offloader, so leave the trainer's activation_offloading arg unset.
+            training_args_kwargs["gradient_checkpointing"] = True
+            training_args_kwargs["gradient_checkpointing_kwargs"] = (
+                self.cfg.gradient_checkpointing_kwargs
+                if self.cfg.gradient_checkpointing_kwargs is not None
+                else {"use_reentrant": False}
+            )
         elif self.cfg.activation_offloading:
             # TRL offloader replaces HF recompute (re-added for full finetune in the
             # model loader), so disable HF checkpointing and pass the mode through.

--- a/src/axolotl/core/trainers/mixins/activation_checkpointing.py
+++ b/src/axolotl/core/trainers/mixins/activation_checkpointing.py
@@ -113,8 +113,9 @@ class ActivationOffloadingMixin(Trainer):
         if self.args.activation_offloading:
             # "legacy" uses the previous synchronous implementation (no CUDA
             # streams), which keeps far fewer activations resident on-GPU than
-            # the stream-overlapped path (True/"disk"); the streams path stashes
-            # several activations to overlap copies, inflating peak reserved.
+            # the stream-overlapped path (True); the streams path stashes several
+            # activations to overlap copies, inflating peak reserved. ("disk" never
+            # reaches here — it uses the Disco checkpoint patch, not this offloader.)
             use_streams = self.args.activation_offloading != "legacy"
             if use_streams:
                 _patch_trl_offload_current_stream()

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -353,6 +353,10 @@ class ModelLoader:
 
             patch_hidden_states_offload()
             return
+        # "disk" uses the Disco checkpoint patch driven by HF gradient checkpointing
+        # (enabled in the trainer), so it must NOT get the manual TRL recompute wrap.
+        if ao == "disk":
+            return
         # TRL offloader is adapter-aware:
         #   - LoRA/QLoRA: offload *replaces* recompute (pure offload is leaner/faster;
         #     recompute would pin the offloaded tensors and balloon memory). No wrap.

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -663,8 +663,7 @@ class PatchManager:
 
             transformers.modeling_utils.checkpoint = hf_grad_checkpoint_offload_wrapper
         elif (
-            self.cfg.gradient_checkpointing
-            and self.cfg.activation_offloading == "offload_disk"
+            self.cfg.gradient_checkpointing and self.cfg.activation_offloading == "disk"
         ):
             from axolotl.monkeypatch.gradient_checkpointing import (
                 hf_grad_checkpoint_disk_offload_wrapper,

--- a/src/axolotl/monkeypatch/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/monkeypatch/gradient_checkpointing/offload_disk.py
@@ -49,13 +49,18 @@ class DiskOffloadManager:
     def __init__(
         self,
         prefetch_size: int = 3,
-        prefetch_to_gpu: bool = True,
+        prefetch_to_gpu: bool = False,
         save_workers: int = 4,
     ):
         """
         Args:
             prefetch_size: Maximum number of tensors to prefetch in the background.
             prefetch_to_gpu: Whether to prefetch tensors directly to GPU memory.
+                Default False: prefetching to GPU does the host->device copy on a
+                background thread (torch.load map_location="cuda"), allocating off
+                the main stream and fragmenting the caching allocator (inflates
+                reserved memory by several GB). With False the background thread
+                loads to CPU and load_tensor moves it to GPU on the main thread.
             save_workers: Maximum number of concurrent save operations.
         """
         self.temp_dir = tempfile.mkdtemp(prefix="disco_")
@@ -435,7 +440,7 @@ class Disco(torch.autograd.Function):
     _manager = None
 
     @staticmethod
-    def get_instance(prefetch_size=1, prefetch_to_gpu=True, save_workers=4):
+    def get_instance(prefetch_size=1, prefetch_to_gpu=False, save_workers=4):
         """Get or create the offload manager"""
         if Disco._manager is None:
             Disco._manager = DiskOffloadManager(
@@ -453,7 +458,7 @@ class Disco(torch.autograd.Function):
         hidden_states,
         *args,
         prefetch_size=1,
-        prefetch_to_gpu=True,
+        prefetch_to_gpu=False,
         save_workers=4,
     ):
         """Forward pass that offloads activations to disk asynchronously"""

--- a/src/axolotl/monkeypatch/gradient_checkpointing/offload_disk.py
+++ b/src/axolotl/monkeypatch/gradient_checkpointing/offload_disk.py
@@ -167,6 +167,9 @@ class DiskOffloadManager:
                         or self.file_status[file_path] == "deleted"
                     ):
                         self.prefetch_queue.task_done()
+                        # without this, we fall through and either double-count
+                        # task_done() or KeyError on the status checks below
+                        continue
                     if file_path in self.prefetch_cache:
                         self.prefetch_queue.task_done()
                         continue

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -624,9 +624,11 @@ class AxolotlInputConfig(
             default=False,
             json_schema_extra={
                 "description": (
-                    "Whether to offload activations. Options: true/false, 'legacy', "
-                    "'disk' (TRL offloader), or 'hidden_states' (checkpoint input "
-                    "offload; non-reentrant by default, ALST-style when "
+                    "Whether to offload activations. Options: true (TRL offloader, "
+                    "stream-overlapped), false, 'legacy' (TRL offloader, synchronous), "
+                    "'disk' (offload activations to disk via the Disco gradient "
+                    "checkpointer), or 'hidden_states' (checkpoint input offload to "
+                    "CPU; non-reentrant by default, ALST-style when "
                     "gradient_checkpointing_kwargs.use_reentrant is true)."
                 )
             },

--- a/tests/e2e/test_activation_offloading.py
+++ b/tests/e2e/test_activation_offloading.py
@@ -84,15 +84,16 @@ class TestActivationOffloading:
 
     @pytest.mark.parametrize(
         "offload_mode,expect_streams",
-        [(True, True), ("legacy", False), ("disk", True)],
+        [(True, True), ("legacy", False)],
     )
     def test_offload_mode_wiring(
         self, temp_dir, monkeypatch, offload_mode, expect_streams
     ):
-        """`activation_offloading` must reach the trainer as a live offload
+        """`activation_offloading` must reach the trainer as a live TRL offload
         context: True => stream-overlapped, 'legacy' => synchronous. Guards the
         regression where string modes fell through to plain gradient
-        checkpointing (no offload at all)."""
+        checkpointing (no offload at all). ('disk' uses a different mechanism —
+        see test_disk_offload_wiring.)"""
         from trl.models.activation_offloading import OffloadActivations
 
         captured = {}
@@ -144,6 +145,71 @@ class TestActivationOffloading:
             f"through to plain gradient checkpointing"
         )
         assert ctx.use_streams is expect_streams
+
+    def test_disk_offload_wiring(self, temp_dir, monkeypatch):
+        """activation_offloading: disk installs the Disco disk-offload checkpoint
+        patch and trains with HF gradient checkpointing enabled — NOT the TRL
+        offloader. Guards the regression where 'disk' silently fell through to the
+        TRL CPU offloader (behaving like true): the patch checked a stale
+        'offload_disk' string and the builder disabled gradient checkpointing."""
+        import transformers
+        from trl.models.activation_offloading import OffloadActivations
+
+        from axolotl.monkeypatch.gradient_checkpointing import (
+            hf_grad_checkpoint_disk_offload_wrapper,
+        )
+
+        captured = {}
+        original_step = ActivationOffloadingMixin.training_step
+        original_ckpt = transformers.modeling_utils.checkpoint
+
+        def capture_step(self, *args, **kwargs):
+            captured["ctx"] = self.activation_offload_context
+            captured["ckpt"] = transformers.modeling_utils.checkpoint
+            return original_step(self, *args, **kwargs)
+
+        monkeypatch.setattr(ActivationOffloadingMixin, "training_step", capture_step)
+
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "sequence_len": 1024,
+                "val_set_size": 0.0,
+                "special_tokens": {"pad_token": "<|endoftext|>"},
+                "datasets": [
+                    {"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"},
+                ],
+                "max_steps": 2,
+                "micro_batch_size": 1,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-5,
+                "optimizer": "adamw_torch",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "sample_packing": True,
+                "bf16": "auto",
+                "gradient_checkpointing": True,
+                "activation_offloading": "disk",
+                "save_first_step": False,
+            }
+        )
+        try:
+            cfg = validate_config(cfg)
+            normalize_config(cfg)
+            dataset_meta = load_datasets(cfg=cfg)
+            train(cfg=cfg, dataset_meta=dataset_meta)
+        finally:
+            transformers.modeling_utils.checkpoint = original_ckpt
+
+        # disk uses the Disco checkpoint patch, not the TRL offloader
+        assert not isinstance(captured.get("ctx"), OffloadActivations), (
+            "disk should not engage the TRL OffloadActivations context"
+        )
+        assert captured.get("ckpt") is hf_grad_checkpoint_disk_offload_wrapper, (
+            "disk did not install the Disco disk-offload checkpoint patch"
+        )
+        check_model_output_exists(temp_dir, cfg)
 
     @pytest.mark.parametrize(
         "adapter,expect_recompute_wrap",


### PR DESCRIPTION
## Summary

`activation_offloading: disk` was effectively dead — it silently behaved like `true` (TRL CPU offloader) and the `Disco` disk checkpointer never ran. This PR makes `disk` actually offload activations to disk, and fixes a memory regression in the disk path that made it look strictly worse than plain gradient checkpointing.

## What was broken

`disk` never reached the Disco disk checkpointer because of three independent issues:

1. **Stale string check** — `patch_manager` gated the Disco patch on `activation_offloading == "offload_disk"`, but after validation the value is `"disk"`, so the branch never matched.
2. **Builder disabled gradient checkpointing** — any truthy `activation_offloading` (including `"disk"`) was routed into the TRL offloader with `gradient_checkpointing=False`, so HF never enabled the checkpointing that drives the Disco patch.
3. **Model loader double-wrapped** — for full-finetune it also applied the TRL recompute wrap (`ac_wrap_hf_model`), colliding with Disco.

Net effect: `disk` did stream-overlapped CPU offload (identical to `true`), while the docs claimed disk offload.

## Changes

- **Wiring**: `disk` now keeps HF gradient checkpointing enabled, installs the Disco patch, and skips the TRL offloader / recompute wrap.
- **Disco prefetch fix**: defaulted `prefetch_to_gpu=False`. The previous default did the host→device copy on a background thread (`torch.load(map_location="cuda")`), allocating off the main stream and fragmenting the caching allocator — reserved memory climbed ~5 GB above plain GC while *allocated* was actually ~1.3 GB below it. The background thread now loads to CPU and the existing `load_tensor` moves it to GPU on the main thread (no change to the save/recompute/cleanup ordering).
- **Disco prefetch-worker bug**: fixed a missing `continue` that caused `task_done() called too many times` (and a latent `KeyError`); only surfaced once disk actually ran.
- Schema description + mixin comment corrected; `disk` is no longer mislabeled "TRL offloader".
- **Tests**: added `test_disk_offload_wiring` (asserts the Disco patch is installed, TRL context is off, training runs and writes output) and removed the now-incorrect `("disk", True)` case from the TRL wiring test.

## Benchmarks

Qwen2.5-1.5B, full-parameter, micro-batch 1, sample packing, 8 steps (median of 5 post-warmup), single RTX PRO 6000. Profiled allocated vs reserved to isolate the fragmentation.

**Disco prefetch fix — multi-step alloc vs reserved @ 16k (the regression):**

| variant | ms/step | reserved GB | allocated GB | loss |
|---|--:|--:|--:|--:|
| none (plain GC) | 1680 | 48.82 | 42.61 | 12.63787 |
| disk `prefetch_to_gpu=True` (before) | 2276 | 50.25 | 41.53 | 12.63757 |
| disk `prefetch_to_gpu=False` (after) | 2237 | **48.88** | **41.34** | 12.63750 |

Reserved drops to ≈none, allocated stays below none, marginally faster, loss unchanged.

**Real `train()` path, chunked cross-entropy (logits removed to expose activation memory):**

| seq | none (resv / ms) | disk after fix (resv / ms) | disk before fix (resv) |
|--:|--:|--:|--:|
| 16384 | 25.64 / 1170 | 25.66 / 1755 | 27.38 |
| 32768 | 40.76 / 2362 | 39.59 / 3572 | (higher) |

After the fix `disk` is no longer worse on memory: reserved ≈ none (below it at 32k) and allocated ~1.3 GB under none.

**Tradeoff note:** `disk` remains ~1.3–1.5x slower than no-offload. That is inherent disk I/O bandwidth (CPU↔disk), the expected cost of the mode — it exists to fit longer context when CPU RAM is exhausted, not to be fast. On this 1.5B model the per-layer-input saving is small (~1.3 GB); the benefit grows with deeper models / longer context where those inputs dominate.

## Testing

`tests/e2e/test_activation_offloading.py` full suite passes (10 passed), including the new `test_disk_offload_wiring`; `true`/`legacy`/`lora`/`qlora`/`hidden_states` paths unaffected. No thread errors from Disco after the prefetch-worker fix.

## Not in scope

The `legacy` patch_manager branch (`CPU_Offloaded` wrapper) is similarly vestigial now that `legacy` = TRL-synchronous; left untouched to keep this PR scoped to `disk`. A CUDA-stream rewrite of Disco's GPU↔CPU copies could overlap that leg for more speed, but the disk-I/O floor remains and it carries correctness risk against the current hardened implementation — deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of disk activation offloading to prevent unintended duplicate optimization paths.
  * Fixed early exit logic in background prefetch worker to prevent incorrect queue accounting.

* **Documentation**
  * Expanded configuration documentation for activation offloading options, clarifying available modes and their behaviors.

* **Tests**
  * Added dedicated test coverage for disk offloading mode to ensure proper patch installation and behavior isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->