### PR TITLE
fix: add EOS token to gemma configs

### DIFF
--- a/examples/gemma2/qlora.yml
+++ b/examples/gemma2/qlora.yml
@@ -10,6 +10,8 @@ load_in_4bit: true
 
 # huggingface repo
 chat_template: gemma
+eot_tokens:
+  - <end_of_turn>
 datasets:
   - path: cgato/SlimOrcaDedupCleaned
     type: chat_template

--- a/examples/gemma4-unified/12b-text-lora.yaml
+++ b/examples/gemma4-unified/12b-text-lora.yaml
@@ -9,6 +9,8 @@ liger_layer_norm: true
 strict: false
 
 chat_template: gemma4_unified
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: mlabonne/FineTome-100k
     type: chat_template

--- a/examples/gemma4-unified/12b-vision-lora.yaml
+++ b/examples/gemma4-unified/12b-vision-lora.yaml
@@ -16,6 +16,8 @@ remove_unused_columns: false
 sample_packing: false
 
 chat_template: gemma4_unified
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: HuggingFaceH4/llava-instruct-mix-vsft
     type: chat_template

--- a/examples/gemma4/26b-a4b-moe-bnb-lora.yaml
+++ b/examples/gemma4/26b-a4b-moe-bnb-lora.yaml
@@ -35,6 +35,8 @@ strict: false
 ddp_find_unused_parameters: true
 
 chat_template: gemma4
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: mlabonne/FineTome-100k
     type: chat_template

--- a/examples/gemma4/26b-a4b-moe-nvfp4-lora.yaml
+++ b/examples/gemma4/26b-a4b-moe-nvfp4-lora.yaml
@@ -29,6 +29,8 @@ strict: false
 ddp_find_unused_parameters: true
 
 chat_template: gemma4
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: mlabonne/FineTome-100k
     type: chat_template

--- a/examples/gemma4/26b-a4b-moe-qlora.yaml
+++ b/examples/gemma4/26b-a4b-moe-qlora.yaml
@@ -22,6 +22,8 @@ strict: false
 ddp_find_unused_parameters: true
 
 chat_template: gemma4
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: mlabonne/FineTome-100k
     type: chat_template

--- a/examples/gemma4/31b-qlora.yaml
+++ b/examples/gemma4/31b-qlora.yaml
@@ -11,6 +11,8 @@ liger_rms_norm_gated: true
 strict: false
 
 chat_template: gemma4
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: mlabonne/FineTome-100k
     type: chat_template

--- a/examples/gemma4/e2b-vision-lora.yaml
+++ b/examples/gemma4/e2b-vision-lora.yaml
@@ -12,6 +12,8 @@ remove_unused_columns: false
 sample_packing: false
 
 chat_template: gemma4
+eot_tokens:
+  - "<turn|>"
 datasets:
   - path: HuggingFaceH4/llava-instruct-mix-vsft
     type: chat_template

--- a/examples/qat_nvfp4/Math-Gemma3-12B_baseline.yml
+++ b/examples/qat_nvfp4/Math-Gemma3-12B_baseline.yml
@@ -16,6 +16,8 @@ liger_layer_norm: true
 liger_fused_linear_cross_entropy: true
 seed: 42
 chat_template: gemma3
+eot_tokens:
+  - <end_of_turn>
 datasets:
   - path: AI-MO/NuminaMath-CoT
     type: chat_template

--- a/examples/qat_nvfp4/Math-Gemma3-12B_qat.yml
+++ b/examples/qat_nvfp4/Math-Gemma3-12B_qat.yml
@@ -16,6 +16,8 @@ liger_layer_norm: true
 liger_fused_linear_cross_entropy: true
 seed: 42
 chat_template: gemma3
+eot_tokens:
+  - <end_of_turn>
 datasets:
   - path: AI-MO/NuminaMath-CoT
     type: chat_template

--- a/examples/qat_nvfp4/Math-Gemma3-27B_baseline.yml
+++ b/examples/qat_nvfp4/Math-Gemma3-27B_baseline.yml
@@ -16,6 +16,8 @@ liger_layer_norm: true
 liger_fused_linear_cross_entropy: true
 seed: 42
 chat_template: gemma3
+eot_tokens:
+  - <end_of_turn>
 datasets:
   - path: AI-MO/NuminaMath-CoT
     type: chat_template

--- a/examples/qat_nvfp4/Math-Gemma3-27B_qat.yml
+++ b/examples/qat_nvfp4/Math-Gemma3-27B_qat.yml
@@ -16,6 +16,8 @@ liger_layer_norm: true
 liger_fused_linear_cross_entropy: true
 seed: 42
 chat_template: gemma3
+eot_tokens:
+  - <end_of_turn>
 datasets:
   - path: AI-MO/NuminaMath-CoT
     type: chat_template

--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -355,7 +355,8 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 and "eos_token" not in self.prompter.chat_template
             ):
                 LOG.warning(
-                    f"EOS token '{self.tokenizer.eos_token}' not found in chat_template. Please check if your template/EOS token is correct."
+                    f"EOS token '{self.tokenizer.eos_token}' not found in chat_template; the turn "
+                    "terminator won't be trained. Set `eot_tokens` to your template's turn-ending token."
                 )
             return
 


### PR DESCRIPTION
# Description

- Set eot_tokens on every Gemma chat_template example that lacked it (gemma2, gemma4, gemma4-unified, qat_nvfp4 Math-Gemma3); existing gemma3/3n examples already set it. reward-model.yaml is skipped (the Bradley-Terry strategy emits scalar labels, so the terminator is moot).
-  Strengthen warning when now EOS present

## Motivation and Context

Gemma keeps tokenizer.eos_token = <eos>, which never appears in the rendered chat (turns end with <end_of_turn> on Gemma 1/2/3/3n or <turn|> on Gemma 4). The default eot_tokens = [eos_token] therefore misses the real terminator and it is never trained, so the model never learns to stop. See GH issue #3754.

Credit to @ferno9 for discovering and troubleshooting

## How has this been tested?

See GH issue #3754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit end-of-turn token settings to several Gemma and Math-Gemma example configurations for more consistent chat and training behavior.

* **Bug Fixes**
  * Updated the chat template warning to give clearer guidance when the end-of-sequence token is not found, including what token to set for turn endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->