### PR TITLE
fix: correct NameError in _get_messages when JSON decodes to non-list

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1066,7 +1066,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 LOG.error(f"Error parsing messages as JSON. Error: {e}")
                 raise
             assert isinstance(messages, list), (
-                f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(message)}"
+                f"For SFT datasets that are stored in `str` format, the turns must be saved in a list of dictionaries, got {type(messages)}"
             )
 
             # Extra check here to make sure decoded json is a list of dicts.

--- a/tests/prompt_strategies/test_get_messages_str_format.py
+++ b/tests/prompt_strategies/test_get_messages_str_format.py
@@ -1,0 +1,92 @@
+"""
+Tests for ChatTemplateStrategy._get_messages with str-encoded messages.
+
+Verifies that when a JSON string decodes to a non-list value (e.g., a dict),
+_get_messages raises AssertionError with the type of the decoded value, not a
+NameError caused by referencing the loop variable `message` before it is bound.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from axolotl.prompt_strategies.chat_template import (
+    ChatTemplatePrompter,
+    ChatTemplateStrategy,
+)
+
+
+@pytest.fixture
+def strategy():
+    """Minimal ChatTemplateStrategy with a mocked tokenizer."""
+    tokenizer = MagicMock()
+    tokenizer.eos_token = "</s>"
+    tokenizer.eos_token_id = 2
+    tokenizer.encode.return_value = [2]
+
+    prompter = MagicMock(spec=ChatTemplatePrompter)
+    prompter.field_messages = "messages"
+    prompter.chat_template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+    prompter.chat_template_msg_variables = set()
+
+    strat = ChatTemplateStrategy.__new__(ChatTemplateStrategy)
+    strat.prompter = prompter
+    strat.tokenizer = tokenizer
+    strat.train_on_inputs = False
+    strat.sequence_len = 512
+    strat.roles_to_train = []
+    strat.train_on_eos = None
+    strat.train_on_eot = None
+    strat.eot_tokens = []
+    strat._eot_token_ids = set()
+    strat.split_thinking = False
+    strat.images = "images"
+    return strat
+
+
+class TestGetMessagesStrFormat:
+    """Tests for _get_messages when messages is stored as a JSON string."""
+
+    def test_valid_str_messages_returned(self, strategy):
+        """A valid JSON list of dicts is decoded and returned."""
+        turns = [{"role": "user", "content": "hello"}]
+        prompt = {"messages": json.dumps(turns)}
+        result = strategy._get_messages(prompt)
+        assert result == turns
+
+    def test_non_list_json_raises_assertion_error_with_type(self, strategy):
+        """When JSON decodes to a non-list, AssertionError is raised with the
+        actual decoded type — NOT a NameError from `type(message)`."""
+        # A JSON-encoded dict (not a list) — common mistake
+        prompt = {"messages": '{"role": "user", "content": "hi"}'}
+
+        with pytest.raises(AssertionError) as exc_info:
+            strategy._get_messages(prompt)
+
+        # The error message should describe the actual type (dict), not raise NameError
+        assert "dict" in str(exc_info.value), (
+            "AssertionError message should name the actual type; "
+            f"got: {exc_info.value}"
+        )
+
+    def test_non_dict_turn_raises_assertion_error(self, strategy):
+        """When a turn inside the decoded list is not a dict, AssertionError fires."""
+        prompt = {"messages": json.dumps(["not_a_dict"])}
+
+        with pytest.raises(AssertionError) as exc_info:
+            strategy._get_messages(prompt)
+
+        assert "str" in str(exc_info.value)
+
+    def test_invalid_json_raises_json_decode_error(self, strategy):
+        """Malformed JSON raises JSONDecodeError."""
+        prompt = {"messages": "not-valid-json"}
+
+        with pytest.raises(json.JSONDecodeError):
+            strategy._get_messages(prompt)
+
+    def test_none_messages_raises_value_error(self, strategy):
+        """Missing field raises ValueError."""
+        with pytest.raises(ValueError, match="null"):
+            strategy._get_messages({})

--- a/tests/prompt_strategies/test_get_messages_str_format.py
+++ b/tests/prompt_strategies/test_get_messages_str_format.py
@@ -1,92 +1,45 @@
 """
 Tests for ChatTemplateStrategy._get_messages with str-encoded messages.
 
-Verifies that when a JSON string decodes to a non-list value (e.g., a dict),
-_get_messages raises AssertionError with the type of the decoded value, not a
-NameError caused by referencing the loop variable `message` before it is bound.
+When a JSON string decodes to a non-list, the assertion must report the decoded type
+instead of raising UnboundLocalError on the not-yet-bound loop variable.
 """
 
 import json
-from unittest.mock import MagicMock
+from types import SimpleNamespace
 
 import pytest
 
-from axolotl.prompt_strategies.chat_template import (
-    ChatTemplatePrompter,
-    ChatTemplateStrategy,
-)
+from axolotl.prompt_strategies.chat_template import ChatTemplateStrategy
 
 
 @pytest.fixture
 def strategy():
-    """Minimal ChatTemplateStrategy with a mocked tokenizer."""
-    tokenizer = MagicMock()
-    tokenizer.eos_token = "</s>"
-    tokenizer.eos_token_id = 2
-    tokenizer.encode.return_value = [2]
-
-    prompter = MagicMock(spec=ChatTemplatePrompter)
-    prompter.field_messages = "messages"
-    prompter.chat_template = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
-    prompter.chat_template_msg_variables = set()
-
+    # _get_messages only reads self.prompter.field_messages; skip __init__ so we
+    # test the real method without a tokenizer/model.
     strat = ChatTemplateStrategy.__new__(ChatTemplateStrategy)
-    strat.prompter = prompter
-    strat.tokenizer = tokenizer
-    strat.train_on_inputs = False
-    strat.sequence_len = 512
-    strat.roles_to_train = []
-    strat.train_on_eos = None
-    strat.train_on_eot = None
-    strat.eot_tokens = []
-    strat._eot_token_ids = set()
-    strat.split_thinking = False
-    strat.images = "images"
+    strat.prompter = SimpleNamespace(field_messages="messages")
     return strat
 
 
 class TestGetMessagesStrFormat:
-    """Tests for _get_messages when messages is stored as a JSON string."""
-
     def test_valid_str_messages_returned(self, strategy):
-        """A valid JSON list of dicts is decoded and returned."""
         turns = [{"role": "user", "content": "hello"}]
-        prompt = {"messages": json.dumps(turns)}
-        result = strategy._get_messages(prompt)
-        assert result == turns
+        assert strategy._get_messages({"messages": json.dumps(turns)}) == turns
 
-    def test_non_list_json_raises_assertion_error_with_type(self, strategy):
-        """When JSON decodes to a non-list, AssertionError is raised with the
-        actual decoded type — NOT a NameError from `type(message)`."""
-        # A JSON-encoded dict (not a list) — common mistake
-        prompt = {"messages": '{"role": "user", "content": "hi"}'}
+    def test_non_list_json_reports_decoded_type(self, strategy):
+        # JSON object instead of a list
+        with pytest.raises(AssertionError, match=r"got <class 'dict'>"):
+            strategy._get_messages({"messages": '{"role": "user", "content": "hi"}'})
 
-        with pytest.raises(AssertionError) as exc_info:
-            strategy._get_messages(prompt)
-
-        # The error message should describe the actual type (dict), not raise NameError
-        assert "dict" in str(exc_info.value), (
-            "AssertionError message should name the actual type; "
-            f"got: {exc_info.value}"
-        )
-
-    def test_non_dict_turn_raises_assertion_error(self, strategy):
-        """When a turn inside the decoded list is not a dict, AssertionError fires."""
-        prompt = {"messages": json.dumps(["not_a_dict"])}
-
-        with pytest.raises(AssertionError) as exc_info:
-            strategy._get_messages(prompt)
-
-        assert "str" in str(exc_info.value)
+    def test_non_dict_turn_reports_turn_type(self, strategy):
+        with pytest.raises(AssertionError, match=r"got <class 'str'> for the turn 0"):
+            strategy._get_messages({"messages": json.dumps(["not_a_dict"])})
 
     def test_invalid_json_raises_json_decode_error(self, strategy):
-        """Malformed JSON raises JSONDecodeError."""
-        prompt = {"messages": "not-valid-json"}
-
         with pytest.raises(json.JSONDecodeError):
-            strategy._get_messages(prompt)
+            strategy._get_messages({"messages": "not-valid-json"})
 
     def test_none_messages_raises_value_error(self, strategy):
-        """Missing field raises ValueError."""
         with pytest.raises(ValueError, match="null"):
             strategy._get_messages({})


### PR DESCRIPTION
# Description

When `field_messages` contains a JSON string that decodes to a non-list value (e.g. a JSON object / dict), `ChatTemplateStrategy._get_messages` raises an `UnboundLocalError` instead of the intended `AssertionError` with a helpful message.

The assertion on line 1069 reads:

```python
assert isinstance(messages, list), (
    f"... got {type(message)}"   # ← 'message' is undefined here
)
```

`message` is only bound inside the `for i, message in enumerate(messages):` loop that follows. Before the loop runs, referencing `type(message)` raises `UnboundLocalError: cannot access local variable 'message' where it is not associated with a value` (Python 3.12+).

The fix is one character: `type(message)` → `type(messages)`.

## Motivation and Context

Introduced in #3607 (support for str-encoded `messages` field). A dataset where the messages JSON field is accidentally serialised as a dict rather than a list of dicts will hit this error path and receive an unhelpful crash instead of a clear validation message.

## How has this been tested?

New isolated test file `tests/prompt_strategies/test_get_messages_str_format.py` (no GPU, no network, no real tokenizer):

```
pytest tests/prompt_strategies/test_get_messages_str_format.py -v --noconftest
```

Before fix → `UnboundLocalError` on `test_non_list_json_raises_assertion_error_with_type`  
After fix  → 5/5 passed

## AI Usage Disclaimer

> GitHub Copilot / Claude assisted with drafting the test and commit message.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected assertion error message to accurately display the type of the provided messages variable when JSON decoding fails or results in invalid data structures.

* **Tests**
  * Added comprehensive test coverage for JSON-encoded message handling, including scenarios for valid messages, type validation, dictionary element validation, malformed JSON, and missing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->