### PR TITLE
fix: avoid IndexError in metharme/reflection _tokenize on empty fields

### DIFF
--- a/src/axolotl/prompt_strategies/metharme.py
+++ b/src/axolotl/prompt_strategies/metharme.py
@@ -37,8 +37,7 @@ class MetharmePromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
         )
         if len(result["input_ids"]) == 0:
             LOG.warning("Tokenizer result is empty. You may want to audit your dataset")
-            # Bail out like the base class instead of indexing into an empty result below;
-            # an empty field with a tokenizer that does not prepend BOS yields no tokens.
+            # An empty field (no-BOS tokenizer) yields no tokens; bail out like the base class.
             return BatchEncoding(data={"input_ids": [], "attention_mask": []})
         # If there's already an EOS token there, subtract from the number added
         if result["input_ids"][-1] == self.tokenizer.eos_token_id:

--- a/src/axolotl/prompt_strategies/metharme.py
+++ b/src/axolotl/prompt_strategies/metharme.py
@@ -37,7 +37,7 @@ class MetharmePromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
         )
         if len(result["input_ids"]) == 0:
             LOG.warning("Tokenizer result is empty. You may want to audit your dataset")
-            # An empty field (no-BOS tokenizer) yields no tokens; bail out like the base class.
+            # A no-BOS tokenizer yields zero tokens for an empty field.
             return BatchEncoding(data={"input_ids": [], "attention_mask": []})
         # If there's already an EOS token there, subtract from the number added
         if result["input_ids"][-1] == self.tokenizer.eos_token_id:

--- a/src/axolotl/prompt_strategies/metharme.py
+++ b/src/axolotl/prompt_strategies/metharme.py
@@ -2,6 +2,8 @@
 
 from typing import Tuple
 
+from transformers import BatchEncoding
+
 from axolotl.prompt_tokenizers import InstructionPromptTokenizingStrategy
 from axolotl.prompters import AlpacaPrompter
 from axolotl.utils.logging import get_logger
@@ -35,6 +37,9 @@ class MetharmePromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
         )
         if len(result["input_ids"]) == 0:
             LOG.warning("Tokenizer result is empty. You may want to audit your dataset")
+            # Bail out like the base class instead of indexing into an empty result below;
+            # an empty field with a tokenizer that does not prepend BOS yields no tokens.
+            return BatchEncoding(data={"input_ids": [], "attention_mask": []})
         # If there's already an EOS token there, subtract from the number added
         if result["input_ids"][-1] == self.tokenizer.eos_token_id:
             num_eos_tokens -= 1

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -303,6 +303,10 @@ class ReflectionPromptTokenizingStrategy(PromptTokenizingStrategy):
         )
 
     def _tokenize(self, prompt, add_eos_token=True, strip_bos_token=False):
+        empty = BatchEncoding(data={"input_ids": [], "attention_mask": []})
+        if not prompt:
+            LOG.warning_once("Empty text requested for tokenization.")
+            return empty
         result = self.tokenizer(
             prompt,
             truncation=True,
@@ -310,6 +314,9 @@ class ReflectionPromptTokenizingStrategy(PromptTokenizingStrategy):
             padding=False,
             return_tensors=None,
         )
+        if len(result["input_ids"]) == 0:
+            LOG.warning("Tokenizer result is empty. You may want to audit your dataset")
+            return empty
         if (
             result["input_ids"][-1] != self.tokenizer.eos_token_id
             and len(result["input_ids"]) < self.sequence_len

--- a/tests/test_empty_tokenization.py
+++ b/tests/test_empty_tokenization.py
@@ -1,0 +1,38 @@
+"""Regression tests: prompt-strategy ``_tokenize`` must not crash on an empty result.
+
+A field that tokenizes to nothing (e.g. an empty ``generation``/sub-field with a
+tokenizer that does not prepend BOS) used to raise ``IndexError`` in these overrides
+because they indexed ``result["input_ids"][-1]`` without the empty-guard the base
+``PromptTokenizingStrategy._tokenize`` already has.
+"""
+
+import pytest
+from transformers import AutoTokenizer
+
+from axolotl.prompt_strategies.metharme import MetharmePromptTokenizingStrategy
+from axolotl.prompt_tokenizers import ReflectionPromptTokenizingStrategy
+
+
+@pytest.fixture(scope="module")
+def gpt2_tokenizer():
+    # gpt2 does not prepend BOS, so tokenizing "" yields an empty input_ids list.
+    return AutoTokenizer.from_pretrained("gpt2")
+
+
+def _build(strategy_cls, tokenizer):
+    strategy = strategy_cls.__new__(strategy_cls)
+    strategy.tokenizer = tokenizer
+    strategy.sequence_len = 2048
+    return strategy
+
+
+def test_metharme_tokenize_empty_does_not_crash(gpt2_tokenizer):
+    strategy = _build(MetharmePromptTokenizingStrategy, gpt2_tokenizer)
+    result = strategy._tokenize("")  # raised IndexError before the fix
+    assert list(result["input_ids"]) == []
+
+
+def test_reflection_tokenize_empty_does_not_crash(gpt2_tokenizer):
+    strategy = _build(ReflectionPromptTokenizingStrategy, gpt2_tokenizer)
+    result = strategy._tokenize("")  # raised IndexError before the fix
+    assert list(result["input_ids"]) == []

--- a/tests/test_empty_tokenization.py
+++ b/tests/test_empty_tokenization.py
@@ -12,11 +12,14 @@ from transformers import AutoTokenizer
 from axolotl.prompt_strategies.metharme import MetharmePromptTokenizingStrategy
 from axolotl.prompt_tokenizers import ReflectionPromptTokenizingStrategy
 
+from tests.hf_offline_utils import enable_hf_offline
+
 
 @pytest.fixture(scope="module")
-def gpt2_tokenizer():
-    # gpt2 does not prepend BOS, so tokenizing "" yields an empty input_ids list.
-    return AutoTokenizer.from_pretrained("gpt2")
+@enable_hf_offline
+def no_bos_tokenizer(download_tiny_qwen3_model):
+    # Qwen3 sets add_bos_token=False, so tokenizing "" yields an empty input_ids list.
+    return AutoTokenizer.from_pretrained("axolotl-ai-co/tiny-qwen3-129m")
 
 
 def _build(strategy_cls, tokenizer):
@@ -26,13 +29,13 @@ def _build(strategy_cls, tokenizer):
     return strategy
 
 
-def test_metharme_tokenize_empty_does_not_crash(gpt2_tokenizer):
-    strategy = _build(MetharmePromptTokenizingStrategy, gpt2_tokenizer)
+def test_metharme_tokenize_empty_does_not_crash(no_bos_tokenizer):
+    strategy = _build(MetharmePromptTokenizingStrategy, no_bos_tokenizer)
     result = strategy._tokenize("")  # raised IndexError before the fix
     assert list(result["input_ids"]) == []
 
 
-def test_reflection_tokenize_empty_does_not_crash(gpt2_tokenizer):
-    strategy = _build(ReflectionPromptTokenizingStrategy, gpt2_tokenizer)
+def test_reflection_tokenize_empty_does_not_crash(no_bos_tokenizer):
+    strategy = _build(ReflectionPromptTokenizingStrategy, no_bos_tokenizer)
     result = strategy._tokenize("")  # raised IndexError before the fix
     assert list(result["input_ids"]) == []


### PR DESCRIPTION
# Description

`MetharmePromptTokenizingStrategy._tokenize` and `ReflectionPromptTokenizingStrategy._tokenize` index `result["input_ids"][-1]` without the empty-result guard that the base `PromptTokenizingStrategy._tokenize` already has, so a field that tokenizes to nothing raises `IndexError` and aborts the whole preprocessing run.

The Metharme override even logs `"Tokenizer result is empty. You may want to audit your dataset"` and then immediately indexes the empty list on the very next line; the Reflection override has no guard at all. This change returns an empty `BatchEncoding` in that case, exactly as the base class does.

## Motivation and Context

A row with an empty field crashes preprocessing when the tokenizer does not prepend a BOS token (gpt2 / GPT-NeoX / Pythia families), because `tokenizer("")` then returns `input_ids == []`. For Metharme this is reachable through `parse_instruction_fields` returning `(prompt["prompt"], "", prompt["generation"])`, where an empty `generation` is tokenized on its own. The base class was hardened for the empty case; these two overrides drifted out of sync. The warning text in the Metharme override shows such rows were meant to be tolerated, not fatal.

No linked issue; found by reading the code.

## How has this been tested?

Added `tests/test_empty_tokenization.py` with a regression test for each strategy: with a gpt2 tokenizer (which does not prepend BOS, so `_tokenize("")` yields an empty result), the strategy must return an empty `BatchEncoding` rather than raise. Both tests fail on `main` (`IndexError: list index out of range`) and pass with this change. The existing fixtures use huggyllama, which prepends BOS and so masks the bug, so the new test uses gpt2 to exercise the empty path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes in prompt tokenization strategies when processing empty or invalid input data, improving system stability.

* **Tests**
  * Added regression tests to prevent recurrence of empty tokenization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->