### PR TITLE
FIX:gemma gibberish

### DIFF
--- a/src/axolotl/cli/utils/lora_merge.py
+++ b/src/axolotl/cli/utils/lora_merge.py
@@ -1108,6 +1108,9 @@ def merge_lora_sharded_efficient(
     total_tensors = 0
     # Track weight_map for index regeneration: {tensor_key: shard_filename}
     weight_map: Dict[str, str] = {}
+    # Accumulate real byte size and parameter count for the index metadata.
+    total_size_bytes = 0
+    total_parameters = 0
 
     for shard_path in tqdm(model_shards, desc="Merging shards"):
         merged_tensors = {}
@@ -1188,8 +1191,10 @@ def merge_lora_sharded_efficient(
             else:
                 torch.save(merged_tensors, output_shard_path)
 
-        for tensor_key in merged_tensors:
+        for tensor_key, tensor in merged_tensors.items():
             weight_map[tensor_key] = output_shard_path.name
+            total_parameters += tensor.numel()
+            total_size_bytes += tensor.numel() * tensor.element_size()
 
         del merged_tensors, shard_tensors
         if device != "cpu" and torch.cuda.is_available():
@@ -1206,7 +1211,10 @@ def merge_lora_sharded_efficient(
             else "pytorch_model.bin.index.json"
         )
         index = {
-            "metadata": {"total_size": total_tensors},
+            "metadata": {
+                "total_parameters": total_parameters,
+                "total_size": total_size_bytes,
+            },
             "weight_map": weight_map,
         }
         with open(output_path / index_name, "w") as f:

--- a/tests/utils/lora/test_merge_lora.py
+++ b/tests/utils/lora/test_merge_lora.py
@@ -716,6 +716,14 @@ class TestEfficientMerge:
         for _key, shard_name in idx["weight_map"].items():
             assert (output_dir / shard_name).exists(), f"Missing shard: {shard_name}"
 
+        # Metadata must report real byte size + param count, not the tensor count.
+        expected_params = sum(t.numel() for t in {**shard1, **shard2}.values())
+        expected_bytes = sum(
+            t.numel() * t.element_size() for t in {**shard1, **shard2}.values()
+        )
+        assert idx["metadata"]["total_parameters"] == expected_params
+        assert idx["metadata"]["total_size"] == expected_bytes
+
     def test_dora_end_to_end(self, tmp_path):
         """DoRA merge through the full sharded merge pipeline."""
         hidden = 16


### PR DESCRIPTION


# Description

for now only fixes total param metadata,
when the merged model is re-sharded, the index is regenerated with the tensor count written into the total_size field instead of the byte size
so , total_tensors is incremented as total_tensors += len(shard_tensors) 


## Motivation and Context
https://discord.com/channels/1104757954588196865/1110594519226925137/1519645544211939430


## How has this been tested?



## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of model merge index metadata for sharded outputs.
  * Generated index files now report both total parameter count and total size, helping ensure downstream tools read the correct model metadata.
  * Added validation to confirm sharded merge outputs produce the expected metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->