### PR TITLE
perf(scattermoe): NVFP4+LoRA experts via dequant→bf16 grouped GEMM

### DIFF
--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -4,11 +4,28 @@ PEFT LoRA on ``gate_up_proj`` / ``down_proj`` is fused into the
 ScatterMoE Triton call via ``parallel_linear_lora``.
 """
 
+import os
+
 import torch
 
 from .mx_weights import selective_mx_weights_fwd, selective_nvfp4_weights_fwd
+
+# NVFP4 + LoRA fast path: dequantize the frozen FP4 experts to bf16 ONCE and run the plain
+# bf16 LoRA grouped GEMM (fwd+bwd), instead of the fused kernel that re-dequantizes FP4
+# inside the GEMM K-loop. The fused FP4 dequant starves the tensor cores; routing through
+# the bf16 grouped GEMM is far faster (~15x fwd+bwd at the expert layer on B200/B300) at the
+# cost of a transient bf16 weight (~2x the packed-FP4 bytes), kept transient via the same
+# recompute-in-backward recipe. Set AXOLOTL_NVFP4_LORA_FUSED=1 to fall back to the fused path.
+_NVFP4_LORA_DEQUANT_BF16 = os.environ.get("AXOLOTL_NVFP4_LORA_FUSED", "0") != "1"
+# Within that bf16 fast path, also run the fused dX backward kernel (scatter2scatter_lora_dX)
+# instead of the non-fused base scatter2scatter + Python LoRA dX — the same backward fusion the
+# MXFP4 fused path forces internally. Default on; AXOLOTL_NVFP4_LORA_NONFUSED_BWD=1 reverts to
+# the non-fused backward (fallback + A/B measurement). dA/dB are unaffected (the fused-gather
+# threshold leaves the grouped-Gram path, which is already optimal at high expert counts).
+_NVFP4_LORA_FUSED_BWD = os.environ.get("AXOLOTL_NVFP4_LORA_NONFUSED_BWD", "0") != "1"
 from .parallel_experts import flatten_sort_count, parallel_linear
 from .parallel_linear_lora import get_lora_params_from_wrapper, parallel_linear_lora
+from .selective_dequant_kernel import dequant_nvfp4_full_triton
 from .selective_dequant import (
     get_active_experts,
     is_mxfp4_param,
@@ -100,8 +117,13 @@ def _parallel_linear_maybe_lora(
     grouped_out,
     gates=None,
     expert_biases=None,
+    use_fused_bwd=False,
 ):
-    """Call parallel_linear or parallel_linear_lora depending on whether LoRA is active."""
+    """Call parallel_linear or parallel_linear_lora depending on whether LoRA is active.
+
+    ``use_fused_bwd`` selects the fused dX / gather backward kernels (the NVFP4->bf16
+    fast path opts in, matching what the fused MXFP4 path forces internally).
+    """
     if lora_tuple is not None:
         lora_A, lora_B, scaling = lora_tuple
         return parallel_linear_lora(
@@ -118,6 +140,8 @@ def _parallel_linear_maybe_lora(
             grouped_in=grouped_in,
             grouped_out=grouped_out,
             gates=gates,
+            use_fused_dX=use_fused_bwd,
+            use_fused_gather=use_fused_bwd,
         )
     return parallel_linear(
         x,
@@ -154,10 +178,49 @@ def _prepare_weights_and_lora(
     fused kernel is LoRA-only and the FP4 tensors have no transpose).
 
     Returns ``(gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
-    gup_lora, down_lora)``.
+    gup_lora, down_lora, use_fused_bwd)``. ``use_fused_bwd`` is True only for the
+    NVFP4->bf16 fast path, where the fused dX / gather backward kernels apply (as the
+    fused MXFP4 path forces internally); the bf16 base/no-LoRA paths leave it False.
     """
     is_mx, is_nv = is_mxfp4_param(gu_param), is_nvfp4_param(gu_param)
-    if (is_mx or is_nv) and gup_lora is not None and down_lora is not None:
+    use_fused_bwd = False
+    if (
+        is_nv
+        and _NVFP4_LORA_DEQUANT_BF16
+        and gup_lora is not None
+        and down_lora is not None
+    ):
+        # NVFP4 + LoRA FAST PATH: dequant->bf16 once, then the plain bf16 LoRA grouped GEMM.
+        # Returning bf16 [E, in, out] (not an MXWeights) flips ScatterMoELoRA to is_mx=False,
+        # selecting the bf16 fwd/bwd kernels. A .recipe that rebuilds bf16 keeps the (larger)
+        # transient weight recomputed in backward rather than pinned across depth. Routing and
+        # LoRA tuples are passed through unchanged (no active-expert compaction needed: the
+        # bf16 grouped GEMM indexes the full [E,...] set, and training routing is dense).
+        gate_up_weight = dequant_nvfp4_full_triton(gu_param, dtype).transpose(2, 1)
+        down_weight = dequant_nvfp4_full_triton(dn_param, dtype).transpose(2, 1)
+        # is_mx=False here (plain bf16 Tensor), so ScatterMoELoRA won't auto-force the
+        # fused backward the way the MXFP4 path does — opt in explicitly so the bf16 dX
+        # runs the fused scatter2scatter_lora_dX kernel instead of base + Python LoRA.
+        use_fused_bwd = _NVFP4_LORA_FUSED_BWD
+        if module is not None:
+            gate_up_weight.recipe = (
+                lambda m=module, d=dtype: dequant_nvfp4_full_triton(
+                    _get_base_param(m.gate_up_proj), d
+                ).transpose(2, 1)
+            )
+            down_weight.recipe = (
+                lambda m=module, d=dtype: dequant_nvfp4_full_triton(
+                    _get_base_param(m.down_proj), d
+                ).transpose(2, 1)
+            )
+        else:
+            gate_up_weight.recipe = (
+                lambda p=gu_param, d=dtype: dequant_nvfp4_full_triton(p, d).transpose(2, 1)
+            )
+            down_weight.recipe = (
+                lambda p=dn_param, d=dtype: dequant_nvfp4_full_triton(p, d).transpose(2, 1)
+            )
+    elif (is_mx or is_nv) and gup_lora is not None and down_lora is not None:
         select = selective_mx_weights_fwd if is_mx else selective_nvfp4_weights_fwd
         active = get_active_experts(sorted_expert_idxs, num_experts)
         sorted_expert_idxs, expert_offsets = remap_expert_indices(
@@ -210,6 +273,7 @@ def _prepare_weights_and_lora(
         expert_offsets,
         gup_lora,
         down_lora,
+        use_fused_bwd,
     )
 
 
@@ -363,6 +427,7 @@ def scattermoe_experts_forward(
         expert_offsets,
         gup_lora,
         down_lora,
+        use_fused_bwd,
     ) = _prepare_weights_and_lora(
         _get_base_param(self.gate_up_proj),
         _get_base_param(self.down_proj),
@@ -386,6 +451,7 @@ def scattermoe_experts_forward(
         gup_lora,
         grouped_in=False,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     gates, h = gates_h.chunk(2, dim=-1)
     # Clamped SwiGLU when the model defines a swiglu_limit (e.g. DeepSeek-V4: limit=10) —
@@ -409,6 +475,7 @@ def scattermoe_experts_forward(
         grouped_in=True,
         grouped_out=False,
         gates=routing_weights,
+        use_fused_bwd=use_fused_bwd,
     )
 
     return output
@@ -465,7 +532,7 @@ def scattermoe_experts_forward_ep(
     elif _has_peft_wrapper(self):
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
 
-    gate_up_weight, down_weight, se, expert_offsets, gup_lora, down_lora = (
+    gate_up_weight, down_weight, se, expert_offsets, gup_lora, down_lora, use_fused_bwd = (
         _prepare_weights_and_lora(
             _get_base_param(self.gate_up_proj),
             _get_base_param(self.down_proj),
@@ -491,6 +558,7 @@ def scattermoe_experts_forward_ep(
         gup_lora,
         grouped_in=True,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     gates, h = gates_h.chunk(2, dim=-1)
     _limit = getattr(self, "limit", None)
@@ -509,6 +577,7 @@ def scattermoe_experts_forward_ep(
         down_lora,
         grouped_in=True,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     down_out = down_out * w_sorted.unsqueeze(-1)
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
@@ -177,3 +177,110 @@ def selective_dequant_nf4_triton(
     )
 
     return out.reshape(num_active, *expert_shape)
+
+
+# --- NVFP4 (E2M1 + E4M3 block-16) fast dequant -----------------------------------------
+# torchao's eager ``NVFP4Tensor.dequantize()`` materializes large unfused fp32 intermediates
+# (~145 GB / ~164 ms at E=256) and torch.compile miscompiles its subclass dispatch, so the
+# NVFP4+LoRA fast path needs a dedicated kernel. One memory-bound pass: unpack the E2M1
+# nibble, gather the codebook, multiply the linear E4M3 block-16 scale. Validated bit-exact
+# vs torchao at E up to 256. (per_tensor_scale is folded outside the kernel.)
+#
+# OCP E2M1 codebook (low nibble first); ``scale`` is the un-swizzled linear E4M3 block scale.
+_NVFP4_E2M1_LUT = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+                   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0]
+
+
+@triton.jit
+def _nvfp4_dequant_kernel(
+    QDATA,  # [R, C/2] uint8 packed E2M1 (2 nibbles/byte, low=col 2j, high=col 2j+1)
+    SCALE,  # [R, C/16] E4M3 linear block scale
+    LUT,    # [16] fp32 E2M1 codebook
+    OUT,    # [R*C] output, dtype = OUT.dtype.element_ty
+    PTS,    # fp32 per_tensor_scale: [1] (scalar) or [E] (per-expert); dummy ptr if unused
+    total,
+    C: tl.constexpr,    # last (contracted) dim; power-of-2 so //C,%C,>>1,>>4 are shifts
+    C2: tl.constexpr,   # C // 2
+    C16: tl.constexpr,  # C // 16
+    ROWS_PER_E: tl.constexpr,  # rows per expert (R // E); for per-expert pts indexing
+    PTS_MODE: tl.constexpr,    # 0 none, 1 scalar, 2 per-expert
+    BLOCK: tl.constexpr,
+):
+    # flat 1D over output elements; int64 offsets (r*C2 reaches ~4e9, int32 overflows).
+    g = tl.program_id(0).to(tl.int64) * BLOCK + tl.arange(0, BLOCK).to(tl.int64)
+    m = g < total
+    r = g // C
+    c = (g % C).to(tl.int32)
+    q = tl.load(QDATA + r * C2 + (c >> 1), mask=m, other=0)
+    nib = tl.where((c & 1) == 1, (q >> 4) & 0xF, q & 0xF).to(tl.int32)
+    val = tl.load(LUT + nib)
+    sc = tl.load(SCALE + r * C16 + (c >> 4), mask=m, other=0.0).to(tl.float32)
+    # Fold per_tensor_scale onto the block scale in fp32, then a single bf16 round at the
+    # store. Folding onto `sc` (not the product) reproduces the validated path's exact
+    # `block_scale * per_tensor` order (mx_weights.py) -> bit-identical, single-rounding.
+    # (A post-store bf16 multiply double-rounds, ~2x the error.)
+    if PTS_MODE == 1:
+        sc = sc * tl.load(PTS).to(tl.float32)
+    elif PTS_MODE == 2:
+        e = r // ROWS_PER_E
+        sc = sc * tl.load(PTS + e, mask=m, other=0.0).to(tl.float32)
+    tl.store(OUT + g, (val * sc).to(OUT.dtype.element_ty), mask=m)
+
+
+def dequant_nvfp4_full_triton(nv_param, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+    """Dequantize a full NVFP4Tensor expert weight ``[E, N, K]`` to ``dtype`` (one pass).
+
+    Drop-in fast replacement for ``nv_param.dequantize(dtype)`` for the un-swizzled linear
+    E4M3-block-16 layout the axolotl loader produces (see ``selective_nvfp4_weights_fwd``),
+    folding the optional ``per_tensor_scale`` in-kernel in fp32 (single rounding, torchao
+    parity). Accepts a scalar pts (the loader's shape) or a per-expert ``[E]`` / ``[E,1,1]``
+    (the FSDP carry shape).
+    """
+    qd, sc = nv_param.qdata, nv_param.scale
+    lead = qd.shape[:-1]
+    C2 = qd.shape[-1]
+    C = C2 * 2
+    assert C & (C - 1) == 0, f"NVFP4 fast dequant needs power-of-2 last dim, got {C}"
+    rows = 1
+    for d in lead:
+        rows *= d
+    total = rows * C
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+
+    # Resolve the per_tensor_scale into a flat fp32 buffer + a mode the kernel folds in fp32.
+    pts = getattr(nv_param, "per_tensor_scale", None)
+    rows_per_e = 1
+    if pts is None:
+        pts_buf = lut  # unused dummy pointer (PTS_MODE=0 never loads it)
+        pts_mode = 0
+    elif pts.numel() == 1:
+        pts_buf = pts.reshape(1).to(torch.float32).contiguous()
+        pts_mode = 1
+    else:
+        # per-expert: leading dim of pts is the expert axis ([E] or [E,1,1]); index by r // (R/E)
+        n_experts = pts.shape[0]
+        assert rows % n_experts == 0, (
+            f"per-expert per_tensor_scale [{n_experts}] does not divide rows {rows}"
+        )
+        rows_per_e = rows // n_experts
+        pts_buf = pts.reshape(n_experts).to(torch.float32).contiguous()
+        pts_mode = 2
+
+    out = torch.empty(total, device=qd.device, dtype=dtype)
+    BLOCK = 8192
+    grid = (triton.cdiv(total, BLOCK),)
+    _nvfp4_dequant_kernel[grid](
+        qd.reshape(-1).contiguous(),
+        sc.reshape(-1).contiguous(),
+        lut,
+        out,
+        pts_buf,
+        total,
+        C=C,
+        C2=C2,
+        C16=C // 16,
+        ROWS_PER_E=rows_per_e,
+        PTS_MODE=pts_mode,
+        BLOCK=BLOCK,
+    )
+    return out.reshape(*lead, C)

--- a/tests/integrations/kernels/scattermoe_lora/test_nvfp4_dequant.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_nvfp4_dequant.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""dequant_nvfp4_full_triton matches the validated NVFP4 linear fold, bit-exactly.
+
+The NVFP4 + LoRA fast path dequantizes the frozen experts to bf16 once via a custom Triton
+kernel (the eager ``NVFP4Tensor.dequantize()`` materializes ~145 GB of unfused intermediates
+and ``torch.compile`` miscompiles the subclass). Correctness bar = the SAME linear fold the
+fused path uses (``selective_nvfp4_weights_fwd``: ``LUT[nibble] * (scale_e4m3.float() *
+per_tensor.float())``), which the model's ``test_nvfp4_experts_forward`` already validates.
+
+Covers the three ``per_tensor_scale`` shapes the loader / FSDP carry: None, a shared scalar
+(what the loader emits), and a per-expert ``[E, 1, 1]``. The in-kernel fp32 fold must be
+bit-exact against the reference in every case (a post-store bf16 multiply double-rounds, and a
+bare ``[E]`` per-expert scale previously crashed on a broadcast mismatch).
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+NVFP4Tensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.nvfp4_tensor", reason="torchao required"
+).NVFP4Tensor
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant_kernel import (  # noqa: E402
+    _NVFP4_E2M1_LUT,
+    dequant_nvfp4_full_triton,
+)
+
+DEV = "cuda"
+E, ROWS, COLS = 8, 256, 512  # [E, N, K]; K power-of-2 (kernel requirement)
+
+
+def _validated_fold(nv, dtype=torch.float32):
+    """The fused path's exact linear fold (mx_weights.selective_nvfp4_weights_fwd):
+    value = LUT[nibble] * (scale_e4m3.float() * per_tensor.float())."""
+    qd = nv.qdata
+    scale_f = nv.scale.to(torch.float32)
+    pts = getattr(nv, "per_tensor_scale", None)
+    if pts is not None:
+        scale_f = scale_f * pts.to(torch.float32)
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+    lo = lut[(qd & 0xF).long()]
+    hi = lut[((qd >> 4) & 0xF).long()]
+    val = torch.stack([lo, hi], dim=-1).reshape(*qd.shape[:-1], qd.shape[-1] * 2)
+    return (val * scale_f.repeat_interleave(16, dim=-1)).to(dtype)
+
+
+def _build(pts_mode):
+    g = torch.Generator(device=DEV).manual_seed(0)
+    t = torch.randn(E, ROWS, COLS, device=DEV, dtype=torch.bfloat16, generator=g) * 0.1
+    if pts_mode == "none":
+        return NVFP4Tensor.to_nvfp4(t, block_size=16)
+    if pts_mode == "scalar":
+        pts = (t.abs().amax() / (6.0 * 448.0)).to(torch.float32)  # mirrors the loader's gpts
+        return NVFP4Tensor.to_nvfp4(t, block_size=16, per_tensor_scale=pts)
+    # per-expert [E,1,1]: a valid NVFP4 tensor carrying a per-expert scale (FSDP carry shape)
+    nv = NVFP4Tensor.to_nvfp4(t, block_size=16)
+    nv.per_tensor_scale = (
+        torch.rand(E, 1, 1, device=DEV, generator=g).to(torch.float32) + 0.5
+    )
+    return nv
+
+
+@pytest.mark.parametrize("pts_mode", ["none", "scalar", "perexpert"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_dequant_matches_validated_fold(pts_mode, dtype):
+    nv = _build(pts_mode)
+    ours = dequant_nvfp4_full_triton(nv, dtype)
+    ref = _validated_fold(nv, dtype)
+    assert ours.shape == ref.shape == (E, ROWS, COLS)
+    # The fp32 fold is computed identically (LUT * scale * pts), so the kernel must match the
+    # reference exactly at fp32 and after the single bf16 round.
+    assert torch.equal(ours, ref), (
+        f"{pts_mode}/{dtype}: max rel "
+        f"{(ours - ref).float().abs().max().item() / max(ref.float().abs().max().item(), 1e-9):.2e}"
+    )


### PR DESCRIPTION
## Summary

The fused NVFP4 expert kernel re-dequantizes the 4-bit weights **inside** the grouped-GEMM K-loop (and again in the backward), which starves the tensor cores: the dequant, not the matmul, dominates. For LoRA fine-tuning — where the expert weights are **frozen** — we can dequantize each expert to bf16 **once** and run the existing fast bf16 LoRA grouped GEMM instead.

This routes NVFP4 + LoRA through **dequant→bf16 (one pass) + the bf16 LoRA fwd/bwd kernels**, behind a flag. It is **10.5× faster fwd+bwd at the expert layer on B200** (sm_100) and **2.5× on RTX PRO 6000** (sm_120), bit-exact dequant, all LoRA/dX gradients validated, and FSDP2-safe.

## The change (2 files + 1 test)

**`scattermoe_lora/experts.py`**
- `_prepare_weights_and_lora`: new first branch for `is_nv and gup_lora and down_lora`, gated by `_NVFP4_LORA_DEQUANT_BF16` (env `AXOLOTL_NVFP4_LORA_FUSED=1` reverts). Dequantizes the frozen NVFP4 experts to bf16 `[E, in, out]` and returns a **plain `Tensor`, not an `MXWeights`**. The fused-vs-bf16 dispatch in `ScatterMoELoRA.forward` keys only on `isinstance(expert_weights, MXWeights)` — returning bf16 flips `is_mx=False` and selects the plain bf16 fwd/bwd kernels. A `.recipe` (rebuilds the bf16 weight) keeps the transient **recomputed in backward**, not pinned across depth.
- **Fused bf16 backward**: `is_mx=True` force-enables the fused dX/gather backward, but the new `is_mx=False` path was defaulting it off (the slower non-fused base + Python LoRA dX). Threaded a `use_fused_bwd` flag so the bf16 path takes the fused `scatter2scatter_lora_dX`, matching the MXFP4 path. Default on; env `AXOLOTL_NVFP4_LORA_NONFUSED_BWD=1` reverts.

**`scattermoe_lora/selective_dequant_kernel.py`**
- `dequant_nvfp4_full_triton` + `_nvfp4_dequant_kernel`: a one-pass NVFP4→bf16 Triton kernel (int64 offsets, pow2-`C` constexpr shifts, E2M1 LUT, in-kernel E4M3 block-16 scale decode). Folds the optional `per_tensor_scale` **in-kernel in fp32** (scalar / per-expert `[E]` / `[E,1,1]`), single-rounding.
- Why a custom kernel: torchao's eager `NVFP4Tensor.dequantize()` materializes ~145 GB of unfused fp32 intermediates (~164 ms at E=256) — slower than the fused kernel; and `torch.compile` of the subclass `.dequantize()` *miscompiles* (fast but numerically wrong). The custom kernel is ~7 ms and bit-exact.

**`tests/.../scattermoe_lora/test_nvfp4_dequant.py`** (new, GPU-gated): asserts the dequant is **bit-exact** (`torch.equal`) with the validated linear fold for `per_tensor_scale` = None / scalar / per-expert, in fp32 and bf16.

## Validation

| | result | evidence |
|---|---|---|
| Forward FAST-vs-fused | rel 2.9e-3 (bf16 floor) | — |
| fwd+bwd grads (dX, dA/dB) | match fused ref (≤1.0e-2) | — |
| Dequant incl. `per_tensor_scale` | **bit-exact** vs validated fold (None/scalar/per-expert) | new test, 6/6 |
| Expert layer fwd+bwd | **10.5× B200 / 13.2× B200 E128 / 2.5× RTX** | — |
| Full reduced-model step (B200) | **6.38×** (experts = 93% of per-layer time) | — |
| **FSDP2** (2×RTX, single node) | sharded grads match unsharded; dX bit-exact | — |

## Design decisions

- **dequant→bf16, not fp8/fp4.** FP4×FP4-native wins (3.3×) only on the bandwidth-bound RTX PRO 6000 *and* needs FP4 activations (a quality risk). bf16 is the universal, safe win. See the follow-up below for fp8-read.
- **NVFP4 only.** MXFP4 stays on the fused path (different block-32 ue8m0 scale decode). Future work.
- **Memory:** the bf16 transient is ~2× the packed-FP4 bytes (+~5.6 GB/layer at E=128, +~11 GB at E=256), recomputed-in-backward via `.recipe` so it isn't pinned across depth. The flag lets users trade speed for memory.

## Honest caveats

- **FSDP2 validated** on 2×RTX PRO 6000 (single node); not yet exercised multi-node (cross-node NCCL) — the sharding logic is identical.
- The baseline is the as-shipped (autotuned) fused kernel.
- **Dense routing assumed** (LoRA fine-tuning at non-trivial batch×seq hits all experts): the path dequantizes all E experts. A sparse-routing selective dequant would help tiny-batch/eval — deferred.

## Follow-up opportunity (not in this PR): fp8-read grouped GEMM

The bf16 path reads the full bf16 weight each pass. A custom **fp8-read** grouped kernel — read the fp8-packed weight (~half the bytes), upcast to bf16 **in-register**, bf16 MMA — halves the weight bandwidth. Measured (forward GEMM microbench): **1.79× on RTX PRO 6000** (bandwidth-bound) but only **~1.1–1.15× on B200/B300** (not bandwidth-bound at HBM3e). Capturing it needs a custom fp8-read kernel for **both** forward and the dX backward (and both weight orientations) plus end-to-end validation. Deferred because the datacenter payoff is small and the win is workstation-skewed; the bf16 path here is the load-bearing, universally-validated win.
