### PR TITLE
fix(dpo): user_defined strategy KeyError on custom field names

### DIFF
--- a/src/axolotl/prompt_strategies/dpo/user_defined.py
+++ b/src/axolotl/prompt_strategies/dpo/user_defined.py
@@ -15,22 +15,19 @@ def default(cfg, dataset_idx=0, **kwargs):
     field_rejected = ds_cfg.get("field_rejected", "rejected")
     prompt_format = ds_cfg.get("prompt_format")
     if not prompt_format:
-        prompt_format = "{" + field_prompt + "}"
+        prompt_format = "{prompt}"
     chosen_format = ds_cfg.get("chosen_format")
     if not chosen_format:
-        chosen_format = "{" + field_chosen + "}"
+        chosen_format = "{chosen}"
     rejected_format = ds_cfg.get("rejected_format")
     if not rejected_format:
-        rejected_format = "{" + field_rejected + "}"
+        rejected_format = "{rejected}"
 
     def transform_fn(sample):
-        if (
-            "{" + field_system + "}" in prompt_format
-            and field_system in sample
-            and sample[field_system]
-        ):
+        if "{system}" in prompt_format:
             sample["prompt"] = prompt_format.format(
-                system=sample[field_system], prompt=sample[field_prompt]
+                system=sample.get(field_system) or "",
+                prompt=sample[field_prompt],
             )
         else:
             sample["prompt"] = prompt_format.format(prompt=sample[field_prompt])

--- a/tests/prompt_strategies/test_dpo_user_defined.py
+++ b/tests/prompt_strategies/test_dpo_user_defined.py
@@ -39,8 +39,7 @@ class TestDPOUserDefined:
         assert sample["rejected"] == "bad"
 
     def test_defaults_without_formats(self):
-        """Transform falls back to canonical {prompt}/{chosen}/{rejected} formats
-        when no explicit formats are configured."""
+        """Falls back to canonical {prompt}/{chosen}/{rejected} when no formats given."""
         cfg = make_cfg({})
         transform_fn = default(cfg)
         sample = transform_fn({"prompt": "hello", "chosen": "good", "rejected": "bad"})
@@ -49,13 +48,7 @@ class TestDPOUserDefined:
         assert sample["rejected"] == "bad"
 
     def test_custom_field_names(self):
-        """Transform reads from custom field_prompt/field_chosen/field_rejected
-        columns and writes the canonical prompt/chosen/rejected keys.
-
-        Regression test for issue #2645: the default format strings used the
-        custom field name as the placeholder (e.g. "{my_chosen}") while .format()
-        was called with the canonical keyword (chosen=), raising KeyError for any
-        non-default field name."""
+        """Custom field_* columns are read and written to the canonical keys."""
         cfg = make_cfg(
             {
                 "field_prompt": "question",
@@ -72,8 +65,7 @@ class TestDPOUserDefined:
         assert sample["rejected"] == "bad"
 
     def test_system_in_prompt_format(self):
-        """A {system} placeholder in prompt_format is filled from the system
-        field when present in the sample."""
+        """{system} is filled from the system field when present."""
         cfg = make_cfg({"prompt_format": "{system} {prompt}"})
         transform_fn = default(cfg)
         sample = transform_fn(
@@ -85,33 +77,37 @@ class TestDPOUserDefined:
             }
         )
         assert sample["prompt"] == "be helpful hello"
-        assert sample["chosen"] == "good"
-        assert sample["rejected"] == "bad"
 
-    def test_system_in_prompt_format_missing_system_field(self):
-        """A {system} placeholder does not raise KeyError when the system field
-        is absent from a sample (common in mixed datasets where only some rows
-        carry a system prompt): the missing value renders as an empty string."""
-        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
-        transform_fn = default(cfg)
-        sample = transform_fn({"prompt": "hello", "chosen": "good", "rejected": "bad"})
-        assert sample["prompt"] == " hello"
-        assert sample["chosen"] == "good"
-        assert sample["rejected"] == "bad"
-
-    def test_system_in_prompt_format_none_system_field(self):
-        """A None system value (how datasets represent a missing optional column)
-        renders as an empty string rather than the literal text 'None'."""
-        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
+    def test_system_in_prompt_format_custom_field(self):
+        """{system} reads from a custom field_system column."""
+        cfg = make_cfg({"field_system": "sys", "prompt_format": "{system} {prompt}"})
         transform_fn = default(cfg)
         sample = transform_fn(
-            {"system": None, "prompt": "hello", "chosen": "good", "rejected": "bad"}
+            {
+                "sys": "be helpful",
+                "prompt": "hello",
+                "chosen": "good",
+                "rejected": "bad",
+            }
         )
-        assert sample["prompt"] == " hello"
+        assert sample["prompt"] == "be helpful hello"
+
+    @pytest.mark.parametrize(
+        "sample",
+        [
+            {"prompt": "hello", "chosen": "good", "rejected": "bad"},
+            {"system": None, "prompt": "hello", "chosen": "good", "rejected": "bad"},
+        ],
+        ids=["missing", "none"],
+    )
+    def test_system_in_prompt_format_empty_system(self, sample):
+        """A missing or None system field renders as "" instead of raising or 'None'."""
+        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
+        transform_fn = default(cfg)
+        assert transform_fn(sample)["prompt"] == " hello"
 
     def test_custom_chosen_rejected_formats(self):
-        """Explicit chosen_format/rejected_format are honored alongside custom
-        field names."""
+        """Explicit chosen_format/rejected_format are honored with custom field names."""
         cfg = make_cfg(
             {
                 "field_chosen": "good",
@@ -134,8 +130,7 @@ class TestDPOUserDefined:
             default(cfg)
 
     def test_load_dpo_user_defined_returns_callable(self):
-        """The loader path resolves user_defined.default to a callable transform
-        for a config with custom field names."""
+        """The loader resolves user_defined.default to a callable transform."""
         cfg = make_cfg(
             {
                 "field_prompt": "question",

--- a/tests/prompt_strategies/test_dpo_user_defined.py
+++ b/tests/prompt_strategies/test_dpo_user_defined.py
@@ -1,0 +1,147 @@
+"""
+Tests for user-defined DPO dataset transform strategies
+"""
+
+import pytest
+
+from axolotl.prompt_strategies.dpo import load as load_dpo
+from axolotl.prompt_strategies.dpo.user_defined import default
+from axolotl.utils.dict import DictDefault
+
+
+def make_cfg(type_cfg: dict) -> DictDefault:
+    """Build a minimal config with a single user-defined DPO dataset."""
+    return DictDefault({"datasets": [{"type": type_cfg}]})
+
+
+class TestDPOUserDefined:
+    """
+    Test user_defined.default DPO transforms
+    """
+
+    def test_explicit_config(self):
+        """Transform works with explicit prompt/chosen/rejected formats."""
+        cfg = make_cfg(
+            {
+                "field_prompt": "prompt",
+                "field_system": "system",
+                "field_chosen": "chosen",
+                "field_rejected": "rejected",
+                "prompt_format": "{prompt}",
+                "chosen_format": "{chosen}",
+                "rejected_format": "{rejected}",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn({"prompt": "hello", "chosen": "good", "rejected": "bad"})
+        assert sample["prompt"] == "hello"
+        assert sample["chosen"] == "good"
+        assert sample["rejected"] == "bad"
+
+    def test_defaults_without_formats(self):
+        """Transform falls back to canonical {prompt}/{chosen}/{rejected} formats
+        when no explicit formats are configured."""
+        cfg = make_cfg({})
+        transform_fn = default(cfg)
+        sample = transform_fn({"prompt": "hello", "chosen": "good", "rejected": "bad"})
+        assert sample["prompt"] == "hello"
+        assert sample["chosen"] == "good"
+        assert sample["rejected"] == "bad"
+
+    def test_custom_field_names(self):
+        """Transform reads from custom field_prompt/field_chosen/field_rejected
+        columns and writes the canonical prompt/chosen/rejected keys.
+
+        Regression test for issue #2645: the default format strings used the
+        custom field name as the placeholder (e.g. "{my_chosen}") while .format()
+        was called with the canonical keyword (chosen=), raising KeyError for any
+        non-default field name."""
+        cfg = make_cfg(
+            {
+                "field_prompt": "question",
+                "field_chosen": "my_chosen",
+                "field_rejected": "my_rejected",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn(
+            {"question": "hello", "my_chosen": "good", "my_rejected": "bad"}
+        )
+        assert sample["prompt"] == "hello"
+        assert sample["chosen"] == "good"
+        assert sample["rejected"] == "bad"
+
+    def test_system_in_prompt_format(self):
+        """A {system} placeholder in prompt_format is filled from the system
+        field when present in the sample."""
+        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
+        transform_fn = default(cfg)
+        sample = transform_fn(
+            {
+                "system": "be helpful",
+                "prompt": "hello",
+                "chosen": "good",
+                "rejected": "bad",
+            }
+        )
+        assert sample["prompt"] == "be helpful hello"
+        assert sample["chosen"] == "good"
+        assert sample["rejected"] == "bad"
+
+    def test_system_in_prompt_format_missing_system_field(self):
+        """A {system} placeholder does not raise KeyError when the system field
+        is absent from a sample (common in mixed datasets where only some rows
+        carry a system prompt): the missing value renders as an empty string."""
+        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
+        transform_fn = default(cfg)
+        sample = transform_fn({"prompt": "hello", "chosen": "good", "rejected": "bad"})
+        assert sample["prompt"] == " hello"
+        assert sample["chosen"] == "good"
+        assert sample["rejected"] == "bad"
+
+    def test_system_in_prompt_format_none_system_field(self):
+        """A None system value (how datasets represent a missing optional column)
+        renders as an empty string rather than the literal text 'None'."""
+        cfg = make_cfg({"prompt_format": "{system} {prompt}"})
+        transform_fn = default(cfg)
+        sample = transform_fn(
+            {"system": None, "prompt": "hello", "chosen": "good", "rejected": "bad"}
+        )
+        assert sample["prompt"] == " hello"
+
+    def test_custom_chosen_rejected_formats(self):
+        """Explicit chosen_format/rejected_format are honored alongside custom
+        field names."""
+        cfg = make_cfg(
+            {
+                "field_chosen": "good",
+                "field_rejected": "bad",
+                "chosen_format": "Answer: {chosen}",
+                "rejected_format": "Answer: {rejected}",
+            }
+        )
+        transform_fn = default(cfg)
+        sample = transform_fn({"prompt": "q", "good": "yes", "bad": "no"})
+        assert sample["prompt"] == "q"
+        assert sample["chosen"] == "Answer: yes"
+        assert sample["rejected"] == "Answer: no"
+
+    def test_non_dict_type_raises(self):
+        """A non-dict dataset type raises a clear ValueError."""
+        cfg = make_cfg({})
+        cfg["datasets"][0]["type"] = "user_defined.default"
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            default(cfg)
+
+    def test_load_dpo_user_defined_returns_callable(self):
+        """The loader path resolves user_defined.default to a callable transform
+        for a config with custom field names."""
+        cfg = make_cfg(
+            {
+                "field_prompt": "question",
+                "field_chosen": "my_chosen",
+                "field_rejected": "my_rejected",
+            }
+        )
+        transform_fn = load_dpo("user_defined.default", cfg, dataset_idx=0)
+        assert callable(transform_fn)


### PR DESCRIPTION
# Description

Fixes #2645.

The `user_defined` DPO dataset strategy (`src/axolotl/prompt_strategies/dpo/user_defined.py`) raised `KeyError` and did not work as documented in two related ways.

**1. Custom field names (the reported bug).** When `prompt_format` / `chosen_format` / `rejected_format` are not provided, the defaults were built from the *configured field names*:

```python
chosen_format = "{" + field_chosen + "}"   # e.g. "{my_chosen}"
```

but `transform_fn` formats them with the *canonical* keyword:

```python
sample["chosen"] = chosen_format.format(chosen=sample[field_chosen])
# "{my_chosen}".format(chosen=...) -> KeyError: 'my_chosen'
```

So a config such as:

```yaml
datasets:
  - path: ...
    type:
      field_prompt: question
      field_chosen: my_chosen
      field_rejected: my_rejected
```

raised `KeyError: 'question'` (surfacing in `utils/data/rl.py`, as the issue notes). The strategy only worked when every field kept its default name.

**2. `{system}` with a missing/empty system value.** With `prompt_format: "{system} {prompt}"`, any row whose system field is missing, empty, or `None` (common in mixed datasets where only some rows carry a system prompt) fell through to the `else` branch and raised `KeyError: 'system'` on the unfilled placeholder.

## Motivation and Context

This is the DPO counterpart of the KTO `user_defined` bug fixed in #3730: the same placeholder/keyword mismatch existed in both files, and #3730 left the DPO version live.

- The default format strings now use the canonical placeholders (`{prompt}`, `{chosen}`, `{rejected}`) that match the keywords passed to `.format()`, and the system check uses `"{system}" in prompt_format`. Field names are still read via `sample[field_*]`, so custom columns are honored; only the placeholder names are canonicalized.
- When `prompt_format` contains `{system}`, a system value is always supplied via `sample.get(field_system) or ""`, so missing / empty / `None` system values render as an empty string instead of crashing (and never the literal text `"None"`).

(The merged KTO strategy has the same guarded `{system}` pattern and the same latent edge case; happy to send a follow-up to align it.)

## How has this been tested?

Added `tests/prompt_strategies/test_dpo_user_defined.py` (mirrors `test_kto_user_defined.py`), covering:

- custom `field_prompt` / `field_chosen` / `field_rejected` (the issue repro: raises `KeyError` on `main`, passes here),
- defaults with no explicit formats,
- explicit `prompt_format` / `chosen_format` / `rejected_format`,
- `{system}` formatting when present, when the field is missing, and when it is `None`,
- a non-dict `type` raising a clear `ValueError`,
- the loader path returning a callable.

The custom-field-name and missing/None-system tests fail before this change (`KeyError`) and pass after; the others pass before and after.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)