### PR TITLE
perf(scattermoe): NVFP4+LoRA fp8-read split path (sm_120 memory win)

### DIFF
--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -23,9 +23,20 @@ _NVFP4_LORA_DEQUANT_BF16 = os.environ.get("AXOLOTL_NVFP4_LORA_FUSED", "0") != "1
 # the non-fused backward (fallback + A/B measurement). dA/dB are unaffected (the fused-gather
 # threshold leaves the grouped-Gram path, which is already optimal at high expert counts).
 _NVFP4_LORA_FUSED_BWD = os.environ.get("AXOLOTL_NVFP4_LORA_NONFUSED_BWD", "0") != "1"
+# fp8-READ variant of the NVFP4+LoRA fast path (workstation Blackwell / sm_120). Materialize the
+# frozen NVFP4 weight as fp8 (e4m3) instead of bf16 and read it in the grouped GEMM, upcasting to
+# bf16 in-register (bf16 MMA, bf16 activations) — half the weight bytes on the bandwidth-bound
+# expert GEMM (~1.3x fwd+bwd on sm_120). Routed through the split/non-fused kernels (the fused
+# LoRA kernel serializes the fp8 upcast and loses). Default OFF: the datacenter gain is small and
+# the split overhead regresses there, and it adds ~2.5% to the (already accepted) NVFP4 weight
+# error. AXOLOTL_NVFP4_LORA_FP8_READ=1 enables (NVFP4 + LoRA only). See selective_dequant_kernel.
+_NVFP4_LORA_FP8_READ = os.environ.get("AXOLOTL_NVFP4_LORA_FP8_READ", "0") == "1"
 from .parallel_experts import flatten_sort_count, parallel_linear
 from .parallel_linear_lora import get_lora_params_from_wrapper, parallel_linear_lora
-from .selective_dequant_kernel import dequant_nvfp4_full_triton
+from .selective_dequant_kernel import (
+    dequant_nvfp4_fp8_triton,
+    dequant_nvfp4_full_triton,
+)
 from .selective_dequant import (
     get_active_experts,
     is_mxfp4_param,
@@ -103,6 +114,22 @@ def _get_base_param(param):
     except ImportError:
         pass
     return param
+
+
+def _fp8_read_arch_ok(device=None) -> bool:
+    """Whether the fp8-read path should activate on this GPU.
+
+    fp8-read wins only in the weight-bandwidth-bound regime: workstation Blackwell (sm_120,
+    GDDR7). On datacenter Blackwell (sm_100 / sm_103, HBM) the expert GEMM is compute/MMA-bound,
+    fp8 ≈ bf16, and the split structure is slower than the fused kernel -> a regression. So gate
+    fp8-read to the validated sm_120; everywhere else falls back to the universal bf16-read path.
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        return torch.cuda.get_device_capability(device) == (12, 0)
+    except Exception:
+        return False
 
 
 def _parallel_linear_maybe_lora(
@@ -185,6 +212,40 @@ def _prepare_weights_and_lora(
     is_mx, is_nv = is_mxfp4_param(gu_param), is_nvfp4_param(gu_param)
     use_fused_bwd = False
     if (
+        is_nv
+        and _NVFP4_LORA_DEQUANT_BF16
+        and _NVFP4_LORA_FP8_READ
+        and _fp8_read_arch_ok(_get_base_param(gu_param).device)
+        and gup_lora is not None
+        and down_lora is not None
+    ):
+        # NVFP4 + LoRA fp8-READ PATH (sm_120 / workstation): dequant the frozen NVFP4 experts to
+        # fp8 (e4m3) once; the base scatter2scatter reads fp8 and upcasts to bf16 in-register
+        # (half the bf16 weight bytes -> ~1.3x fwd+bwd on the bandwidth-bound expert GEMM). Forced
+        # onto the SPLIT / NON-fused path (use_fused_bwd=False): the FUSED LoRA kernel serializes
+        # the fp8->bf16 upcast (~0.7x) while the base scatter pipelines it cleanly (~1.7x), so
+        # split (base fp8 + bf16 LoRA fwd, base fp8 dX + bf16 LoRA dX) wins. No per-expert scale
+        # (it does not improve output quality; b19). `scatter2scatter_lora` routes fp8 W -> split,
+        # and `ScatterMoELoRA.forward` skips the host bf16 upcast for fp8. A .recipe rebuilds the
+        # fp8 weight in backward (transient, like the bf16 path).
+        gate_up_weight = dequant_nvfp4_fp8_triton(gu_param, scale_mode="none")[0].transpose(2, 1)
+        down_weight = dequant_nvfp4_fp8_triton(dn_param, scale_mode="none")[0].transpose(2, 1)
+        use_fused_bwd = False  # split/non-fused: fp8 wins only off the fused kernel
+        if module is not None:
+            gate_up_weight.recipe = lambda m=module: dequant_nvfp4_fp8_triton(
+                _get_base_param(m.gate_up_proj), scale_mode="none"
+            )[0].transpose(2, 1)
+            down_weight.recipe = lambda m=module: dequant_nvfp4_fp8_triton(
+                _get_base_param(m.down_proj), scale_mode="none"
+            )[0].transpose(2, 1)
+        else:
+            gate_up_weight.recipe = lambda p=gu_param: dequant_nvfp4_fp8_triton(
+                p, scale_mode="none"
+            )[0].transpose(2, 1)
+            down_weight.recipe = lambda p=dn_param: dequant_nvfp4_fp8_triton(
+                p, scale_mode="none"
+            )[0].transpose(2, 1)
+    elif (
         is_nv
         and _NVFP4_LORA_DEQUANT_BF16
         and gup_lora is not None

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -4,11 +4,28 @@ PEFT LoRA on ``gate_up_proj`` / ``down_proj`` is fused into the
 ScatterMoE Triton call via ``parallel_linear_lora``.
 """
 
+import os
+
 import torch
 
 from .mx_weights import selective_mx_weights_fwd, selective_nvfp4_weights_fwd
+
+# NVFP4 + LoRA fast path: dequantize the frozen FP4 experts to bf16 ONCE and run the plain
+# bf16 LoRA grouped GEMM (fwd+bwd), instead of the fused kernel that re-dequantizes FP4
+# inside the GEMM K-loop. The fused FP4 dequant starves the tensor cores; routing through
+# the bf16 grouped GEMM is far faster (~15x fwd+bwd at the expert layer on B200/B300) at the
+# cost of a transient bf16 weight (~2x the packed-FP4 bytes), kept transient via the same
+# recompute-in-backward recipe. Set AXOLOTL_NVFP4_LORA_FUSED=1 to fall back to the fused path.
+_NVFP4_LORA_DEQUANT_BF16 = os.environ.get("AXOLOTL_NVFP4_LORA_FUSED", "0") != "1"
+# Within that bf16 fast path, also run the fused dX backward kernel (scatter2scatter_lora_dX)
+# instead of the non-fused base scatter2scatter + Python LoRA dX — the same backward fusion the
+# MXFP4 fused path forces internally. Default on; AXOLOTL_NVFP4_LORA_NONFUSED_BWD=1 reverts to
+# the non-fused backward (fallback + A/B measurement). dA/dB are unaffected (the fused-gather
+# threshold leaves the grouped-Gram path, which is already optimal at high expert counts).
+_NVFP4_LORA_FUSED_BWD = os.environ.get("AXOLOTL_NVFP4_LORA_NONFUSED_BWD", "0") != "1"
 from .parallel_experts import flatten_sort_count, parallel_linear
 from .parallel_linear_lora import get_lora_params_from_wrapper, parallel_linear_lora
+from .selective_dequant_kernel import dequant_nvfp4_full_triton
 from .selective_dequant import (
     get_active_experts,
     is_mxfp4_param,
@@ -100,8 +117,13 @@ def _parallel_linear_maybe_lora(
     grouped_out,
     gates=None,
     expert_biases=None,
+    use_fused_bwd=False,
 ):
-    """Call parallel_linear or parallel_linear_lora depending on whether LoRA is active."""
+    """Call parallel_linear or parallel_linear_lora depending on whether LoRA is active.
+
+    ``use_fused_bwd`` selects the fused dX / gather backward kernels (the NVFP4->bf16
+    fast path opts in, matching what the fused MXFP4 path forces internally).
+    """
     if lora_tuple is not None:
         lora_A, lora_B, scaling = lora_tuple
         return parallel_linear_lora(
@@ -118,6 +140,8 @@ def _parallel_linear_maybe_lora(
             grouped_in=grouped_in,
             grouped_out=grouped_out,
             gates=gates,
+            use_fused_dX=use_fused_bwd,
+            use_fused_gather=use_fused_bwd,
         )
     return parallel_linear(
         x,
@@ -154,10 +178,49 @@ def _prepare_weights_and_lora(
     fused kernel is LoRA-only and the FP4 tensors have no transpose).
 
     Returns ``(gate_up_weight, down_weight, sorted_expert_idxs, expert_offsets,
-    gup_lora, down_lora)``.
+    gup_lora, down_lora, use_fused_bwd)``. ``use_fused_bwd`` is True only for the
+    NVFP4->bf16 fast path, where the fused dX / gather backward kernels apply (as the
+    fused MXFP4 path forces internally); the bf16 base/no-LoRA paths leave it False.
     """
     is_mx, is_nv = is_mxfp4_param(gu_param), is_nvfp4_param(gu_param)
-    if (is_mx or is_nv) and gup_lora is not None and down_lora is not None:
+    use_fused_bwd = False
+    if (
+        is_nv
+        and _NVFP4_LORA_DEQUANT_BF16
+        and gup_lora is not None
+        and down_lora is not None
+    ):
+        # NVFP4 + LoRA FAST PATH: dequant->bf16 once, then the plain bf16 LoRA grouped GEMM.
+        # Returning bf16 [E, in, out] (not an MXWeights) flips ScatterMoELoRA to is_mx=False,
+        # selecting the bf16 fwd/bwd kernels. A .recipe that rebuilds bf16 keeps the (larger)
+        # transient weight recomputed in backward rather than pinned across depth. Routing and
+        # LoRA tuples are passed through unchanged (no active-expert compaction needed: the
+        # bf16 grouped GEMM indexes the full [E,...] set, and training routing is dense).
+        gate_up_weight = dequant_nvfp4_full_triton(gu_param, dtype).transpose(2, 1)
+        down_weight = dequant_nvfp4_full_triton(dn_param, dtype).transpose(2, 1)
+        # is_mx=False here (plain bf16 Tensor), so ScatterMoELoRA won't auto-force the
+        # fused backward the way the MXFP4 path does — opt in explicitly so the bf16 dX
+        # runs the fused scatter2scatter_lora_dX kernel instead of base + Python LoRA.
+        use_fused_bwd = _NVFP4_LORA_FUSED_BWD
+        if module is not None:
+            gate_up_weight.recipe = (
+                lambda m=module, d=dtype: dequant_nvfp4_full_triton(
+                    _get_base_param(m.gate_up_proj), d
+                ).transpose(2, 1)
+            )
+            down_weight.recipe = (
+                lambda m=module, d=dtype: dequant_nvfp4_full_triton(
+                    _get_base_param(m.down_proj), d
+                ).transpose(2, 1)
+            )
+        else:
+            gate_up_weight.recipe = (
+                lambda p=gu_param, d=dtype: dequant_nvfp4_full_triton(p, d).transpose(2, 1)
+            )
+            down_weight.recipe = (
+                lambda p=dn_param, d=dtype: dequant_nvfp4_full_triton(p, d).transpose(2, 1)
+            )
+    elif (is_mx or is_nv) and gup_lora is not None and down_lora is not None:
         select = selective_mx_weights_fwd if is_mx else selective_nvfp4_weights_fwd
         active = get_active_experts(sorted_expert_idxs, num_experts)
         sorted_expert_idxs, expert_offsets = remap_expert_indices(
@@ -210,6 +273,7 @@ def _prepare_weights_and_lora(
         expert_offsets,
         gup_lora,
         down_lora,
+        use_fused_bwd,
     )
 
 
@@ -363,6 +427,7 @@ def scattermoe_experts_forward(
         expert_offsets,
         gup_lora,
         down_lora,
+        use_fused_bwd,
     ) = _prepare_weights_and_lora(
         _get_base_param(self.gate_up_proj),
         _get_base_param(self.down_proj),
@@ -386,6 +451,7 @@ def scattermoe_experts_forward(
         gup_lora,
         grouped_in=False,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     gates, h = gates_h.chunk(2, dim=-1)
     # Clamped SwiGLU when the model defines a swiglu_limit (e.g. DeepSeek-V4: limit=10) —
@@ -409,6 +475,7 @@ def scattermoe_experts_forward(
         grouped_in=True,
         grouped_out=False,
         gates=routing_weights,
+        use_fused_bwd=use_fused_bwd,
     )
 
     return output
@@ -465,7 +532,7 @@ def scattermoe_experts_forward_ep(
     elif _has_peft_wrapper(self):
         _, gup_lora, down_lora = _unwrap_experts_lora(self)
 
-    gate_up_weight, down_weight, se, expert_offsets, gup_lora, down_lora = (
+    gate_up_weight, down_weight, se, expert_offsets, gup_lora, down_lora, use_fused_bwd = (
         _prepare_weights_and_lora(
             _get_base_param(self.gate_up_proj),
             _get_base_param(self.down_proj),
@@ -491,6 +558,7 @@ def scattermoe_experts_forward_ep(
         gup_lora,
         grouped_in=True,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     gates, h = gates_h.chunk(2, dim=-1)
     _limit = getattr(self, "limit", None)
@@ -509,6 +577,7 @@ def scattermoe_experts_forward_ep(
         down_lora,
         grouped_in=True,
         grouped_out=True,
+        use_fused_bwd=use_fused_bwd,
     )
     down_out = down_out * w_sorted.unsqueeze(-1)
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -737,6 +737,27 @@ def scatter2scatter_lora(
     K = W.size(1)
     N = W.size(2)
 
+    # fp8-read weight: always route through the SPLIT path (base fp8 grouped GEMM + bf16 LoRA).
+    # The FUSED LoRA kernel serializes the in-register fp8->bf16 upcast (its two dots + extra
+    # A-tile load break the pipeline -> ~0.7x vs bf16); the base scatter2scatter reads fp8
+    # cleanly (~1.7x), so split wins for fp8 regardless of expert count.
+    if W.dtype == torch.float8_e4m3fn:
+        return _scatter2scatter_lora_split(
+            X,
+            W,
+            sorted_expert_idxs,
+            sorted_scattered_idxs,
+            k,
+            lora_A,
+            lora_B,
+            scaling,
+            b,
+            x_grouped,
+            y_grouped,
+            out,
+            int64_indices=int64_indices,
+        )
+
     # Dispatch: split for few large experts, fused for many small experts
     if E <= _SPLIT_LORA_FWD_MAX_EXPERTS and K * N >= _SPLIT_LORA_FWD_THRESHOLD:
         return _scatter2scatter_lora_split(

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
@@ -55,7 +55,10 @@ def _compute_expert_block(
 
         X_blk_ptrs += BLOCK_K * stride_xk
         W_blk_ptrs += BLOCK_K * stride_wk
-        acc = tl.dot(x, w, acc, allow_tf32=allow_tf32)
+        # Upcast the weight tile to the activation dtype in-register. A no-op when W is already
+        # bf16/fp16; for an fp8 (e4m3) fp8-read weight it is the half-bandwidth upcast that lets
+        # the base grouped GEMM read fp8 and run a bf16 MMA (NVFP4+LoRA fp8-read fast path).
+        acc = tl.dot(x, w.to(x.dtype), acc, allow_tf32=allow_tf32)
     return acc
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/parallel_linear_lora.py
@@ -75,8 +75,14 @@ class ScatterMoELoRA(torch.autograd.Function):
             )
             is_mx = True
         else:
-            # Cast weights to match input dtype (e.g. 8-bit LoRA)
-            if expert_weights.dtype != x.dtype:
+            # Cast weights to match input dtype (e.g. 8-bit LoRA) — but NOT an fp8 (e4m3)
+            # fp8-read weight, which the grouped kernel upcasts to bf16 in-register; host-casting
+            # it here would materialize the full bf16 weight and discard the fp8-read bandwidth
+            # win. The fp8 path is routed to the split/non-fused kernels (which read fp8 directly).
+            if (
+                expert_weights.dtype != x.dtype
+                and expert_weights.dtype != torch.float8_e4m3fn
+            ):
                 expert_weights = expert_weights.to(x.dtype)
             is_mx = False
         if expert_biases is not None and expert_biases.dtype != x.dtype:

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
@@ -284,3 +284,97 @@ def dequant_nvfp4_full_triton(nv_param, dtype: torch.dtype = torch.bfloat16) -> 
         BLOCK=BLOCK,
     )
     return out.reshape(*lead, C)
+
+
+# --- NVFP4 -> fp8 (e4m3) fast dequant for the fp8-READ grouped GEMM --------------------------
+# Same one-pass kernel, fp8 output: read the frozen NVFP4 weight as fp8 (half the bf16 bytes),
+# upcast to bf16 in-register, bf16 MMA -- a weight-bandwidth win on the bandwidth-bound expert
+# GEMM (W8-read / A16, no fp8 activations -> no activation-quality risk). e4m3 (3 mantissa, ~6%
+# step) is finer than the 4-bit NVFP4 source, so the re-quant is near-free quality-wise PROVIDED
+# the dequantized values land in e4m3's normal range. A per-expert POWER-OF-TWO scale shifts
+# small weights off the subnormal floor (min normal 2^-6); being pow2 it is an exact exponent
+# shift (1/S exact), so the only error is e4m3 mantissa rounding -- and the GEMM undoes it with a
+# single per-expert multiply of the base accumulator.
+
+
+def _nvfp4_per_expert_amax_ub(nv_param) -> torch.Tensor:
+    """Cheap per-expert amax UPPER BOUND from the scale tensor (no bf16 dequant pass).
+
+    The largest dequantized magnitude in expert ``e`` is at most ``6.0`` (max |E2M1|) times that
+    expert's max block scale (times the per_tensor_scale). Reducing over ``scale`` (16x smaller
+    than ``qdata``) gives a safe bound -> the derived pow2 scale never overflows e4m3.
+    """
+    sc = nv_param.scale  # [E, rows, C/16] e4m3 (or [rows, C/16] for a single expert)
+    e = sc.shape[0]
+    per_e = sc.reshape(e, -1).to(torch.float32).abs().amax(dim=1) * 6.0
+    pts = getattr(nv_param, "per_tensor_scale", None)
+    if pts is not None:
+        pf = pts.reshape(-1).to(torch.float32)
+        per_e = per_e * (pf if pf.numel() == e else pf.expand(e))
+    return per_e.clamp_min(1e-12)
+
+
+def dequant_nvfp4_fp8_triton(nv_param, scale_mode: str = "perexpert"):
+    """Dequantize a full NVFP4Tensor expert weight ``[E, N, K]`` to fp8 (e4m3) in one pass.
+
+    Returns ``(w_fp8, inv_scale)`` where ``w_fp8`` is ``torch.float8_e4m3fn`` of the same shape
+    and ``inv_scale`` is the per-expert reciprocal scale to undo in the GEMM (``None`` for
+    ``scale_mode="none"``). ``scale_mode="perexpert"`` applies an exact per-expert pow2 scale so
+    the weights use e4m3's normal range; the grouped kernel multiplies the base accumulator by
+    ``inv_scale[e]`` once per expert.
+    """
+    qd, sc = nv_param.qdata, nv_param.scale
+    lead = qd.shape[:-1]
+    C2 = qd.shape[-1]
+    C = C2 * 2
+    assert C & (C - 1) == 0, f"NVFP4 fp8 dequant needs power-of-2 last dim, got {C}"
+    rows = 1
+    for d in lead:
+        rows *= d
+    total = rows * C
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+
+    pts = getattr(nv_param, "per_tensor_scale", None)
+    n_experts = lead[0] if len(lead) > 1 else 1
+
+    if scale_mode == "none":
+        return dequant_nvfp4_full_triton(nv_param, torch.float8_e4m3fn), None
+
+    if scale_mode != "perexpert":
+        raise ValueError(f"unknown scale_mode {scale_mode!r}")
+
+    # Per-expert pow2 scale mapping amax -> ~256 (mid e4m3, headroom to 448).
+    amax = _nvfp4_per_expert_amax_ub(nv_param)              # [n_experts] fp32
+    s_exp = torch.floor(torch.log2(256.0 / amax))           # S = 2^s_exp (exact)
+    S = torch.exp2(s_exp)                                    # [n_experts]
+    inv_S = torch.exp2(-s_exp).contiguous()                 # exact reciprocal
+
+    # Fold (per_tensor_scale * S) as a single per-expert multiplier via the kernel's PTS_MODE=2.
+    if pts is None:
+        mult = S
+    elif pts.numel() == 1:
+        mult = pts.reshape(1).to(torch.float32) * S
+    else:
+        mult = pts.reshape(n_experts).to(torch.float32) * S
+    mult = mult.to(torch.float32).contiguous()
+    assert rows % n_experts == 0
+    rows_per_e = rows // n_experts
+
+    out = torch.empty(total, device=qd.device, dtype=torch.float8_e4m3fn)
+    BLOCK = 8192
+    grid = (triton.cdiv(total, BLOCK),)
+    _nvfp4_dequant_kernel[grid](
+        qd.reshape(-1).contiguous(),
+        sc.reshape(-1).contiguous(),
+        lut,
+        out,
+        mult,
+        total,
+        C=C,
+        C2=C2,
+        C16=C // 16,
+        ROWS_PER_E=rows_per_e,
+        PTS_MODE=2,
+        BLOCK=BLOCK,
+    )
+    return out.reshape(*lead, C), inv_S

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/selective_dequant_kernel.py
@@ -177,3 +177,110 @@ def selective_dequant_nf4_triton(
     )
 
     return out.reshape(num_active, *expert_shape)
+
+
+# --- NVFP4 (E2M1 + E4M3 block-16) fast dequant -----------------------------------------
+# torchao's eager ``NVFP4Tensor.dequantize()`` materializes large unfused fp32 intermediates
+# (~145 GB / ~164 ms at E=256) and torch.compile miscompiles its subclass dispatch, so the
+# NVFP4+LoRA fast path needs a dedicated kernel. One memory-bound pass: unpack the E2M1
+# nibble, gather the codebook, multiply the linear E4M3 block-16 scale. Validated bit-exact
+# vs torchao at E up to 256. (per_tensor_scale is folded outside the kernel.)
+#
+# OCP E2M1 codebook (low nibble first); ``scale`` is the un-swizzled linear E4M3 block scale.
+_NVFP4_E2M1_LUT = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+                   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0]
+
+
+@triton.jit
+def _nvfp4_dequant_kernel(
+    QDATA,  # [R, C/2] uint8 packed E2M1 (2 nibbles/byte, low=col 2j, high=col 2j+1)
+    SCALE,  # [R, C/16] E4M3 linear block scale
+    LUT,    # [16] fp32 E2M1 codebook
+    OUT,    # [R*C] output, dtype = OUT.dtype.element_ty
+    PTS,    # fp32 per_tensor_scale: [1] (scalar) or [E] (per-expert); dummy ptr if unused
+    total,
+    C: tl.constexpr,    # last (contracted) dim; power-of-2 so //C,%C,>>1,>>4 are shifts
+    C2: tl.constexpr,   # C // 2
+    C16: tl.constexpr,  # C // 16
+    ROWS_PER_E: tl.constexpr,  # rows per expert (R // E); for per-expert pts indexing
+    PTS_MODE: tl.constexpr,    # 0 none, 1 scalar, 2 per-expert
+    BLOCK: tl.constexpr,
+):
+    # flat 1D over output elements; int64 offsets (r*C2 reaches ~4e9, int32 overflows).
+    g = tl.program_id(0).to(tl.int64) * BLOCK + tl.arange(0, BLOCK).to(tl.int64)
+    m = g < total
+    r = g // C
+    c = (g % C).to(tl.int32)
+    q = tl.load(QDATA + r * C2 + (c >> 1), mask=m, other=0)
+    nib = tl.where((c & 1) == 1, (q >> 4) & 0xF, q & 0xF).to(tl.int32)
+    val = tl.load(LUT + nib)
+    sc = tl.load(SCALE + r * C16 + (c >> 4), mask=m, other=0.0).to(tl.float32)
+    # Fold per_tensor_scale onto the block scale in fp32, then a single bf16 round at the
+    # store. Folding onto `sc` (not the product) reproduces the validated path's exact
+    # `block_scale * per_tensor` order (mx_weights.py) -> bit-identical, single-rounding.
+    # (A post-store bf16 multiply double-rounds, ~2x the error.)
+    if PTS_MODE == 1:
+        sc = sc * tl.load(PTS).to(tl.float32)
+    elif PTS_MODE == 2:
+        e = r // ROWS_PER_E
+        sc = sc * tl.load(PTS + e, mask=m, other=0.0).to(tl.float32)
+    tl.store(OUT + g, (val * sc).to(OUT.dtype.element_ty), mask=m)
+
+
+def dequant_nvfp4_full_triton(nv_param, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+    """Dequantize a full NVFP4Tensor expert weight ``[E, N, K]`` to ``dtype`` (one pass).
+
+    Drop-in fast replacement for ``nv_param.dequantize(dtype)`` for the un-swizzled linear
+    E4M3-block-16 layout the axolotl loader produces (see ``selective_nvfp4_weights_fwd``),
+    folding the optional ``per_tensor_scale`` in-kernel in fp32 (single rounding, torchao
+    parity). Accepts a scalar pts (the loader's shape) or a per-expert ``[E]`` / ``[E,1,1]``
+    (the FSDP carry shape).
+    """
+    qd, sc = nv_param.qdata, nv_param.scale
+    lead = qd.shape[:-1]
+    C2 = qd.shape[-1]
+    C = C2 * 2
+    assert C & (C - 1) == 0, f"NVFP4 fast dequant needs power-of-2 last dim, got {C}"
+    rows = 1
+    for d in lead:
+        rows *= d
+    total = rows * C
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+
+    # Resolve the per_tensor_scale into a flat fp32 buffer + a mode the kernel folds in fp32.
+    pts = getattr(nv_param, "per_tensor_scale", None)
+    rows_per_e = 1
+    if pts is None:
+        pts_buf = lut  # unused dummy pointer (PTS_MODE=0 never loads it)
+        pts_mode = 0
+    elif pts.numel() == 1:
+        pts_buf = pts.reshape(1).to(torch.float32).contiguous()
+        pts_mode = 1
+    else:
+        # per-expert: leading dim of pts is the expert axis ([E] or [E,1,1]); index by r // (R/E)
+        n_experts = pts.shape[0]
+        assert rows % n_experts == 0, (
+            f"per-expert per_tensor_scale [{n_experts}] does not divide rows {rows}"
+        )
+        rows_per_e = rows // n_experts
+        pts_buf = pts.reshape(n_experts).to(torch.float32).contiguous()
+        pts_mode = 2
+
+    out = torch.empty(total, device=qd.device, dtype=dtype)
+    BLOCK = 8192
+    grid = (triton.cdiv(total, BLOCK),)
+    _nvfp4_dequant_kernel[grid](
+        qd.reshape(-1).contiguous(),
+        sc.reshape(-1).contiguous(),
+        lut,
+        out,
+        pts_buf,
+        total,
+        C=C,
+        C2=C2,
+        C16=C // 16,
+        ROWS_PER_E=rows_per_e,
+        PTS_MODE=pts_mode,
+        BLOCK=BLOCK,
+    )
+    return out.reshape(*lead, C)

--- a/tests/integrations/kernels/scattermoe_lora/test_fp8_read_arch_gate.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_fp8_read_arch_gate.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""The NVFP4 fp8-read path is gated to sm_120 (workstation Blackwell, the validated win).
+
+fp8-read wins only in the weight-bandwidth-bound regime; on datacenter Blackwell (sm_100 /
+sm_103, HBM, compute-bound) it regresses, so the path must auto-fall-back to bf16-read there.
+`_fp8_read_arch_ok` is the gate (added to the fp8 branch of `_prepare_weights_and_lora`). This
+test mocks the device capability, so it needs no GPU.
+"""
+
+from unittest import mock
+
+import pytest
+
+ex = pytest.importorskip(
+    "axolotl.integrations.kernels.libs.scattermoe_lora.experts",
+    reason="triton/torchao required to import the experts module",
+)
+
+
+def test_arch_gate_requires_cuda():
+    with mock.patch("torch.cuda.is_available", return_value=False):
+        assert ex._fp8_read_arch_ok() is False
+
+
+def test_arch_gate_enables_only_sm120():
+    with mock.patch("torch.cuda.is_available", return_value=True):
+        with mock.patch("torch.cuda.get_device_capability", return_value=(12, 0)):
+            assert ex._fp8_read_arch_ok() is True  # sm_120 workstation Blackwell
+        # datacenter Blackwell + every other arch must fall back to bf16-read
+        for cap in [(10, 0), (10, 3), (9, 0), (12, 1), (8, 6), (8, 0)]:
+            with mock.patch("torch.cuda.get_device_capability", return_value=cap):
+                assert ex._fp8_read_arch_ok() is False, f"sm_{cap[0]}{cap[1]} should disable fp8-read"

--- a/tests/integrations/kernels/scattermoe_lora/test_nvfp4_dequant.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_nvfp4_dequant.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""dequant_nvfp4_full_triton matches the validated NVFP4 linear fold, bit-exactly.
+
+The NVFP4 + LoRA fast path dequantizes the frozen experts to bf16 once via a custom Triton
+kernel (the eager ``NVFP4Tensor.dequantize()`` materializes ~145 GB of unfused intermediates
+and ``torch.compile`` miscompiles the subclass). Correctness bar = the SAME linear fold the
+fused path uses (``selective_nvfp4_weights_fwd``: ``LUT[nibble] * (scale_e4m3.float() *
+per_tensor.float())``), which the model's ``test_nvfp4_experts_forward`` already validates.
+
+Covers the three ``per_tensor_scale`` shapes the loader / FSDP carry: None, a shared scalar
+(what the loader emits), and a per-expert ``[E, 1, 1]``. The in-kernel fp32 fold must be
+bit-exact against the reference in every case (a post-store bf16 multiply double-rounds, and a
+bare ``[E]`` per-expert scale previously crashed on a broadcast mismatch).
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+NVFP4Tensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.nvfp4_tensor", reason="torchao required"
+).NVFP4Tensor
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant_kernel import (  # noqa: E402
+    _NVFP4_E2M1_LUT,
+    dequant_nvfp4_full_triton,
+)
+
+DEV = "cuda"
+E, ROWS, COLS = 8, 256, 512  # [E, N, K]; K power-of-2 (kernel requirement)
+
+
+def _validated_fold(nv, dtype=torch.float32):
+    """The fused path's exact linear fold (mx_weights.selective_nvfp4_weights_fwd):
+    value = LUT[nibble] * (scale_e4m3.float() * per_tensor.float())."""
+    qd = nv.qdata
+    scale_f = nv.scale.to(torch.float32)
+    pts = getattr(nv, "per_tensor_scale", None)
+    if pts is not None:
+        scale_f = scale_f * pts.to(torch.float32)
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+    lo = lut[(qd & 0xF).long()]
+    hi = lut[((qd >> 4) & 0xF).long()]
+    val = torch.stack([lo, hi], dim=-1).reshape(*qd.shape[:-1], qd.shape[-1] * 2)
+    return (val * scale_f.repeat_interleave(16, dim=-1)).to(dtype)
+
+
+def _build(pts_mode):
+    g = torch.Generator(device=DEV).manual_seed(0)
+    t = torch.randn(E, ROWS, COLS, device=DEV, dtype=torch.bfloat16, generator=g) * 0.1
+    if pts_mode == "none":
+        return NVFP4Tensor.to_nvfp4(t, block_size=16)
+    if pts_mode == "scalar":
+        pts = (t.abs().amax() / (6.0 * 448.0)).to(torch.float32)  # mirrors the loader's gpts
+        return NVFP4Tensor.to_nvfp4(t, block_size=16, per_tensor_scale=pts)
+    # per-expert [E,1,1]: a valid NVFP4 tensor carrying a per-expert scale (FSDP carry shape)
+    nv = NVFP4Tensor.to_nvfp4(t, block_size=16)
+    nv.per_tensor_scale = (
+        torch.rand(E, 1, 1, device=DEV, generator=g).to(torch.float32) + 0.5
+    )
+    return nv
+
+
+@pytest.mark.parametrize("pts_mode", ["none", "scalar", "perexpert"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_dequant_matches_validated_fold(pts_mode, dtype):
+    nv = _build(pts_mode)
+    ours = dequant_nvfp4_full_triton(nv, dtype)
+    ref = _validated_fold(nv, dtype)
+    assert ours.shape == ref.shape == (E, ROWS, COLS)
+    # The fp32 fold is computed identically (LUT * scale * pts), so the kernel must match the
+    # reference exactly at fp32 and after the single bf16 round.
+    assert torch.equal(ours, ref), (
+        f"{pts_mode}/{dtype}: max rel "
+        f"{(ours - ref).float().abs().max().item() / max(ref.float().abs().max().item(), 1e-9):.2e}"
+    )

--- a/tests/integrations/kernels/scattermoe_lora/test_nvfp4_fp8_read.py
+++ b/tests/integrations/kernels/scattermoe_lora/test_nvfp4_fp8_read.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""dequant_nvfp4_fp8_triton produces the NVFP4 weights as fp8 (e4m3) for the fp8-read path.
+
+The NVFP4 + LoRA fp8-read fast path (workstation Blackwell / sm_120) materializes the frozen
+experts as fp8 instead of bf16, halving the transient weight, and the base grouped GEMM upcasts
+to bf16 in-register. The fp8 dequant runs the same one-pass NVFP4 kernel with an fp8 store, so it
+must equal the validated linear fold computed in fp32 and rounded once to fp8 (a single
+fp32->fp8 round, not fp32->bf16->fp8). ``scale_mode="none"`` (the shipped path, no per-expert
+scale) carries no reciprocal; ``scale_mode="perexpert"`` returns a reciprocal that reconstructs
+the weight after the kernel's per-expert pow2 scale.
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+NVFP4Tensor = pytest.importorskip(
+    "torchao.prototype.mx_formats.nvfp4_tensor", reason="torchao required"
+).NVFP4Tensor
+
+from axolotl.integrations.kernels.libs.scattermoe_lora.selective_dequant_kernel import (  # noqa: E402
+    _NVFP4_E2M1_LUT,
+    dequant_nvfp4_fp8_triton,
+    dequant_nvfp4_full_triton,
+)
+
+DEV = "cuda"
+E, ROWS, COLS = 8, 256, 512  # [E, N, K]; K power-of-2 (kernel requirement)
+F8 = torch.float8_e4m3fn
+
+
+def _validated_fold_fp32(nv):
+    """The fused path's exact linear fold in fp32: LUT[nibble] * (scale_e4m3 * per_tensor)."""
+    qd = nv.qdata
+    scale_f = nv.scale.to(torch.float32)
+    pts = getattr(nv, "per_tensor_scale", None)
+    if pts is not None:
+        scale_f = scale_f * pts.to(torch.float32)
+    lut = torch.tensor(_NVFP4_E2M1_LUT, device=qd.device, dtype=torch.float32)
+    lo = lut[(qd & 0xF).long()]
+    hi = lut[((qd >> 4) & 0xF).long()]
+    val = torch.stack([lo, hi], dim=-1).reshape(*qd.shape[:-1], qd.shape[-1] * 2)
+    return val * scale_f.repeat_interleave(16, dim=-1)
+
+
+def _build(pts_mode):
+    g = torch.Generator(device=DEV).manual_seed(0)
+    t = torch.randn(E, ROWS, COLS, device=DEV, dtype=torch.bfloat16, generator=g) * 0.1
+    if pts_mode == "none":
+        return NVFP4Tensor.to_nvfp4(t, block_size=16)
+    pts = (t.abs().amax() / (6.0 * 448.0)).to(torch.float32)  # mirrors the loader's gpts
+    return NVFP4Tensor.to_nvfp4(t, block_size=16, per_tensor_scale=pts)
+
+
+@pytest.mark.parametrize("pts_mode", ["none", "scalar"])
+def test_fp8_noscale_matches_fold_cast(pts_mode):
+    """scale_mode="none" == the validated fp32 fold rounded once to fp8 (no reciprocal)."""
+    nv = _build(pts_mode)
+    out, inv_s = dequant_nvfp4_fp8_triton(nv, scale_mode="none")
+    assert out.dtype == F8 and out.shape == (E, ROWS, COLS)
+    assert inv_s is None
+    ref = _validated_fold_fp32(nv).to(F8)
+    assert torch.equal(out, ref), (
+        f"{pts_mode}: fp8 dequant != fold-cast-to-fp8 "
+        f"(max |Δ| {(out.float() - ref.float()).abs().max().item():.2e})"
+    )
+
+
+@pytest.mark.parametrize("pts_mode", ["none", "scalar"])
+def test_fp8_perexpert_reconstructs(pts_mode):
+    """scale_mode="perexpert": fp8(S·W) · (1/S) reconstructs the weight; pow2 S keeps 1/S exact,
+    and using the e4m3 normal range is no worse than the no-scale fp8 vs the bf16 reference."""
+    nv = _build(pts_mode)
+    out, inv_s = dequant_nvfp4_fp8_triton(nv, scale_mode="perexpert")
+    assert out.dtype == F8 and inv_s is not None and inv_s.numel() == E
+    recon = out.float() * inv_s.reshape(E, 1, 1).float()
+    ref = dequant_nvfp4_full_triton(nv, torch.bfloat16).float()  # the bf16-read weight
+    rel = (recon - ref).norm() / ref.norm()
+    assert torch.isfinite(recon).all() and rel < 0.05, f"{pts_mode}: relL2 {rel:.3e}"


### PR DESCRIPTION
> **Stacked on #3743** (the NVFP4→bf16 fast path). Until that merges, this PR's diff also shows its commit; the fp8-read commit is the top one. Rebase/retarget onto the branch once #3743 lands.


## Summary

#3743 dequantizes the frozen NVFP4 experts to **bf16** once and runs the bf16 LoRA grouped GEMM
(10.5× B200 / 2.5× RTX vs the fused FP4 kernel). This follow-up adds an **fp8-read** variant: keep
the dequantized weight in **fp8 (e4m3)** instead of bf16, read it in the grouped GEMM, and upcast to
bf16 **in-register** (bf16 MMA, bf16 activations — W8-read / A16, no fp8 activations). The fp8
transient weight is **half** the bf16 one, so it **halves the per-layer weight materialization**.

On the bandwidth-bound workstation expert GEMM this is **~1.36× lower peak memory** (≈6.3 GB/layer
saved at E=256) and **~1.07× faster** fwd+bwd — i.e. **a memory optimization that is roughly
speed-neutral**, behind a flag, default off. **sm_120 (workstation Blackwell) only.**

## The key finding: fp8-read must use the SPLIT path, not the fused LoRA kernel

A standalone grouped GEMM reads fp8 weights ~1.7–1.8× faster than bf16 (weight-bandwidth-bound,
the fp8→bf16 upcast is a near-free HW op). But routing fp8 through the **fused** LoRA kernel
(`scatter2scatter_lora`) is **0.73× — a regression**: the fused kernel's two dots + extra LoRA
A-tile load per K-iteration serialize the in-register fp8→bf16 conversion and expose its latency.

Isolating it: the **base** `scatter2scatter` (no LoRA, same scatter routing) reads fp8 at **1.70×** —
so it is the LoRA *fusion*, not the scatter structure, that breaks fp8. fp8-read therefore routes
through the **split / non-fused** path (base fp8 grouped GEMM + separate bf16 LoRA passes; non-fused
base-fp8 dX + bf16 LoRA-dX) — the opposite of the bf16 path, which prefers the fused kernel. The
isolated split-fp8 forward is ~1.27× over fused-bf16; on the full fwd+bwd this dilutes to ~1.07×
because the dA/dB grouped-Gram, the LoRA passes, and the activation work are all dtype-independent.

## The change (5 files)

- **`kernels/ops.py`** — base `_compute_expert_block`: `tl.dot(x, w.to(x.dtype), ...)` (in-register
  weight upcast; no-op for bf16/fp16, the half-bandwidth upcast for an fp8 weight). Makes the base
  grouped GEMM fp8-read-capable.
- **`kernels/lora_ops.py`** — `scatter2scatter_lora`: route an fp8 (`float8_e4m3fn`) weight to the
  existing `_scatter2scatter_lora_split` (base fp8 + bf16 LoRA) regardless of expert count.
- **`parallel_linear_lora.py`** — `ScatterMoELoRA.forward`: skip the host bf16 upcast for an fp8
  weight (it would discard the fp8-read bandwidth/memory win); the kernels upcast in-register. The
  non-fused dX path (`use_fused_dX=False`) already reads the base weight via `scatter2scatter`, now
  fp8-capable.
- **`experts.py`** — `_prepare_weights_and_lora`: new fp8-read branch (before the bf16 branch, which
  is left untouched) gated by `_NVFP4_LORA_FP8_READ` (env `AXOLOTL_NVFP4_LORA_FP8_READ=1`, default
  off). Dequant NVFP4→fp8, return the fp8 tensor with `use_fused_bwd=False` (split/non-fused) and a
  `.recipe` that rebuilds fp8 in backward.
- **`selective_dequant_kernel.py`** — `dequant_nvfp4_fp8_triton`: one-pass NVFP4→fp8 (reuses the b5
  NVFP4 dequant kernel with an fp8 store). `scale_mode="none"` (no per-expert scale — a pow2 scale
  does **not** improve output quality, b19, because the subnormal weights are small and don't move
  the output).

## Validation (RTX PRO 6000, sm_120)

| | result | evidence |
|---|---|---|
| Forward / grads fp8 vs bf16-read | 3.2e-2 / 3–9e-2 (fp8 weight-error floor) | b21, E=256 |
| Expert-layer fwd+bwd, E=256 | **1.07× speed, 1.36× peak memory** (44.9 vs 48.1 ms; 17.5 vs 23.8 GB) | b21 |
| Expert-layer fwd+bwd, E=128 | 1.01× speed, 1.34× memory | b21 |
| Base scatter2scatter fp8 vs bf16 | 1.70× (the isolated win) | b20d |
| Fused LoRA kernel fp8 (rejected) | 0.73× — why split is used | b20/b20b/b20c |
| Weight-quant error (fp8 vs bf16-read) | +0.0315 relL2 = +2.5% on the NVFP4 error | b19 |
| **FSDP2** (2×RTX, single node) | **PASS — sharded grads bit-exact** (dX + LoRA grads 0.00e+00) | b22 |

## Design decisions

- **Memory, not speed, is the value.** The full fwd+bwd is ~speed-neutral (1.07×); the durable win
  is halving the transient bf16 weight (≈6.3 GB/layer at E=256) on the 96 GB workstation.
- **sm_120-only, enforced.** On datacenter (B200/B300) the expert GEMM is compute/MMA-bound, not
  bandwidth-bound, so fp8 ≈ bf16; and the split structure is slower than fused for bf16 — so fp8-read
  would regress there. An arch gate (`_fp8_read_arch_ok`) makes the flag a **no-op off sm_120**: the
  path auto-falls-back to bf16-read, so the flag is safe on both targets (datacenter not re-measured;
  gated by arch, with a GPU-free mock unit test of the gate).
- **W8-read / A16.** Weights fp8, activations + MMA bf16 — no fp8/fp4 activation quality risk.
- **No per-expert scale** (b19). **NVFP4 only** (MXFP4 keeps the fused path). Default **off**.

## Honest caveats

- The speed win is marginal (1.07× expert layer; ~1.04–1.06× full step after non-expert dilution).
  Ship it for the **memory** headroom, not speed.
- +2.5% on the (already accepted) NVFP4 weight error — the frozen base is perturbed slightly more;
  LoRA adapts around it. Synthetic-weight worst case; real-weight impact likely smaller.
- Datacenter is gated off by arch, not re-measured in this PR.
