### PR TITLE
fix token inf time

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -170,7 +170,6 @@ class ChatTemplatePrompter(Prompter):
     def build_prompt_text(
         self,
         conversation: list[dict],
-        add_generation_prompt=False,
         tools=None,
     ) -> str | None:
         """Render a conversation to text without tokenizing.
@@ -184,7 +183,7 @@ class ChatTemplatePrompter(Prompter):
 
         chat_template_kwargs = {
             "chat_template": self.chat_template,
-            "add_generation_prompt": add_generation_prompt,
+            "add_generation_prompt": False,
             **self.chat_template_kwargs,
         }
 
@@ -695,6 +694,21 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 return i
         return -1
 
+    def _log_fallback_once(self, reason: str):
+        """Note, once per worker, why the fast char-space path is unavailable.
+
+        Preprocessing forks per ``num_proc``, so this fires up to ``num_proc`` times
+        rather than exactly once.
+        """
+        seen = self.__dict__.setdefault("_logged_fallbacks", set())
+        if reason not in seen:
+            seen.add(reason)
+            LOG.info(
+                "chat_template: locating turns via the slower token-diff path (%s). "
+                "Labels are unaffected.",
+                reason,
+            )
+
     def _build_turn_locator(
         self, turns: list[dict], tools: list[dict] | None, input_ids: list[int]
     ) -> tuple[str, list[int], list[int]] | None:
@@ -705,10 +719,12 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         fall back to diffing tokens.
         """
         if not getattr(self.tokenizer, "is_fast", False):
+            self._log_fallback_once("tokenizer is not a fast tokenizer")
             return None
 
         full_text = self.prompter.build_prompt_text(turns, tools=tools)  # type: ignore
         if not full_text:
+            self._log_fallback_once("no plain-text render (processor or empty)")
             return None
 
         encoded = self.tokenizer(
@@ -717,6 +733,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         # Spans are used to index into input_ids, so bail unless re-tokenizing the
         # render reproduces it exactly.
         if list(encoded["input_ids"]) != list(input_ids):
+            self._log_fallback_once("re-tokenized render does not match input_ids")
             return None
 
         offsets = encoded["offset_mapping"]
@@ -726,26 +743,12 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
     # a per-character Python loop here costs more than the tokenization it saves.
     _DIFF_BLOCK = 4096
 
-    @classmethod
-    def _common_prefix_len(cls, left: str, right: str, limit: int) -> int:
-        """Length of the shared prefix of ``left`` and ``right``, capped at ``limit``."""
-        matched = 0
-        block = cls._DIFF_BLOCK
-        while (
-            matched + block <= limit
-            and left[matched : matched + block] == right[matched : matched + block]
-        ):
-            matched += block
-
-        lo, hi = matched, limit
-        while lo < hi:
-            mid = (lo + hi + 1) // 2
-            if left[matched:mid] == right[matched:mid]:
-                lo = mid
-            else:
-                hi = mid - 1
-
-        return lo
+    # Placeholders diffed against the real turn. They share no first or last
+    # character, so an edge char a template glues onto one placeholder (absorbing it
+    # into the diff's common prefix/suffix) is still exposed by the other; the union
+    # of both spans is the true span. Only one field is ever replaced at a time, so a
+    # single string per placeholder covers both content and reasoning.
+    _SENTINELS = ("[[dummy_message]]", "zzdummymessagezz")
 
     @classmethod
     def _diff_char_span(cls, full_text: str, dummy_text: str) -> tuple[int, int]:
@@ -754,44 +757,65 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         The suffix scan is bounded by the prefix match so the two can't overlap when
         the surrounding template repeats itself.
         """
-        limit = min(len(full_text), len(dummy_text))
-        start = cls._common_prefix_len(full_text, dummy_text, limit)
-        suffix = cls._common_prefix_len(
-            full_text[::-1], dummy_text[::-1], limit - start
-        )
 
+        def prefix_len(left: str, right: str, limit: int) -> int:
+            # Block compares stay in C; the char loop only refines the final block.
+            block, i = cls._DIFF_BLOCK, 0
+            while i + block <= limit and left[i : i + block] == right[i : i + block]:
+                i += block
+            while i < limit and left[i] == right[i]:
+                i += 1
+            return i
+
+        limit = min(len(full_text), len(dummy_text))
+        start = prefix_len(full_text, dummy_text, limit)
+        suffix = prefix_len(full_text[::-1], dummy_text[::-1], limit - start)
         return start, len(full_text) - suffix
 
     def _find_turn_from_text(
         self,
         turns: list[dict],
         turn_idx: int,
-        dummy_turn: dict,
+        content_only: bool,
+        reasoning_only: bool,
         tools: list[dict] | None,
         locator: tuple[str, list[int], list[int]],
     ) -> tuple[int, int] | None:
-        """Locate a turn by diffing two full renders in char space.
+        """Locate a turn by diffing the real render against placeholder renders.
 
-        Both renders keep the turn at its original index, so position-dependent
+        Every render keeps the turn at its original index, so position-dependent
         template logic (thinking stripped from non-final turns, tool-call collapsing)
         applies identically to each and cancels out in the diff.
+
+        Three-valued return: ``None`` means "can't resolve here, fall back to the
+        token diff"; ``(-1, -1)`` means "resolved, but the field is absent from the
+        render so there is nothing to label"; a span means the content tokens.
         """
         full_text, token_starts, token_ends = locator
 
-        dummy_text = self.prompter.build_prompt_text(  # type: ignore
-            turns[:turn_idx] + [dummy_turn] + turns[turn_idx + 1 :], tools=tools
-        )
-        if not dummy_text:
-            return None
+        spans = []
+        for sentinel in self._SENTINELS:
+            dummy_turn = self._build_dummy_turn(
+                turns[turn_idx], content_only, reasoning_only, sentinel
+            )
+            dummy_text = self.prompter.build_prompt_text(  # type: ignore
+                turns[:turn_idx] + [dummy_turn] + turns[turn_idx + 1 :], tools=tools
+            )
+            if not dummy_text:
+                return None
+            spans.append(self._diff_char_span(full_text, dummy_text))
 
-        char_start, char_end = self._diff_char_span(full_text, dummy_text)
+        # A diff never extends past the real content (identical template on both
+        # sides), so absorbed edge chars only shrink a span; the widest span across
+        # edge-disjoint sentinels recovers the truth.
+        char_start = min(start for start, _ in spans)
+        char_end = max(end for _, end in spans)
         if char_end <= char_start:
-            # The field never made it into the render, so there is nothing to label.
             return -1, -1
 
-        # Byte-level BPE can split one character across tokens that share a char
-        # offset, so the exclusive end has to come from starts, not ends — bisecting
-        # ends would drop the trailing piece of a multi-token character.
+        # BPE can split one character across tokens sharing an offset, so the
+        # exclusive end comes from starts, not ends: bisecting ends would drop the
+        # trailing piece of a multi-token character.
         start_idx = bisect_right(token_ends, char_start)
         end_idx = bisect_left(token_starts, char_end)
         if start_idx >= len(token_ends) or end_idx > len(token_ends):
@@ -858,30 +882,21 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         return start_idx, end_idx
 
     def _build_dummy_turn(
-        self, turn: dict, content_only: bool, reasoning_only: bool
+        self, turn: dict, content_only: bool, reasoning_only: bool, sentinel: str
     ) -> dict:
         thinking_key = self.prompter.template_thinking_key
 
         if reasoning_only:
-            # Keep content as-is, replace reasoning with dummy
-            dummy_turn = {
-                "role": turn.get("role"),
-                "content": turn.get("content", ""),
-            }
+            # Keep content as-is, replace reasoning with the placeholder.
+            dummy_turn = {"role": turn.get("role"), "content": turn.get("content", "")}
             if thinking_key and thinking_key in turn:
-                dummy_turn[thinking_key] = "[[dummy_reasoning]]"
+                dummy_turn[thinking_key] = sentinel
             return dummy_turn
 
-        dummy_turn = {
-            "role": turn.get("role"),
-            "content": "[[dummy_message]]",
-        }
-
-        # When content_only is True, copy reasoning_content to the dummy turn so
-        # the diff only captures the content field (not reasoning + separator).
+        # Replace content; keep reasoning when content_only so the diff excludes it.
+        dummy_turn = {"role": turn.get("role"), "content": sentinel}
         if content_only and thinking_key and thinking_key in turn:
             dummy_turn[thinking_key] = turn[thinking_key]
-
         return dummy_turn
 
     def find_turn(
@@ -919,16 +934,15 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         ):
             return -1, -1
 
-        dummy_turn = self._build_dummy_turn(
-            turns[turn_idx], content_only, reasoning_only
-        )
-
         span = None
         if locator is not None:
             span = self._find_turn_from_text(
-                turns, turn_idx, dummy_turn, tools, locator
+                turns, turn_idx, content_only, reasoning_only, tools, locator
             )
         if span is None:
+            dummy_turn = self._build_dummy_turn(
+                turns[turn_idx], content_only, reasoning_only, self._SENTINELS[0]
+            )
             span = self._find_turn_from_tokens(turns, turn_idx, dummy_turn, tools)
         if span is None:
             return -1, -1

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -333,9 +333,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             if len(token_ids) == 1:
                 self._eot_token_ids.add(token_ids[0])
 
-        self._fast_spans_disabled = False
-        self._fast_validated_samples = 0
-
     def _validate_eot_and_eos_tokens(self):
         """
         - Validates that EOT tokens (or eos_token) are in the chat_template
@@ -451,6 +448,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             and not self.prompter.message_field_training_detail  # type: ignore
         ):
             turns = self.get_conversation_thread(prompt)
+            if not turns:
+                return {}
             images = self._get_images(prompt)
             prompt_ids = self.prompter.build_prompt(  # type: ignore
                 turns[:-1],
@@ -481,6 +480,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             return tokenized_prompt
 
         turns = self.get_conversation_thread(prompt)
+        if not turns:
+            return {}
         tools = self._get_tools(prompt)
         result = self.prompter.build_prompt(turns, tools=tools)  # type: ignore
         if not isinstance(result, dict):
@@ -702,6 +703,9 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             if input_ids[i] in self._eot_token_ids:
                 return i
         return -1
+
+    _fast_spans_disabled = False
+    _fast_validated_samples = 0
 
     # Number of initial samples whose fast-path spans are cross-checked against the
     # reference find_turn before the fast path is trusted for the remainder of the run.
@@ -989,6 +993,9 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         turns = []
 
         messages = self._get_messages(prompt)
+
+        if not messages:
+            return []
 
         possible_sys_turn = self.transform_message(messages[0])
 

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -3,6 +3,7 @@ HF Chat Templates prompt strategy
 """
 
 import json
+from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
 
@@ -166,6 +167,37 @@ class ChatTemplatePrompter(Prompter):
             **chat_template_kwargs,
         )
 
+    def build_prompt_text(
+        self,
+        conversation: list[dict],
+        add_generation_prompt=False,
+        tools=None,
+    ) -> str | None:
+        """Render a conversation to text without tokenizing.
+
+        Returns ``None`` when the render can't be mapped back to token offsets, i.e.
+        a processor is in play (it splices in image/audio tokens that have no
+        counterpart in the text).
+        """
+        if self.processor:
+            return None
+
+        chat_template_kwargs = {
+            "chat_template": self.chat_template,
+            "add_generation_prompt": add_generation_prompt,
+            **self.chat_template_kwargs,
+        }
+
+        if tools:
+            chat_template_kwargs["tools"] = tools
+
+        text = self.tokenizer.apply_chat_template(
+            conversation,
+            tokenize=False,
+            **chat_template_kwargs,
+        )
+        return text if isinstance(text, str) else None
+
     def get_offsets_for_train_detail(
         self, text: str, train_details: List[Dict], mask_untrainable: bool = True
     ) -> List[int]:
@@ -319,9 +351,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         self.split_thinking = split_thinking
 
         self.images = "images"
-
-        self._fast_spans_disabled = False
-        self._fast_validated_samples = 0
 
         LOG.debug(
             f"The chat template uses the following properites on the message: {self.prompter.chat_template_msg_variables}"
@@ -488,16 +517,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         input_ids = result["input_ids"]
         labels = [IGNORE_TOKEN_ID] * len(input_ids)
 
-        fast_spans = None
-        if not self._fast_spans_disabled and self._fast_spans_supported():
-            fast_spans = self._fast_content_spans(turns, tools, input_ids)
-            if fast_spans is None:
-                self._fast_spans_disabled = True
-        validating = (
-            fast_spans is not None
-            and self._fast_validated_samples < self._FAST_VALIDATION_SAMPLES
-        )
-        used_fast = False
+        locator = self._build_turn_locator(turns, tools, input_ids)
 
         last_eos_idx = -1
         last_eot_idx = -1
@@ -545,38 +565,13 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             # (excluding reasoning_content + template separator tokens).
             use_content_only = bool(has_any_detail and has_reasoning)
 
-            fast_span = (
-                fast_spans.get(index)
-                if (
-                    fast_spans is not None
-                    and not use_content_only
-                    and train_detail is None
-                    and reasoning_train_detail is None
-                )
-                else None
+            turn_start_idx, turn_end_idx = self.find_turn(
+                turns=turns,
+                turn_idx=index,
+                tools=tools,
+                content_only=use_content_only,
+                locator=locator,
             )
-            if fast_span is not None and not validating:
-                turn_start_idx, turn_end_idx = fast_span
-                used_fast = True
-            else:
-                turn_start_idx, turn_end_idx = self.find_turn(
-                    turns=turns,
-                    turn_idx=index,
-                    tools=tools,
-                    content_only=use_content_only,
-                )
-                if fast_span is not None:
-                    used_fast = True
-                    if fast_span != (turn_start_idx, turn_end_idx):
-                        # Fast path disagrees with the reference: disable it for the
-                        # whole run and keep the reference result for this turn.
-                        LOG.warning(
-                            "chat_template fast turn-boundary path disagreed with the "
-                            "reference; disabling it for this run and using find_turn."
-                        )
-                        self._fast_spans_disabled = True
-                        fast_spans = None
-                        validating = False
 
             LOG.debug(f"Turn indices: start={turn_start_idx}, end={turn_end_idx}")
 
@@ -621,6 +616,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                     turn_idx=index,
                     tools=tools,
                     reasoning_only=True,
+                    locator=locator,
                 )
 
                 if reasoning_start != -1 and reasoning_end != -1:
@@ -678,10 +674,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         LOG.debug(f"Final labels: {labels}")
 
-        # Bank a clean sample: once enough have agreed with find_turn, trust the fast path.
-        if used_fast and validating and not self._fast_spans_disabled:
-            self._fast_validated_samples += 1
-
         # ``result`` already carries any processor outputs (pixel_values, image
         # grid info, etc.); just set the fields we computed locally.
         result["labels"] = labels
@@ -703,88 +695,194 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 return i
         return -1
 
-    # Number of initial samples whose fast-path spans are cross-checked against the
-    # reference find_turn before the fast path is trusted for the remainder of the run.
-    _FAST_VALIDATION_SAMPLES = 8
+    def _build_turn_locator(
+        self, turns: list[dict], tools: list[dict] | None, input_ids: list[int]
+    ) -> tuple[str, list[int], list[int]] | None:
+        """Render and tokenize the conversation once so turns can be located in char space.
 
-    def _fast_spans_supported(self) -> bool:
-        """Fast spans need char->token offsets, so a fast HF tokenizer and no processor."""
-        return self.prompter.processor is None and getattr(
-            self.tokenizer, "is_fast", False
+        Returns ``(rendered_text, token_starts, token_ends)``, or ``None`` when the
+        render can't be trusted to line up with ``input_ids`` and ``find_turn`` has to
+        fall back to diffing tokens.
+        """
+        if not getattr(self.tokenizer, "is_fast", False):
+            return None
+
+        full_text = self.prompter.build_prompt_text(turns, tools=tools)  # type: ignore
+        if not full_text:
+            return None
+
+        encoded = self.tokenizer(
+            full_text, add_special_tokens=False, return_offsets_mapping=True
+        )
+        # Spans are used to index into input_ids, so bail unless re-tokenizing the
+        # render reproduces it exactly.
+        if list(encoded["input_ids"]) != list(input_ids):
+            return None
+
+        offsets = encoded["offset_mapping"]
+        return full_text, [s for s, _ in offsets], [e for _, e in offsets]
+
+    # Chunk size for the char-space diff. Comparing block slices keeps the scan in C;
+    # a per-character Python loop here costs more than the tokenization it saves.
+    _DIFF_BLOCK = 4096
+
+    @classmethod
+    def _common_prefix_len(cls, left: str, right: str, limit: int) -> int:
+        """Length of the shared prefix of ``left`` and ``right``, capped at ``limit``."""
+        matched = 0
+        block = cls._DIFF_BLOCK
+        while (
+            matched + block <= limit
+            and left[matched : matched + block] == right[matched : matched + block]
+        ):
+            matched += block
+
+        lo, hi = matched, limit
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if left[matched:mid] == right[matched:mid]:
+                lo = mid
+            else:
+                hi = mid - 1
+
+        return lo
+
+    @classmethod
+    def _diff_char_span(cls, full_text: str, dummy_text: str) -> tuple[int, int]:
+        """Char span of ``full_text`` that differs from ``dummy_text``.
+
+        The suffix scan is bounded by the prefix match so the two can't overlap when
+        the surrounding template repeats itself.
+        """
+        limit = min(len(full_text), len(dummy_text))
+        start = cls._common_prefix_len(full_text, dummy_text, limit)
+        suffix = cls._common_prefix_len(
+            full_text[::-1], dummy_text[::-1], limit - start
         )
 
-    def _fast_content_spans(
-        self, turns: list[dict], tools: list[dict] | None, input_ids: list[int]
-    ) -> dict[int, tuple[int, int]] | None:
-        """Locate every plain-string turn's content token span in a single pass.
+        return start, len(full_text) - suffix
 
-        ``find_turn`` re-renders and re-tokenizes the whole conversation prefix once
-        per turn — O(turns^2) work that makes long multi-turn datasets crawl (#2396).
-        Here we render + tokenize the conversation once, recover char->token offsets,
-        and map each turn's content substring to its token span with a forward cursor.
+    def _find_turn_from_text(
+        self,
+        turns: list[dict],
+        turn_idx: int,
+        dummy_turn: dict,
+        tools: list[dict] | None,
+        locator: tuple[str, list[int], list[int]],
+    ) -> tuple[int, int] | None:
+        """Locate a turn by diffing two full renders in char space.
 
-        Returns ``{turn_idx: (start, end)}`` for the turns it can resolve exactly
-        (turns it can't are omitted, so the caller falls back to ``find_turn`` for
-        them), or ``None`` when the re-tokenization does not reproduce build_prompt's
-        ids.
+        Both renders keep the turn at its original index, so position-dependent
+        template logic (thinking stripped from non-final turns, tool-call collapsing)
+        applies identically to each and cancels out in the diff.
         """
-        tokenizer = self.tokenizer
+        full_text, token_starts, token_ends = locator
 
-        # Mirror build_prompt(turns, tools=tools) exactly so the ids line up with input_ids.
-        chat_template_kwargs = {
-            "chat_template": self.prompter.chat_template,
-            "add_generation_prompt": False,
-            **self.prompter.chat_template_kwargs,
-        }
-        if tools:
-            chat_template_kwargs["tools"] = tools
-        try:
-            text = tokenizer.apply_chat_template(
-                turns, tokenize=False, **chat_template_kwargs
+        dummy_text = self.prompter.build_prompt_text(  # type: ignore
+            turns[:turn_idx] + [dummy_turn] + turns[turn_idx + 1 :], tools=tools
+        )
+        if not dummy_text:
+            return None
+
+        char_start, char_end = self._diff_char_span(full_text, dummy_text)
+        if char_end <= char_start:
+            # The field never made it into the render, so there is nothing to label.
+            return -1, -1
+
+        # Byte-level BPE can split one character across tokens that share a char
+        # offset, so the exclusive end has to come from starts, not ends — bisecting
+        # ends would drop the trailing piece of a multi-token character.
+        start_idx = bisect_right(token_ends, char_start)
+        end_idx = bisect_left(token_starts, char_end)
+        if start_idx >= len(token_ends) or end_idx > len(token_ends):
+            return None
+
+        return start_idx, end_idx
+
+    def _find_turn_from_tokens(
+        self,
+        turns: list[dict],
+        turn_idx: int,
+        dummy_turn: dict,
+        tools: list[dict] | None,
+    ) -> tuple[int, int] | None:
+        """Locate a turn by re-tokenizing the conversation prefix twice.
+
+        Fallback for renders that can't be mapped to char offsets (processors, slow
+        tokenizers). Costs a full tokenization per turn, and because it renders a
+        prefix rather than the whole conversation it can't see position-dependent
+        template logic — prefer ``_find_turn_from_text`` whenever a locator exists.
+        """
+        real_last_index = len(turns) - 1
+
+        dummy_ids = _extract_input_ids(
+            self.prompter.build_prompt(  # type: ignore
+                turns[:turn_idx] + [dummy_turn],
+                tools=tools,
+                real_last_index=real_last_index,
             )
-            enc = tokenizer(text, add_special_tokens=False, return_offsets_mapping=True)
-        except Exception:  # pragma: no cover - degrade to find_turn
+        )
+        full_ids = _extract_input_ids(
+            self.prompter.build_prompt(  # type: ignore
+                turns[: turn_idx + 1], tools=tools, real_last_index=real_last_index
+            )
+        )
+
+        if not full_ids or not dummy_ids:
+            LOG.warning(f"Empty template generated for turn {turn_idx}")
             return None
 
-        # Spans index into input_ids (from build_prompt); only safe if our render
-        # reproduces it byte-for-byte. If specials are handled differently, bail.
-        if list(enc["input_ids"]) != list(input_ids):
+        start_idx = None
+        min_len = min(len(dummy_ids), len(full_ids))
+        for i in range(min_len):
+            if dummy_ids[i] != full_ids[i]:
+                start_idx = i
+                break
+
+        if start_idx is None:
+            LOG.warning(f"Could not find content start boundary for turn {turn_idx}")
             return None
 
+        end_idx = None
+        for i in range(min_len):
+            dummy_pos = len(dummy_ids) - 1 - i
+            full_pos = len(full_ids) - 1 - i
+            if dummy_ids[dummy_pos] != full_ids[full_pos]:
+                end_idx = full_pos + 1  # Add one to include the last token when slice
+                break
+
+        if end_idx is None:
+            LOG.warning(f"Could not find content end boundary for turn {turn_idx}")
+            return None
+
+        return start_idx, end_idx
+
+    def _build_dummy_turn(
+        self, turn: dict, content_only: bool, reasoning_only: bool
+    ) -> dict:
         thinking_key = self.prompter.template_thinking_key
-        is_mistral = "mistral" in self.tokenizer.name_or_path.lower()
-        offsets = enc["offset_mapping"]
-        n_tok = len(offsets)
-        spans: dict[int, tuple[int, int]] = {}
-        char_cursor = 0
-        tok = 0
-        for idx, turn in enumerate(turns):
-            content = turn.get("content")
-            if not isinstance(content, str) or not content:
-                continue
-            # Skip turns where find_turn applies handling the char-span can't mirror:
-            # reasoning_content (spans content + separator) and mistral's system turn.
-            if thinking_key and turn.get(thinking_key) is not None:
-                continue
-            if idx == 0 and turn.get("role") == "system" and is_mistral:
-                continue
-            pos = text.find(content, char_cursor)
-            if pos == -1:
-                continue
-            c0, c1 = pos, pos + len(content)
-            char_cursor = c1
-            # First token starting exactly at the content start (forward-only cursor).
-            while tok < n_tok and offsets[tok][0] < c0:
-                tok += 1
-            if tok >= n_tok or offsets[tok][0] != c0:
-                continue  # content not token-aligned (template glued it on) -> find_turn
-            start = tok
-            while tok < n_tok and offsets[tok][1] <= c1:
-                tok += 1
-            if tok == start or offsets[tok - 1][1] != c1:
-                continue  # content end not token-aligned -> find_turn
-            spans[idx] = (start, tok)
-        return spans
+
+        if reasoning_only:
+            # Keep content as-is, replace reasoning with dummy
+            dummy_turn = {
+                "role": turn.get("role"),
+                "content": turn.get("content", ""),
+            }
+            if thinking_key and thinking_key in turn:
+                dummy_turn[thinking_key] = "[[dummy_reasoning]]"
+            return dummy_turn
+
+        dummy_turn = {
+            "role": turn.get("role"),
+            "content": "[[dummy_message]]",
+        }
+
+        # When content_only is True, copy reasoning_content to the dummy turn so
+        # the diff only captures the content field (not reasoning + separator).
+        if content_only and thinking_key and thinking_key in turn:
+            dummy_turn[thinking_key] = turn[thinking_key]
+
+        return dummy_turn
 
     def find_turn(
         self,
@@ -793,6 +891,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         tools: list[dict] | None = None,
         content_only: bool = False,
         reasoning_only: bool = False,
+        locator: tuple[str, list[int], list[int]] | None = None,
     ):
         """
         Locate the starting and ending indices of the specified turn in a conversation.
@@ -805,6 +904,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             reasoning_only: If True, preserve content in the dummy turn and replace
                 reasoning_content with a dummy, so the diff only captures the
                 reasoning_content field boundaries.
+            locator: Prepared render from ``_build_turn_locator``. When supplied the
+                boundaries are diffed in char space instead of by re-tokenizing.
         """
 
         if turn_idx >= len(turns):
@@ -818,74 +919,22 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         ):
             return -1, -1
 
-        thinking_key = self.prompter.template_thinking_key
-
-        if reasoning_only:
-            # Keep content as-is, replace reasoning with dummy
-            empty_turn = {
-                "role": turns[turn_idx].get("role"),
-                "content": turns[turn_idx].get("content", ""),
-            }
-            if thinking_key and thinking_key in turns[turn_idx]:
-                empty_turn[thinking_key] = "[[dummy_reasoning]]"
-        else:
-            empty_turn = {
-                "role": turns[turn_idx].get("role"),
-                "content": "[[dummy_message]]",
-            }
-
-            # When content_only is True, copy reasoning_content to the dummy turn so
-            # the diff only captures the content field (not reasoning + separator).
-            if content_only and thinking_key and thinking_key in turns[turn_idx]:
-                empty_turn[thinking_key] = turns[turn_idx][thinking_key]
-
-        # Create conversation versions
-        turns_with_empty = turns[:turn_idx] + [empty_turn]
-        turns_with_content = turns[: turn_idx + 1]
-
-        real_last_index = len(turns) - 1
-
-        # Generate the conversation up to the turn, with final turn replaced with dummy content
-        dummy_ids = _extract_input_ids(
-            self.prompter.build_prompt(  # type: ignore
-                turns_with_empty, tools=tools, real_last_index=real_last_index
-            )
+        dummy_turn = self._build_dummy_turn(
+            turns[turn_idx], content_only, reasoning_only
         )
 
-        # Generate the conversation up to the turn, with final turn included
-        full_ids = _extract_input_ids(
-            self.prompter.build_prompt(  # type: ignore
-                turns_with_content, tools=tools, real_last_index=real_last_index
+        span = None
+        if locator is not None:
+            span = self._find_turn_from_text(
+                turns, turn_idx, dummy_turn, tools, locator
             )
-        )
-
-        if not full_ids or not dummy_ids:
-            LOG.warning(f"Empty template generated for turn {turn_idx}")
+        if span is None:
+            span = self._find_turn_from_tokens(turns, turn_idx, dummy_turn, tools)
+        if span is None:
             return -1, -1
 
-        # Find first difference (start of content)
-        start_idx = None
-        min_len = min(len(dummy_ids), len(full_ids))
-        for i in range(min_len):
-            if dummy_ids[i] != full_ids[i]:
-                start_idx = i
-                break
-
-        if start_idx is None:
-            LOG.warning(f"Could not find content start boundary for turn {turn_idx}")
-            return -1, -1
-
-        # Find last difference (end of content)
-        end_idx = None
-        for i in range(min_len):
-            dummy_pos = len(dummy_ids) - 1 - i
-            full_pos = len(full_ids) - 1 - i
-            if dummy_ids[dummy_pos] != full_ids[full_pos]:
-                end_idx = full_pos + 1  # Add one to include the last token when slice
-                break
-
-        if end_idx is None:
-            LOG.warning(f"Could not find content end boundary for turn {turn_idx}")
+        start_idx, end_idx = span
+        if start_idx == -1 or end_idx == -1:
             return -1, -1
 
         if end_idx < start_idx:
@@ -901,9 +950,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             return -1, -1
 
         LOG.debug(f"Content boundaries: {start_idx}, {end_idx}")
-        LOG.debug(
-            f"Content tokens: {self.tokenizer.convert_ids_to_tokens(full_ids[start_idx:end_idx])}"
-        )
 
         return start_idx, end_idx
 
@@ -1257,9 +1303,6 @@ class MistralStrategy(ChatTemplateStrategy):
         self.split_thinking = split_thinking
 
         self.images = "images"
-
-        self._fast_spans_disabled = False
-        self._fast_validated_samples = 0
 
         LOG.debug(
             f"The chat template uses the following properites on the message: {self.prompter.chat_template_msg_variables}"

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -704,8 +704,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         if reason not in seen:
             seen.add(reason)
             LOG.info(
-                "chat_template: locating turns via the slower token-diff path (%s). "
-                "Labels are unaffected.",
+                "chat_template: locating turns via the slower token-diff fallback (%s).",
                 reason,
             )
 

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -320,6 +320,9 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         self.images = "images"
 
+        self._fast_spans_disabled = False
+        self._fast_validated_samples = 0
+
         LOG.debug(
             f"The chat template uses the following properites on the message: {self.prompter.chat_template_msg_variables}"
         )
@@ -448,8 +451,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             and not self.prompter.message_field_training_detail  # type: ignore
         ):
             turns = self.get_conversation_thread(prompt)
-            if not turns:
-                return {}
             images = self._get_images(prompt)
             prompt_ids = self.prompter.build_prompt(  # type: ignore
                 turns[:-1],
@@ -480,8 +481,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             return tokenized_prompt
 
         turns = self.get_conversation_thread(prompt)
-        if not turns:
-            return {}
         tools = self._get_tools(prompt)
         result = self.prompter.build_prompt(turns, tools=tools)  # type: ignore
         if not isinstance(result, dict):
@@ -490,10 +489,10 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         labels = [IGNORE_TOKEN_ID] * len(input_ids)
 
         fast_spans = None
-        if not self._fast_spans_disabled:
+        if not self._fast_spans_disabled and self._fast_spans_supported():
             fast_spans = self._fast_content_spans(turns, tools, input_ids)
             if fast_spans is None:
-                self._fast_spans_disabled = True  # unsupported here; stop trying
+                self._fast_spans_disabled = True
         validating = (
             fast_spans is not None
             and self._fast_validated_samples < self._FAST_VALIDATION_SAMPLES
@@ -704,12 +703,15 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 return i
         return -1
 
-    _fast_spans_disabled = False
-    _fast_validated_samples = 0
-
     # Number of initial samples whose fast-path spans are cross-checked against the
     # reference find_turn before the fast path is trusted for the remainder of the run.
     _FAST_VALIDATION_SAMPLES = 8
+
+    def _fast_spans_supported(self) -> bool:
+        """Fast spans need char->token offsets, so a fast HF tokenizer and no processor."""
+        return self.prompter.processor is None and getattr(
+            self.tokenizer, "is_fast", False
+        )
 
     def _fast_content_spans(
         self, turns: list[dict], tools: list[dict] | None, input_ids: list[int]
@@ -721,16 +723,12 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         Here we render + tokenize the conversation once, recover char->token offsets,
         and map each turn's content substring to its token span with a forward cursor.
 
-        Returns ``{turn_idx: (start, end)}`` for the turns it can resolve exactly, or
-        ``None`` when the fast path is unsupported (multimodal / slow tokenizer / the
-        re-tokenization does not reproduce build_prompt's ids). The caller falls back
-        to ``find_turn`` for any turn not present in the returned dict.
+        Returns ``{turn_idx: (start, end)}`` for the turns it can resolve exactly
+        (turns it can't are omitted, so the caller falls back to ``find_turn`` for
+        them), or ``None`` when the re-tokenization does not reproduce build_prompt's
+        ids.
         """
         tokenizer = self.tokenizer
-        if self.prompter.processor is not None or not getattr(
-            tokenizer, "is_fast", False
-        ):
-            return None
 
         # Mirror build_prompt(turns, tools=tools) exactly so the ids line up with input_ids.
         chat_template_kwargs = {
@@ -753,6 +751,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         if list(enc["input_ids"]) != list(input_ids):
             return None
 
+        thinking_key = self.prompter.template_thinking_key
+        is_mistral = "mistral" in self.tokenizer.name_or_path.lower()
         offsets = enc["offset_mapping"]
         n_tok = len(offsets)
         spans: dict[int, tuple[int, int]] = {}
@@ -761,6 +761,12 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         for idx, turn in enumerate(turns):
             content = turn.get("content")
             if not isinstance(content, str) or not content:
+                continue
+            # Skip turns where find_turn applies handling the char-span can't mirror:
+            # reasoning_content (spans content + separator) and mistral's system turn.
+            if thinking_key and turn.get(thinking_key) is not None:
+                continue
+            if idx == 0 and turn.get("role") == "system" and is_mistral:
                 continue
             pos = text.find(content, char_cursor)
             if pos == -1:
@@ -993,9 +999,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         turns = []
 
         messages = self._get_messages(prompt)
-
-        if not messages:
-            return []
 
         possible_sys_turn = self.transform_message(messages[0])
 
@@ -1254,6 +1257,9 @@ class MistralStrategy(ChatTemplateStrategy):
         self.split_thinking = split_thinking
 
         self.images = "images"
+
+        self._fast_spans_disabled = False
+        self._fast_validated_samples = 0
 
         LOG.debug(
             f"The chat template uses the following properites on the message: {self.prompter.chat_template_msg_variables}"

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -333,6 +333,9 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             if len(token_ids) == 1:
                 self._eot_token_ids.add(token_ids[0])
 
+        self._fast_spans_disabled = False
+        self._fast_validated_samples = 0
+
     def _validate_eot_and_eos_tokens(self):
         """
         - Validates that EOT tokens (or eos_token) are in the chat_template
@@ -485,6 +488,17 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         input_ids = result["input_ids"]
         labels = [IGNORE_TOKEN_ID] * len(input_ids)
 
+        fast_spans = None
+        if not self._fast_spans_disabled:
+            fast_spans = self._fast_content_spans(turns, tools, input_ids)
+            if fast_spans is None:
+                self._fast_spans_disabled = True  # unsupported here; stop trying
+        validating = (
+            fast_spans is not None
+            and self._fast_validated_samples < self._FAST_VALIDATION_SAMPLES
+        )
+        used_fast = False
+
         last_eos_idx = -1
         last_eot_idx = -1
         for index, turn in enumerate(turns):
@@ -531,12 +545,38 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             # (excluding reasoning_content + template separator tokens).
             use_content_only = bool(has_any_detail and has_reasoning)
 
-            turn_start_idx, turn_end_idx = self.find_turn(
-                turns=turns,
-                turn_idx=index,
-                tools=tools,
-                content_only=use_content_only,
+            fast_span = (
+                fast_spans.get(index)
+                if (
+                    fast_spans is not None
+                    and not use_content_only
+                    and train_detail is None
+                    and reasoning_train_detail is None
+                )
+                else None
             )
+            if fast_span is not None and not validating:
+                turn_start_idx, turn_end_idx = fast_span
+                used_fast = True
+            else:
+                turn_start_idx, turn_end_idx = self.find_turn(
+                    turns=turns,
+                    turn_idx=index,
+                    tools=tools,
+                    content_only=use_content_only,
+                )
+                if fast_span is not None:
+                    used_fast = True
+                    if fast_span != (turn_start_idx, turn_end_idx):
+                        # Fast path disagrees with the reference: disable it for the
+                        # whole run and keep the reference result for this turn.
+                        LOG.warning(
+                            "chat_template fast turn-boundary path disagreed with the "
+                            "reference; disabling it for this run and using find_turn."
+                        )
+                        self._fast_spans_disabled = True
+                        fast_spans = None
+                        validating = False
 
             LOG.debug(f"Turn indices: start={turn_start_idx}, end={turn_end_idx}")
 
@@ -638,6 +678,10 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         LOG.debug(f"Final labels: {labels}")
 
+        # Bank a clean sample: once enough have agreed with find_turn, trust the fast path.
+        if used_fast and validating and not self._fast_spans_disabled:
+            self._fast_validated_samples += 1
+
         # ``result`` already carries any processor outputs (pixel_values, image
         # grid info, etc.); just set the fields we computed locally.
         result["labels"] = labels
@@ -658,6 +702,79 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             if input_ids[i] in self._eot_token_ids:
                 return i
         return -1
+
+    # Number of initial samples whose fast-path spans are cross-checked against the
+    # reference find_turn before the fast path is trusted for the remainder of the run.
+    _FAST_VALIDATION_SAMPLES = 8
+
+    def _fast_content_spans(
+        self, turns: list[dict], tools: list[dict] | None, input_ids: list[int]
+    ) -> dict[int, tuple[int, int]] | None:
+        """Locate every plain-string turn's content token span in a single pass.
+
+        ``find_turn`` re-renders and re-tokenizes the whole conversation prefix once
+        per turn — O(turns^2) work that makes long multi-turn datasets crawl (#2396).
+        Here we render + tokenize the conversation once, recover char->token offsets,
+        and map each turn's content substring to its token span with a forward cursor.
+
+        Returns ``{turn_idx: (start, end)}`` for the turns it can resolve exactly, or
+        ``None`` when the fast path is unsupported (multimodal / slow tokenizer / the
+        re-tokenization does not reproduce build_prompt's ids). The caller falls back
+        to ``find_turn`` for any turn not present in the returned dict.
+        """
+        tokenizer = self.tokenizer
+        if self.prompter.processor is not None or not getattr(
+            tokenizer, "is_fast", False
+        ):
+            return None
+
+        # Mirror build_prompt(turns, tools=tools) exactly so the ids line up with input_ids.
+        chat_template_kwargs = {
+            "chat_template": self.prompter.chat_template,
+            "add_generation_prompt": False,
+            **self.prompter.chat_template_kwargs,
+        }
+        if tools:
+            chat_template_kwargs["tools"] = tools
+        try:
+            text = tokenizer.apply_chat_template(
+                turns, tokenize=False, **chat_template_kwargs
+            )
+            enc = tokenizer(text, add_special_tokens=False, return_offsets_mapping=True)
+        except Exception:  # pragma: no cover - degrade to find_turn
+            return None
+
+        # Spans index into input_ids (from build_prompt); only safe if our render
+        # reproduces it byte-for-byte. If specials are handled differently, bail.
+        if list(enc["input_ids"]) != list(input_ids):
+            return None
+
+        offsets = enc["offset_mapping"]
+        n_tok = len(offsets)
+        spans: dict[int, tuple[int, int]] = {}
+        char_cursor = 0
+        tok = 0
+        for idx, turn in enumerate(turns):
+            content = turn.get("content")
+            if not isinstance(content, str) or not content:
+                continue
+            pos = text.find(content, char_cursor)
+            if pos == -1:
+                continue
+            c0, c1 = pos, pos + len(content)
+            char_cursor = c1
+            # First token starting exactly at the content start (forward-only cursor).
+            while tok < n_tok and offsets[tok][0] < c0:
+                tok += 1
+            if tok >= n_tok or offsets[tok][0] != c0:
+                continue  # content not token-aligned (template glued it on) -> find_turn
+            start = tok
+            while tok < n_tok and offsets[tok][1] <= c1:
+                tok += 1
+            if tok == start or offsets[tok - 1][1] != c1:
+                continue  # content end not token-aligned -> find_turn
+            spans[idx] = (start, tok)
+        return spans
 
     def find_turn(
         self,

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -174,9 +174,8 @@ class ChatTemplatePrompter(Prompter):
     ) -> str | None:
         """Render a conversation to text without tokenizing.
 
-        Returns ``None`` when the render can't be mapped back to token offsets, i.e.
-        a processor is in play (it splices in image/audio tokens that have no
-        counterpart in the text).
+        Returns ``None`` under a processor, whose spliced-in image/audio tokens have
+        no text counterpart to map offsets back from.
         """
         if self.processor:
             return None
@@ -695,11 +694,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         return -1
 
     def _log_fallback_once(self, reason: str):
-        """Note, once per worker, why the fast char-space path is unavailable.
-
-        Preprocessing forks per ``num_proc``, so this fires up to ``num_proc`` times
-        rather than exactly once.
-        """
+        """Log why the char-space path is unavailable, once per ``num_proc`` worker."""
         seen = self.__dict__.setdefault("_logged_fallbacks", set())
         if reason not in seen:
             seen.add(reason)
@@ -714,8 +709,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         """Render and tokenize the conversation once so turns can be located in char space.
 
         Returns ``(rendered_text, token_starts, token_ends)``, or ``None`` when the
-        render can't be trusted to line up with ``input_ids`` and ``find_turn`` has to
-        fall back to diffing tokens.
+        render can't be trusted to line up with ``input_ids``.
         """
         if not getattr(self.tokenizer, "is_fast", False):
             self._log_fallback_once("tokenizer is not a fast tokenizer")
@@ -729,8 +723,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         encoded = self.tokenizer(
             full_text, add_special_tokens=False, return_offsets_mapping=True
         )
-        # Spans are used to index into input_ids, so bail unless re-tokenizing the
-        # render reproduces it exactly.
+        # Spans index into input_ids, so the render must re-tokenize to it exactly.
         if list(encoded["input_ids"]) != list(input_ids):
             self._log_fallback_once("re-tokenized render does not match input_ids")
             return None
@@ -738,15 +731,13 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         offsets = encoded["offset_mapping"]
         return full_text, [s for s, _ in offsets], [e for _, e in offsets]
 
-    # Chunk size for the char-space diff. Comparing block slices keeps the scan in C;
-    # a per-character Python loop here costs more than the tokenization it saves.
+    # Block compares keep the diff scan in C; a per-char Python loop would cost more
+    # than the tokenization it saves.
     _DIFF_BLOCK = 4096
 
-    # Placeholders diffed against the real turn. They share no first or last
-    # character, so an edge char a template glues onto one placeholder (absorbing it
-    # into the diff's common prefix/suffix) is still exposed by the other; the union
-    # of both spans is the true span. Only one field is ever replaced at a time, so a
-    # single string per placeholder covers both content and reasoning.
+    # Two placeholders with disjoint first/last chars: a template can glue a shared
+    # edge char onto one placeholder, hiding it in the diff's common prefix/suffix,
+    # but the other then exposes it. The union of both spans is the true span.
     _SENTINELS = ("[[dummy_message]]", "zzdummymessagezz")
 
     @classmethod
@@ -758,7 +749,6 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         """
 
         def prefix_len(left: str, right: str, limit: int) -> int:
-            # Block compares stay in C; the char loop only refines the final block.
             block, i = cls._DIFF_BLOCK, 0
             while i + block <= limit and left[i : i + block] == right[i : i + block]:
                 i += block
@@ -784,11 +774,10 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         Every render keeps the turn at its original index, so position-dependent
         template logic (thinking stripped from non-final turns, tool-call collapsing)
-        applies identically to each and cancels out in the diff.
+        cancels out in the diff.
 
-        Three-valued return: ``None`` means "can't resolve here, fall back to the
-        token diff"; ``(-1, -1)`` means "resolved, but the field is absent from the
-        render so there is nothing to label"; a span means the content tokens.
+        Returns ``None`` to fall back to the token diff, ``(-1, -1)`` when the field
+        is absent from the render, otherwise the token span.
         """
         full_text, token_starts, token_ends = locator
 
@@ -804,17 +793,15 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 return None
             spans.append(self._diff_char_span(full_text, dummy_text))
 
-        # A diff never extends past the real content (identical template on both
-        # sides), so absorbed edge chars only shrink a span; the widest span across
-        # edge-disjoint sentinels recovers the truth.
+        # The template is identical on both sides, so a span can only come out too
+        # small; the widest across edge-disjoint sentinels is the true one.
         char_start = min(start for start, _ in spans)
         char_end = max(end for _, end in spans)
         if char_end <= char_start:
             return -1, -1
 
-        # BPE can split one character across tokens sharing an offset, so the
-        # exclusive end comes from starts, not ends: bisecting ends would drop the
-        # trailing piece of a multi-token character.
+        # BPE can split one char across tokens sharing an offset, so the exclusive
+        # end bisects starts: bisecting ends would drop the char's trailing piece.
         start_idx = bisect_right(token_ends, char_start)
         end_idx = bisect_left(token_starts, char_end)
         if start_idx >= len(token_ends) or end_idx > len(token_ends):
@@ -831,10 +818,9 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
     ) -> tuple[int, int] | None:
         """Locate a turn by re-tokenizing the conversation prefix twice.
 
-        Fallback for renders that can't be mapped to char offsets (processors, slow
-        tokenizers). Costs a full tokenization per turn, and because it renders a
-        prefix rather than the whole conversation it can't see position-dependent
-        template logic — prefer ``_find_turn_from_text`` whenever a locator exists.
+        Fallback for renders with no char offsets (processors, slow tokenizers). Costs
+        a tokenization per turn and, rendering only a prefix, misses position-dependent
+        template logic.
         """
         real_last_index = len(turns) - 1
 
@@ -886,13 +872,12 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
         thinking_key = self.prompter.template_thinking_key
 
         if reasoning_only:
-            # Keep content as-is, replace reasoning with the placeholder.
             dummy_turn = {"role": turn.get("role"), "content": turn.get("content", "")}
             if thinking_key and thinking_key in turn:
                 dummy_turn[thinking_key] = sentinel
             return dummy_turn
 
-        # Replace content; keep reasoning when content_only so the diff excludes it.
+        # Keep reasoning under content_only so the diff excludes it.
         dummy_turn = {"role": turn.get("role"), "content": sentinel}
         if content_only and thinking_key and thinking_key in turn:
             dummy_turn[thinking_key] = turn[thinking_key]
@@ -918,7 +903,7 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
             reasoning_only: If True, preserve content in the dummy turn and replace
                 reasoning_content with a dummy, so the diff only captures the
                 reasoning_content field boundaries.
-            locator: Prepared render from ``_build_turn_locator``. When supplied the
+            locator: Prepared render from ``_build_turn_locator``. When supplied,
                 boundaries are diffed in char space instead of by re-tokenizing.
         """
 

--- a/tests/prompt_strategies/test_chat_templates_advanced.py
+++ b/tests/prompt_strategies/test_chat_templates_advanced.py
@@ -1904,3 +1904,248 @@ class TestChatTemplateReasoningContent:
         assert "Step 1: addition." in full_text
         assert "Step 2: 2+2=4." in full_text
         assert "The answer is 4." in full_text
+
+
+def _turn_span_strategy(tokenizer, **kwargs):
+    return ChatTemplateStrategy(
+        ChatTemplatePrompter(
+            tokenizer,
+            chat_template=tokenizer.get_chat_template(),
+            max_length=8192,
+        ),
+        tokenizer=tokenizer,
+        train_on_inputs=False,
+        sequence_len=8192,
+        roles_to_train=["assistant"],
+        **kwargs,
+    )
+
+
+def _turn_span_trained_text(strategy, tokenizer, turns):
+    res = strategy._tokenize_single_prompt(  # pylint: disable=protected-access
+        {"messages": turns}
+    )
+    trained = [
+        input_id
+        for input_id, label in zip(res["input_ids"], res["labels"], strict=True)
+        if label != IGNORE_TOKEN_ID
+    ]
+    return tokenizer.decode(trained)
+
+
+class TestTurnSpansThinking:
+    """
+    Templates that strip reasoning from non-final turns render a turn differently
+    depending on where it sits, so boundaries have to be derived from a render that
+    keeps every turn at its original index.
+    """
+
+    def test_middle_turn_does_not_bleed(self, qwen3_tokenizer):
+        strategy = _turn_span_strategy(qwen3_tokenizer)
+        turns = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "content": "The answer is done.",
+                "reasoning_content": "hidden thinking",
+            },
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "done"},
+        ]
+
+        # The middle turn's reasoning is dropped from the render, so only the two
+        # assistant contents are trainable: no control tokens, no user content.
+        assert (
+            _turn_span_trained_text(strategy, qwen3_tokenizer, turns)
+            == "The answer is done.done"
+        )
+
+    def test_repeated_content_across_turns(self, qwen3_tokenizer):
+        strategy = _turn_span_strategy(qwen3_tokenizer)
+        turns = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "content": "42\ndone",
+                "reasoning_content": "hidden thinking",
+            },
+            {"role": "user", "content": "42"},
+            {"role": "assistant", "content": "done"},
+        ]
+
+        # "done" and "42" both occur earlier in the render; the final reply must
+        # still resolve to its own span rather than the earlier occurrence.
+        assert (
+            _turn_span_trained_text(strategy, qwen3_tokenizer, turns) == "42\ndonedone"
+        )
+
+
+class TestTurnSpansLocator:
+    """Char-space boundaries must agree with the token-diff fallback."""
+
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            ["hi", "hello", "bye", "goodbye"],
+            ["héllo 世界 🎉", "respondé 世界 🎉"],
+            ["a\nb\nc", "x\n\ny\tz"],
+            ["42", "42", "42", "42"],
+            ["<|im_start|>weird", "plain reply"],
+        ],
+        ids=["plain", "unicode", "whitespace", "repeated", "template-literals"],
+    )
+    def test_matches_token_fallback(self, llama3_tokenizer, contents):
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user" if idx % 2 == 0 else "assistant", "content": content}
+            for idx, content in enumerate(contents)
+        ]
+
+        # pylint: disable=protected-access
+        input_ids = strategy.prompter.build_prompt(turns)
+        locator = strategy._build_turn_locator(turns, None, input_ids)
+        assert locator is not None
+
+        for turn_idx in range(len(turns)):
+            assert strategy.find_turn(
+                turns=turns, turn_idx=turn_idx, locator=locator
+            ) == strategy.find_turn(turns=turns, turn_idx=turn_idx, locator=None)
+
+    @pytest.mark.parametrize(
+        "content",
+        ["[hi]", "[hi", "hi]", "[[x]]", '["a","b"]', "[[dummy_message]] literal"],
+        ids=[
+            "bracket-wrap",
+            "left-bracket",
+            "right-bracket",
+            "double",
+            "json",
+            "sentinel-substring",
+        ],
+    )
+    def test_edge_chars_not_absorbed(self, llama3_tokenizer, content):
+        """Content sharing edge chars with a placeholder must keep its full span.
+
+        A single placeholder lets the template glue a shared edge char onto it,
+        absorbing it into the diff's common prefix/suffix; the second, edge-disjoint
+        placeholder exposes it again.
+        """
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": content},
+        ]
+
+        assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == content
+
+    def test_sentinels_have_disjoint_edges(self):
+        """The union fix only works if no content char can collide with both
+        placeholders on the same side, i.e. their first and last chars all differ."""
+        firsts = [sentinel[0] for sentinel in ChatTemplateStrategy._SENTINELS]
+        lasts = [sentinel[-1] for sentinel in ChatTemplateStrategy._SENTINELS]
+        assert len(set(firsts)) == len(firsts)
+        assert len(set(lasts)) == len(lasts)
+
+    def test_span_covers_multi_token_characters(self, llama3_tokenizer):
+        """An emoji spans several tokens that share a char offset."""
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "party 🎉🎉 time"},
+        ]
+
+        assert (
+            _turn_span_trained_text(strategy, llama3_tokenizer, turns)
+            == "party 🎉🎉 time"
+        )
+
+    def test_falls_back_without_locator(self, llama3_tokenizer, monkeypatch):
+        """A tokenizer without offsets still resolves turns via the token diff."""
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"},
+        ]
+
+        # pylint: disable=protected-access
+        input_ids = strategy.prompter.build_prompt(turns)
+        assert strategy._build_turn_locator(turns, None, input_ids) is not None
+
+        monkeypatch.setattr(type(llama3_tokenizer), "is_fast", False, raising=False)
+        assert strategy._build_turn_locator(turns, None, input_ids) is None
+        assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == "pong"
+
+    def test_falls_back_when_render_unavailable(self, llama3_tokenizer, monkeypatch):
+        """Processors return no plain-text render, so the token diff has to cover it."""
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"},
+        ]
+
+        monkeypatch.setattr(
+            strategy.prompter, "build_prompt_text", lambda *a, **k: None
+        )
+        # pylint: disable=protected-access
+        input_ids = strategy.prompter.build_prompt(turns)
+        assert strategy._build_turn_locator(turns, None, input_ids) is None
+        assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == "pong"
+
+    def test_falls_back_when_render_mismatches_ids(self, llama3_tokenizer, monkeypatch):
+        """If the text render doesn't re-tokenize to input_ids, char spans would
+        index the wrong sequence, so the locator has to bail to the token diff."""
+        strategy = _turn_span_strategy(llama3_tokenizer)
+        turns = [
+            {"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"},
+        ]
+
+        # pylint: disable=protected-access
+        input_ids = strategy.prompter.build_prompt(turns)
+        assert strategy._build_turn_locator(turns, None, input_ids) is not None
+
+        monkeypatch.setattr(
+            strategy.prompter,
+            "build_prompt_text",
+            lambda *a, **k: "totally different text",
+        )
+        assert strategy._build_turn_locator(turns, None, input_ids) is None
+        assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == "pong"
+
+
+class TestDiffCharSpan:
+    """The block-scanned diff has to agree with a naive character scan."""
+
+    @pytest.mark.parametrize(
+        "full,dummy,expected",
+        [
+            ("abcXYZdef", "abcQdef", (3, 6)),
+            ("aaaaXaaaa", "aaaaaaaa", (4, 5)),
+            ("prefix", "prefix", (6, 6)),
+            ("", "", (0, 0)),
+            ("xy", "xAAAy", (1, 1)),
+        ],
+    )
+    def test_known_spans(self, full, dummy, expected):
+        # pylint: disable=protected-access
+        assert ChatTemplateStrategy._diff_char_span(full, dummy) == expected
+
+    def test_matches_naive_scan_across_block_boundary(self):
+        # pylint: disable=protected-access
+        block = ChatTemplateStrategy._DIFF_BLOCK
+        for offset in (block - 1, block, block + 1):
+            full = ("a" * offset) + "CHANGED" + ("b" * 10)
+            dummy = ("a" * offset) + "X" + ("b" * 10)
+
+            limit = min(len(full), len(dummy))
+            start = 0
+            while start < limit and full[start] == dummy[start]:
+                start += 1
+            suffix = 0
+            while suffix < limit - start and full[-1 - suffix] == dummy[-1 - suffix]:
+                suffix += 1
+
+            assert ChatTemplateStrategy._diff_char_span(full, dummy) == (
+                start,
+                len(full) - suffix,
+            )

--- a/tests/prompt_strategies/test_chat_templates_advanced.py
+++ b/tests/prompt_strategies/test_chat_templates_advanced.py
@@ -1953,8 +1953,8 @@ class TestTurnSpansThinking:
             {"role": "assistant", "content": "done"},
         ]
 
-        # The middle turn's reasoning is dropped from the render, so only the two
-        # assistant contents are trainable: no control tokens, no user content.
+        # The middle turn's reasoning is dropped from the render, leaving only the
+        # two assistant contents trainable.
         assert (
             _turn_span_trained_text(strategy, qwen3_tokenizer, turns)
             == "The answer is done.done"
@@ -2024,12 +2024,7 @@ class TestTurnSpansLocator:
         ],
     )
     def test_edge_chars_not_absorbed(self, llama3_tokenizer, content):
-        """Content sharing edge chars with a placeholder must keep its full span.
-
-        A single placeholder lets the template glue a shared edge char onto it,
-        absorbing it into the diff's common prefix/suffix; the second, edge-disjoint
-        placeholder exposes it again.
-        """
+        """Content sharing edge chars with a placeholder must keep its full span."""
         strategy = _turn_span_strategy(llama3_tokenizer)
         turns = [
             {"role": "user", "content": "go"},
@@ -2039,8 +2034,8 @@ class TestTurnSpansLocator:
         assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == content
 
     def test_sentinels_have_disjoint_edges(self):
-        """The union fix only works if no content char can collide with both
-        placeholders on the same side, i.e. their first and last chars all differ."""
+        """The union fix relies on no content char colliding with both placeholders
+        on the same side, i.e. their first and last chars all differ."""
         firsts = [sentinel[0] for sentinel in ChatTemplateStrategy._SENTINELS]
         lasts = [sentinel[-1] for sentinel in ChatTemplateStrategy._SENTINELS]
         assert len(set(firsts)) == len(firsts)
@@ -2092,8 +2087,8 @@ class TestTurnSpansLocator:
         assert _turn_span_trained_text(strategy, llama3_tokenizer, turns) == "pong"
 
     def test_falls_back_when_render_mismatches_ids(self, llama3_tokenizer, monkeypatch):
-        """If the text render doesn't re-tokenize to input_ids, char spans would
-        index the wrong sequence, so the locator has to bail to the token diff."""
+        """A render that doesn't re-tokenize to input_ids would index the wrong
+        sequence, so the locator has to bail to the token diff."""
         strategy = _turn_span_strategy(llama3_tokenizer)
         turns = [
             {"role": "user", "content": "ping"},


### PR DESCRIPTION

# Description
casuses inf time for tokenization for conservation dataset , 

## Motivation and Context
#2396 

### Speed (`_tokenize_single_prompt`, Qwen2.5, ~120 words/turn)

| turns | tokens | before | after | speedup |
|------:|-------:|-------:|------:|--------:|
| 4     | 2.4k   | 7.4 ms    | 5.9 ms  | 1.3× |
| 16    | 10k    | 63.7 ms   | 15.1 ms | 4.2× |
| 40    | 28k    | 380.8 ms  | 46.5 ms | 8.2× |
| 80    | 57k    | 1577.6 ms | 96.4 ms | **16.4×** |

Scaling per doubling: before ~4.1× (quadratic), after ~2.1× (linear). Gains grow
with conversation length — short chats were never the bottleneck.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat template token span computation for improved performance during prompt processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->