### PR TITLE
feat(glm_moe_dsa): GLM-5.2 DSA kernels, NVFP4 loading, and expert parallelism (incl. EP×dp_shard / EP×cp)

### DIFF
--- a/cicd/cicd.sh
+++ b/cicd/cicd.sh
@@ -24,6 +24,7 @@ done
 # Run unit tests with initial coverage report
 pytest -v --durations=10 -n8 \
   --ignore=tests/e2e/ \
+  --ignore=tests/integrations/ \
   --ignore=tests/patched/ \
   --ignore=tests/cli \
   /workspace/axolotl/tests/ \
@@ -60,6 +61,11 @@ pytest -v --durations=10 -s \
 # Run integration tests with coverage append
 pytest -v --durations=10 \
   /workspace/axolotl/tests/e2e/integrations/ \
+  --cov=axolotl \
+  --cov-append
+
+pytest -v --durations=10 \
+  /workspace/axolotl/tests/integrations/ \
   --cov=axolotl \
   --cov-append
 

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -40,10 +40,15 @@ strict: false
 # The DSA kernels own attention; sdpa is the fallback the dispatcher uses below the sparse crossover.
 attn_implementation: sdpa
 
-# Expert parallelism (pure EP): set expert_parallel_size to the TOTAL number of GPUs so each rank
-# owns 256/world_size routed experts (256 must divide it evenly), with dp_shard_size 1. The non-expert
-# weights still FSDP-shard across all ranks. (ep < world composition — experts on ep, data on a
-# separate dp_shard axis — is a work in progress; use pure EP.)
+# Expert parallelism. Pure EP: set expert_parallel_size to the TOTAL number of GPUs so each rank owns
+# 256/world_size routed experts (256 must divide it evenly), with dp_shard_size 1. The non-expert
+# weights still FSDP-shard across all ranks.
+#   2D composition (ep < world_size) also works, as long as ep * dp_shard * cp == world_size:
+#     - EP × dp_shard (e.g. expert_parallel_size: 4 + dp_shard_size: 2): experts shard on the ep axis
+#       and are FSDP-sharded across the dp_shard ranks of each ep-group; data parallel on dp_shard.
+#     - EP × cp (e.g. expert_parallel_size: 4 + context_parallel_size: 2): the sequence shards on cp
+#       (the DSA attention all-gathers the 576-wide compressed KV on that axis) and the experts are
+#       FSDP-sharded across the cp ranks of each ep-group so they don't sit replicated per rank.
 expert_parallel_size: 8                      # = number of GPUs (8 for 8xH100; 2 for 2xB200)
 dp_shard_size: 1
 expert_parallel_num_nvl_bytes: 4294967296    # 4 GiB DeepEP intranode (NVLink) dispatch/combine buffer
@@ -61,7 +66,9 @@ expert_parallel_token_capacity: 1000000
 
 # For multi-GPU at long context, shard the sequence with context parallelism (the DSA attention
 # all-gathers only the 576-wide compressed KV on the cp axis). Composes with expert parallelism for
-# the MoE (experts shard on ep, sequence on cp) — see examples/expert_parallel and the EP plugin.
+# the MoE (experts shard on ep, sequence on cp). To use it, lower expert_parallel_size so that
+# ep * cp == world_size (e.g. expert_parallel_size: 4 with context_parallel_size: 2 on 8 GPUs) and
+# uncomment the line below. Uses the DSA kernels' own CP attention (no ring_flash_attn needed).
 # context_parallel_size: 2
 
 chat_template: tokenizer_default

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -45,9 +45,16 @@ attn_implementation: sdpa
 expert_parallel_size: 8                      # = number of GPUs (8 for 8xH100; 2 for 2xB200)
 dp_shard_size: 1
 expert_parallel_num_nvl_bytes: 4294967296    # 4 GiB DeepEP intranode (NVLink) dispatch/combine buffer
-# Max tokens routed to any single expert per forward; the lowest-weight excess are dropped. A safety
-# cap that guards the DeepEP intranode combine against a hot expert at long context (the GLM router
-# concentrates with depth); effectively inactive at short/medium sequence lengths.
+# Max tokens routed to any single expert per forward (per rank); the lowest-weight excess are dropped
+# to -1. Guards the DeepEP intranode combine, which HANGS once one expert's token count exceeds the
+# NVLink buffer (the GLM router concentrates with depth). This is a FIXED token threshold tied to
+# expert_parallel_num_nvl_bytes — NOT proportional to sequence length, so don't scale it with seq_len.
+# The 1,000,000 default is an effectively-off ceiling: per rank there are only seq_len*top_k assignments
+# spread over 256 experts (e.g. 64k seq = 512k total < 1M, so it never fires), so it won't over-drop at
+# normal lengths. But it also barely protects — at very long context (64k/128k) a hot expert can cross
+# the combine-hang threshold while still under 1M. If you train at long context, lower this toward the
+# actual hang threshold (measure it: raise seq until combine hangs, set just below) and/or raise
+# expert_parallel_num_nvl_bytes.
 expert_parallel_token_capacity: 1000000
 
 # For multi-GPU at long context, shard the sequence with context parallelism (the DSA attention

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -83,6 +83,7 @@ weight_decay: 0.0
 fsdp_version: 2
 fsdp_config:
   offload_params: false
+  cpu_ram_efficient_loading: true   # required: rank0-only NVFP4 load + FSDP broadcast fills the rest
   state_dict_type: SHARDED_STATE_DICT
   auto_wrap_policy: TRANSFORMER_BASED_WRAP
   transformer_layer_cls_to_wrap: GlmMoeDsaDecoderLayer

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -16,6 +16,13 @@
 base_model: Mapika/GLM-5.2-NVFP4
 
 plugins:
+  # Expert parallelism: shard the 256 routed experts across GPUs (each rank owns 1/world_size of
+  # them) and dispatch tokens via DeepEP all-to-all. The local expert GEMM runs through the SAME
+  # grouped-NVFP4 kernel as the non-EP path, so EP is both faster AND lower-memory than plain FSDP2
+  # at scale (verified at 8k seq: ~1.3x faster and ~12% less peak activation, beating FSDP2 on both).
+  # Requires the `deep_ep` package. Drop this plugin (+ the expert_parallel_* keys below) to fall back
+  # to plain FSDP2.
+  - axolotl.integrations.expert_parallel.ExpertParallelPlugin
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
   - axolotl.integrations.kernels.KernelsPlugin
 use_kernels: true
@@ -30,6 +37,18 @@ strict: false
 
 # The DSA kernels own attention; sdpa is the fallback the dispatcher uses below the sparse crossover.
 attn_implementation: sdpa
+
+# Expert parallelism (pure EP): set expert_parallel_size to the TOTAL number of GPUs so each rank
+# owns 256/world_size routed experts (256 must divide it evenly), with dp_shard_size 1. The non-expert
+# weights still FSDP-shard across all ranks. (ep < world composition — experts on ep, data on a
+# separate dp_shard axis — is a work in progress; use pure EP.)
+expert_parallel_size: 8                      # = number of GPUs (8 for 8xH100; 2 for 2xB200)
+dp_shard_size: 1
+expert_parallel_num_nvl_bytes: 4294967296    # 4 GiB DeepEP intranode (NVLink) dispatch/combine buffer
+# Max tokens routed to any single expert per forward; the lowest-weight excess are dropped. A safety
+# cap that guards the DeepEP intranode combine against a hot expert at long context (the GLM router
+# concentrates with depth); effectively inactive at short/medium sequence lengths.
+expert_parallel_token_capacity: 1000000
 
 # For multi-GPU at long context, shard the sequence with context parallelism (the DSA attention
 # all-gathers only the 576-wide compressed KV on the cp axis). Composes with expert parallelism for
@@ -72,7 +91,10 @@ learning_rate: 0.0002
 bf16: auto
 tf32: true
 gradient_checkpointing: true
-activation_offloading: true
+# EP shards the experts across GPUs, leaving activation-memory headroom — keep offloading off (faster).
+# Re-enable (true) for plain FSDP2 / tight-memory runs, or use AXOLOTL_EP_EXPERT_SHARD_TOKENS to tile
+# the grouped expert forward (opt-in activation-memory knob; trades step time for memory).
+activation_offloading: false
 
 warmup_ratio: 0.1
 evals_per_epoch: 4

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -20,8 +20,10 @@ plugins:
   # them) and dispatch tokens via DeepEP all-to-all. The local expert GEMM runs through the SAME
   # grouped-NVFP4 kernel as the non-EP path, so EP is both faster AND lower-memory than plain FSDP2
   # at scale (verified at 8k seq: ~1.3x faster and ~12% less peak activation, beating FSDP2 on both).
-  # Requires the `deep_ep` package. Drop this plugin (+ the expert_parallel_* keys below) to fall back
-  # to plain FSDP2.
+  # Parity: EP matches the FSDP2 baseline on loss and grad_norm to within ~1% per step (verified at
+  # 2k and 8k) — the routed-expert LoRA is sliced to each rank's local experts so it trains the
+  # correct experts, and FSDP grad-averaging gives the right per-expert scale. Requires the `deep_ep`
+  # package. Drop this plugin (+ the expert_parallel_* keys below) to fall back to plain FSDP2.
   - axolotl.integrations.expert_parallel.ExpertParallelPlugin
   - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
   - axolotl.integrations.kernels.KernelsPlugin

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -22,11 +22,19 @@ use_kernels: true
 use_scattermoe: true
 experts_implementation: scattermoe
 dsv4_fp4_grouped_mode: nvfp4        # fused 4-bit grouped MoE GEMM (Marlin sm120 / DeepGEMM sm90,100)
+# Fused DSA attention: MLA weight absorption + head-batched sparse-gather flash attn (fwd+bwd) +
+# fused Lightning-Indexer, replacing the dense [B,S,T]-mask sdpa path. Router kept fp32. Wins at
+# long context (S >> index_topk); a length-aware dispatcher uses the dense path below the crossover.
+use_glm_dsa_kernels: true
 strict: false
 
-# DSA sparse-MLA: eager/sdpa build a dense [B,S,T] additive mask from the top-k indices.
-# (Phase-1 will replace this with a fused top-k gather attention kernel.)
+# The DSA kernels own attention; sdpa is the fallback the dispatcher uses below the sparse crossover.
 attn_implementation: sdpa
+
+# For multi-GPU at long context, shard the sequence with context parallelism (the DSA attention
+# all-gathers only the 576-wide compressed KV on the cp axis). Composes with expert parallelism for
+# the MoE (experts shard on ep, sequence on cp) — see examples/expert_parallel and the EP plugin.
+# context_parallel_size: 2
 
 chat_template: tokenizer_default
 datasets:

--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -1,0 +1,81 @@
+# GLM-5.2 (glm_moe_dsa) MoE LoRA on an NVFP4 (modelopt) checkpoint.
+#
+# GLM-5.2 is the DeepSeek-V3.2 sparse-MLA (DSA / Lightning-Indexer) lineage: 78 layers, 256 routed
+# experts top-8 + 1 shared, MLA attention (qk_head_dim 256, v_head_dim 256), and a per-query top-k
+# token selector (index_topk 2048) with cross-layer top-k sharing. ~500B params, so the NVFP4
+# experts (~250 GB 4-bit) require multi-GPU FSDP2 (2xB200 / 8xH100).
+#
+# Loading: the checkpoint is quant_method=modelopt / quant_algo=NVFP4 (unrecognized by transformers
+# -> bf16 skeleton). The kernels plugin's GlmMoeDsaAdapter registers WeightConverters that fuse the
+# per-expert NVFP4 tensors into 3D NVFP4Tensors (routed experts) and dequantize the shared experts +
+# leading dense MLPs to bf16. Attention projections + lm_head are bf16 in the checkpoint.
+#
+# LoRA: routed experts via scattermoe (3D Parameter LoRA + fused 4-bit grouped GEMM); the MLA
+# attention projections + shared/dense MLP linears via PEFT-default LoRA (the Llama-style fused
+# qkv/o/mlp kernels don't fit MLA q_a/q_b/kv_a/kv_b/o or the shared-expert MLP — Phase-1 work).
+base_model: Mapika/GLM-5.2-NVFP4
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+  - axolotl.integrations.kernels.KernelsPlugin
+use_kernels: true
+use_scattermoe: true
+experts_implementation: scattermoe
+dsv4_fp4_grouped_mode: nvfp4        # fused 4-bit grouped MoE GEMM (Marlin sm120 / DeepGEMM sm90,100)
+strict: false
+
+# DSA sparse-MLA: eager/sdpa build a dense [B,S,T] additive mask from the top-k indices.
+# (Phase-1 will replace this with a fused top-k gather attention kernel.)
+attn_implementation: sdpa
+
+chat_template: tokenizer_default
+datasets:
+  - path: mlabonne/FineTome-100k
+    type: chat_template
+    split: train[:5%]
+    field_messages: conversations
+    message_property_mappings:
+      role: from
+      content: value
+val_set_size: 0.02
+output_dir: ./outputs/glm-5.2-nvfp4-lora
+
+sequence_len: 4096
+sample_packing: true
+
+adapter: lora
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0
+# MLA attention projections + shared/dense MLP linears (NOT the no-grad indexer wq_b/wk/weights_proj).
+lora_target_modules: 'model.layers.[\d]+.(self_attn.(q_a_proj|q_b_proj|kv_a_proj_with_mqa|kv_b_proj|o_proj)|mlp.(shared_experts.)?(gate_proj|up_proj|down_proj))'
+# MoE routed-expert LoRA (3D Parameter tensors, not nn.Linear).
+lora_target_parameters:
+  - experts.gate_up_proj
+  - experts.down_proj
+
+gradient_accumulation_steps: 4
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: true
+gradient_checkpointing: true
+activation_offloading: true
+
+warmup_ratio: 0.1
+evals_per_epoch: 4
+saves_per_epoch: 1
+weight_decay: 0.0
+
+# ~500B model: shard across GPUs with FSDP2 (run via `accelerate launch` / axolotl multi-GPU).
+fsdp_version: 2
+fsdp_config:
+  offload_params: false
+  state_dict_type: SHARDED_STATE_DICT
+  auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  transformer_layer_cls_to_wrap: GlmMoeDsaDecoderLayer
+  reshard_after_forward: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "huggingface_hub>=1.5.0",
     "peft>=0.19.1,<0.20.0",
     "tokenizers>=0.22.1",
-    "transformers==5.10.2",
+    "transformers==5.12.1",
     "accelerate==1.13.0",
     "datasets>=4.8.4,<4.9.0",
     "trl==1.5.1",

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -799,12 +799,54 @@ class AxolotlTrainer(
             self._stored_metrics[train_eval][key]["values"].append(value)
             self._stored_metrics[train_eval][key]["reduction"] = _reduction
 
+    def _save_fsdp2_quantized_lora_adapter(self, model, output_dir) -> bool:
+        """Save just the LoRA adapter (gathered via DTensor.full_tensor) when the run is FSDP2 + a
+        quantized (NVFP4/Float8) frozen base — the case where the DCP sharded save raises
+        "Failed to validate global plan". Returns True if it handled the save, else False (caller
+        falls back to the normal checkpoint path). No-op for non-PEFT / non-FSDP2 / non-quantized runs.
+        """
+        if not getattr(self, "is_fsdp_enabled", False):
+            return False
+        try:
+            from peft import PeftModel
+
+            unwrapped = self.accelerator.unwrap_model(model)
+            if not isinstance(unwrapped, PeftModel):
+                return False
+            # quantized base? (torchao tensor-subclass DTensors — what breaks DCP). Handle DTensor
+            # by inspecting the local tensor.
+            quant_names = {"NVFP4Tensor", "Float8Tensor", "MXTensor"}
+            has_quant = any(
+                type(getattr(p, "_local_tensor", p)).__name__ in quant_names
+                for p in unwrapped.parameters()
+            )
+            if not has_quant:
+                return False
+            from axolotl.integrations.expert_parallel.shard import (
+                save_fsdp2_lora_adapter,
+            )
+
+            return bool(save_fsdp2_lora_adapter(unwrapped, output_dir))
+        except Exception as exc:  # pylint: disable=broad-except
+            LOG.warning(
+                "FSDP2 quantized-LoRA adapter save failed (%s); falling back to default save.",
+                exc,
+            )
+            return False
+
     def _save_checkpoint(self, model, trial, **kwargs):
         # make sure the checkpoint dir exists, since trainer is flakey
         checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
         run_dir = self._get_output_dir(trial=trial)
         output_dir = os.path.join(run_dir, checkpoint_folder)
         os.makedirs(output_dir, exist_ok=True)
+
+        # FSDP2 + a quantized (NVFP4/Float8) frozen base breaks the DCP sharded save
+        # ("Failed to validate global plan" — the torchao tensor-subclass DTensors are unvalidatable).
+        # For a PEFT (LoRA) run we only need the adapter, so gather it directly and skip the DCP save.
+        if self._save_fsdp2_quantized_lora_adapter(model, output_dir):
+            gc.collect()
+            return None
 
         # Save total_tokens state if tracking is enabled
         if self.args.include_tkps and hasattr(self.state, "tokens"):

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -845,6 +845,28 @@ class AxolotlTrainer(
         # ("Failed to validate global plan" — the torchao tensor-subclass DTensors are unvalidatable).
         # For a PEFT (LoRA) run we only need the adapter, so gather it directly and skip the DCP save.
         if self._save_fsdp2_quantized_lora_adapter(model, output_dir):
+            # The adapter is written above in place of the DCP model state. Still persist the
+            # optimizer/scheduler/scaler/RNG and trainer state so the checkpoint stays RESUMABLE —
+            # only the trainable adapter carries optimizer state (the quantized base is frozen), so
+            # these saves don't touch the unvalidatable NVFP4 DTensors. Defensive: if any of them
+            # fails under FSDP2, keep the (already-written) adapter rather than aborting the save.
+            try:
+                if not self.args.save_only_model:
+                    self._save_optimizer_and_scheduler(output_dir)
+                    self._save_scaler(output_dir)
+                    self._save_rng_state(output_dir)
+                if self.args.should_save:
+                    # "trainer_state.json" is HF's canonical resume file (global_step, epoch, ...).
+                    self.state.save_to_json(
+                        os.path.join(output_dir, "trainer_state.json")
+                    )
+            except Exception as exc:  # pylint: disable=broad-except
+                LOG.warning(
+                    "Could not persist optimizer/RNG/trainer state for %s (%s); the checkpoint is "
+                    "adapter-only and not resumable.",
+                    output_dir,
+                    exc,
+                )
             gc.collect()
             return None
 

--- a/src/axolotl/core/trainers/mixins/activation_checkpointing.py
+++ b/src/axolotl/core/trainers/mixins/activation_checkpointing.py
@@ -4,6 +4,7 @@ Trainer mixin for activation checkpointing w offloading
 
 import contextlib
 
+import torch
 from peft import PeftModel
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -22,6 +23,42 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 
+def _patch_trl_offload_current_stream() -> None:
+    """Make TRL ``OffloadActivations`` sync its CPU<->GPU copies against the LIVE compute stream
+    instead of the once-captured ``torch.cuda.default_stream()``.
+
+    ``OffloadActivations`` caches ``self.s0 = torch.cuda.default_stream()`` in ``__init__`` and uses
+    it for every ``s0.wait_stream(s1)`` / ``s0.wait_event`` / ``record_stream(s0)``. When the actual
+    forward/backward compute runs on a NON-default stream — FSDP2, the checkpoint recompute, or any
+    custom autograd Function whose backward launches kernels (e.g. the scattermoe NVFP4 MoE) — that
+    sync targets the wrong stream, so a streamed-in activation is read before its H2D copy finishes:
+    garbage saved tensors -> NaN/illegal-memory in the backward (silent, finite forward). Querying
+    ``current_stream()`` at each use site fixes the ordering (xpu/npu already use ``current_stream``).
+    """
+    from trl.models.activation_offloading import OffloadActivations
+
+    if getattr(OffloadActivations, "_axolotl_live_stream", False):
+        return
+
+    def _live_compute_stream(self):
+        t = getattr(self, "accelerator_type", "cuda")
+        if t == "xpu":
+            return torch.xpu.current_stream()
+        if t == "npu":
+            import torch_npu  # noqa: F401
+
+            return torch.npu.current_stream()
+        return torch.cuda.current_stream()
+
+    # property read returns the live stream; the no-op setter swallows __init__'s `self.s0 = ...`.
+    OffloadActivations.s0 = property(_live_compute_stream, lambda self, _v: None)
+    OffloadActivations._axolotl_live_stream = True
+    LOG.info(
+        "Patched TRL OffloadActivations to sync against the live compute stream "
+        "(fixes streamed activation offloading under FSDP2 / custom-Function backward)"
+    )
+
+
 class ActivationOffloadingMixin(Trainer):
     """
     Trainer mixin class for activation checkpointing w offloading
@@ -35,6 +72,8 @@ class ActivationOffloadingMixin(Trainer):
             # the stream-overlapped path (True/"disk"); the streams path stashes
             # several activations to overlap copies, inflating peak reserved.
             use_streams = self.args.activation_offloading != "legacy"
+            if use_streams:
+                _patch_trl_offload_current_stream()
             if isinstance(self.model, PeftModel):
                 self.activation_offload_context = get_lora_act_offloading_ctx_manager(
                     self.model, use_streams=use_streams

--- a/src/axolotl/integrations/expert_parallel/README.md
+++ b/src/axolotl/integrations/expert_parallel/README.md
@@ -183,7 +183,10 @@ EP composes with FSDP on orthogonal mesh axes: experts are sharded across the `e
 
 - Models' modeling code must use `@use_experts_implementation` (canonical 3D `gate_up_proj` / `down_proj`). `ModuleList` as used in Mixtral is not supported.
 - `num_experts` must be divisible by `expert_parallel_size`.
-- 3+ axis composition (EP × DP × TP/CP) is not yet supported in v1; raises `NotImplementedError`.
+- Supported mesh axes: EP, EP × dp_shard, **EP × cp**, EP × cp × dp_shard (experts shard on `ep`,
+  the sequence on `cp`, non-expert weights on `dp_shard`). EP × **TP** is not yet supported and
+  raises `NotImplementedError`. EP × CP requires the model's attention to be context-parallel-aware
+  on the `cp` axis (e.g. GLM-5.2 DSA via the kernels plugin); stock attention uses accelerate CP.
 - DeepEP limitation: Low-latency (LL) kernels are inter-node only by design (pure RDMA via IBGDA). Single-node + intranode setups always use the standard kernels and don't benefit from LL.
 - FP8 dispatch needs Hopper + DISABLE_SM90_FEATURES=0.
 

--- a/src/axolotl/integrations/expert_parallel/args.py
+++ b/src/axolotl/integrations/expert_parallel/args.py
@@ -29,6 +29,11 @@ class ExpertParallelArgs(BaseModel):
 
     expert_parallel_num_rdma_bytes: int = 0
 
+    expert_parallel_token_capacity: int | None = None
+    """Max tokens routed to any single expert per forward; the lowest-weight excess (token,expert)
+    assignments are dropped. DeepEP's intranode combine deadlocks once one expert is overloaded, and
+    GLM-style routers concentrate more with depth — set this (e.g. 1024) for them. ``None`` = no cap."""
+
     expert_parallel_fallback_on_unsupported: bool = True
 
     @model_validator(mode="after")

--- a/src/axolotl/integrations/expert_parallel/buffer.py
+++ b/src/axolotl/integrations/expert_parallel/buffer.py
@@ -22,6 +22,8 @@ import torch.distributed as dist
 _BUFFER = None
 _EP_GROUP: Optional[dist.ProcessGroup] = None
 _NUM_NVL_BYTES = 256 << 20
+_DISPATCH_CONFIG = None
+_COMBINE_CONFIG = None
 _NUM_RDMA_BYTES = 0
 
 
@@ -56,7 +58,53 @@ def get_buffer():
     return _BUFFER
 
 
+def _ep_world() -> int:
+    grp = _EP_GROUP if _EP_GROUP is not None else dist.group.WORLD
+    return dist.get_world_size(grp)
+
+
+def get_dispatch_config():
+    """Recommended DeepEP dispatch Config for the EP group. DeepEP's own tests ALWAYS pass an
+    explicit config to dispatch/combine; the no-config default deadlocks / launch-fails the combine
+    on the singleton buffer's reuse across MoE layers (cudaErrorLaunchFailure)."""
+    global _DISPATCH_CONFIG
+    if _DISPATCH_CONFIG is None:
+        import deep_ep
+
+        _DISPATCH_CONFIG = deep_ep.Buffer.get_dispatch_config(_ep_world())
+    return _DISPATCH_CONFIG
+
+
+def get_combine_config():
+    """Recommended DeepEP combine Config for the EP group (see get_dispatch_config)."""
+    global _COMBINE_CONFIG
+    if _COMBINE_CONFIG is None:
+        import deep_ep
+
+        _COMBINE_CONFIG = deep_ep.Buffer.get_combine_config(_ep_world())
+    return _COMBINE_CONFIG
+
+
+def barrier_ep() -> None:
+    """Barrier on the EP group. Placed before each DeepEP ``combine`` so the fast ranks wait (on
+    NCCL, no short timeout) for any rank still AUTOTUNING the local expert kernel — otherwise the
+    combine collective hits DeepEP's short internal timeout (``value=0``) and aborts. Negligible cost
+    once kernels are cached (all ranks arrive together). Disable with AXOLOTL_EP_NO_BARRIER=1."""
+    import os
+
+    if os.environ.get("AXOLOTL_EP_NO_BARRIER"):
+        return
+    if not dist.is_initialized():
+        return
+    import torch
+
+    torch.cuda.synchronize()
+    dist.barrier(_EP_GROUP if _EP_GROUP is not None else dist.group.WORLD)
+
+
 def reset_buffer() -> None:
-    """Drop the cached Buffer. Used in tests."""
-    global _BUFFER
+    """Drop the cached Buffer + configs. Used in tests."""
+    global _BUFFER, _DISPATCH_CONFIG, _COMBINE_CONFIG
     _BUFFER = None
+    _DISPATCH_CONFIG = None
+    _COMBINE_CONFIG = None

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -20,6 +20,46 @@ import torch.nn.functional as F
 
 from .buffer import get_buffer
 
+# Per-forward [B*S] bool mask of real (non-padding) tokens, set by the EP plugin's model
+# pre-hook from the batch `attention_mask` and consumed by `_deep_ep_forward` to exclude
+# padding from the dispatch. ``None`` when there is no padding (packed / no attention_mask).
+_VALID_TOKEN_MASK: torch.Tensor | None = None
+
+
+def _apply_expert_capacity(topk_idx, topk_w, cap):
+    """Cap tokens-per-expert to ``cap`` by sentinelling (-1) the lowest-weight excess (token,expert)
+    assignments. DeepEP's intranode combine hangs once one expert receives too many tokens (the
+    GLM router concentrates more with depth, crossing the hang threshold ~layer 31); standard MoE
+    capacity-dropping keeps every expert under the limit. Already-(-1) slots are left untouched."""
+    import torch
+
+    ntok, K = topk_idx.shape
+    flat_e = topk_idx.reshape(-1)
+    flat_w = topk_w.reshape(-1)
+    # sort assignments by (expert asc, weight desc) via two stable passes
+    o1 = torch.argsort(flat_w, descending=True, stable=True)
+    o2 = torch.argsort(flat_e[o1], stable=True)
+    order = o1[o2]
+    se = flat_e[order]
+    pos = torch.arange(se.numel(), device=se.device)
+    is_new = torch.ones_like(se, dtype=torch.bool)
+    is_new[1:] = se[1:] != se[:-1]
+    grp_start = torch.cummax(torch.where(is_new, pos, torch.zeros_like(pos)), 0).values
+    within = pos - grp_start
+    drop_sorted = (within >= cap) & (se >= 0)
+    drop = torch.zeros_like(flat_e, dtype=torch.bool)
+    drop[order] = drop_sorted
+    return topk_idx.reshape(-1).masked_fill(drop, -1).reshape(ntok, K)
+
+
+def set_valid_token_mask(mask: torch.Tensor | None) -> None:
+    global _VALID_TOKEN_MASK
+    _VALID_TOKEN_MASK = mask
+
+
+def _get_valid_token_mask() -> torch.Tensor | None:
+    return _VALID_TOKEN_MASK
+
 
 def _eager_local(experts, recv_x, recv_topk_idx, recv_topk_weights):
     """Eager Python loop over local experts. Reference for numerics."""
@@ -211,6 +251,25 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
 
     topk_idx_i64 = top_k_index.to(torch.int64)
     topk_w_f32 = top_k_weights.to(torch.float32)
+
+    # Drop padding tokens from the dispatch. Under non-packed training with
+    # `pad_to_sequence_len`, padding rows carry identical embeddings, so the router
+    # sends them all to the same one or two experts — a routing imbalance DeepEP's
+    # intranode dispatch can't survive ('unspecified launch failure'). Sentinelling
+    # their routing to -1 makes `get_dispatch_layout` skip them entirely (they get a
+    # zero expert output, which is correct: their loss is masked anyway). Real long
+    # sequences (packed, or a single long sample) have no padding and are unaffected.
+    valid = _get_valid_token_mask()
+    if valid is not None and valid.numel() == topk_idx_i64.shape[0]:
+        import os as _os
+
+        if _os.environ.get("AXOLOTL_EP_DEBUG"):
+            from axolotl.utils.logging import get_logger
+
+            get_logger(__name__).info(
+                f"EP padding sentinel: {int(valid.sum())}/{valid.numel()} real tokens dispatched"
+            )
+        topk_idx_i64 = topk_idx_i64.masked_fill(~valid.view(-1, 1), -1)
 
     # Layout is non-differentiable (bookkeeping only).
     with torch.no_grad():

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
-from .buffer import get_buffer
+from .buffer import barrier_ep, get_buffer, get_combine_config, get_dispatch_config
 
 # Per-forward [B*S] bool mask of real (non-padding) tokens, set by the EP plugin's model
 # pre-hook from the batch `attention_mask` and consumed by `_deep_ep_forward` to exclude
@@ -184,6 +184,7 @@ class _DeepEPDispatch(torch.autograd.Function):
             num_tokens_per_expert=num_per_expert,
             topk_idx=topk_idx,
             topk_weights=topk_weights,
+            config=get_dispatch_config(),
         )
         ctx.handle = handle
         return recv_x, recv_topk_idx, recv_topk_weights, _DeepEPHandleHolder(handle)
@@ -198,10 +199,12 @@ class _DeepEPDispatch(torch.autograd.Function):
             if (grad_recv_w is not None and grad_recv_w.numel() > 0)
             else None
         )
+        barrier_ep()
         grad_x, grad_topk_w, _ = buffer.combine(
             grad_recv_x.contiguous(),
             ctx.handle,
             topk_weights=topk_w_grad,
+            config=get_combine_config(),
         )
         return grad_x, None, grad_topk_w, None, None, None
 
@@ -217,7 +220,9 @@ class _DeepEPCombine(torch.autograd.Function):
     def forward(ctx, x, handle_holder):
         buffer = get_buffer()
         ctx.handle = handle_holder.handle
-        combined, _, _ = buffer.combine(x.contiguous(), handle_holder.handle)
+        combined, _, _ = buffer.combine(
+            x.contiguous(), handle_holder.handle, config=get_combine_config()
+        )
         return combined
 
     @staticmethod
@@ -226,7 +231,7 @@ class _DeepEPCombine(torch.autograd.Function):
         # backward-of-combine is dispatch: reuse the cached handle to send
         # gradients to the ranks that produced partial outputs.
         recv_grad, _, _, _, _, _ = buffer.dispatch(
-            grad_combined.contiguous(), handle=ctx.handle
+            grad_combined.contiguous(), handle=ctx.handle, config=get_dispatch_config()
         )
         return recv_grad, None
 
@@ -307,6 +312,7 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
         self, recv_x, recv_topk_idx, recv_topk_weights
     )
 
+    barrier_ep()  # wait out the local-kernel autotune skew before the combine collective
     combined = _DeepEPCombine.apply(local_out, handle_holder)
 
     if original_dtype is not None:

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -25,6 +25,16 @@ from .buffer import get_buffer
 # padding from the dispatch. ``None`` when there is no padding (packed / no attention_mask).
 _VALID_TOKEN_MASK: torch.Tensor | None = None
 
+# Max tokens routed to any single expert per forward (``expert_parallel_token_capacity``), set by the
+# EP plugin. ``None`` disables the cap. Overloaded experts deadlock DeepEP's intranode combine, so
+# GLM-style routers (concentration grows with depth) need this.
+_TOKEN_CAPACITY: int | None = None
+
+
+def set_token_capacity(cap: int | None) -> None:
+    global _TOKEN_CAPACITY
+    _TOKEN_CAPACITY = cap
+
 
 def _apply_expert_capacity(topk_idx, topk_w, cap):
     """Cap tokens-per-expert to ``cap`` by sentinelling (-1) the lowest-weight excess (token,expert)
@@ -251,6 +261,11 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
 
     topk_idx_i64 = top_k_index.to(torch.int64)
     topk_w_f32 = top_k_weights.to(torch.float32)
+
+    # Cap tokens-per-expert before building the dispatch layout — an overloaded expert deadlocks
+    # DeepEP's intranode combine (the GLM router concentrates with depth).
+    if _TOKEN_CAPACITY is not None:
+        topk_idx_i64 = _apply_expert_capacity(topk_idx_i64, topk_w_f32, _TOKEN_CAPACITY)
 
     # Drop padding tokens from the dispatch. Under non-packed training with
     # `pad_to_sequence_len`, padding rows carry identical embeddings, so the router

--- a/src/axolotl/integrations/expert_parallel/plugin.py
+++ b/src/axolotl/integrations/expert_parallel/plugin.py
@@ -219,24 +219,35 @@ class ExpertParallelPlugin(BasePlugin):
         if ep_size == world_size:
             return dist.group.WORLD
 
-        # EP + FSDP — read the ep group from accelerate's mesh, or build one
-        # ourselves if accelerate hasn't (e.g., topology unit tests that drive
-        # `_resolve_ep_group` directly without an Accelerator).
-        if dp_shard_size > 1:
-            if tp_size > 1 or cp_size > 1:
+        # EP composed with FSDP (`dp_shard`) and/or context parallel (`cp`) on orthogonal mesh
+        # axes — read the ep group from accelerate's mesh, or build one ourselves if accelerate
+        # hasn't (e.g., topology unit tests that drive `_resolve_ep_group` directly). Experts shard
+        # on `ep` (tokens move via all-to-all); the sequence shards on `cp` (DSA attention gathers
+        # the compressed KV on that axis); non-expert weights shard on `dp_shard`. TP is still
+        # unsupported in composition.
+        if dp_shard_size > 1 or cp_size > 1:
+            if tp_size > 1:
                 raise NotImplementedError(
-                    "EP composition with TP/CP not yet supported. Got "
+                    "EP × TP composition not yet supported. Got "
                     f"ep={ep_size}, dp_shard={dp_shard_size}, tp={tp_size}, cp={cp_size}. "
-                    "v1 supports only EP-only or EP × dp_shard."
+                    "Supported: EP, EP × dp_shard, EP × cp, EP × cp × dp_shard."
                 )
             mesh = ExpertParallelPlugin._accelerate_mesh()
-            if mesh is None or "ep" not in mesh.mesh_dim_names:
+            if mesh is None or "ep" not in (mesh.mesh_dim_names or ()):
                 from torch.distributed.device_mesh import init_device_mesh
 
+                # Fallback mesh from the >1 axes (ep outermost). Orthogonality of the ep/cp/dp
+                # groups is what matters; accelerate's mesh is preferred when present so the ep
+                # group matches the one used for the experts' FSDP exclusion.
+                axes = [("ep", ep_size)]
+                if cp_size > 1:
+                    axes.append(("cp", cp_size))
+                if dp_shard_size > 1:
+                    axes.append(("dp_shard", dp_shard_size))
                 mesh = init_device_mesh(
                     "cuda" if torch.cuda.is_available() else "cpu",
-                    (ep_size, dp_shard_size),
-                    mesh_dim_names=("ep", "dp_shard"),
+                    tuple(s for _, s in axes),
+                    mesh_dim_names=tuple(n for n, _ in axes),
                 )
             ExpertParallelPlugin._device_mesh = mesh
             LOG.debug(
@@ -246,13 +257,29 @@ class ExpertParallelPlugin(BasePlugin):
             )
             return mesh["ep"].get_group()
 
-        # ep_size > 1, ep_size < world_size, dp_shard_size == 1 — invalid.
+        # ep_size > 1, ep_size < world_size, no dp_shard/cp to fill the rest — invalid.
         raise ValueError(
             f"expert_parallel_size ({ep_size}) < world_size ({world_size}) "
-            "without dp_shard_size > 1 to fill the remaining axes is not supported. "
-            "Set dp_shard_size such that ep × dp_shard == world_size, or set "
-            "expert_parallel_size = world_size for pure EP."
+            "without dp_shard_size/context_parallel_size > 1 to fill the remaining axes is not "
+            "supported. Set dp_shard_size and/or context_parallel_size such that "
+            "ep × cp × dp_shard == world_size, or set expert_parallel_size = world_size for pure EP."
         )
+
+    @staticmethod
+    def _resolve_cp_group(cfg):
+        """Return the context-parallel ProcessGroup (the `cp` axis of the EP mesh), or None when
+        ``context_parallel_size <= 1``. The DSA attention shards the sequence on this axis (gathering
+        the compressed KV across it); experts shard on the orthogonal ``ep`` axis. Reads the mesh
+        built by ``_resolve_ep_group`` / accelerate."""
+        cp_size = getattr(cfg, "context_parallel_size", None) or 1
+        if cp_size <= 1:
+            return None
+        mesh = (
+            ExpertParallelPlugin._device_mesh or ExpertParallelPlugin._accelerate_mesh()
+        )
+        if mesh is not None and "cp" in (mesh.mesh_dim_names or ()):
+            return mesh["cp"].get_group()
+        return None
 
     @staticmethod
     def fully_shard_experts(model, dp_shard_mesh, fsdp2_kwargs):

--- a/src/axolotl/integrations/expert_parallel/plugin.py
+++ b/src/axolotl/integrations/expert_parallel/plugin.py
@@ -21,6 +21,25 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 
+def expert_shard_axis(mesh_dim_names) -> str | None:
+    """The non-``ep`` mesh axis the routed experts FSDP-shard on under EP composition, or ``None``.
+
+    Prefers ``dp_shard`` (EP×dp_shard: experts shard on the data axis); falls back to ``cp`` (EP×cp,
+    where the cp ranks of an ep-group hold the SAME experts since cp shards the sequence, not the
+    experts, so FSDP-sharding them on cp keeps each rank from holding the full ep-group slice). Returns
+    ``None`` for pure EP (no secondary axis) or when there is no ``ep`` axis to compose with — those
+    paths don't pre-wrap the experts here.
+    """
+    names = tuple(mesh_dim_names or ())
+    if "ep" not in names:
+        return None
+    if "dp_shard" in names:
+        return "dp_shard"
+    if "cp" in names:
+        return "cp"
+    return None
+
+
 class ExpertParallelPlugin(BasePlugin):
     """Plugin that swaps MoE dispatch/combine for DeepEP-fused kernels."""
 

--- a/src/axolotl/integrations/expert_parallel/plugin.py
+++ b/src/axolotl/integrations/expert_parallel/plugin.py
@@ -92,6 +92,8 @@ class ExpertParallelPlugin(BasePlugin):
         if not self._is_ep_enabled(cfg):
             return
 
+        self._register_padding_dispatch_hook(model)
+
         # Find the inner module that has the attribute (shard set it on whatever
         # was the top-level model at post_model_build time).
         inner = getattr(model, "base_model", model)
@@ -135,6 +137,55 @@ class ExpertParallelPlugin(BasePlugin):
             f"expert_parallel: propagated {len(resolved)} DDP-ignored param "
             f"name(s) onto outer wrapper {type(model).__name__}."
         )
+
+    @staticmethod
+    def _register_padding_dispatch_hook(model) -> None:
+        """Feed the batch's real-token mask to the DeepEP dispatch so padding tokens are
+        not routed (they'd otherwise pile onto one expert and break intranode dispatch).
+
+        A model-level forward pre-hook reads the 2D ``attention_mask`` (1=real, 0=pad) and
+        stashes a flattened ``[B*S]`` bool mask; ``_deep_ep_forward`` sentinels those rows.
+        Under sample packing there is no 2D mask, but the multipack collator pads partial
+        packs to ``seq_len`` — those identical pad embeddings still pile onto one expert and
+        break DeepEP intranode dispatch — so fall back to ``input_ids != pad_token_id``."""
+        from .experts_fn import set_valid_token_mask
+
+        if getattr(model, "_ep_padding_hook", False):
+            return
+
+        pad_id = getattr(getattr(model, "config", None), "pad_token_id", None)
+
+        def _pre_hook(_module, args, kwargs):
+            am = kwargs.get("attention_mask")
+            if am is None and args:
+                am = next(
+                    (a for a in args if torch.is_tensor(a) and a.dim() == 2), None
+                )
+            if am is not None and am.dim() == 2:
+                set_valid_token_mask((am != 0).reshape(-1))
+                return args, kwargs
+            # Packing (no 2D mask): exclude pad rows so they don't overload one expert.
+            ids = kwargs.get("input_ids")
+            if ids is None and args:
+                ids = next(
+                    (
+                        a
+                        for a in args
+                        if torch.is_tensor(a)
+                        and a.dim() == 2
+                        and a.dtype in (torch.long, torch.int, torch.int32)
+                    ),
+                    None,
+                )
+            set_valid_token_mask(
+                (ids != pad_id).reshape(-1)
+                if (ids is not None and pad_id is not None)
+                else None
+            )
+            return args, kwargs
+
+        model.register_forward_pre_hook(_pre_hook, with_kwargs=True)
+        model._ep_padding_hook = True
 
     @staticmethod
     def _infer_local_kernel(cfg) -> str:
@@ -292,7 +343,11 @@ class ExpertParallelPlugin(BasePlugin):
         """
         from torch.distributed.fsdp import fully_shard
 
-        from .shard import _detect_experts_modules
+        from .shard import (
+            _detect_experts_modules,
+            _is_param_wrapper,
+            _real_experts_base,
+        )
 
         kwargs = dict(fsdp2_kwargs)
         kwargs["mesh"] = dp_shard_mesh
@@ -301,9 +356,29 @@ class ExpertParallelPlugin(BasePlugin):
         for _name, module in _detect_experts_modules(model):
             fully_shard(module, **kwargs)
 
+        # `target_parameters` expert LoRA lives on the ParamWrapper chain wrapping the experts
+        # module (which `_detect_experts_modules` skips). Left to the outer decoder-layer auto-wrap
+        # it shards on the FULL ep×dp mesh — i.e. ACROSS the ep axis — corrupting the per-ep-rank
+        # expert slice (grads averaged over ranks owning different experts; save reconstructs the
+        # wrong shape). Wrap the OUTERMOST expert ParamWrapper as its own FSDP unit on dp_shard:
+        # its forward IS the fused-LoRA fastpath, so FSDP unshards the adapter (incl. the nested
+        # inner wrapper's, which is not a separate unit) to plain tensors right before the kernel
+        # reads them — sharded on the same axis as the weights, but gathered during use.
+        all_pws = [m for _n, m in model.named_modules() if _is_param_wrapper(m)]
+        inner = {getattr(pw, "base_layer", None) for pw in all_pws}
+        outer_expert_pws = [
+            pw
+            for pw in all_pws
+            if pw not in inner
+            and _real_experts_base(pw) is not None
+            and getattr(_real_experts_base(pw), "num_local_experts", None) is not None
+        ]
+        for pw in outer_expert_pws:
+            fully_shard(pw, **kwargs)
+
         LOG.debug(
-            f"expert_parallel: pre-wrapped Experts modules on dp_shard mesh "
-            f"(size={dp_shard_mesh.size()})."
+            f"expert_parallel: pre-wrapped Experts modules + {len(outer_expert_pws)} expert "
+            f"ParamWrapper(s) on dp_shard mesh (size={dp_shard_mesh.size()})."
         )
 
         root = dp_shard_mesh._get_root_mesh()
@@ -332,6 +407,11 @@ class ExpertParallelPlugin(BasePlugin):
         n_hooks = 0
         for _name, module in _detect_experts_modules(model):
             for p in module.parameters(recurse=True):
+                # Only trainable params have a grad to scale — and a hook can only be
+                # registered on a tensor that requires grad. Under LoRA the base expert
+                # weights are frozen (only the adapters train), so skip them.
+                if not p.requires_grad:
+                    continue
                 p.register_post_accumulate_grad_hook(_scale)
                 n_hooks += 1
         LOG.debug(

--- a/src/axolotl/integrations/expert_parallel/plugin.py
+++ b/src/axolotl/integrations/expert_parallel/plugin.py
@@ -75,6 +75,9 @@ class ExpertParallelPlugin(BasePlugin):
             num_nvl_bytes=cfg.expert_parallel_num_nvl_bytes,
             num_rdma_bytes=cfg.expert_parallel_num_rdma_bytes,
         )
+        from .experts_fn import set_token_capacity
+
+        set_token_capacity(getattr(cfg, "expert_parallel_token_capacity", None))
         # Pure-EP path: register the grad-scale hook now. FSDP+EP defers
         # registration to `fully_shard_experts` (after experts become DTensors).
         if (cfg.dp_shard_size or 1) <= 1:

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -62,6 +62,11 @@ def _detect_experts_modules(model):
     for v1.
     """
     for name, module in model.named_modules():
+        # A PEFT ParamWrapper delegates `gate_up_proj` to its `base_layer`, so it
+        # would match too and double-count the experts (double grad-scale, redundant
+        # fully_shard). Yield only the real experts module (the wrapped base_layer).
+        if _is_param_wrapper(module):
+            continue
         gp = getattr(module, "gate_up_proj", None)
         dp = getattr(module, "down_proj", None)
         if gp is None or dp is None:
@@ -164,3 +169,312 @@ def shard_expert_weights(model, ep_group) -> int:
             f"Marked {len(ignore_names)} param(s) as DDP-ignored."
         )
     return sharded
+
+
+def _is_param_wrapper(module) -> bool:
+    """True for a PEFT ParamWrapper, including after ``fully_shard`` renames its class
+    (e.g. ``FSDPParamWrapper``) — FSDP2 sets ``__class__`` to a subclass, so ``isinstance``
+    still holds while a ``type(...).__name__ == 'ParamWrapper'`` check would miss it."""
+    try:
+        from peft.tuners.lora.layer import ParamWrapper
+
+        if isinstance(module, ParamWrapper):
+            return True
+    except (ImportError, AttributeError):
+        pass
+    return "ParamWrapper" in type(module).__name__
+
+
+def _real_experts_base(wrapper):
+    """Walk a (possibly chained) PEFT ParamWrapper down to the real experts module."""
+    base = getattr(wrapper, "base_layer", None)
+    while base is not None and _is_param_wrapper(base):
+        base = getattr(base, "base_layer", None)
+    return base
+
+
+def _slice_expert_lora_param(linear, dim: int, e_global: int, start: int, end: int):
+    """Replace ``linear.weight`` with its local-experts slice.
+
+    ``dim`` is the axis carrying the ``E*r`` packing:
+      * lora_A: ``[E*r, in]`` expert-major  -> slice rows ``[start*r:end*r]`` (dim 0).
+      * lora_B: ``[out, r*E]`` rank-major    -> reshape ``[out, r, E]``, take experts, flatten.
+    Returns the rank ``r`` (so the caller can keep ``in_features``/``out_features`` consistent).
+    """
+    w = linear.weight
+    if dim == 0:  # lora_A: expert-major rows
+        r = w.shape[0] // e_global
+        new = w.data[start * r : end * r, :].detach().clone()
+        linear.out_features = new.shape[0]
+    else:  # lora_B: rank-major columns [out, r, E]
+        out_dim = w.shape[0]
+        r = w.shape[1] // e_global
+        new = (
+            w.data.reshape(out_dim, r, e_global)[:, :, start:end]
+            .reshape(out_dim, r * (end - start))
+            .detach()
+            .clone()
+        )
+        linear.in_features = new.shape[1]
+    linear.weight = torch.nn.Parameter(new, requires_grad=w.requires_grad)
+    return r
+
+
+def shard_expert_lora(model, ep_size: int) -> int:
+    """Slice PEFT ``target_parameters`` expert LoRA to each rank's local experts.
+
+    PEFT sizes the LoRA for a 3D ``experts.{gate_up,down}_proj`` from the parameter's
+    own dim-0 (the *global* expert count) at adapter-application time, before EP's
+    weight slice takes effect on the parameter PEFT wrapped. Left alone, the fused
+    EP kernel (``num_experts = E_local``) and the FSDP2 parametrize merge both see a
+    full-expert LoRA against a local-expert weight -> shape mismatch. This realigns
+    the LoRA with the EP-sharded weights (same ``[offset:offset+E_local]`` slice) and
+    registers the ``1/ep_size`` expert grad-scale on the new params. Idempotent.
+
+    Run AFTER PEFT applies the adapter and BEFORE FSDP wraps. Returns the count of
+    LoRA params sliced.
+    """
+    if ep_size <= 1:
+        return 0
+
+    scale = 1.0 / ep_size
+
+    def _scale_hook(p):
+        if p.grad is not None:
+            p.grad.mul_(scale)
+
+    n = 0
+    for _name, wrapper in model.named_modules():
+        if not _is_param_wrapper(wrapper):
+            continue
+        if getattr(wrapper, "_ep_lora_sharded", False):
+            continue
+        base = _real_experts_base(wrapper)
+        e_local = getattr(base, "num_local_experts", None) if base is not None else None
+        e_global = (
+            getattr(base, "num_experts_global", None) if base is not None else None
+        )
+        if e_local is None or e_global is None or e_local >= e_global:
+            continue
+        start = base.local_expert_offset
+        end = start + e_local
+
+        for adapters, dim in (
+            (getattr(wrapper, "lora_A", {}), 0),
+            (getattr(wrapper, "lora_B", {}), 1),
+        ):
+            for ad in list(adapters.keys()):
+                _slice_expert_lora_param(adapters[ad], dim, e_global, start, end)
+                adapters[ad].weight.register_post_accumulate_grad_hook(_scale_hook)
+                n += 1
+        wrapper._ep_lora_sharded = True
+
+    if n:
+        LOG.info(
+            f"Sharded {n} expert-LoRA param(s) to local experts "
+            f"(ep_size={ep_size}, grad-scale=1/{ep_size})."
+        )
+    return n
+
+
+def save_ep_lora_adapter(model, output_dir: str, ep_group) -> bool:
+    """Write a complete LoRA adapter when experts are EP-sharded.
+
+    The attention/router LoRA is replicated across EP, but ``target_parameters`` expert
+    LoRA is EP-sharded (each rank holds ``[offset:offset+E_local]``). A plain save would
+    persist only the local rank's experts. This gathers each adapter param to a full
+    tensor (FSDP all-gather via ``full_tensor`` + EP all-gather for expert LoRA), renames
+    to PEFT adapter keys, and writes ``adapter_model.safetensors`` on rank 0. Returns
+    ``True`` if it handled the save.
+    """
+    from pathlib import Path
+
+    from peft.utils.save_and_load import get_peft_model_state_dict
+    from safetensors.torch import save_file
+
+    # The EP-sharded 3D expert params and the global expert count. Gather straight from the
+    # ParamWrappers by parameter_name (chaining `base_layer` through FSDP-wrapped units to reach
+    # the experts module via `_real_experts_base` is brittle once the outer wrapper is its own
+    # FSDP unit).
+    expert_param_names: set = set()
+    e_global = None
+    for _n, m in model.named_modules():
+        if (
+            getattr(m, "num_local_experts", None) is not None
+            and getattr(m, "num_experts_global", None) is not None
+            and m.num_local_experts < m.num_experts_global
+        ):
+            e_global = m.num_experts_global
+            for pn in ("gate_up_proj", "down_proj"):
+                if hasattr(m, pn):
+                    expert_param_names.add(pn)
+    if e_global is None or not expert_param_names:
+        return False
+
+    expert_wrappers = [
+        (wname, wrapper)
+        for wname, wrapper in model.named_modules()
+        if _is_param_wrapper(wrapper)
+        and getattr(wrapper, "parameter_name", None) in expert_param_names
+    ]
+    if not expert_wrappers:
+        return False
+
+    active = model.active_adapter if hasattr(model, "active_adapter") else "default"
+    if isinstance(active, (list, tuple)):
+        active = active[0]
+
+    # Prefer the ep group captured at FSDP-setup time; re-resolving from cfg at save can
+    # return a stale/degenerate (size-1) mesh.
+    stashed = getattr(model, "_ep_lora_group", None)
+    if stashed is not None:
+        ep_group = stashed
+
+    # Replicated (attention/router) LoRA: full tensors via FSDP all-gather, canonical PEFT keys.
+    sd = {
+        name: (p.full_tensor() if type(p).__name__ == "DTensor" else p.data).detach()
+        for name, p in model.named_parameters()
+        if "lora_" in name
+    }
+    adapter_sd = get_peft_model_state_dict(model, state_dict=sd)
+
+    # Expert LoRA: gather each wrapper's adapter across FSDP (dp_shard) + EP, key by module name.
+    gathered = 0
+    for wname, wrapper in expert_wrappers:
+        for sub, kind in (("lora_A", "A"), ("lora_B", "B")):
+            for w in (mod.weight for mod in getattr(wrapper, sub, {}).values()):
+                full_local = (
+                    w.full_tensor() if type(w).__name__ == "DTensor" else w.data
+                )
+                full = gather_expert_lora_full(
+                    full_local.detach().contiguous(), kind, e_global, ep_group
+                )
+                key = f"{wname}.{sub}.weight"
+                target = (
+                    key
+                    if key in adapter_sd
+                    else next(
+                        (
+                            k
+                            for k in adapter_sd
+                            if k.endswith(key.split("base_model.model.")[-1])
+                        ),
+                        None,
+                    )
+                )
+                if target is not None:
+                    adapter_sd[target] = full
+                    gathered += 1
+                else:
+                    LOG.warning(f"EP-LoRA save: no adapter key for {key!r}.")
+
+    if dist.get_rank() == 0:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        save_file(
+            {k: v.cpu().contiguous() for k, v in adapter_sd.items()},
+            str(out / "adapter_model.safetensors"),
+        )
+        model.peft_config[active].save_pretrained(str(out))
+        LOG.info(
+            f"Saved EP-gathered LoRA adapter ({len(adapter_sd)} tensors, "
+            f"{gathered} expert params gathered across EP) to {out}."
+        )
+    dist.barrier()
+    return True
+
+
+def save_fsdp2_lora_adapter(model, output_dir: str) -> bool:
+    """Write a complete LoRA adapter under FSDP2 WITHOUT expert parallelism.
+
+    The DCP ``SHARDED_STATE_DICT`` save fails ("Failed to validate global plan") on the frozen NVFP4
+    base params (torchao tensor-subclass DTensors the planner can't validate). For a LoRA run we only
+    need the (tiny) adapter, so gather each ``lora_`` param to a full tensor via FSDP all-gather
+    (``DTensor.full_tensor``) and write ``adapter_model.safetensors`` on rank 0. ``target_parameters``
+    expert LoRA lives on PEFT ParamWrappers (``lora_A``/``lora_B`` submodules) — gather those too and
+    key by module name (no EP axis to gather here, unlike :func:`save_ep_lora_adapter`).
+
+    Returns ``True`` if it handled the save (model has LoRA params), else ``False``.
+    """
+    from pathlib import Path
+
+    from peft.utils.save_and_load import get_peft_model_state_dict
+    from safetensors.torch import save_file
+
+    if not any("lora_" in n for n, _ in model.named_parameters()):
+        return False
+
+    active = model.active_adapter if hasattr(model, "active_adapter") else "default"
+    if isinstance(active, (list, tuple)):
+        active = active[0]
+
+    # Replicated + dp-sharded LoRA: full tensors via FSDP all-gather (collective — same iteration
+    # order on every rank). Canonical PEFT keys via get_peft_model_state_dict.
+    sd = {
+        name: (p.full_tensor() if type(p).__name__ == "DTensor" else p.data).detach()
+        for name, p in model.named_parameters()
+        if "lora_" in name
+    }
+    adapter_sd = get_peft_model_state_dict(model, state_dict=sd)
+
+    gathered = 0
+    for wname, wrapper in model.named_modules():
+        if not _is_param_wrapper(wrapper):
+            continue
+        for sub in ("lora_A", "lora_B"):
+            for w in (mod.weight for mod in getattr(wrapper, sub, {}).values()):
+                full = (
+                    w.full_tensor() if type(w).__name__ == "DTensor" else w.data
+                ).detach()
+                key = f"{wname}.{sub}.weight"
+                target = (
+                    key
+                    if key in adapter_sd
+                    else next(
+                        (
+                            k
+                            for k in adapter_sd
+                            if k.endswith(key.split("base_model.model.")[-1])
+                        ),
+                        None,
+                    )
+                )
+                if target is not None:
+                    adapter_sd[target] = full
+                    gathered += 1
+
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        save_file(
+            {k: v.cpu().contiguous() for k, v in adapter_sd.items()},
+            str(out / "adapter_model.safetensors"),
+        )
+        model.peft_config[active].save_pretrained(str(out))
+        LOG.info(
+            f"Saved FSDP2-gathered LoRA adapter ({len(adapter_sd)} tensors, "
+            f"{gathered} expert params) to {out}."
+        )
+    if dist.is_initialized():
+        dist.barrier()
+    return True
+
+
+def gather_expert_lora_full(local: torch.Tensor, kind: str, e_global: int, ep_group):
+    """Inverse of the EP LoRA slice: all-gather a local-experts LoRA tensor across the
+    EP group and reassemble the full ``e_global``-expert tensor in the PEFT layout.
+
+      * ``kind="A"`` (expert-major ``[E*r, in]``): concat gathered slices along rows.
+      * ``kind="B"`` (rank-major ``[out, r*E]``): place each rank's experts into the
+        ``E`` axis of ``[out, r, E]`` and flatten.
+    """
+    ep_size = dist.get_world_size(ep_group)
+    gathered = [torch.empty_like(local) for _ in range(ep_size)]
+    dist.all_gather(gathered, local.contiguous(), group=ep_group)
+    if kind == "A":
+        return torch.cat(gathered, dim=0)
+    out_dim = local.shape[0]
+    e_local = e_global // ep_size
+    r = local.shape[1] // e_local
+    parts = [g.reshape(out_dim, r, e_local) for g in gathered]
+    return torch.cat(parts, dim=2).reshape(out_dim, r * e_global)

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -213,6 +213,9 @@ def shard_expert_weights(model, ep_group) -> int:
         module.local_expert_offset = start
         module.num_local_experts = E_local
         module.num_experts_global = E
+        # Single global expert count for the cpu_ram_efficient load path (all routed-expert modules
+        # share it); used to reshape the global expert-LoRA adapter when slicing per-rank shards.
+        model._ep_num_experts_global = E
         # Override the kernel's view of num_experts for grouped_mm/scattermoe bucketing.
         module.num_experts = E_local
 
@@ -292,6 +295,39 @@ def _slice_expert_lora_param(linear, dim: int, e_global: int, start: int, end: i
         linear.in_features = new.shape[1]
     linear.weight = torch.nn.Parameter(new, requires_grad=w.requires_grad)
     return r
+
+
+def ep_adapter_load_local_shard(
+    global_adapter, ep_dim, e_global, ep_coord, ep_size, placements, dp_size, dp_rank
+):
+    """Slice an EP-composition expert-LoRA adapter from rank-0's GLOBAL (all-experts) tensor down to
+    THIS rank's local FSDP shard — the inverse of ``shard_expert_lora`` + the FSDP dp/cp sharding, used
+    by the cpu_ram_efficient load path. First take this ep-group's experts, then this rank's dp/cp shard
+    along each Shard placement.
+
+    ``ep_dim`` is the adapter's expert axis: 0 for lora_A's expert-major ``[E*r, in]`` rows, 1 for
+    lora_B's ``[out, r*E]`` columns. lora_B's experts are the LAST axis of the ``[out, r, E]`` view (NOT
+    contiguous in the flat ``r*E`` dim), so a plain ``chunk`` on dim 1 would pick a rank-component, not
+    this ep-group's experts — hence the reshape-slice that mirrors :func:`_slice_expert_lora_param`.
+    """
+    from torch.distributed.tensor import Shard
+
+    e_local = e_global // ep_size
+    start, end = ep_coord * e_local, (ep_coord + 1) * e_local
+    if ep_dim == 0:  # lora_A: [E*r, in] expert-major rows
+        r = global_adapter.shape[0] // e_global
+        ep_slice = global_adapter[start * r : end * r, :]
+    else:  # lora_B: [out, r*E] -> [out, r, E], experts on the last axis
+        out_dim = global_adapter.shape[0]
+        r = global_adapter.shape[1] // e_global
+        ep_slice = global_adapter.reshape(out_dim, r, e_global)[:, :, start:end].reshape(
+            out_dim, r * e_local
+        )
+    local = ep_slice
+    for placement in placements:
+        if isinstance(placement, Shard):
+            local = local.chunk(dp_size, dim=placement.dim)[dp_rank]
+    return local.contiguous()
 
 
 def shard_expert_lora(model, ep_size: int) -> int:

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -53,6 +53,69 @@ def _replace_with_slice(module, attr_name: str, start: int, end: int) -> None:
     # `old` goes out of scope on return.
 
 
+def _scatter_expert_from_rank0(module, attr_name, group, ep_rank, ep_size, e_local):
+    """Populate ``module.{attr_name}`` with THIS rank's real ``[e_local]`` expert slice by scattering
+    rank-0's full param. Under cpu_ram_efficient_loading the rank0-only converter leaves non-rank-0
+    experts ZERO; plain-slicing them (``_replace_with_slice``) + DDP-ignore means ranks 1..N keep zero
+    experts. Rank 0 holds the full real param here (post from_pretrained, before FSDP), so scatter its
+    dim-0 (expert-axis) slices to every rank. Handles torchao NVFP4Tensor (scatter qdata/scale/
+    per_tensor_scale components) and plain tensors. The scatter runs on GPU (NCCL); the rebuilt slice
+    is moved back to the param's original device."""
+    import torch.distributed as dist
+
+    old = getattr(module, attr_name)
+    nv = old.data
+    dev = torch.device("cuda", torch.cuda.current_device())
+    src = dist.get_global_rank(group, 0)
+    dst_device = old.data.device if old.data.device.type != "meta" else torch.device("cpu")
+    requires_grad = old.requires_grad
+
+    def _scatter_dim0(full_comp, like):
+        out = torch.empty((e_local, *like.shape[1:]), dtype=like.dtype, device=dev)
+        chunks = None
+        if ep_rank == 0:
+            chunks = [c.contiguous().to(dev) for c in full_comp.chunk(ep_size, dim=0)]
+        dist.scatter(out, scatter_list=chunks, src=src, group=group)
+        return out
+
+    try:
+        from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+    except ImportError:
+        NVFP4Tensor = None
+
+    if NVFP4Tensor is not None and isinstance(nv, NVFP4Tensor):
+        full_q = nv.qdata if ep_rank == 0 else None
+        local_q = _scatter_dim0(full_q, nv.qdata)
+        # scale (e4m3) isn't a collective dtype on all backends -> scatter the uint8 view.
+        full_s = nv.scale.view(torch.uint8) if ep_rank == 0 else None
+        local_s = _scatter_dim0(full_s, nv.scale.view(torch.uint8)).view(nv.scale.dtype)
+        pts = getattr(nv, "per_tensor_scale", None)
+        local_pts = None
+        if pts is not None:
+            if pts.dim() >= 1 and pts.shape[0] == nv.qdata.shape[0]:
+                local_pts = _scatter_dim0(
+                    pts if ep_rank == 0 else None, pts
+                )
+            else:  # replicated scalar
+                local_pts = pts.to(dev).clone()
+                dist.broadcast(local_pts, src=src, group=group)
+        local_nv = NVFP4Tensor(
+            local_q.to(dst_device),
+            local_s.to(dst_device),
+            nv.block_size,
+            nv.dtype,
+            per_tensor_scale=(local_pts.to(dst_device) if local_pts is not None else None),
+        )
+        new_param = torch.nn.Parameter(local_nv, requires_grad=requires_grad)
+    else:
+        local = _scatter_dim0(nv if ep_rank == 0 else None, nv)
+        new_param = torch.nn.Parameter(local.to(dst_device), requires_grad=requires_grad)
+
+    if attr_name in module._parameters:
+        del module._parameters[attr_name]
+    setattr(module, attr_name, new_param)
+
+
 def _detect_experts_modules(model):
     """Yield (name, module) pairs for every module that looks like an Experts class.
 
@@ -108,6 +171,11 @@ def shard_expert_weights(model, ep_group) -> int:
         return 0
 
     ep_rank = dist.get_rank(ep_group)
+    # `_scatter_expert_from_rank0` sources the full expert tensor from the EP group's rank 0, which
+    # only holds real (non-meta) data under cpu_ram_efficient_loading when it IS global rank 0 — i.e.
+    # pure EP (ep group == WORLD). In EP×dp_shard composition the experts are loaded via the FSDP
+    # mesh (fully_shard_experts + the NVFP4 broadcast), so plain-slice here and let FSDP fill them.
+    pure_ep = ep_size == dist.get_world_size()
     sharded = 0
     ignore_names: list[str] = []
 
@@ -121,19 +189,41 @@ def shard_expert_weights(model, ep_group) -> int:
             )
         E_local = E // ep_size
         start = ep_rank * E_local
-        end = start + E_local
 
+        end = start + E_local
         with torch.no_grad():
-            _replace_with_slice(module, "gate_up_proj", start, end)
-            _replace_with_slice(module, "down_proj", start, end)
-            for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
-                bias = getattr(module, bias_name, None)
-                if (
-                    isinstance(bias, torch.nn.Parameter)
-                    and bias.dim() >= 1
-                    and bias.shape[0] == E
-                ):
-                    _replace_with_slice(module, bias_name, start, end)
+            if pure_ep:
+                # Pure EP: no FSDP mesh fills the experts, and after the slice rank 0 keeps only
+                # experts[0:E_local], so the full tensor is gone. Scatter rank-0's REAL per-rank
+                # slices NOW (rank 0 == EP rank 0 holds the full tensor). See
+                # _scatter_expert_from_rank0; the outer FSDP must then ignore these params.
+                _scatter_expert_from_rank0(
+                    module, "gate_up_proj", ep_group, ep_rank, ep_size, E_local
+                )
+                _scatter_expert_from_rank0(
+                    module, "down_proj", ep_group, ep_rank, ep_size, E_local
+                )
+                for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
+                    bias = getattr(module, bias_name, None)
+                    if (
+                        isinstance(bias, torch.nn.Parameter)
+                        and bias.dim() >= 1
+                        and bias.shape[0] == E
+                    ):
+                        _scatter_expert_from_rank0(
+                            module, bias_name, ep_group, ep_rank, ep_size, E_local
+                        )
+            else:
+                _replace_with_slice(module, "gate_up_proj", start, end)
+                _replace_with_slice(module, "down_proj", start, end)
+                for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
+                    bias = getattr(module, bias_name, None)
+                    if (
+                        isinstance(bias, torch.nn.Parameter)
+                        and bias.dim() >= 1
+                        and bias.shape[0] == E
+                    ):
+                        _replace_with_slice(module, bias_name, start, end)
 
         # Stash metadata the registered fn needs.
         module.local_expert_offset = start

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -451,13 +451,20 @@ def save_ep_lora_adapter(model, output_dir: str, ep_group) -> bool:
     # Expert LoRA: gather each wrapper's adapter across FSDP (dp_shard) + EP, key by module name.
     gathered = 0
     for wname, wrapper in expert_wrappers:
+        # Only EP×dp_shard/cp composition physically slices the adapter to E_local (shard_expert_lora
+        # sets _ep_lora_sharded), so it must be EP-all-gathered back to E_global. Pure EP keeps the
+        # adapter GLOBAL (E_global, forward-sliced at runtime) — gathering it would replicate every
+        # expert ep_size times into an oversized adapter, so write the FSDP-gathered tensor as-is.
+        ep_sharded = getattr(wrapper, "_ep_lora_sharded", False)
         for sub, kind in (("lora_A", "A"), ("lora_B", "B")):
             for w in (mod.weight for mod in getattr(wrapper, sub, {}).values()):
                 full_local = (
                     w.full_tensor() if type(w).__name__ == "DTensor" else w.data
-                )
-                full = gather_expert_lora_full(
-                    full_local.detach().contiguous(), kind, e_global, ep_group
+                ).detach().contiguous()
+                full = (
+                    gather_expert_lora_full(full_local, kind, e_global, ep_group)
+                    if ep_sharded
+                    else full_local
                 )
                 key = f"{wname}.{sub}.weight"
                 target = (

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -70,7 +70,9 @@ def _scatter_expert_from_rank0(module, attr_name, e_local, dp_size):
     dev = torch.device("cuda", torch.cuda.current_device())
     world = dist.get_world_size()
     is_src = dist.get_rank() == 0
-    dst_device = old.data.device if old.data.device.type != "meta" else torch.device("cpu")
+    dst_device = (
+        old.data.device if old.data.device.type != "meta" else torch.device("cpu")
+    )
     requires_grad = old.requires_grad
 
     def _scatter_dim0(full_comp, like):
@@ -110,12 +112,16 @@ def _scatter_expert_from_rank0(module, attr_name, e_local, dp_size):
             local_s.to(dst_device),
             nv.block_size,
             nv.dtype,
-            per_tensor_scale=(local_pts.to(dst_device) if local_pts is not None else None),
+            per_tensor_scale=(
+                local_pts.to(dst_device) if local_pts is not None else None
+            ),
         )
         new_param = torch.nn.Parameter(local_nv, requires_grad=requires_grad)
     else:
         local = _scatter_dim0(nv if is_src else None, nv)
-        new_param = torch.nn.Parameter(local.to(dst_device), requires_grad=requires_grad)
+        new_param = torch.nn.Parameter(
+            local.to(dst_device), requires_grad=requires_grad
+        )
 
     if attr_name in module._parameters:
         del module._parameters[attr_name]
@@ -320,9 +326,9 @@ def ep_adapter_load_local_shard(
     else:  # lora_B: [out, r*E] -> [out, r, E], experts on the last axis
         out_dim = global_adapter.shape[0]
         r = global_adapter.shape[1] // e_global
-        ep_slice = global_adapter.reshape(out_dim, r, e_global)[:, :, start:end].reshape(
-            out_dim, r * e_local
-        )
+        ep_slice = global_adapter.reshape(out_dim, r, e_global)[
+            :, :, start:end
+        ].reshape(out_dim, r * e_local)
     local = ep_slice
     for placement in placements:
         if isinstance(placement, Shard):
@@ -459,8 +465,10 @@ def save_ep_lora_adapter(model, output_dir: str, ep_group) -> bool:
         for sub, kind in (("lora_A", "A"), ("lora_B", "B")):
             for w in (mod.weight for mod in getattr(wrapper, sub, {}).values()):
                 full_local = (
-                    w.full_tensor() if type(w).__name__ == "DTensor" else w.data
-                ).detach().contiguous()
+                    (w.full_tensor() if type(w).__name__ == "DTensor" else w.data)
+                    .detach()
+                    .contiguous()
+                )
                 full = (
                     gather_expert_lora_full(full_local, kind, e_global, ep_group)
                     if ep_sharded

--- a/src/axolotl/integrations/expert_parallel/shard.py
+++ b/src/axolotl/integrations/expert_parallel/shard.py
@@ -53,29 +53,37 @@ def _replace_with_slice(module, attr_name: str, start: int, end: int) -> None:
     # `old` goes out of scope on return.
 
 
-def _scatter_expert_from_rank0(module, attr_name, group, ep_rank, ep_size, e_local):
+def _scatter_expert_from_rank0(module, attr_name, e_local, dp_size):
     """Populate ``module.{attr_name}`` with THIS rank's real ``[e_local]`` expert slice by scattering
-    rank-0's full param. Under cpu_ram_efficient_loading the rank0-only converter leaves non-rank-0
-    experts ZERO; plain-slicing them (``_replace_with_slice``) + DDP-ignore means ranks 1..N keep zero
-    experts. Rank 0 holds the full real param here (post from_pretrained, before FSDP), so scatter its
-    dim-0 (expert-axis) slices to every rank. Handles torchao NVFP4Tensor (scatter qdata/scale/
-    per_tensor_scale components) and plain tensors. The scatter runs on GPU (NCCL); the rebuilt slice
-    is moved back to the param's original device."""
+    GLOBAL rank-0's full expert tensor over the WORLD group. Under cpu_ram_efficient_loading only global
+    rank 0 materializes real weights, so it is the single source (sourcing from an ep-subgroup's rank-0
+    would crash on the meta ranks). Each rank ``r`` receives its ep-group's slice
+    ``full[(r//dp_size)*e_local : ((r//dp_size)+1)*e_local]`` — the ``dp_size`` ranks within an ep-group
+    get the SAME ep slice (the dp axis FSDP-shards it across them later). ``dp_size == 1`` is pure EP
+    (each rank its own [e_local]); ``dp_size > 1`` is EP×dp_shard / EP×cp composition. Handles torchao
+    NVFP4Tensor (qdata/scale/per_tensor_scale) and plain tensors; runs on GPU (NCCL), result moved to
+    the param's original device."""
     import torch.distributed as dist
 
     old = getattr(module, attr_name)
     nv = old.data
     dev = torch.device("cuda", torch.cuda.current_device())
-    src = dist.get_global_rank(group, 0)
+    world = dist.get_world_size()
+    is_src = dist.get_rank() == 0
     dst_device = old.data.device if old.data.device.type != "meta" else torch.device("cpu")
     requires_grad = old.requires_grad
 
     def _scatter_dim0(full_comp, like):
         out = torch.empty((e_local, *like.shape[1:]), dtype=like.dtype, device=dev)
         chunks = None
-        if ep_rank == 0:
-            chunks = [c.contiguous().to(dev) for c in full_comp.chunk(ep_size, dim=0)]
-        dist.scatter(out, scatter_list=chunks, src=src, group=group)
+        if is_src:
+            chunks = [
+                full_comp[(r // dp_size) * e_local : (r // dp_size + 1) * e_local]
+                .contiguous()
+                .to(dev)
+                for r in range(world)
+            ]
+        dist.scatter(out, scatter_list=chunks, src=0)
         return out
 
     try:
@@ -84,21 +92,19 @@ def _scatter_expert_from_rank0(module, attr_name, group, ep_rank, ep_size, e_loc
         NVFP4Tensor = None
 
     if NVFP4Tensor is not None and isinstance(nv, NVFP4Tensor):
-        full_q = nv.qdata if ep_rank == 0 else None
+        full_q = nv.qdata if is_src else None
         local_q = _scatter_dim0(full_q, nv.qdata)
         # scale (e4m3) isn't a collective dtype on all backends -> scatter the uint8 view.
-        full_s = nv.scale.view(torch.uint8) if ep_rank == 0 else None
+        full_s = nv.scale.view(torch.uint8) if is_src else None
         local_s = _scatter_dim0(full_s, nv.scale.view(torch.uint8)).view(nv.scale.dtype)
         pts = getattr(nv, "per_tensor_scale", None)
         local_pts = None
         if pts is not None:
             if pts.dim() >= 1 and pts.shape[0] == nv.qdata.shape[0]:
-                local_pts = _scatter_dim0(
-                    pts if ep_rank == 0 else None, pts
-                )
+                local_pts = _scatter_dim0(pts if is_src else None, pts)
             else:  # replicated scalar
                 local_pts = pts.to(dev).clone()
-                dist.broadcast(local_pts, src=src, group=group)
+                dist.broadcast(local_pts, src=0)
         local_nv = NVFP4Tensor(
             local_q.to(dst_device),
             local_s.to(dst_device),
@@ -108,7 +114,7 @@ def _scatter_expert_from_rank0(module, attr_name, group, ep_rank, ep_size, e_loc
         )
         new_param = torch.nn.Parameter(local_nv, requires_grad=requires_grad)
     else:
-        local = _scatter_dim0(nv if ep_rank == 0 else None, nv)
+        local = _scatter_dim0(nv if is_src else None, nv)
         new_param = torch.nn.Parameter(local.to(dst_device), requires_grad=requires_grad)
 
     if attr_name in module._parameters:
@@ -171,11 +177,6 @@ def shard_expert_weights(model, ep_group) -> int:
         return 0
 
     ep_rank = dist.get_rank(ep_group)
-    # `_scatter_expert_from_rank0` sources the full expert tensor from the EP group's rank 0, which
-    # only holds real (non-meta) data under cpu_ram_efficient_loading when it IS global rank 0 — i.e.
-    # pure EP (ep group == WORLD). In EP×dp_shard composition the experts are loaded via the FSDP
-    # mesh (fully_shard_experts + the NVFP4 broadcast), so plain-slice here and let FSDP fill them.
-    pure_ep = ep_size == dist.get_world_size()
     sharded = 0
     ignore_names: list[str] = []
 
@@ -190,40 +191,23 @@ def shard_expert_weights(model, ep_group) -> int:
         E_local = E // ep_size
         start = ep_rank * E_local
 
-        end = start + E_local
+        # Scatter global rank-0's REAL experts to every rank's ep-group slice. Under
+        # cpu_ram_efficient_loading only global rank 0 has data; plain-slicing (the old path) kept
+        # only rank 0's own ep-group's slice and zeroed the rest, so ep-groups 1..N had dead experts.
+        # dp_size>1 (EP×dp_shard / EP×cp) gives the dp ranks within an ep-group the same ep slice; the
+        # FSDP dp-axis shards it across them afterwards. See _scatter_expert_from_rank0.
+        dp_size = dist.get_world_size() // ep_size
         with torch.no_grad():
-            if pure_ep:
-                # Pure EP: no FSDP mesh fills the experts, and after the slice rank 0 keeps only
-                # experts[0:E_local], so the full tensor is gone. Scatter rank-0's REAL per-rank
-                # slices NOW (rank 0 == EP rank 0 holds the full tensor). See
-                # _scatter_expert_from_rank0; the outer FSDP must then ignore these params.
-                _scatter_expert_from_rank0(
-                    module, "gate_up_proj", ep_group, ep_rank, ep_size, E_local
-                )
-                _scatter_expert_from_rank0(
-                    module, "down_proj", ep_group, ep_rank, ep_size, E_local
-                )
-                for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
-                    bias = getattr(module, bias_name, None)
-                    if (
-                        isinstance(bias, torch.nn.Parameter)
-                        and bias.dim() >= 1
-                        and bias.shape[0] == E
-                    ):
-                        _scatter_expert_from_rank0(
-                            module, bias_name, ep_group, ep_rank, ep_size, E_local
-                        )
-            else:
-                _replace_with_slice(module, "gate_up_proj", start, end)
-                _replace_with_slice(module, "down_proj", start, end)
-                for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
-                    bias = getattr(module, bias_name, None)
-                    if (
-                        isinstance(bias, torch.nn.Parameter)
-                        and bias.dim() >= 1
-                        and bias.shape[0] == E
-                    ):
-                        _replace_with_slice(module, bias_name, start, end)
+            _scatter_expert_from_rank0(module, "gate_up_proj", E_local, dp_size)
+            _scatter_expert_from_rank0(module, "down_proj", E_local, dp_size)
+            for bias_name in ("gate_up_proj_bias", "down_proj_bias"):
+                bias = getattr(module, bias_name, None)
+                if (
+                    isinstance(bias, torch.nn.Parameter)
+                    and bias.dim() >= 1
+                    and bias.shape[0] == E
+                ):
+                    _scatter_expert_from_rank0(module, bias_name, E_local, dp_size)
 
         # Stash metadata the registered fn needs.
         module.local_expert_offset = start

--- a/src/axolotl/integrations/kernels/adapters/__init__.py
+++ b/src/axolotl/integrations/kernels/adapters/__init__.py
@@ -48,8 +48,9 @@ class ModelAdapter:
 def _all_adapters() -> list[ModelAdapter]:
     from axolotl.integrations.kernels.adapters.dsv4 import DSV4Adapter
     from axolotl.integrations.kernels.adapters.gemma4 import Gemma4Adapter
+    from axolotl.integrations.kernels.adapters.glm_moe_dsa import GlmMoeDsaAdapter
 
-    return [DSV4Adapter(), Gemma4Adapter()]
+    return [DSV4Adapter(), Gemma4Adapter(), GlmMoeDsaAdapter()]
 
 
 def get_active_adapters(cfg) -> list[ModelAdapter]:

--- a/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
+++ b/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
@@ -22,6 +22,23 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 
+def _disable_cudnn_sdp() -> None:
+    """Disable the cuDNN SDPA backend for the stock-sdpa GLM path.
+
+    GLM-5.2 develops "massive activations" (residual-stream outliers ~600+ in the top layers). The
+    cuDNN flash-attention BACKWARD produces NaN on the resulting extreme q/k (the math/mem-efficient
+    backends are robust), which propagates to every gradient → grad_norm=nan. Forward is finite, so
+    it only shows in training. Disabling the cuDNN backend makes SDPA fall back to flash/mem-efficient.
+    No-op cost on the ``use_glm_dsa_kernels`` path (that replaces SDPA with the fused DSA flash kernel).
+    """
+    import torch
+
+    try:
+        torch.backends.cuda.enable_cudnn_sdp(False)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
 def is_glm_moe_dsa_nvfp4_modelopt(cfg) -> bool:
     """True iff the base model is a GLM-5.2 (``glm_moe_dsa``) NVFP4-modelopt checkpoint
     (``quant_method=modelopt``, ``quant_algo=NVFP4``). Any failure returns False."""
@@ -92,14 +109,43 @@ class GlmMoeDsaAdapter(ModelAdapter):
         return bool(cfg.get("use_glm_dsa_kernels")) and _is_glm_moe_dsa(cfg)
 
     def pre_model_load(self, cfg) -> None:
+        # The cuDNN SDPA backward NaNs on GLM's massive activations (see _disable_cudnn_sdp).
+        _disable_cudnn_sdp()
         if not (cfg.use_scattermoe and is_glm_moe_dsa_nvfp4_modelopt(cfg)):
             return  # NVFP4 converter registration is only for modelopt-NVFP4 checkpoints
         from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_moe_loading import (
             inspect_nvfp4_layout,
+            patch_nvfp4_tensor_meta_ops,
         )
         from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_weight_converter import (
+            patch_conversion_loader_rank0_only,
             register_nvfp4_converters_for_layout,
         )
+
+        # FSDP2 cpu_ram_efficient_loading materializes meta receive-buffers via zeros_like/empty_like.
+        patch_nvfp4_tensor_meta_ops()
+        # transformers' conversion loader ignores cpu_ram_efficient_loading (loads on every rank);
+        # gate it to rank0-only so the full model doesn't blow up CPU RAM by the world size. Only
+        # safe when the FSDP broadcast will later fill the non-rank-0 meta params — i.e. when
+        # cpu_ram_efficient_loading is set — so DDP ranks (which each need real weights) are spared.
+        if (cfg.get("fsdp_config") or {}).get("cpu_ram_efficient_loading"):
+            patch_conversion_loader_rank0_only()
+            # transformers gates the META SKELETON (and its own load path) on is_fsdp_enabled(),
+            # which requires the process group to be initialized. axolotl doesn't init it until
+            # AFTER model load, so without this non-rank-0 builds a full real-storage skeleton
+            # (world-size× CPU blowup) before any weights even load. Init it now.
+            from transformers.integrations.fsdp import is_fsdp_enabled
+
+            from axolotl.utils.distributed import init_distributed_state
+
+            init_distributed_state()
+            LOG.info(
+                "glm_moe_dsa: initialized distributed state for rank0-only loading "
+                "(is_fsdp_enabled=%s)",
+                is_fsdp_enabled(),
+            )
+
+        import os
 
         layout = inspect_nvfp4_layout(cfg.base_model)
         LOG.info(
@@ -109,12 +155,43 @@ class GlmMoeDsaAdapter(ModelAdapter):
             layout["routed_projs"],
             layout["nonrouted_suffixes"],
         )
-        register_nvfp4_converters_for_layout("glm_moe_dsa", layout)
+        # FAST routed-expert load (opt-in): skip the routed converters here and read+fuse the experts
+        # DIRECTLY in post_model_load — bypasses transformers' ~7-min per-tensor conversion loop over
+        # ~240k expert source tensors (direct path ~25s). Non-routed converters still register.
+        self._direct_expert_load = (
+            bool(os.environ.get("AXOLOTL_DIRECT_EXPERT_LOAD"))
+            and layout["routed_present"]
+        )
+        self._routed_projs = layout.get("routed_projs", [])
+        if self._direct_expert_load:
+            reg_layout = dict(layout)
+            reg_layout["routed_present"] = (
+                False  # don't register the slow routed converters
+            )
+            register_nvfp4_converters_for_layout("glm_moe_dsa", reg_layout)
+            LOG.info("glm_moe_dsa: routed experts will be DIRECT-loaded (fast path)")
+        else:
+            register_nvfp4_converters_for_layout("glm_moe_dsa", layout)
 
     def post_model_load(self, cfg, model) -> None:
         """Patch the DSA attention with the fused absorbed-MLA kernels + keep the MoE router fp32.
         Gated on ``use_glm_dsa_kernels``. Wires the context-parallel group so the attention shards
         the sequence on the `cp` axis (composes with EP on the orthogonal `ep` axis)."""
+        if getattr(self, "_direct_expert_load", False):
+            import time
+
+            from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_moe_loading import (
+                direct_load_nvfp4_experts,
+            )
+
+            t0 = time.time()
+            n = direct_load_nvfp4_experts(model, cfg.base_model, self._routed_projs)
+            LOG.info(
+                "glm_moe_dsa: direct-loaded %d fused expert params in %.1fs (fast path)",
+                n,
+                time.time() - t0,
+            )
+
         if not cfg.get("use_glm_dsa_kernels"):
             return
         from axolotl.integrations.kernels.libs.glm_dsa import (

--- a/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
+++ b/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
@@ -1,0 +1,69 @@
+"""GLM-5.2 (``glm_moe_dsa``) NVFP4 kernel adapter.
+
+GLM-5.2 is the DeepSeek-V3.2 sparse-MLA (DSA / Lightning-Indexer) lineage. A ``quant_method:
+modelopt`` / ``quant_algo: NVFP4`` checkpoint is not a recognized transformers quantizer, so the
+model loads as a bf16 skeleton; we then register ``WeightConverter``s so the NVFP4 tensors load
+correctly. Rather than assume a fixed layout, the adapter inspects the checkpoint's safetensors
+index (:func:`inspect_nvfp4_layout`) to discover what is actually quantized — the per-expert
+projections (fused into 3D ``NVFP4Tensor`` for the scattermoe path) and any non-routed NVFP4
+linears (dequantized to bf16) — and registers exactly those converters for THIS checkpoint.
+
+The DSA attention / indexer / RoPE fused training kernels are a separate (Phase-1) concern and
+are intentionally NOT owned here yet.
+"""
+
+from __future__ import annotations
+
+from axolotl.integrations.kernels.adapters import ModelAdapter
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def is_glm_moe_dsa_nvfp4_modelopt(cfg) -> bool:
+    """True iff the base model is a GLM-5.2 (``glm_moe_dsa``) NVFP4-modelopt checkpoint
+    (``quant_method=modelopt``, ``quant_algo=NVFP4``). Any failure returns False."""
+    try:
+        from transformers import AutoConfig
+
+        hf_cfg = AutoConfig.from_pretrained(cfg.base_model, trust_remote_code=True)
+    except Exception:
+        return False
+    if str(getattr(hf_cfg, "model_type", "")) != "glm_moe_dsa":
+        return False
+    qcfg = getattr(hf_cfg, "quantization_config", None)
+    if qcfg is None:
+        return False
+    if isinstance(qcfg, dict):
+        return (
+            qcfg.get("quant_method") == "modelopt" and qcfg.get("quant_algo") == "NVFP4"
+        )
+    return (
+        getattr(qcfg, "quant_method", None) == "modelopt"
+        and getattr(qcfg, "quant_algo", None) == "NVFP4"
+    )
+
+
+class GlmMoeDsaAdapter(ModelAdapter):
+    name = "glm_moe_dsa_nvfp4"
+
+    def matches(self, cfg) -> bool:
+        return bool(cfg.use_scattermoe) and is_glm_moe_dsa_nvfp4_modelopt(cfg)
+
+    def pre_model_load(self, cfg) -> None:
+        from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_moe_loading import (
+            inspect_nvfp4_layout,
+        )
+        from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_weight_converter import (
+            register_nvfp4_converters_for_layout,
+        )
+
+        layout = inspect_nvfp4_layout(cfg.base_model)
+        LOG.info(
+            "glm_moe_dsa: detected NVFP4 layout — routed experts: %s (projs=%s); "
+            "non-routed NVFP4 linears: %s",
+            layout["routed_present"],
+            layout["routed_projs"],
+            layout["nonrouted_suffixes"],
+        )
+        register_nvfp4_converters_for_layout("glm_moe_dsa", layout)

--- a/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
+++ b/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
@@ -8,8 +8,10 @@ index (:func:`inspect_nvfp4_layout`) to discover what is actually quantized — 
 projections (fused into 3D ``NVFP4Tensor`` for the scattermoe path) and any non-routed NVFP4
 linears (dequantized to bf16) — and registers exactly those converters for THIS checkpoint.
 
-The DSA attention / indexer / RoPE fused training kernels are a separate (Phase-1) concern and
-are intentionally NOT owned here yet.
+When ``use_glm_dsa_kernels`` is set, ``post_model_load`` also patches the DSA attention with the
+fused absorbed-MLA sparse-gather kernels + fused Lightning-Indexer (``libs/glm_dsa``), keeps the MoE
+router fp32, and wires the context-parallel group so the attention shards the sequence on the ``cp``
+axis (composing with EP on the orthogonal ``ep`` axis).
 """
 
 from __future__ import annotations
@@ -44,13 +46,54 @@ def is_glm_moe_dsa_nvfp4_modelopt(cfg) -> bool:
     )
 
 
+def _is_glm_moe_dsa(cfg) -> bool:
+    """True iff the base model is a glm_moe_dsa checkpoint (any quant)."""
+    try:
+        from transformers import AutoConfig
+
+        hf_cfg = AutoConfig.from_pretrained(cfg.base_model, trust_remote_code=True)
+    except Exception:
+        return False
+    return str(getattr(hf_cfg, "model_type", "")) == "glm_moe_dsa"
+
+
+def _resolve_cp_group(cfg):
+    """The context-parallel ProcessGroup (the `cp` axis of accelerate's mesh / the EP mesh), or None
+    when ``context_parallel_size <= 1``. The DSA attention shards the sequence on this axis."""
+    if (getattr(cfg, "context_parallel_size", None) or 1) <= 1:
+        return None
+    try:  # the EP plugin owns the mesh when EP is on; else read accelerate's mesh
+        from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
+
+        grp = ExpertParallelPlugin._resolve_cp_group(cfg)
+        if grp is not None:
+            return grp
+    except Exception:
+        pass
+    try:
+        from accelerate.state import AcceleratorState
+
+        mesh = getattr(AcceleratorState(), "device_mesh", None)
+        if mesh is not None and "cp" in (mesh.mesh_dim_names or ()):
+            return mesh["cp"].get_group()
+    except Exception:
+        pass
+    return None
+
+
 class GlmMoeDsaAdapter(ModelAdapter):
-    name = "glm_moe_dsa_nvfp4"
+    name = "glm_moe_dsa"
 
     def matches(self, cfg) -> bool:
-        return bool(cfg.use_scattermoe) and is_glm_moe_dsa_nvfp4_modelopt(cfg)
+        # NVFP4 loading needs scattermoe + a modelopt-NVFP4 checkpoint; the DSA kernels need only
+        # use_glm_dsa_kernels on a glm_moe_dsa model. Activate for either.
+        if bool(cfg.use_scattermoe) and is_glm_moe_dsa_nvfp4_modelopt(cfg):
+            return True
+        return bool(cfg.get("use_glm_dsa_kernels")) and _is_glm_moe_dsa(cfg)
 
     def pre_model_load(self, cfg) -> None:
+        if not (cfg.use_scattermoe and is_glm_moe_dsa_nvfp4_modelopt(cfg)):
+            return  # NVFP4 converter registration is only for modelopt-NVFP4 checkpoints
         from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_moe_loading import (
             inspect_nvfp4_layout,
         )
@@ -67,3 +110,27 @@ class GlmMoeDsaAdapter(ModelAdapter):
             layout["nonrouted_suffixes"],
         )
         register_nvfp4_converters_for_layout("glm_moe_dsa", layout)
+
+    def post_model_load(self, cfg, model) -> None:
+        """Patch the DSA attention with the fused absorbed-MLA kernels + keep the MoE router fp32.
+        Gated on ``use_glm_dsa_kernels``. Wires the context-parallel group so the attention shards
+        the sequence on the `cp` axis (composes with EP on the orthogonal `ep` axis)."""
+        if not cfg.get("use_glm_dsa_kernels"):
+            return
+        from axolotl.integrations.kernels.libs.glm_dsa import (
+            keep_router_fp32,
+            patch_glm_moe_dsa_attention,
+        )
+
+        cp_group = _resolve_cp_group(cfg)
+        n = patch_glm_moe_dsa_attention(
+            model, use_fused_indexer=True, cp_group=cp_group
+        )
+        r = keep_router_fp32(model)
+        LOG.info(
+            "glm_moe_dsa: patched %d attention modules with fused DSA kernels (fused indexer, "
+            "context_parallel=%s); kept %d routers fp32",
+            n,
+            cp_group is not None,
+            r,
+        )

--- a/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
+++ b/src/axolotl/integrations/kernels/adapters/glm_moe_dsa.py
@@ -45,7 +45,12 @@ def is_glm_moe_dsa_nvfp4_modelopt(cfg) -> bool:
     try:
         from transformers import AutoConfig
 
-        hf_cfg = AutoConfig.from_pretrained(cfg.base_model, trust_remote_code=True)
+        # Honor the user's opt-in rather than forcing remote code: glm_moe_dsa is a native
+        # transformers model, so config loading needs no remote code by default.
+        hf_cfg = AutoConfig.from_pretrained(
+            cfg.base_model,
+            trust_remote_code=bool(getattr(cfg, "trust_remote_code", False)),
+        )
     except Exception:
         return False
     if str(getattr(hf_cfg, "model_type", "")) != "glm_moe_dsa":
@@ -68,7 +73,12 @@ def _is_glm_moe_dsa(cfg) -> bool:
     try:
         from transformers import AutoConfig
 
-        hf_cfg = AutoConfig.from_pretrained(cfg.base_model, trust_remote_code=True)
+        # Honor the user's opt-in rather than forcing remote code: glm_moe_dsa is a native
+        # transformers model, so config loading needs no remote code by default.
+        hf_cfg = AutoConfig.from_pretrained(
+            cfg.base_model,
+            trust_remote_code=bool(getattr(cfg, "trust_remote_code", False)),
+        )
     except Exception:
         return False
     return str(getattr(hf_cfg, "model_type", "")) == "glm_moe_dsa"

--- a/src/axolotl/integrations/kernels/args.py
+++ b/src/axolotl/integrations/kernels/args.py
@@ -47,6 +47,11 @@ class KernelsArgs(BaseModel):
     use_sonicmoe: bool | None = None
     # Fused Triton training kernels for DeepSeek-V4 (attention / RoPE / mHC).
     use_dsv4_kernels: bool | None = None
+    # GLM-5.2 (glm_moe_dsa) DSA fused attention: MLA-absorption head-batched sparse-gather attn
+    # (fwd+bwd) + fused Lightning-Indexer + length-aware dense/sparse dispatch, replacing the dense
+    # [B,S,T]-mask eager/sdpa path. The router is kept fp32. Composes with use_scattermoe (experts)
+    # and context_parallel_size (the attention shards the sequence on the cp axis).
+    use_glm_dsa_kernels: bool | None = None
     # DeepSeek-V4 FP8 non-expert weight storage: "float8tensor" (default, 1-byte torchao
     # Float8Tensor base) or "bf16" (dequantize to bf16 at load).
     dsv4_fp8_nonexpert_mode: str | None = None

--- a/src/axolotl/integrations/kernels/autotune_collector.py
+++ b/src/axolotl/integrations/kernels/autotune_collector.py
@@ -64,8 +64,9 @@ def _find_lora_ops_module() -> ModuleType | None:
     return None
 
 
-# Substrings identifying the kernel-bearing modules to scan in sys.modules. Covers both
-# the HF-`kernels` hash-suffixed scattermoe copies and the normally-imported dsv4 kernels.
+# Substrings identifying the kernel-bearing modules to scan in sys.modules. Covers the HF-`kernels`
+# hash-suffixed scattermoe copies, the normally-imported dsv4 kernels, and the glm_dsa (GLM-5.2
+# sparse-MLA) kernels.
 _KERNEL_MODULE_HINTS: tuple[str, ...] = (
     "lora_ops",
     "scattermoe_lora.kernels",
@@ -77,6 +78,10 @@ _KERNEL_MODULE_HINTS: tuple[str, ...] = (
     "libs.dsv4.gated_pool",
     "libs.dsv4.indexer",
     ".dsv4.",
+    "libs.glm_dsa.attention_topk",
+    "libs.glm_dsa.attention_mla_absorb",
+    "libs.glm_dsa.indexer",
+    ".glm_dsa.",
 )
 
 
@@ -153,7 +158,10 @@ def collect_autotune_configs() -> list[dict[str, Any]]:
                     {
                         "kernel": kname,
                         "module": modname.rsplit(".", 1)[-1],
-                        "module_path": modname,
+                        # Fully-qualified dotted module name (NOT a filesystem path). Named
+                        # `module_fqn` rather than `module_path` so the telemetry PII redactor
+                        # (which scrubs any key containing "path") doesn't blank this safe value.
+                        "module_fqn": modname,
                         "key": _label_key(obj, key_tuple),
                         "config": _config_to_dict(config),
                     }

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/__init__.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/__init__.py
@@ -1,0 +1,19 @@
+"""GLM-5.2 (glm_moe_dsa) DSA fused training kernels.
+
+DeepSeek-V3.2 sparse-MLA (DSA / Lightning-Indexer) attention for GLM-5.2: MLA weight absorption +
+head-batched sparse-gather flash attention (fwd+bwd), a fused Lightning-Indexer scorer + top-k,
+length-aware dense/sparse dispatch, and a context-parallel path that all-gathers only the 576-wide
+compressed KV. See ``patch.patch_glm_moe_dsa_attention``.
+"""
+
+from .patch import (
+    fused_indexer_topk,
+    keep_router_fp32,
+    patch_glm_moe_dsa_attention,
+)
+
+__all__ = [
+    "patch_glm_moe_dsa_attention",
+    "keep_router_fp32",
+    "fused_indexer_topk",
+]

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/_autotune.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/_autotune.py
@@ -1,0 +1,42 @@
+"""Autotune helpers: portable shared-memory pruning.
+
+Triton's autotune raises ``OutOfResources`` on a config whose tiles exceed the device's shared
+memory (it does NOT silently skip it), so a config grid with big tiles crashes on a small-SMEM
+GPU. ``smem_prune`` drops the over-budget configs up front by estimating each config's SMEM and
+comparing to the *device's* real ``max_shared_mem`` (queried + memoized, not hardcoded) — so the
+same grid runs on sm120 (~99 KB) and uses bigger tiles on Hopper/Blackwell-datacenter (~228 KB).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+
+_SMEM: dict[int, int] = {}
+
+
+def max_smem(dev: int | None = None) -> int:
+    dev = torch.cuda.current_device() if dev is None else dev
+    if dev not in _SMEM:
+        props = triton.runtime.driver.active.utils.get_device_properties(dev)
+        _SMEM[dev] = int(props["max_shared_mem"])
+    return _SMEM[dev]
+
+
+def smem_prune(est_bytes, headroom: float = 0.95):
+    """Build an ``early_config_prune`` callback. ``est_bytes(config_kwargs, num_stages, **constexprs)``
+    returns a config's estimated SMEM in bytes; configs over ``headroom * device_limit`` are dropped
+    (keeping the single smallest if all exceed, so autotune never gets an empty set)."""
+
+    def prune(configs, named_args, **kwargs):
+        limit = int(max_smem() * headroom)
+        keep = [
+            c for c in configs if est_bytes(c.kwargs, c.num_stages, **kwargs) <= limit
+        ]
+        if keep:
+            return keep
+        return sorted(
+            configs, key=lambda c: est_bytes(c.kwargs, c.num_stages, **kwargs)
+        )[:1]
+
+    return prune

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
@@ -1,0 +1,413 @@
+"""MLA weight-absorption + head-batched sparse gather attention for GLM-5.2 DSA.
+
+In MLA the per-head key/value are produced from a SHARED compressed latent ``c_kv`` [S, kv_lora=512]:
+    k_nope[t,h] = c_kv[t] @ W_kb_k[h]        value[t,h] = c_kv[t] @ W_kb_v[h]
+so the nope score absorbs kv_b into the query:
+    q_nope[h]·k_nope[t,h] = (q_nope[h] @ W_kb_kᵀ[h]) · c_kv[t]
+With the rope part (k_rot shared across heads) appended, every head attends the SAME key tensor
+    K_shared[t] = cat(c_kv[t] [512], k_rot[t] [64])   (576-wide, shared across heads)
+    Q_abs[s,h]  = cat(q_nope[s,h] @ W_kb_kᵀ[h] [512], q_rot[s,h] [64])
+    score[s,h,t] = Q_abs[s,h] · K_shared[t] * scale
+    out_latent[s,h] = Σ_t softmax(score)[h,t] · c_kv[t]        (512-wide)
+    out[s,h] = out_latent[s,h] @ W_kb_v[h]                     (-> v_head_dim 256, then o_proj)
+
+Now all heads share K_shared -> a head-batched MMA (M=H), and the sparse gather loads the 576-wide
+shared KV ONCE per query position instead of per head (the win that the per-(b,h,s) GEMV lacked).
+The absorption/value GEMMs (q_nope@W_kb_kᵀ, out_latent@W_kb_v) stay in torch and are differentiable,
+so gradients flow to kv_b_proj in full-parameter training and to its LoRA adapter in LoRA training;
+the kernel differentiates Q_abs / K_shared.
+
+This module currently provides the absorption helpers + the head-batched gather FORWARD kernel,
+validated against the eager dense-mask MLA reference. Backward is added next.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from ._autotune import smem_prune
+from .config import KV_LORA_RANK, QK_NOPE_HEAD_DIM, QK_ROPE_HEAD_DIM, V_HEAD_DIM
+
+# Measured: actual SMEM ≈ the single-count tile estimate + ~2KB (tl.trans is handled by the MMA,
+# no extra buffer). Use the raw estimate + a small fixed overhead; headroom 0.97 leaves margin
+# without pruning borderline-fitting configs (e.g. BH=16,BN=32 which is the fast one on sm120).
+_SMEM_OVERHEAD = 3072
+
+
+def _fwd_smem(cfg, num_stages, **kw):
+    # bf16: qn+qr [BH,w] loaded once; c_kv+k_rot [BN,w] pipelined x num_stages.
+    w = kw["DL"] + kw["DR"]
+    return (cfg["BH"] * w + num_stages * cfg["BN"] * w) * 2 + _SMEM_OVERHEAD
+
+
+def _bwd_smem(cfg, num_stages, **kw):
+    # bwd also holds out_l/dout_l [BH,DL] (loaded once).
+    DL, DR = kw["DL"], kw["DR"]
+    w = DL + DR
+    return (cfg["BH"] * (w + 2 * DL) + num_stages * cfg["BN"] * w) * 2 + _SMEM_OVERHEAD
+
+
+_ABSORB_CONFIGS = [
+    triton.Config({"BH": bh, "BN": bn}, num_warps=warps, num_stages=st)
+    for bh in (16, 32)
+    for bn in (16, 32, 64, 128)
+    for warps in (4, 8)
+    for st in (1, 2, 3)
+]
+
+DQK = KV_LORA_RANK + QK_ROPE_HEAD_DIM  # 576 (compressed score dim)
+
+
+def split_kv_b(kv_b_weight: torch.Tensor, n_heads: int):
+    """Split kv_b_proj.weight [H*(qk_nope+v_head), kv_lora] into per-head
+    W_kb_k [H, qk_nope, kv_lora] and W_kb_v [H, v_head, kv_lora]."""
+    w = kv_b_weight.view(n_heads, QK_NOPE_HEAD_DIM + V_HEAD_DIM, KV_LORA_RANK)
+    return w[:, :QK_NOPE_HEAD_DIM, :], w[:, QK_NOPE_HEAD_DIM:, :]
+
+
+def absorb_query(q_nope, q_rot, w_kb_k):
+    """q_nope [B,H,S,qk_nope], q_rot [B,H,S,qk_rope], w_kb_k [H,qk_nope,kv_lora] ->
+    Q_abs [B,H,S,DQK] = cat(q_nope @ W_kb_kᵀ, q_rot). Differentiable."""
+    q_abs_nope = torch.einsum("bhsn,hnl->bhsl", q_nope, w_kb_k)  # [B,H,S,kv_lora]
+    return torch.cat([q_abs_nope, q_rot], dim=-1)
+
+
+def project_value(out_latent, w_kb_v):
+    """out_latent [B,H,S,kv_lora] -> out [B,H,S,v_head] = out_latent @ W_kb_vᵀ. Differentiable."""
+    return torch.einsum("bhsl,hvl->bhsv", out_latent, w_kb_v)
+
+
+@triton.autotune(
+    configs=_ABSORB_CONFIGS,
+    key=["TOPK"],
+    prune_configs_by={"early_config_prune": smem_prune(_fwd_smem)},
+)
+@triton.jit
+def _absorb_fwd_kernel(
+    QABS,
+    KSH,
+    IDX,
+    OUT,
+    LSE,
+    scale,
+    S,
+    TOPK,
+    H,
+    q_offset,
+    sqa_b,
+    sqa_h,
+    sqa_s,
+    sqa_d,
+    sks_b,
+    sks_s,
+    sks_d,
+    si_b,
+    si_s,
+    si_t,
+    so_b,
+    so_h,
+    so_s,
+    so_d,
+    sl_b,
+    sl_h,
+    sl_s,
+    DL: tl.constexpr,  # kv_lora_rank (=value latent dim), power of 2
+    DR: tl.constexpr,  # qk_rope_head_dim, power of 2
+    BH: tl.constexpr,
+    BN: tl.constexpr,
+):
+    # S on axis 0 (X, up to 2^31-1); CUDA caps grid Y/Z at 65535 so S must not be on Y/Z.
+    s = tl.program_id(0)
+    b = tl.program_id(1)
+    h0 = tl.program_id(2) * BH
+    offs_h = h0 + tl.arange(0, BH)
+    hmask = offs_h < H
+    offs_l = tl.arange(0, DL)  # compressed-latent dims [0, kv_lora)
+    offs_r = tl.arange(0, DR)  # rope dims, stored at [kv_lora, kv_lora+rope)
+
+    # split q_abs into its nope-latent (DL) and rope (DR) parts (avoids padding 576 to a pow2)
+    # keep tiles in their native (bf16) dtype for the tensor-core dot (fp32 accumulation)
+    base_q = QABS + b * sqa_b + offs_h[:, None] * sqa_h + s * sqa_s
+    qn = tl.load(base_q + offs_l[None, :] * sqa_d, mask=hmask[:, None], other=0.0)
+    qr = tl.load(
+        base_q + (DL + offs_r)[None, :] * sqa_d, mask=hmask[:, None], other=0.0
+    )
+
+    m_i = tl.full((BH,), -float("inf"), tl.float32)
+    l_i = tl.zeros((BH,), tl.float32)
+    acc = tl.zeros((BH, DL), tl.float32)
+
+    s_global = (
+        s + q_offset
+    )  # CP: query's global position for the causal check (q_offset=0 single-GPU)
+    for t0 in range(0, TOPK, BN):
+        offs_t = t0 + tl.arange(0, BN)
+        tmask = offs_t < TOPK
+        idx = tl.load(
+            IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
+        ).to(tl.int64)
+        valid = tmask & (idx <= s_global)
+
+        # gather the shared KV once: c_kv [BN, DL] (also the value latent) + k_rot [BN, DR]
+        base_k = KSH + b * sks_b + idx[:, None] * sks_s
+        c_kv = tl.load(base_k + offs_l[None, :] * sks_d, mask=valid[:, None], other=0.0)
+        k_rot = tl.load(
+            base_k + (DL + offs_r)[None, :] * sks_d, mask=valid[:, None], other=0.0
+        )
+
+        scores = tl.dot(qn, tl.trans(c_kv))  # bf16 tensor core, fp32 accum
+        scores += tl.dot(qr, tl.trans(k_rot))
+        scores = tl.where(valid[None, :], scores * scale, -float("inf"))  # [BH, BN]
+
+        m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+        p = tl.exp(scores - m_new[:, None])  # [BH, BN]
+        alpha = tl.exp(m_i - m_new)
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(c_kv.dtype), c_kv)
+        m_i = m_new
+
+    acc = acc / l_i[:, None]
+    o_ptr = OUT + b * so_b + offs_h[:, None] * so_h + s * so_s + offs_l[None, :] * so_d
+    tl.store(o_ptr, acc.to(OUT.dtype.element_ty), mask=hmask[:, None])
+    tl.store(LSE + b * sl_b + offs_h * sl_h + s * sl_s, m_i + tl.log(l_i), mask=hmask)
+
+
+@triton.autotune(
+    configs=_ABSORB_CONFIGS,
+    key=["TOPK"],
+    reset_to_zero=[
+        "DKSH"
+    ],  # dk_shared is atomic-accumulated across positions + head-tiles
+    prune_configs_by={"early_config_prune": smem_prune(_bwd_smem)},
+)
+@triton.jit
+def _absorb_bwd_kernel(
+    QABS,
+    KSH,
+    IDX,
+    OUTL,
+    DOUTL,
+    LSE,
+    DQABS,
+    DKSH,
+    scale,
+    S,
+    TOPK,
+    H,
+    q_offset,
+    sqa_b,
+    sqa_h,
+    sqa_s,
+    sqa_d,
+    sks_b,
+    sks_s,
+    sks_d,
+    si_b,
+    si_s,
+    si_t,
+    so_b,
+    so_h,
+    so_s,
+    so_d,
+    sl_b,
+    sl_h,
+    sl_s,
+    DL: tl.constexpr,
+    DR: tl.constexpr,
+    BH: tl.constexpr,
+    BN: tl.constexpr,
+):
+    # S on axis 0 (X, up to 2^31-1); CUDA caps grid Y/Z at 65535 so S must not be on Y/Z.
+    s = tl.program_id(0)
+    b = tl.program_id(1)
+    h0 = tl.program_id(2) * BH
+    offs_h = h0 + tl.arange(0, BH)
+    hmask = offs_h < H
+    offs_l = tl.arange(0, DL)
+    offs_r = tl.arange(0, DR)
+
+    base_q = QABS + b * sqa_b + offs_h[:, None] * sqa_h + s * sqa_s
+    qn = tl.load(base_q + offs_l[None, :] * sqa_d, mask=hmask[:, None], other=0.0)
+    qr = tl.load(
+        base_q + (DL + offs_r)[None, :] * sqa_d, mask=hmask[:, None], other=0.0
+    )
+    base_o = (
+        OUTL + b * so_b + offs_h[:, None] * so_h + s * so_s + offs_l[None, :] * so_d
+    )
+    out_l = tl.load(base_o, mask=hmask[:, None], other=0.0).to(tl.float32)  # [BH, DL]
+    dout_l = tl.load(
+        DOUTL + b * so_b + offs_h[:, None] * so_h + s * so_s + offs_l[None, :] * so_d,
+        mask=hmask[:, None],
+        other=0.0,
+    )  # [BH, DL]
+    lse = tl.load(LSE + b * sl_b + offs_h * sl_h + s * sl_s, mask=hmask, other=0.0)
+    delta = tl.sum(dout_l.to(tl.float32) * out_l, axis=1)  # [BH]
+
+    s_global = s + q_offset
+    dqn = tl.zeros((BH, DL), tl.float32)
+    dqr = tl.zeros((BH, DR), tl.float32)
+    for t0 in range(0, TOPK, BN):
+        offs_t = t0 + tl.arange(0, BN)
+        tmask = offs_t < TOPK
+        idx = tl.load(
+            IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
+        ).to(tl.int64)
+        valid = tmask & (idx <= s_global)
+        base_k = KSH + b * sks_b + idx[:, None] * sks_s
+        c_kv = tl.load(base_k + offs_l[None, :] * sks_d, mask=valid[:, None], other=0.0)
+        k_rot = tl.load(
+            base_k + (DL + offs_r)[None, :] * sks_d, mask=valid[:, None], other=0.0
+        )
+
+        score = tl.dot(qn, tl.trans(c_kv)) + tl.dot(qr, tl.trans(k_rot))
+        score = tl.where(valid[None, :], score * scale, -float("inf"))
+        p = tl.exp(score - lse[:, None])  # [BH, BN]
+        dp = tl.dot(dout_l, tl.trans(c_kv))  # [BH, BN] = dout_latent·c_kv
+        ds = (p * (dp - delta[:, None])) * scale  # [BH, BN]  grad wrt scaled score
+        ds_b = ds.to(c_kv.dtype)
+        p_b = p.to(c_kv.dtype)
+
+        dqn += tl.dot(ds_b, c_kv)  # [BH, DL]
+        dqr += tl.dot(ds_b, k_rot)  # [BH, DR]
+        # dc_kv = value-path (Σ_h p·dout_latent) + score-path (Σ_h ds·qn); dk_rot = Σ_h ds·qr
+        dc = tl.dot(tl.trans(p_b), dout_l.to(c_kv.dtype)) + tl.dot(
+            tl.trans(ds_b), qn
+        )  # [BN, DL]
+        dkr = tl.dot(tl.trans(ds_b), qr)  # [BN, DR]
+        dk_ptr = DKSH + b * sks_b + idx[:, None] * sks_s
+        tl.atomic_add(
+            dk_ptr + offs_l[None, :] * sks_d, tl.where(valid[:, None], dc, 0.0)
+        )
+        tl.atomic_add(
+            dk_ptr + (DL + offs_r)[None, :] * sks_d, tl.where(valid[:, None], dkr, 0.0)
+        )
+
+    dq_ptr = DQABS + b * sqa_b + offs_h[:, None] * sqa_h + s * sqa_s
+    tl.store(
+        dq_ptr + offs_l[None, :] * sqa_d,
+        dqn.to(DQABS.dtype.element_ty),
+        mask=hmask[:, None],
+    )
+    tl.store(
+        dq_ptr + (DL + offs_r)[None, :] * sqa_d,
+        dqr.to(DQABS.dtype.element_ty),
+        mask=hmask[:, None],
+    )
+
+
+def _grid_fn(B, S, H):
+    def grid(m):
+        return (S, B, triton.cdiv(H, m["BH"]))
+
+    return grid
+
+
+class _MlaAbsorbAttn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q_abs, k_shared, topk_idx, scale, q_offset):
+        B, H, S, _ = (
+            q_abs.shape
+        )  # S = local queries; k_shared may be longer (global, under CP)
+        DV = KV_LORA_RANK
+        TOPK = topk_idx.shape[-1]
+        q_abs, k_shared = q_abs.contiguous(), k_shared.contiguous()
+        idx = topk_idx.contiguous()
+        out = torch.empty(B, H, S, DV, device=q_abs.device, dtype=q_abs.dtype)
+        lse = torch.empty(B, H, S, device=q_abs.device, dtype=torch.float32)
+        _absorb_fwd_kernel[_grid_fn(B, S, H)](
+            q_abs,
+            k_shared,
+            idx,
+            out,
+            lse,
+            float(scale),
+            S,
+            TOPK,
+            H,
+            int(q_offset),
+            q_abs.stride(0),
+            q_abs.stride(1),
+            q_abs.stride(2),
+            q_abs.stride(3),
+            k_shared.stride(0),
+            k_shared.stride(1),
+            k_shared.stride(2),
+            idx.stride(0),
+            idx.stride(1),
+            idx.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            lse.stride(0),
+            lse.stride(1),
+            lse.stride(2),
+            DL=KV_LORA_RANK,
+            DR=QK_ROPE_HEAD_DIM,
+        )
+        ctx.save_for_backward(q_abs, k_shared, idx, out, lse)
+        ctx.scale = float(scale)
+        ctx.q_offset = int(q_offset)
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q_abs, k_shared, idx, out, lse = ctx.saved_tensors
+        B, H, S, DQk = q_abs.shape
+        Skv = k_shared.shape[1]  # global key count (>= S under CP)
+        TOPK = idx.shape[-1]
+        dout = dout.contiguous()
+        dq_abs = torch.zeros(B, H, S, DQk, device=q_abs.device, dtype=q_abs.dtype)
+        # dk_shared scatters at GLOBAL key positions -> size it like k_shared, not the local queries.
+        dk_shared = torch.zeros(B, Skv, DQk, device=q_abs.device, dtype=torch.float32)
+        _absorb_bwd_kernel[_grid_fn(B, S, H)](
+            q_abs,
+            k_shared,
+            idx,
+            out,
+            dout,
+            lse,
+            dq_abs,
+            dk_shared,
+            ctx.scale,
+            S,
+            TOPK,
+            H,
+            ctx.q_offset,
+            q_abs.stride(0),
+            q_abs.stride(1),
+            q_abs.stride(2),
+            q_abs.stride(3),
+            dk_shared.stride(0),
+            dk_shared.stride(1),
+            dk_shared.stride(2),
+            idx.stride(0),
+            idx.stride(1),
+            idx.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            lse.stride(0),
+            lse.stride(1),
+            lse.stride(2),
+            DL=KV_LORA_RANK,
+            DR=QK_ROPE_HEAD_DIM,
+        )
+        return dq_abs, dk_shared.to(k_shared.dtype), None, None, None
+
+
+def mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset=0):
+    """Differentiable head-batched MLA-absorption sparse attention. q_abs [B,H,S,576] (local
+    queries), k_shared [B,Skv,576] (first kv_lora cols = c_kv; Skv>=S under context parallel),
+    topk_idx [B,S,T] int32 referencing GLOBAL key positions. ``q_offset`` is the global position of
+    local query 0 (for causal masking under CP). Returns out_latent [B,H,S,kv_lora]."""
+    return _MlaAbsorbAttn.apply(q_abs, k_shared, topk_idx, scale, q_offset)
+
+
+def mla_absorb_attn_fwd(q_abs, k_shared, topk_idx, scale, q_offset=0):
+    """Forward-only (no autograd) — for benchmarking. Returns (out_latent, None)."""
+    with torch.no_grad():
+        return _MlaAbsorbAttn.apply(q_abs, k_shared, topk_idx, scale, q_offset), None

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
@@ -114,10 +114,17 @@ def _absorb_fwd_kernel(
     sl_b,
     sl_h,
     sl_s,
+    SEQQ,
+    SEQK,
+    ssq_b,
+    ssq_s,
+    ssk_b,
+    ssk_s,
     DL: tl.constexpr,  # kv_lora_rank (=value latent dim), power of 2
     DR: tl.constexpr,  # qk_rope_head_dim, power of 2
     BH: tl.constexpr,
     BN: tl.constexpr,
+    HAS_DOC: tl.constexpr,  # sample-packing: forbid cross-document keys
 ):
     # S on axis 0 (X, up to 2^31-1); CUDA caps grid Y/Z at 65535 so S must not be on Y/Z.
     s = tl.program_id(0)
@@ -143,6 +150,7 @@ def _absorb_fwd_kernel(
     s_global = (
         s + q_offset
     )  # CP: query's global position for the causal check (q_offset=0 single-GPU)
+    seqq_s = tl.load(SEQQ + b * ssq_b + s * ssq_s) if HAS_DOC else 0
     for t0 in range(0, TOPK, BN):
         offs_t = t0 + tl.arange(0, BN)
         tmask = offs_t < TOPK
@@ -150,6 +158,9 @@ def _absorb_fwd_kernel(
             IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
         ).to(tl.int64)
         valid = tmask & (idx <= s_global)
+        if HAS_DOC:
+            seqk = tl.load(SEQK + b * ssk_b + idx * ssk_s, mask=tmask, other=-1)
+            valid = valid & (seqk == seqq_s)
 
         # gather the shared KV once: c_kv [BN, DL] (also the value latent) + k_rot [BN, DR]
         base_k = KSH + b * sks_b + idx[:, None] * sks_s
@@ -163,16 +174,45 @@ def _absorb_fwd_kernel(
         scores = tl.where(valid[None, :], scores * scale, -float("inf"))  # [BH, BN]
 
         m_new = tl.maximum(m_i, tl.max(scores, axis=1))
-        p = tl.exp(scores - m_new[:, None])  # [BH, BN]
-        alpha = tl.exp(m_i - m_new)
+        # A query whose leading topk block is entirely causally/doc-masked has m_new == -inf, so
+        # exp(m_i - m_new) = exp(-inf + inf) = NaN. Subtract a finite max (0 there; all scores are
+        # -inf so every p is exp(-inf)=0 regardless) — matches the dense path on masked rows.
+        m_safe = tl.where(m_new == -float("inf"), 0.0, m_new)
+        p = tl.exp(scores - m_safe[:, None])  # [BH, BN]
+        alpha = tl.exp(m_i - m_safe)
         l_i = l_i * alpha + tl.sum(p, axis=1)
         acc = acc * alpha[:, None] + tl.dot(p.to(c_kv.dtype), c_kv)
         m_i = m_new
 
-    acc = acc / l_i[:, None]
+    acc = (
+        acc / tl.where(l_i == 0.0, 1.0, l_i)[:, None]
+    )  # fully-masked query -> 0 output (loss masked)
     o_ptr = OUT + b * so_b + offs_h[:, None] * so_h + s * so_s + offs_l[None, :] * so_d
     tl.store(o_ptr, acc.to(OUT.dtype.element_ty), mask=hmask[:, None])
     tl.store(LSE + b * sl_b + offs_h * sl_h + s * sl_s, m_i + tl.log(l_i), mask=hmask)
+
+
+def _bwd_prune_sm90_safe(configs, named_args, **kwargs):
+    """sm90 (Hopper) trips a nondeterministic invalid-PC (CUDA 718) while autotune trials the full
+    bwd grid (each config is individually clean — it's the trialing that corrupts the context). Force
+    a single sanitizer-clean config there; elsewhere fall back to SMEM pruning."""
+    import torch
+
+    base = smem_prune(_bwd_smem)
+    kept = base(configs, named_args, **kwargs)
+    if torch.cuda.get_device_capability() == (9, 0):
+        safe = [
+            c
+            for c in kept
+            if c.kwargs.get("BH") == 32
+            and c.kwargs.get("BN") == 64
+            and c.num_warps == 8
+            and c.num_stages == 3
+        ]
+        if safe:
+            return safe[:1]
+        return sorted(kept, key=lambda c: (c.kwargs.get("BN", 0), c.num_stages))[:1]
+    return kept
 
 
 @triton.autotune(
@@ -181,7 +221,7 @@ def _absorb_fwd_kernel(
     reset_to_zero=[
         "DKSH"
     ],  # dk_shared is atomic-accumulated across positions + head-tiles
-    prune_configs_by={"early_config_prune": smem_prune(_bwd_smem)},
+    prune_configs_by={"early_config_prune": _bwd_prune_sm90_safe},
 )
 @triton.jit
 def _absorb_bwd_kernel(
@@ -215,10 +255,17 @@ def _absorb_bwd_kernel(
     sl_b,
     sl_h,
     sl_s,
+    SEQQ,
+    SEQK,
+    ssq_b,
+    ssq_s,
+    ssk_b,
+    ssk_s,
     DL: tl.constexpr,
     DR: tl.constexpr,
     BH: tl.constexpr,
     BN: tl.constexpr,
+    HAS_DOC: tl.constexpr,
 ):
     # S on axis 0 (X, up to 2^31-1); CUDA caps grid Y/Z at 65535 so S must not be on Y/Z.
     s = tl.program_id(0)
@@ -247,6 +294,7 @@ def _absorb_bwd_kernel(
     delta = tl.sum(dout_l.to(tl.float32) * out_l, axis=1)  # [BH]
 
     s_global = s + q_offset
+    seqq_s = tl.load(SEQQ + b * ssq_b + s * ssq_s) if HAS_DOC else 0
     dqn = tl.zeros((BH, DL), tl.float32)
     dqr = tl.zeros((BH, DR), tl.float32)
     for t0 in range(0, TOPK, BN):
@@ -256,6 +304,9 @@ def _absorb_bwd_kernel(
             IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
         ).to(tl.int64)
         valid = tmask & (idx <= s_global)
+        if HAS_DOC:
+            seqk = tl.load(SEQK + b * ssk_b + idx * ssk_s, mask=tmask, other=-1)
+            valid = valid & (seqk == seqq_s)
         base_k = KSH + b * sks_b + idx[:, None] * sks_s
         c_kv = tl.load(base_k + offs_l[None, :] * sks_d, mask=valid[:, None], other=0.0)
         k_rot = tl.load(
@@ -264,7 +315,10 @@ def _absorb_bwd_kernel(
 
         score = tl.dot(qn, tl.trans(c_kv)) + tl.dot(qr, tl.trans(k_rot))
         score = tl.where(valid[None, :], score * scale, -float("inf"))
-        p = tl.exp(score - lse[:, None])  # [BH, BN]
+        lse_safe = tl.where(
+            lse == -float("inf"), 0.0, lse
+        )  # fully-masked query: avoid exp(-inf+inf)=NaN
+        p = tl.exp(score - lse_safe[:, None])  # [BH, BN]
         dp = tl.dot(dout_l, tl.trans(c_kv))  # [BH, BN] = dout_latent·c_kv
         ds = (p * (dp - delta[:, None])) * scale  # [BH, BN]  grad wrt scaled score
         ds_b = ds.to(c_kv.dtype)
@@ -307,7 +361,9 @@ def _grid_fn(B, S, H):
 
 class _MlaAbsorbAttn(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q_abs, k_shared, topk_idx, scale, q_offset):
+    def forward(
+        ctx, q_abs, k_shared, topk_idx, scale, q_offset, seq_q=None, seq_k=None
+    ):
         B, H, S, _ = (
             q_abs.shape
         )  # S = local queries; k_shared may be longer (global, under CP)
@@ -315,6 +371,20 @@ class _MlaAbsorbAttn(torch.autograd.Function):
         TOPK = topk_idx.shape[-1]
         q_abs, k_shared = q_abs.contiguous(), k_shared.contiguous()
         idx = topk_idx.contiguous()
+        has_doc = seq_q is not None and seq_k is not None
+        if has_doc:
+            seq_q = seq_q.contiguous()
+            seq_k = seq_k.contiguous()
+            doc_args = (
+                seq_q,
+                seq_k,
+                seq_q.stride(0),
+                seq_q.stride(1),
+                seq_k.stride(0),
+                seq_k.stride(1),
+            )
+        else:
+            doc_args = (idx, idx, 0, 0, 0, 0)
         out = torch.empty(B, H, S, DV, device=q_abs.device, dtype=q_abs.dtype)
         lse = torch.empty(B, H, S, device=q_abs.device, dtype=torch.float32)
         _absorb_fwd_kernel[_grid_fn(B, S, H)](
@@ -345,17 +415,32 @@ class _MlaAbsorbAttn(torch.autograd.Function):
             lse.stride(0),
             lse.stride(1),
             lse.stride(2),
+            *doc_args,
             DL=KV_LORA_RANK,
             DR=QK_ROPE_HEAD_DIM,
+            HAS_DOC=has_doc,
         )
-        ctx.save_for_backward(q_abs, k_shared, idx, out, lse)
+        ctx.save_for_backward(q_abs, k_shared, idx, out, lse, doc_args[0], doc_args[1])
         ctx.scale = float(scale)
         ctx.q_offset = int(q_offset)
+        ctx.has_doc = has_doc
         return out
 
     @staticmethod
     def backward(ctx, dout):
-        q_abs, k_shared, idx, out, lse = ctx.saved_tensors
+        q_abs, k_shared, idx, out, lse, seq_q, seq_k = ctx.saved_tensors
+        has_doc = ctx.has_doc
+        if has_doc:
+            doc_args = (
+                seq_q,
+                seq_k,
+                seq_q.stride(0),
+                seq_q.stride(1),
+                seq_k.stride(0),
+                seq_k.stride(1),
+            )
+        else:
+            doc_args = (idx, idx, 0, 0, 0, 0)
         B, H, S, DQk = q_abs.shape
         Skv = k_shared.shape[1]  # global key count (>= S under CP)
         TOPK = idx.shape[-1]
@@ -394,18 +479,24 @@ class _MlaAbsorbAttn(torch.autograd.Function):
             lse.stride(0),
             lse.stride(1),
             lse.stride(2),
+            *doc_args,
             DL=KV_LORA_RANK,
             DR=QK_ROPE_HEAD_DIM,
+            HAS_DOC=has_doc,
         )
-        return dq_abs, dk_shared.to(k_shared.dtype), None, None, None
+        return dq_abs, dk_shared.to(k_shared.dtype), None, None, None, None, None
 
 
-def mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset=0):
+def mla_absorb_attn(
+    q_abs, k_shared, topk_idx, scale, q_offset=0, seq_q=None, seq_k=None
+):
     """Differentiable head-batched MLA-absorption sparse attention. q_abs [B,H,S,576] (local
     queries), k_shared [B,Skv,576] (first kv_lora cols = c_kv; Skv>=S under context parallel),
     topk_idx [B,S,T] int32 referencing GLOBAL key positions. ``q_offset`` is the global position of
     local query 0 (for causal masking under CP). Returns out_latent [B,H,S,kv_lora]."""
-    return _MlaAbsorbAttn.apply(q_abs, k_shared, topk_idx, scale, q_offset)
+    return _MlaAbsorbAttn.apply(
+        q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k
+    )
 
 
 def mla_absorb_attn_fwd(q_abs, k_shared, topk_idx, scale, q_offset=0):

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
@@ -69,14 +69,15 @@ def split_kv_b(kv_b_weight: torch.Tensor, n_heads: int):
 
 def absorb_query(q_nope, q_rot, w_kb_k):
     """q_nope [B,H,S,qk_nope], q_rot [B,H,S,qk_rope], w_kb_k [H,qk_nope,kv_lora] ->
-    Q_abs [B,H,S,DQK] = cat(q_nope @ W_kb_kᵀ, q_rot). Differentiable."""
-    q_abs_nope = torch.einsum("bhsn,hnl->bhsl", q_nope, w_kb_k)  # [B,H,S,kv_lora]
+    Q_abs [B,H,S,DQK] = cat(q_nope @ W_kb_kᵀ, q_rot). Differentiable. ``w_kb_k`` is cast to the
+    activation dtype (under LoRA the effective kv_b weight promotes to fp32 via the adapters)."""
+    q_abs_nope = torch.einsum("bhsn,hnl->bhsl", q_nope, w_kb_k.to(q_nope.dtype))
     return torch.cat([q_abs_nope, q_rot], dim=-1)
 
 
 def project_value(out_latent, w_kb_v):
     """out_latent [B,H,S,kv_lora] -> out [B,H,S,v_head] = out_latent @ W_kb_vᵀ. Differentiable."""
-    return torch.einsum("bhsl,hvl->bhsv", out_latent, w_kb_v)
+    return torch.einsum("bhsl,hvl->bhsv", out_latent, w_kb_v.to(out_latent.dtype))
 
 
 @triton.autotune(

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
@@ -1,0 +1,340 @@
+"""Sparse top-k MLA attention for GLM-5.2 DSA (forward + backward, training-correct).
+
+The DSA training path (eager/sdpa) scatters the per-query top-k indices into a dense ``[B,S,T]``
+additive mask and runs full attention over all T keys — O(S^2) memory + compute even though only
+``index_topk`` (2048) keys per query matter. This kernel **gathers** each query's selected keys and
+runs flash online-softmax over just those: O(S·topk).
+
+``sparse_attn`` is a ``torch.autograd.Function`` — fwd + bwd — so it composes with training. It
+differentiates wrt q, k, v (the MLA projection activations), so gradients flow to the projection
+weights in **full-parameter** training and to the LoRA adapters in **LoRA** training identically;
+the kernel is agnostic to how q/k/v were produced. The top-k indices are treated as constants
+(``topk`` is non-differentiable, exactly as in the eager model), and the DSA indexer itself is
+``@torch.no_grad`` upstream, so no gradient flows through key selection.
+
+Layout: q,k ``[B,H,S,D]`` (D=qk_head_dim=256), v ``[B,H,S,Dv]`` (Dv=v_head_dim=256), ``topk_idx``
+``[B,S,T]`` int32 (selected key positions, shared across heads). Gathered indices beyond the query
+position are causal-masked so over-selected top-k padding contributes nothing (fwd) and gets no
+gradient (bwd). One program = (b, h, query position s); MMA-efficient batching is a later
+optimization — this is the correct, gradient-validated baseline.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=w, num_stages=s)
+        for bt in (64, 128, 256)
+        for w in (4, 8)
+        for s in (2, 3)
+    ],
+    key=["TOPK", "D", "DV"],
+)
+@triton.jit
+def _fwd_kernel(
+    Q,
+    K,
+    V,
+    IDX,
+    OUT,
+    LSE,
+    scale,
+    S,
+    TOPK,
+    sq_b,
+    sq_h,
+    sq_s,
+    sq_d,
+    sk_b,
+    sk_h,
+    sk_s,
+    sk_d,
+    sv_b,
+    sv_h,
+    sv_s,
+    sv_d,
+    si_b,
+    si_s,
+    si_t,
+    so_b,
+    so_h,
+    so_s,
+    so_d,
+    sl_b,
+    sl_h,
+    sl_s,
+    H,
+    D: tl.constexpr,
+    DV: tl.constexpr,
+    BT: tl.constexpr,
+):
+    pid_bh = tl.program_id(0)
+    s = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+
+    offs_d = tl.arange(0, D)
+    offs_dv = tl.arange(0, DV)
+    q = tl.load(Q + b * sq_b + h * sq_h + s * sq_s + offs_d * sq_d).to(tl.float32)
+
+    m_i = -float("inf")
+    l_i = 0.0
+    acc = tl.zeros((DV,), dtype=tl.float32)
+
+    for t0 in range(0, TOPK, BT):
+        offs_t = t0 + tl.arange(0, BT)
+        tmask = offs_t < TOPK
+        idx = tl.load(
+            IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
+        ).to(tl.int64)
+        valid = tmask & (idx <= s)
+
+        k_ptr = K + b * sk_b + h * sk_h + idx[:, None] * sk_s + offs_d[None, :] * sk_d
+        k = tl.load(k_ptr, mask=valid[:, None], other=0.0).to(tl.float32)  # [BT, D]
+        qk = tl.sum(q[None, :] * k, axis=1) * scale  # [BT]
+        qk = tl.where(valid, qk, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(qk, axis=0))
+        p = tl.exp(qk - m_new)
+        alpha = tl.exp(m_i - m_new)
+        l_i = l_i * alpha + tl.sum(p, axis=0)
+        v_ptr = V + b * sv_b + h * sv_h + idx[:, None] * sv_s + offs_dv[None, :] * sv_d
+        v = tl.load(v_ptr, mask=valid[:, None], other=0.0).to(tl.float32)  # [BT, DV]
+        acc = acc * alpha + tl.sum(p[:, None] * v, axis=0)
+        m_i = m_new
+
+    acc = acc / l_i
+    tl.store(
+        OUT + b * so_b + h * so_h + s * so_s + offs_dv * so_d,
+        acc.to(OUT.dtype.element_ty),
+    )
+    tl.store(LSE + b * sl_b + h * sl_h + s * sl_s, m_i + tl.log(l_i))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=w, num_stages=s)
+        for bt in (64, 128, 256)
+        for w in (4, 8)
+        for s in (2, 3)
+    ],
+    key=["TOPK", "D", "DV"],
+    # dK/dV are atomic-accumulated; zero them between autotune trials or benchmarking corrupts them.
+    reset_to_zero=["DKO", "DVO"],
+)
+@triton.jit
+def _bwd_kernel(
+    Q,
+    K,
+    V,
+    IDX,
+    OUT,
+    DOUT,
+    LSE,
+    DQO,
+    DKO,
+    DVO,
+    scale,
+    S,
+    TOPK,
+    sq_b,
+    sq_h,
+    sq_s,
+    sq_d,
+    sk_b,
+    sk_h,
+    sk_s,
+    sk_d,
+    sv_b,
+    sv_h,
+    sv_s,
+    sv_d,
+    si_b,
+    si_s,
+    si_t,
+    so_b,
+    so_h,
+    so_s,
+    so_d,
+    sl_b,
+    sl_h,
+    sl_s,
+    H,
+    D: tl.constexpr,
+    DV: tl.constexpr,
+    BT: tl.constexpr,
+):
+    pid_bh = tl.program_id(0)
+    s = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+
+    offs_d = tl.arange(0, D)
+    offs_dv = tl.arange(0, DV)
+    q = tl.load(Q + b * sq_b + h * sq_h + s * sq_s + offs_d * sq_d).to(tl.float32)
+    dout = tl.load(DOUT + b * so_b + h * so_h + s * so_s + offs_dv * so_d).to(
+        tl.float32
+    )
+    out = tl.load(OUT + b * so_b + h * so_h + s * so_s + offs_dv * so_d).to(tl.float32)
+    lse = tl.load(LSE + b * sl_b + h * sl_h + s * sl_s)
+    delta = tl.sum(dout * out, axis=0)  # = Σ_j p_j (dout·V_j)
+
+    dq = tl.zeros((D,), dtype=tl.float32)
+    for t0 in range(0, TOPK, BT):
+        offs_t = t0 + tl.arange(0, BT)
+        tmask = offs_t < TOPK
+        idx = tl.load(
+            IDX + b * si_b + s * si_s + offs_t * si_t, mask=tmask, other=0
+        ).to(tl.int64)
+        valid = tmask & (idx <= s)
+
+        k_ptr = K + b * sk_b + h * sk_h + idx[:, None] * sk_s + offs_d[None, :] * sk_d
+        k = tl.load(k_ptr, mask=valid[:, None], other=0.0).to(tl.float32)  # [BT, D]
+        v_ptr = V + b * sv_b + h * sv_h + idx[:, None] * sv_s + offs_dv[None, :] * sv_d
+        v = tl.load(v_ptr, mask=valid[:, None], other=0.0).to(tl.float32)  # [BT, DV]
+
+        s_j = tl.sum(q[None, :] * k, axis=1) * scale  # [BT]
+        p = tl.where(valid, tl.exp(s_j - lse), 0.0)  # [BT]
+        dp = tl.sum(dout[None, :] * v, axis=1)  # [BT] = dout·V_j
+        ds = p * (dp - delta)  # [BT] grad wrt pre-softmax score
+
+        dq += tl.sum((ds * scale)[:, None] * k, axis=0)  # [D]
+        # scatter-add dK_j = scale·ds_j·q, dV_j = p_j·dout  (race across query positions -> atomic)
+        dk_j = (ds * scale)[:, None] * q[None, :]  # [BT, D]
+        dv_j = p[:, None] * dout[None, :]  # [BT, DV]
+        dk_ptr = (
+            DKO + b * sk_b + h * sk_h + idx[:, None] * sk_s + offs_d[None, :] * sk_d
+        )
+        dv_ptr = (
+            DVO + b * sv_b + h * sv_h + idx[:, None] * sv_s + offs_dv[None, :] * sv_d
+        )
+        tl.atomic_add(dk_ptr, tl.where(valid[:, None], dk_j, 0.0))
+        tl.atomic_add(dv_ptr, tl.where(valid[:, None], dv_j, 0.0))
+
+    tl.store(DQO + b * sq_b + h * sq_h + s * sq_s + offs_d * sq_d, dq)
+
+
+class _SparseAttnTopK(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, topk_idx, scale):
+        B, H, S, D = q.shape
+        DV = v.shape[-1]
+        TOPK = topk_idx.shape[-1]
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+        idx = topk_idx.contiguous()
+        out = torch.empty(B, H, S, DV, device=q.device, dtype=q.dtype)
+        lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+        grid = (B * H, S)
+        _fwd_kernel[grid](
+            q,
+            k,
+            v,
+            idx,
+            out,
+            lse,
+            float(scale),
+            S,
+            TOPK,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            idx.stride(0),
+            idx.stride(1),
+            idx.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            lse.stride(0),
+            lse.stride(1),
+            lse.stride(2),
+            H,
+            D=D,
+            DV=DV,
+        )
+        ctx.save_for_backward(q, k, v, idx, out, lse)
+        ctx.scale = float(scale)
+        ctx.H = H
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, idx, out, lse = ctx.saved_tensors
+        B, H, S, D = q.shape
+        DV = v.shape[-1]
+        TOPK = idx.shape[-1]
+        dout = dout.contiguous()
+        dq = torch.zeros_like(q, dtype=torch.float32)
+        # dK/dV accumulate across query positions selecting the same key -> fp32 atomics.
+        dk = torch.zeros(B, H, S, D, device=q.device, dtype=torch.float32)
+        dv = torch.zeros(B, H, S, DV, device=q.device, dtype=torch.float32)
+        grid = (B * H, S)
+        _bwd_kernel[grid](
+            q,
+            k,
+            v,
+            idx,
+            out,
+            dout,
+            lse,
+            dq,
+            dk,
+            dv,
+            ctx.scale,
+            S,
+            TOPK,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            dk.stride(0),
+            dk.stride(1),
+            dk.stride(2),
+            dk.stride(3),
+            dv.stride(0),
+            dv.stride(1),
+            dv.stride(2),
+            dv.stride(3),
+            idx.stride(0),
+            idx.stride(1),
+            idx.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            lse.stride(0),
+            lse.stride(1),
+            lse.stride(2),
+            H,
+            D=D,
+            DV=DV,
+        )
+        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), None, None
+
+
+def sparse_attn(q, k, v, topk_idx, scale):
+    """Differentiable sparse top-k MLA attention. q,k [B,H,S,D], v [B,H,S,Dv], topk_idx [B,S,T]
+    int32. Returns out [B,H,S,Dv]; backprops dq/dk/dv (topk_idx is a constant)."""
+    return _SparseAttnTopK.apply(q, k, v, topk_idx, scale)
+
+
+def sparse_attn_fwd(q, k, v, topk_idx, scale):
+    """Forward-only (no autograd) — for benchmarking the kernel in isolation."""
+    with torch.no_grad():
+        return _SparseAttnTopK.apply(
+            q.detach(), k.detach(), v.detach(), topk_idx, scale
+        )

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/config.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/config.py
@@ -1,0 +1,54 @@
+"""Real GLM-5.2 (glm_moe_dsa) shapes for kernel development + validation.
+
+Kernels are validated at the REAL model dims (head_dim 256, index_head_dim 128, top-k 2048, ...)
+with a truncated layer count / per-op isolation — shrinking the dims would hide shape-specific
+behavior (SMEM pressure at head_dim 256, the 128-wide indexer dot, the 2048 top-k gather). These
+mirror ``GlmMoeDsaConfig`` defaults == the published GLM-5.2 checkpoint.
+"""
+
+from __future__ import annotations
+
+# --- attention (DeepSeek-V3.2 MLA) ---
+HIDDEN = 6144
+N_HEADS = 64
+N_KV_HEADS = 64
+Q_LORA_RANK = 2048
+KV_LORA_RANK = 512
+QK_NOPE_HEAD_DIM = 192
+QK_ROPE_HEAD_DIM = 64
+QK_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM  # 256
+V_HEAD_DIM = 256
+ATTN_SCALE = QK_HEAD_DIM**-0.5
+ROPE_THETA = 8_000_000.0
+
+# --- DSA Lightning indexer ---
+INDEX_N_HEADS = 32
+INDEX_HEAD_DIM = 128
+INDEX_TOPK = 2048
+INDEX_SOFTMAX_SCALE = INDEX_HEAD_DIM**-0.5
+
+# --- MoE (not exercised by the attention/indexer/rope kernels) ---
+N_ROUTED_EXPERTS = 256
+N_SHARED_EXPERTS = 1
+NUM_EXPERTS_PER_TOK = 8
+MOE_INTERMEDIATE = 2048
+
+NUM_HIDDEN_LAYERS = 78
+FIRST_K_DENSE_REPLACE = 3
+INDEX_TOPK_FREQ = 4
+
+
+def probe_shapes(seq: int = 4096, batch: int = 1) -> dict:
+    """A single (batch, seq) probe at real dims for kernel tests/benches."""
+    return {
+        "B": batch,
+        "S": seq,
+        "H": N_HEADS,
+        "D": QK_HEAD_DIM,
+        "Dv": V_HEAD_DIM,
+        "IDX_H": INDEX_N_HEADS,
+        "IDX_D": INDEX_HEAD_DIM,
+        "TOPK": min(INDEX_TOPK, seq),
+        "scale": ATTN_SCALE,
+        "idx_scale": INDEX_SOFTMAX_SCALE,
+    }

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/context_parallel.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/context_parallel.py
@@ -1,0 +1,107 @@
+"""Context-parallel DSA attention for GLM-5.2.
+
+GLM-5.2 is always multi-GPU; at long context the sequence is sharded across a context-parallel (CP)
+group. The MLA compression makes CP cheap: each rank needs every key, but a key is only the 576-wide
+*compressed* ``k_shared`` (kv_lora 512 + rope 64) — ~1.1 KB/token — NOT the per-head 64x256 expanded
+keys (~32 KB/token). So we all-gather the compressed KV (a ~28x smaller collective than gathering
+expanded K/V) and each rank attends its local queries against the global KV with the absorbed kernel
+(already global-KV-aware via ``q_offset`` + global top-k indices).
+
+The all-gather is differentiable (its backward reduce-scatters the per-rank ``dk_shared`` grads), so
+training is correct. ``topk_idx`` must reference GLOBAL key positions (the indexer scores against the
+same gathered KV). Sequence sharding here is contiguous (rank r owns ``[r·L, (r+1)·L)``).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from .attention_mla_absorb import absorb_query
+from .dispatch import mla_attn
+
+_COMM_STREAM = {}
+
+
+def _comm_stream(dev):
+    if dev not in _COMM_STREAM:
+        _COMM_STREAM[dev] = torch.cuda.Stream(device=dev)
+    return _COMM_STREAM[dev]
+
+
+class _OverlapGather(torch.autograd.Function):
+    """Differentiable seq all-gather whose data movement was already started (async) before this op,
+    so it overlaps with intervening compute. Backward all-reduces the global grad and slices the
+    rank-local part (== the reduce-scatter the standard differentiable all-gather does)."""
+
+    @staticmethod
+    def forward(ctx, k_local, gathered, work, group, world, rank):
+        if work is not None:
+            work.wait()
+        ctx.group, ctx.world, ctx.rank, ctx.sl = group, world, rank, k_local.shape[1]
+        return torch.cat(gathered, dim=1)
+
+    @staticmethod
+    def backward(ctx, dg):
+        dg = dg.contiguous()
+        dist.all_reduce(dg, op=dist.ReduceOp.SUM, group=ctx.group)
+        s = slice(ctx.rank * ctx.sl, (ctx.rank + 1) * ctx.sl)
+        return dg[:, s].contiguous(), None, None, None, None, None
+
+
+def cp_mla_attn_overlapped(
+    q_pass, q_rot, w_kb_k, k_shared, topk_idx, scale, group=None, crossover=None
+):
+    """Comm-overlapped CP attention: issue the compressed-KV all-gather on a side stream, compute the
+    absorption GEMM (local, ~hidden behind the gather), then attend. Same result as cp_mla_attn but
+    the absorption is hidden behind the collective. Takes the RAW query projections so the GEMM can
+    run in the overlap window. Returns the local out_latent."""
+    world = dist.get_world_size(group) if dist.is_initialized() else 1
+    if world == 1:
+        q_abs = absorb_query(q_pass, q_rot, w_kb_k)
+        return mla_attn(
+            q_abs, k_shared, topk_idx, scale, q_offset=0, crossover=crossover
+        )
+    rank = dist.get_rank(group)
+    s_local = q_pass.shape[2]
+    gathered = [torch.empty_like(k_shared) for _ in range(world)]
+    stream = _comm_stream(k_shared.device)
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        work = dist.all_gather(
+            gathered, k_shared.contiguous(), group=group, async_op=True
+        )
+    q_abs = absorb_query(
+        q_pass, q_rot, w_kb_k
+    )  # overlaps with the gather on the side stream
+    torch.cuda.current_stream().wait_stream(stream)
+    k_global = _OverlapGather.apply(k_shared, gathered, work, group, world, rank)
+    return mla_attn(
+        q_abs, k_global, topk_idx, scale, q_offset=rank * s_local, crossover=crossover
+    )
+
+
+def all_gather_seq(x: torch.Tensor, group=None) -> torch.Tensor:
+    """Differentiable all-gather along the sequence dim (1): [B,S_local,D] -> [B,S_global,D]."""
+    world = dist.get_world_size(group) if dist.is_initialized() else 1
+    if world == 1:
+        return x
+    import torch.distributed.nn as dist_nn
+
+    parts = dist_nn.all_gather(x.contiguous(), group=group)
+    return torch.cat(list(parts), dim=1)
+
+
+def cp_mla_attn(q_abs, k_shared, topk_idx, scale, group=None, crossover=None):
+    """Context-parallel absorbed DSA attention. ``q_abs`` [B,H,S_local,576], ``k_shared``
+    [B,S_local,576], ``topk_idx`` [B,S_local,T] (GLOBAL key positions) are the rank-local shards.
+    All-gathers the compressed KV (cheap), then runs the local queries against the global KV with the
+    correct ``q_offset``. Returns the local out_latent [B,H,S_local,kv_lora]."""
+    rank = dist.get_rank(group) if dist.is_initialized() else 0
+    s_local = q_abs.shape[2]
+    k_global = all_gather_seq(
+        k_shared, group
+    )  # differentiable; backward reduce-scatters dk
+    return mla_attn(
+        q_abs, k_global, topk_idx, scale, q_offset=rank * s_local, crossover=crossover
+    )

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
@@ -1,0 +1,108 @@
+"""Length-aware dispatch for GLM-5.2 DSA attention — robust across short and long sequences.
+
+The sparse gather kernel only wins when ``S >> index_topk`` (it trades MMA locality for skipping
+non-selected keys). Below a hardware-dependent crossover, a DENSE flash over the (absorbed) shared
+KV with the top-k applied as an additive mask is faster; and at ``S <= index_topk`` the top-k
+selects every causal key, so it degenerates to plain causal attention anyway.
+
+``mla_attn`` dispatches on ``S``: dense flash below the crossover, gather above. Both produce the
+same ``out_latent`` and are differentiable, so training is correct in either regime. The crossover
+is **auto-calibrated once** per ``(topk, H, dtype, device)`` by microbenchmarking the two paths —
+so it adapts to sm120 (~22k) vs a datacenter GPU (much lower) instead of hardcoding a threshold.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from .attention_mla_absorb import DQK, mla_absorb_attn
+from .config import KV_LORA_RANK
+
+_CROSSOVER: dict[tuple, int] = {}
+
+
+def _topk_causal_mask(topk_idx, Skv, q_offset, dtype, device):
+    """Additive [B,1,S,Skv] mask: 0 at selected-and-causal global keys, -inf elsewhere. ``topk_idx``
+    references GLOBAL key positions; query i (local) is global position ``q_offset + i``."""
+    B, S = topk_idx.shape[:2]
+    sel = torch.zeros(B, S, Skv, dtype=torch.bool, device=device)
+    sel.scatter_(-1, topk_idx.long(), True)
+    kpos = torch.arange(Skv, device=device)
+    qpos = q_offset + torch.arange(S, device=device)
+    keep = sel & (kpos[None, None, :] <= qpos[None, :, None])
+    mask = torch.zeros(B, 1, S, Skv, dtype=dtype, device=device)
+    return mask.masked_fill_(~keep.unsqueeze(1), float("-inf"))
+
+
+def dense_masked_out_latent(q_abs, k_shared, topk_idx, scale, q_offset=0):
+    """Dense flash over the absorbed shared KV with the top-k as an additive mask (O(S) memory via
+    SDPA; the mask itself is O(S·Skv)). Differentiable. Faster than the gather below the crossover.
+    ``k_shared`` may be the global (gathered) KV under context parallel; ``q_offset`` is local q0's
+    global position."""
+    B, H, S, _ = q_abs.shape
+    Skv = k_shared.shape[1]
+    c_kv = k_shared[..., :KV_LORA_RANK]
+    k_e = k_shared.unsqueeze(1).expand(B, H, Skv, k_shared.shape[-1])
+    v_e = c_kv.unsqueeze(1).expand(B, H, Skv, KV_LORA_RANK)
+    mask = _topk_causal_mask(topk_idx, Skv, q_offset, q_abs.dtype, q_abs.device)
+    return F.scaled_dot_product_attention(q_abs, k_e, v_e, attn_mask=mask, scale=scale)
+
+
+def _bench(fn, it=8):
+    import time
+
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    t = time.time()
+    for _ in range(it):
+        fn()
+    torch.cuda.synchronize()
+    return time.time() - t
+
+
+def calibrate_crossover(topk, H, dtype, device, B=1) -> int:
+    """Microbench gather vs dense at increasing S; return the smallest S where the gather wins
+    (memoized). Falls back to a sparsity heuristic if a probe OOMs."""
+    key = (topk, H, str(dtype), torch.cuda.get_device_name(device))
+    if key in _CROSSOVER:
+        return _CROSSOVER[key]
+    crossover = None
+    for mult in (2, 3, 4, 6, 8, 12, 16):
+        S = topk * mult
+        try:
+            q = torch.randn(B, H, S, DQK, device=device, dtype=dtype)
+            k = torch.randn(B, S, DQK, device=device, dtype=dtype)
+            idx = torch.stack(
+                [torch.arange(topk, device=device).clamp(max=s).int() for s in range(S)]
+            ).unsqueeze(0)
+            tg = _bench(lambda q=q, k=k, idx=idx: mla_absorb_attn(q, k, idx, 1.0).sum())
+            td = _bench(
+                lambda q=q, k=k, idx=idx: dense_masked_out_latent(q, k, idx, 1.0).sum()
+            )
+        except torch.cuda.OutOfMemoryError:
+            crossover = crossover or S  # dense OOMed -> must use gather from here
+            break
+        if tg < td:
+            crossover = S
+            break
+    crossover = crossover or topk * 16
+    _CROSSOVER[key] = crossover
+    return crossover
+
+
+def mla_attn(
+    q_abs, k_shared, topk_idx, scale, q_offset=0, crossover: int | None = None
+):
+    """Differentiable DSA attention, dispatched by total key length (the sparsity that matters):
+    dense flash below the (auto-calibrated) crossover, sparse gather above. ``k_shared`` may be the
+    global gathered KV under context parallel; ``q_offset`` is local query 0's global position.
+    Returns out_latent [B,H,S,kv_lora]."""
+    Skv = k_shared.shape[1]
+    topk = topk_idx.shape[-1]
+    if crossover is None:
+        crossover = calibrate_crossover(topk, q_abs.shape[1], q_abs.dtype, q_abs.device)
+    if Skv >= crossover:
+        return mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset)
+    return dense_masked_out_latent(q_abs, k_shared, topk_idx, scale, q_offset)

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
@@ -20,32 +20,64 @@ from .attention_mla_absorb import DQK, mla_absorb_attn
 from .config import KV_LORA_RANK
 
 _CROSSOVER: dict[tuple, int] = {}
+_GATHER_OK: dict[int, bool] = {}
 
 
-def _topk_causal_mask(topk_idx, Skv, q_offset, dtype, device):
+def _gather_supported(device) -> bool:
+    """Whether to use the sparse absorbed-MLA gather kernel (vs the dense fallback).
+
+    Validated on sm120 (Ada / consumer-Blackwell) and sm90 (Hopper). The earlier sm90 blockers are
+    fixed: the backward's nondeterministic invalid-PC (the full autotune grid trialing — each config
+    is individually clean) is avoided by forcing a single config on sm90 (``_bwd_prune_sm90_safe`` in
+    ``attention_mla_absorb``), and the leading-all-masked-block softmax NaN is guarded in the kernel.
+    Set ``GLM_DSA_DISABLE_GATHER=1`` to force the dense path, or ``GLM_DSA_FORCE_GATHER=1`` to use the
+    gather on an unlisted arch."""
+    import os
+
+    if os.environ.get("GLM_DSA_DISABLE_GATHER"):
+        return False
+    if os.environ.get("GLM_DSA_FORCE_GATHER"):
+        return True
+    dev = getattr(device, "index", None)
+    if dev is None:
+        dev = torch.cuda.current_device()
+    if dev not in _GATHER_OK:
+        _GATHER_OK[dev] = torch.cuda.get_device_capability(dev) in ((9, 0), (12, 0))
+    return _GATHER_OK[dev]
+
+
+def _topk_causal_mask(topk_idx, Skv, q_offset, dtype, device, seq_q=None, seq_k=None):
     """Additive [B,1,S,Skv] mask: 0 at selected-and-causal global keys, -inf elsewhere. ``topk_idx``
-    references GLOBAL key positions; query i (local) is global position ``q_offset + i``."""
+    references GLOBAL key positions; query i (local) is global position ``q_offset + i``. Under
+    sample packing, ``seq_q`` [B,S] / ``seq_k`` [B,Skv] further forbid cross-document keys (the
+    selected set may include earlier-document keys when ``topk == Skv``)."""
     B, S = topk_idx.shape[:2]
     sel = torch.zeros(B, S, Skv, dtype=torch.bool, device=device)
     sel.scatter_(-1, topk_idx.long(), True)
     kpos = torch.arange(Skv, device=device)
     qpos = q_offset + torch.arange(S, device=device)
     keep = sel & (kpos[None, None, :] <= qpos[None, :, None])
+    if seq_q is not None and seq_k is not None:
+        keep = keep & (seq_k[:, None, :] == seq_q[:, :, None])
     mask = torch.zeros(B, 1, S, Skv, dtype=dtype, device=device)
     return mask.masked_fill_(~keep.unsqueeze(1), float("-inf"))
 
 
-def dense_masked_out_latent(q_abs, k_shared, topk_idx, scale, q_offset=0):
+def dense_masked_out_latent(
+    q_abs, k_shared, topk_idx, scale, q_offset=0, seq_q=None, seq_k=None
+):
     """Dense flash over the absorbed shared KV with the top-k as an additive mask (O(S) memory via
     SDPA; the mask itself is O(S·Skv)). Differentiable. Faster than the gather below the crossover.
     ``k_shared`` may be the global (gathered) KV under context parallel; ``q_offset`` is local q0's
-    global position."""
+    global position. ``seq_q``/``seq_k`` enable per-document masking under sample packing."""
     B, H, S, _ = q_abs.shape
     Skv = k_shared.shape[1]
     c_kv = k_shared[..., :KV_LORA_RANK]
     k_e = k_shared.unsqueeze(1).expand(B, H, Skv, k_shared.shape[-1])
     v_e = c_kv.unsqueeze(1).expand(B, H, Skv, KV_LORA_RANK)
-    mask = _topk_causal_mask(topk_idx, Skv, q_offset, q_abs.dtype, q_abs.device)
+    mask = _topk_causal_mask(
+        topk_idx, Skv, q_offset, q_abs.dtype, q_abs.device, seq_q, seq_k
+    )
     return F.scaled_dot_product_attention(q_abs, k_e, v_e, attn_mask=mask, scale=scale)
 
 
@@ -93,16 +125,29 @@ def calibrate_crossover(topk, H, dtype, device, B=1) -> int:
 
 
 def mla_attn(
-    q_abs, k_shared, topk_idx, scale, q_offset=0, crossover: int | None = None
+    q_abs,
+    k_shared,
+    topk_idx,
+    scale,
+    q_offset=0,
+    crossover: int | None = None,
+    seq_q=None,
+    seq_k=None,
 ):
     """Differentiable DSA attention, dispatched by total key length (the sparsity that matters):
     dense flash below the (auto-calibrated) crossover, sparse gather above. ``k_shared`` may be the
     global gathered KV under context parallel; ``q_offset`` is local query 0's global position.
-    Returns out_latent [B,H,S,kv_lora]."""
+    Returns out_latent [B,H,S,kv_lora].
+
+    Under sample packing (``seq_q``/``seq_k`` document ids set) the gather is doc-aware: it masks
+    cross-document keys in-kernel (``seq_k[idx] == seq_q[s]``), so packing keeps the sparse path
+    instead of falling back to the dense per-document mask."""
     Skv = k_shared.shape[1]
     topk = topk_idx.shape[-1]
     if crossover is None:
         crossover = calibrate_crossover(topk, q_abs.shape[1], q_abs.dtype, q_abs.device)
-    if Skv >= crossover:
-        return mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset)
-    return dense_masked_out_latent(q_abs, k_shared, topk_idx, scale, q_offset)
+    if Skv >= crossover and _gather_supported(q_abs.device):
+        return mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k)
+    return dense_masked_out_latent(
+        q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k
+    )

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/dispatch.py
@@ -144,10 +144,17 @@ def mla_attn(
     instead of falling back to the dense per-document mask."""
     Skv = k_shared.shape[1]
     topk = topk_idx.shape[-1]
-    if crossover is None:
-        crossover = calibrate_crossover(topk, q_abs.shape[1], q_abs.dtype, q_abs.device)
-    if Skv >= crossover and _gather_supported(q_abs.device):
-        return mla_absorb_attn(q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k)
+    # Check arch support BEFORE calibrating — calibrate_crossover benchmarks the gather, so on an
+    # unsupported GPU calibration would itself compile/run the gather Triton path we're avoiding.
+    if _gather_supported(q_abs.device):
+        if crossover is None:
+            crossover = calibrate_crossover(
+                topk, q_abs.shape[1], q_abs.dtype, q_abs.device
+            )
+        if Skv >= crossover:
+            return mla_absorb_attn(
+                q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k
+            )
     return dense_masked_out_latent(
         q_abs, k_shared, topk_idx, scale, q_offset, seq_q, seq_k
     )

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/indexer.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/indexer.py
@@ -144,23 +144,33 @@ def indexer_topk(
     index_topk: int,
     attention_mask: torch.Tensor | None = None,
     position_ids: torch.Tensor | None = None,
+    seq_q: torch.Tensor | None = None,
+    seq_k: torch.Tensor | None = None,
+    q_offset: int = 0,
 ) -> torch.Tensor:
     """Fused indexer scoring + causal mask + top-k. Returns int32 indices [B,S,topk].
 
     ``attention_mask`` (additive, broadcastable to [B,S,T]) is added if given; otherwise a causal
     mask from ``position_ids`` (or arange) is applied. Mirrors GlmMoeDsaIndexer's masking + topk.
+
+    Under sample packing, ``seq_q`` [B,S] / ``seq_k`` [B,T] give each query/key its document id;
+    the mask then forbids cross-document keys (a key in an earlier packed document is causally
+    "before" the query by global index but must not be attended). ``q_offset`` shifts local query
+    indices to global positions (context parallel). The selected indices still rank same-document
+    keys first; the attention kernel re-applies the same document mask (``mla_attn`` forces the
+    dense path under packing) so cross-document keys returned when ``topk == T`` are dropped.
     """
     scores = indexer_scores(q, k, weights, softmax_scale)  # [B,S,T]
     B, S, T = scores.shape
-    if attention_mask is not None:
+    packed = seq_q is not None and seq_k is not None
+    if attention_mask is not None and not packed:
         scores = scores + attention_mask.to(scores.dtype)
     else:
         kpos = torch.arange(T, device=scores.device)
-        if position_ids is None:
-            position_ids = (
-                torch.arange(S, device=scores.device).unsqueeze(0).expand(B, S)
-            )
-        causal = kpos[None, None, :] > position_ids[:, :, None]
+        qpos = q_offset + torch.arange(S, device=scores.device)
+        causal = kpos[None, None, :] > qpos[None, :, None]
+        if seq_q is not None and seq_k is not None:
+            causal = causal | (seq_k[:, None, :] != seq_q[:, :, None])
         scores = scores.masked_fill(causal, float("-inf"))
     topk = min(index_topk, T)
     return scores.topk(topk, dim=-1).indices.to(torch.int32)

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/indexer.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/indexer.py
@@ -1,0 +1,166 @@
+"""Fused GLM-5.2 DSA Lightning-Indexer scorer + top-k (forward-only).
+
+Reference (GlmMoeDsaIndexer.forward, post-RoPE):
+    scores       = relu(softmax_scale * q @ k^T)                         # [B, S, H, T]
+    index_scores = Σ_h weights[b,s,h] * scores[b,s,h,t]                  # [B, S, T]
+    (+ causal mask) -> topk(index_topk).indices                          # [B, S, topk] int32
+
+where q [B,S,H,D] (H=index_n_heads=32, D=index_head_dim=128), k [B,S,D] (shared across heads),
+weights[b,s,h] = weights_proj(h)[b,s,h] * H**-0.5.
+
+Eager materializes the full [B,S,H,T] fp32 score tensor (H=32) — the transient hotspot. Fusing
+the H-reduction collapses straight to [B,S,T], never holding the H axis. The indexer runs under
+``@torch.no_grad`` (its output only feeds ``topk().indices``), so this is FORWARD-ONLY.
+
+The scoring kernel is the DeepSeek-V4 ``indexer_scores`` kernel (identical math: relu(sm·qk) summed
+over weighted heads); GLM adds the causal mask + top-k here. ``relu(sm·x) == sm·relu(x)`` for sm>0,
+so applying the scale inside or outside relu is equivalent.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": bs, "BT": bt}, num_warps=w, num_stages=s)
+        for bs in (32, 64, 128)
+        for bt in (32, 64, 128)
+        for w in (4, 8)
+        for s in (2, 3)
+    ],
+    key=["S", "T", "H"],
+)
+@triton.jit
+def _indexer_score_kernel(
+    Q,
+    K,
+    W,
+    OUT,
+    softmax_scale,
+    S,
+    T,
+    H,
+    sq_b,
+    sq_s,
+    sq_h,
+    sq_d,
+    sk_b,
+    sk_t,
+    sk_d,
+    sw_b,
+    sw_s,
+    sw_h,
+    so_b,
+    so_s,
+    so_t,
+    DH: tl.constexpr,
+    BS: tl.constexpr,
+    BT: tl.constexpr,
+):
+    b = tl.program_id(0)
+    s0 = tl.program_id(1) * BS
+    t0 = tl.program_id(2) * BT
+    offs_s = s0 + tl.arange(0, BS)
+    offs_t = t0 + tl.arange(0, BT)
+    offs_d = tl.arange(0, DH)
+    smask = offs_s < S
+    tmask = offs_t < T
+
+    # k block [DH, BT] (transposed for q @ kᵀ), shared across heads
+    k_ptr = K + b * sk_b + offs_d[:, None] * sk_d + offs_t[None, :] * sk_t
+    k = tl.load(k_ptr, mask=tmask[None, :], other=0.0).to(tl.float32)
+
+    acc = tl.zeros((BS, BT), dtype=tl.float32)
+    for h in range(H):
+        q_ptr = (
+            Q + b * sq_b + offs_s[:, None] * sq_s + h * sq_h + offs_d[None, :] * sq_d
+        )
+        q = tl.load(q_ptr, mask=smask[:, None], other=0.0).to(tl.float32)
+        qk = tl.dot(q, k, input_precision="ieee")  # [BS, BT]
+        qk = tl.maximum(qk, 0.0) * softmax_scale  # relu · scale
+        w = tl.load(W + b * sw_b + offs_s * sw_s + h * sw_h, mask=smask, other=0.0).to(
+            tl.float32
+        )
+        acc += qk * w[:, None]
+
+    out_ptr = OUT + b * so_b + offs_s[:, None] * so_s + offs_t[None, :] * so_t
+    tl.store(out_ptr, acc, mask=smask[:, None] & tmask[None, :])
+
+
+def indexer_scores(
+    q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, softmax_scale: float
+) -> torch.Tensor:
+    """q [B,S,H,D], k [B,S,D] (shared across heads), weights [B,S,H] (already ·H**-0.5).
+    Returns index_scores [B,S,T=S] (fp32, no grad). Fuses the H-reduction."""
+    B, S, H, DH = q.shape
+    T = k.shape[1]
+    out = torch.empty(B, S, T, device=q.device, dtype=torch.float32)
+    if T == 0 or S == 0:
+        return out
+    if k.dtype != q.dtype:
+        k = k.to(q.dtype)
+    q, k, w = q.contiguous(), k.contiguous(), weights.contiguous()
+
+    def grid(m):
+        return (B, triton.cdiv(S, m["BS"]), triton.cdiv(T, m["BT"]))
+
+    _indexer_score_kernel[grid](
+        q,
+        k,
+        w,
+        out,
+        float(softmax_scale),
+        S,
+        T,
+        H,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        w.stride(0),
+        w.stride(1),
+        w.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        DH=DH,
+    )
+    return out
+
+
+@torch.no_grad()
+def indexer_topk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    softmax_scale: float,
+    index_topk: int,
+    attention_mask: torch.Tensor | None = None,
+    position_ids: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused indexer scoring + causal mask + top-k. Returns int32 indices [B,S,topk].
+
+    ``attention_mask`` (additive, broadcastable to [B,S,T]) is added if given; otherwise a causal
+    mask from ``position_ids`` (or arange) is applied. Mirrors GlmMoeDsaIndexer's masking + topk.
+    """
+    scores = indexer_scores(q, k, weights, softmax_scale)  # [B,S,T]
+    B, S, T = scores.shape
+    if attention_mask is not None:
+        scores = scores + attention_mask.to(scores.dtype)
+    else:
+        kpos = torch.arange(T, device=scores.device)
+        if position_ids is None:
+            position_ids = (
+                torch.arange(S, device=scores.device).unsqueeze(0).expand(B, S)
+            )
+        causal = kpos[None, None, :] > position_ids[:, :, None]
+        scores = scores.masked_fill(causal, float("-inf"))
+    topk = min(index_topk, T)
+    return scores.topk(topk, dim=-1).indices.to(torch.int32)

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -1,0 +1,222 @@
+"""Patch GlmMoeDsaAttention.forward to use the absorbed-MLA + dispatched sparse-gather kernels.
+
+Replaces the model's dense-mask eager/sdpa attention with: build q_abs / k_shared from the MLA
+projections (compressed latent + interleaved-RoPE rope part), call ``mla_attn`` (dense flash below
+the auto-calibrated crossover, sparse gather above), then ``project_value`` + ``o_proj``. The DSA
+top-k selection is taken from the model's own indexer (``"full"`` layers) or the previous full
+layer's indices (``"shared"`` layers), unchanged. The kv_b_proj weight is read through
+``effective_weight`` so the absorption is correct (and differentiable) under both full-parameter
+and LoRA training.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from .attention_mla_absorb import absorb_query, project_value, split_kv_b
+from .context_parallel import all_gather_seq
+from .dispatch import mla_attn
+from .indexer import indexer_topk
+
+
+@torch.no_grad()
+def fused_indexer_topk(
+    indexer,
+    hidden_states,
+    q_resid,
+    position_embeddings,
+    attention_mask,
+    position_ids,
+    group=None,
+):
+    """Replicates GlmMoeDsaIndexer.forward with the fused scorer (collapses the [B,S,32,T] reduction
+    to [B,S,T], the long-context memory win). Forward-only. Under context parallel (``group`` set),
+    all-gathers the indexer's keys so local queries score against the GLOBAL keys, and uses the
+    global ``position_ids`` for the causal mask. Returns top-k of GLOBAL key positions."""
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        apply_rotary_pos_emb,
+    )
+
+    B, S, _ = hidden_states.shape
+    q = indexer.wq_b(q_resid).view(B, S, indexer.n_heads, indexer.head_dim)
+    q_rot, q_pass = torch.split(
+        q,
+        [indexer.qk_rope_head_dim, indexer.head_dim - indexer.qk_rope_head_dim],
+        dim=-1,
+    )
+    k = indexer.k_norm(indexer.wk(hidden_states)).unsqueeze(2)  # [B,S,1,D]
+    k_rot, k_pass = torch.split(
+        k,
+        [indexer.qk_rope_head_dim, indexer.head_dim - indexer.qk_rope_head_dim],
+        dim=-1,
+    )
+    cos, sin = position_embeddings
+    q_rot, k_rot = apply_rotary_pos_emb(
+        q_rot, k_rot, cos, sin, unsqueeze_dim=2
+    )  # non-interleaved
+    q = torch.cat([q_rot, q_pass], dim=-1)  # [B,S_local,32,128]
+    k = torch.cat([k_rot, k_pass], dim=-1).squeeze(2)  # [B,S_local,128]
+    weights = indexer.weights_proj(
+        hidden_states.to(indexer.weights_proj.weight.dtype)
+    ) * (indexer.n_heads**-0.5)  # [B,S_local,32]
+    cp = group is not None and dist.is_initialized() and dist.get_world_size(group) > 1
+    if cp:
+        k = all_gather_seq(
+            k, group
+        )  # [B,S_global,128]; indexer is no_grad so no bwd comm needed
+        attention_mask = None  # use global position_ids for causality instead
+    return indexer_topk(
+        q,
+        k,
+        weights,
+        indexer.softmax_scale,
+        indexer.index_topk,
+        attention_mask,
+        position_ids,
+    )
+
+
+def effective_weight(linear) -> torch.Tensor:
+    """The weight the projection actually applies, differentiable wrt trainable params:
+    full-parameter -> ``linear.weight``; PEFT-LoRA -> ``base.weight + scaling·(Bᵀ? )`` delta so the
+    absorption flows gradients to the adapter. Falls back to ``.weight``."""
+    if hasattr(linear, "base_layer"):  # PEFT LoRA layer
+        base = linear.base_layer.weight
+        w = base
+        active = getattr(linear, "active_adapters", None) or list(
+            getattr(linear, "lora_A", {}).keys()
+        )
+        for name in active:
+            A = linear.lora_A[name].weight  # [r, in]
+            Bm = linear.lora_B[name].weight  # [out, r]
+            scaling = linear.scaling[name]
+            w = w + scaling * (Bm @ A)
+        return w
+    return linear.weight
+
+
+def _glm_dsa_attention_forward(
+    self,
+    hidden_states,
+    position_embeddings,
+    attention_mask=None,
+    past_key_values=None,
+    position_ids=None,
+    prev_topk_indices=None,
+    **kwargs,
+):
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        apply_rotary_pos_emb_interleave,
+    )
+
+    group = getattr(self, "_cp_group", None)
+    cp = group is not None and dist.is_initialized() and dist.get_world_size(group) > 1
+    rank = dist.get_rank(group) if cp else 0
+
+    B, S = hidden_states.shape[:-1]  # S = local query count under CP
+    q_resid = self.q_a_layernorm(self.q_a_proj(hidden_states))
+    q_states = self.q_b_proj(q_resid).view(B, S, -1, self.qk_head_dim).transpose(1, 2)
+    q_pass, q_rot = torch.split(
+        q_states, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+    )
+
+    compressed = self.kv_a_proj_with_mqa(hidden_states)
+    latent, k_rot = torch.split(
+        compressed, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+    )
+    c_kv = self.kv_a_layernorm(latent)  # [B, S, kv_lora]
+    k_rot = k_rot.view(B, 1, S, self.qk_rope_head_dim)
+    cos, sin = position_embeddings
+    q_rot, k_rot = apply_rotary_pos_emb_interleave(
+        q_rot, k_rot, cos, sin
+    )  # [B,H,S,64],[B,1,S,64]
+
+    # DSA top-k: this layer's own indexer (full) or the previous full layer's selection (shared).
+    # Under CP the indexer gathers global keys; topk indices reference GLOBAL key positions.
+    if self.indexer is not None:
+        idx_mask = (
+            attention_mask[:, 0, :, :]
+            if (attention_mask is not None and not cp)
+            else None
+        )
+        if cp or getattr(self, "_use_fused_indexer", False):
+            topk_indices = fused_indexer_topk(
+                self.indexer,
+                hidden_states,
+                q_resid,
+                position_embeddings,
+                idx_mask,
+                position_ids,
+                group=group if cp else None,
+            )
+        else:
+            topk_indices = self.indexer(
+                hidden_states,
+                q_resid,
+                position_embeddings,
+                idx_mask,
+                position_ids,
+                past_key_values=past_key_values,
+            )
+    else:
+        if prev_topk_indices is None:
+            raise ValueError("shared DSA layer needs prev_topk_indices")
+        topk_indices = prev_topk_indices
+
+    w_kb_k, w_kb_v = split_kv_b(effective_weight(self.kv_b_proj), self.num_heads)
+    q_abs = absorb_query(q_pass, q_rot, w_kb_k)  # [B,H,S_local,576]
+    k_shared = torch.cat([c_kv, k_rot.squeeze(1)], dim=-1)  # [B,S_local,576]
+    q_offset = 0
+    if cp:
+        k_shared = all_gather_seq(k_shared, group)  # [B,S_global,576] (differentiable)
+        q_offset = rank * S
+    out_latent = mla_attn(
+        q_abs, k_shared, topk_indices, self.scaling, q_offset=q_offset
+    )
+    attn = project_value(out_latent, w_kb_v)  # [B,H,S,v_head]
+    attn = attn.transpose(1, 2).reshape(B, S, -1).contiguous()
+    return self.o_proj(attn), None, topk_indices
+
+
+def keep_router_fp32(model) -> int:
+    """Force the MoE router (gate weight + e_score_correction_bias) to fp32 STORAGE, guaranteeing the
+    router never operates below fp32 regardless of the model's compute dtype or any kernelized path.
+
+    Expert selection is discrete (sigmoid -> group top-k), so router precision matters for
+    correctness. GlmMoeDsaTopkRouter.forward already upcasts to fp32 for the logit matmul and the
+    model keeps e_score_correction_bias fp32, so on a bf16 checkpoint (whose gate weight is *already*
+    bf16-rounded at source) this changes no values — it is a guard that the integration's bf16 cast
+    can't downcast the router, and it skips the per-forward upcast. The dominant source of routing
+    variance is the bf16 RESIDUAL-STREAM router INPUT (inherent to bf16 training), not the router;
+    that is addressed model-wide, not here. Returns the router count."""
+    import torch as _t
+
+    n = 0
+    for mod in model.modules():
+        if type(mod).__name__ == "GlmMoeDsaTopkRouter":
+            mod.weight.data = mod.weight.data.to(_t.float32)
+            bias = getattr(mod, "e_score_correction_bias", None)
+            if bias is not None:
+                mod.e_score_correction_bias.data = bias.data.to(_t.float32)
+            n += 1
+    return n
+
+
+def patch_glm_moe_dsa_attention(
+    model, use_fused_indexer: bool = False, cp_group=None
+) -> int:
+    """Swap every GlmMoeDsaAttention.forward for the absorbed-kernel version. ``use_fused_indexer``
+    replaces the eager indexer scoring with the fused [B,S,T] scorer. ``cp_group`` (a torch.distributed
+    process group) enables context parallelism: the attention all-gathers the compressed KV +
+    indexer-k so each rank's local queries attend the global keys. Returns the count."""
+    import types
+
+    n = 0
+    for mod in model.modules():
+        if type(mod).__name__ == "GlmMoeDsaAttention":
+            mod._use_fused_indexer = use_fused_indexer
+            mod._cp_group = cp_group
+            mod.forward = types.MethodType(_glm_dsa_attention_forward, mod)
+            n += 1
+    return n

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -29,6 +29,9 @@ def fused_indexer_topk(
     attention_mask,
     position_ids,
     group=None,
+    seq_q=None,
+    seq_k=None,
+    q_offset=0,
 ):
     """Replicates GlmMoeDsaIndexer.forward with the fused scorer (collapses the [B,S,32,T] reduction
     to [B,S,T], the long-context memory win). Forward-only. Under context parallel (``group`` set),
@@ -78,16 +81,34 @@ def fused_indexer_topk(
 
 
 def _full(t):
-    """All-gather a FSDP2 DTensor param to a plain tensor (kv_b_proj is sharded under dp_shard; the
-    absorption arithmetic must mix plain tensors, not DTensor+Tensor). No-op for plain tensors."""
+    """All-gather a FSDP2 DTensor param to a plain tensor (sharded weights can't mix with plain in
+    the absorption arithmetic). No-op for plain tensors."""
     return t.full_tensor() if type(t).__name__ == "DTensor" else t
+
+
+def _seq_idx_from_position_ids(position_ids):
+    """Per-token document id [B,S] under sample packing, or ``None`` if not packed.
+
+    Multipack resets ``position_ids`` to 0 at each packed document's start, so a non-increasing
+    step marks a boundary; ``cumsum(position_ids == 0)`` numbers the documents. Returns ``None``
+    when ``position_ids`` is absent or strictly increasing (a single unpacked sequence) so the
+    fast sparse path is preserved for ordinary long-context training."""
+    if position_ids is None:
+        return None
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+    if (
+        position_ids.shape[1] < 2
+        or not (position_ids[:, 1:] <= position_ids[:, :-1]).any()
+    ):
+        return None
+    return (position_ids == 0).to(torch.int32).cumsum(-1)
 
 
 def effective_weight(linear) -> torch.Tensor:
     """The weight the projection actually applies, differentiable wrt trainable params:
-    full-parameter -> ``linear.weight``; PEFT-LoRA -> ``base.weight + Σ scaling·(B @ A)`` so the
-    absorption flows gradients to the adapter. Operands are all-gathered to plain tensors so it
-    works under FSDP2 (sharded DTensor weights). Falls back to ``.weight``."""
+    full-parameter -> ``linear.weight``; PEFT-LoRA -> ``base.weight + scaling·(Bᵀ? )`` delta so the
+    absorption flows gradients to the adapter. Falls back to ``.weight``."""
     if hasattr(linear, "base_layer"):  # PEFT LoRA layer
         w = _full(linear.base_layer.weight)
         active = getattr(linear, "active_adapters", None) or list(
@@ -137,15 +158,23 @@ def _glm_dsa_attention_forward(
         q_rot, k_rot, cos, sin
     )  # [B,H,S,64],[B,1,S,64]
 
+    # Per-document ids under sample packing (None for ordinary sequences). seq_q is the local
+    # queries' doc ids; seq_k is the keys' doc ids (gathered across CP so it aligns with k_shared).
+    seq_q = _seq_idx_from_position_ids(position_ids)
+    seq_k = seq_q
+    if seq_q is not None and cp:
+        seq_k = all_gather_seq(seq_q.unsqueeze(-1), group).squeeze(-1)
+
     # DSA top-k: this layer's own indexer (full) or the previous full layer's selection (shared).
     # Under CP the indexer gathers global keys; topk indices reference GLOBAL key positions.
+    packed = seq_q is not None
     if self.indexer is not None:
         idx_mask = (
             attention_mask[:, 0, :, :]
-            if (attention_mask is not None and not cp)
+            if (attention_mask is not None and not cp and not packed)
             else None
         )
-        if cp or getattr(self, "_use_fused_indexer", False):
+        if cp or packed or getattr(self, "_use_fused_indexer", False):
             topk_indices = fused_indexer_topk(
                 self.indexer,
                 hidden_states,
@@ -154,6 +183,9 @@ def _glm_dsa_attention_forward(
                 idx_mask,
                 position_ids,
                 group=group if cp else None,
+                seq_q=seq_q,
+                seq_k=seq_k,
+                q_offset=(rank * S if cp else 0),
             )
         else:
             topk_indices = self.indexer(
@@ -177,7 +209,13 @@ def _glm_dsa_attention_forward(
         k_shared = all_gather_seq(k_shared, group)  # [B,S_global,576] (differentiable)
         q_offset = rank * S
     out_latent = mla_attn(
-        q_abs, k_shared, topk_indices, self.scaling, q_offset=q_offset
+        q_abs,
+        k_shared,
+        topk_indices,
+        self.scaling,
+        q_offset=q_offset,
+        seq_q=seq_q,
+        seq_k=seq_k,
     )
     attn = project_value(out_latent, w_kb_v)  # [B,H,S,v_head]
     attn = attn.transpose(1, 2).reshape(B, S, -1).contiguous()

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -170,9 +170,9 @@ def _glm_dsa_attention_forward(
     # rank's slice for the queries — so a boundary-spanning doc shares one id across ranks. (Also
     # handles a chunk that is entirely mid-document, where the local cumsum would see no reset at all.)
     if cp and position_ids is not None:
-        global_position_ids = all_gather_seq(
-            position_ids.unsqueeze(-1), group
-        ).squeeze(-1)
+        global_position_ids = all_gather_seq(position_ids.unsqueeze(-1), group).squeeze(
+            -1
+        )
         seq_k = _seq_idx_from_position_ids(global_position_ids)
         seq_q = None if seq_k is None else seq_k[:, rank * S : (rank + 1) * S]
     else:

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -162,11 +162,22 @@ def _glm_dsa_attention_forward(
     )  # [B,H,S,64],[B,1,S,64]
 
     # Per-document ids under sample packing (None for ordinary sequences). seq_q is the local
-    # queries' doc ids; seq_k is the keys' doc ids (gathered across CP so it aligns with k_shared).
-    seq_q = _seq_idx_from_position_ids(position_ids)
-    seq_k = seq_q
-    if seq_q is not None and cp:
-        seq_k = all_gather_seq(seq_q.unsqueeze(-1), group).squeeze(-1)
+    # queries' doc ids; seq_k is the keys' doc ids (aligned with k_shared).
+    # Under CP the doc ids MUST be derived globally: cumsum(position_ids == 0) on a local chunk
+    # restarts at 0 on every rank, so a document crossing a CP boundary would get different (and
+    # colliding) ids per rank, masking valid remote keys or letting attention cross documents. Gather
+    # the global position_ids, number the documents ONCE, keep the full ids for the keys and take this
+    # rank's slice for the queries — so a boundary-spanning doc shares one id across ranks. (Also
+    # handles a chunk that is entirely mid-document, where the local cumsum would see no reset at all.)
+    if cp and position_ids is not None:
+        global_position_ids = all_gather_seq(
+            position_ids.unsqueeze(-1), group
+        ).squeeze(-1)
+        seq_k = _seq_idx_from_position_ids(global_position_ids)
+        seq_q = None if seq_k is None else seq_k[:, rank * S : (rank + 1) * S]
+    else:
+        seq_q = _seq_idx_from_position_ids(position_ids)
+        seq_k = seq_q
 
     # DSA top-k: this layer's own indexer (full) or the previous full layer's selection (shared).
     # Under CP the indexer gathers global keys; topk indices reference GLOBAL key positions.

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -77,23 +77,28 @@ def fused_indexer_topk(
     )
 
 
+def _full(t):
+    """All-gather a FSDP2 DTensor param to a plain tensor (kv_b_proj is sharded under dp_shard; the
+    absorption arithmetic must mix plain tensors, not DTensor+Tensor). No-op for plain tensors."""
+    return t.full_tensor() if type(t).__name__ == "DTensor" else t
+
+
 def effective_weight(linear) -> torch.Tensor:
     """The weight the projection actually applies, differentiable wrt trainable params:
-    full-parameter -> ``linear.weight``; PEFT-LoRA -> ``base.weight + scaling·(Bᵀ? )`` delta so the
-    absorption flows gradients to the adapter. Falls back to ``.weight``."""
+    full-parameter -> ``linear.weight``; PEFT-LoRA -> ``base.weight + Σ scaling·(B @ A)`` so the
+    absorption flows gradients to the adapter. Operands are all-gathered to plain tensors so it
+    works under FSDP2 (sharded DTensor weights). Falls back to ``.weight``."""
     if hasattr(linear, "base_layer"):  # PEFT LoRA layer
-        base = linear.base_layer.weight
-        w = base
+        w = _full(linear.base_layer.weight)
         active = getattr(linear, "active_adapters", None) or list(
             getattr(linear, "lora_A", {}).keys()
         )
         for name in active:
-            A = linear.lora_A[name].weight  # [r, in]
-            Bm = linear.lora_B[name].weight  # [out, r]
-            scaling = linear.scaling[name]
-            w = w + scaling * (Bm @ A)
+            A = _full(linear.lora_A[name].weight)  # [r, in]
+            Bm = _full(linear.lora_B[name].weight)  # [out, r]
+            w = w + linear.scaling[name] * (Bm @ A)
         return w
-    return linear.weight
+    return _full(linear.weight)
 
 
 def _glm_dsa_attention_forward(

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/patch.py
@@ -77,6 +77,9 @@ def fused_indexer_topk(
         indexer.index_topk,
         attention_mask,
         position_ids,
+        seq_q=seq_q,
+        seq_k=seq_k,
+        q_offset=q_offset,
     )
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -54,29 +54,47 @@ def _unwrap_experts_lora(experts):
     gup_lora = None
     down_lora = None
 
-    gup_param = experts.gate_up_proj
-    if isinstance(gup_param, ParamWrapper):
-        lora_A, lora_B, scaling = get_lora_params_from_wrapper(gup_param)
-        if lora_A is not None:
-            num_experts = experts.num_experts
-            rank = lora_A.shape[0] // num_experts
-            from .layers import peft_lora_to_scattermoe
+    for param, which in ((experts.gate_up_proj, "gup"), (experts.down_proj, "down")):
+        if not isinstance(param, ParamWrapper):
+            continue
+        lora_A, lora_B, scaling = get_lora_params_from_wrapper(param)
+        if lora_A is None:
+            continue
+        from .layers import peft_lora_to_scattermoe
 
-            sm_A, sm_B = peft_lora_to_scattermoe(lora_A, lora_B, num_experts, rank)
+        a, b, n_local, rank = _ep_local_expert_lora(lora_A, lora_B, experts)
+        sm_A, sm_B = peft_lora_to_scattermoe(a, b, n_local, rank)
+        if which == "gup":
             gup_lora = (sm_A, sm_B, scaling)
-
-    down_param = experts.down_proj
-    if isinstance(down_param, ParamWrapper):
-        lora_A, lora_B, scaling = get_lora_params_from_wrapper(down_param)
-        if lora_A is not None:
-            num_experts = experts.num_experts
-            rank = lora_A.shape[0] // num_experts
-            from .layers import peft_lora_to_scattermoe
-
-            sm_A, sm_B = peft_lora_to_scattermoe(lora_A, lora_B, num_experts, rank)
+        else:
             down_lora = (sm_A, sm_B, scaling)
 
     return base_experts, gup_lora, down_lora
+
+
+def _ep_local_expert_lora(lora_A, lora_B, experts):
+    """Slice the routed-expert LoRA down to THIS EP rank's local experts.
+
+    Under expert parallelism the base weights are EP-sharded to ``num_experts`` (= E_local) but the
+    PEFT adapter param stays a single GLOBAL tensor over all ``num_experts_global`` experts (it is
+    FSDP-managed/gathered to full here — keeping it global avoids a plain-vs-DTensor mismatch in the
+    optimizer/grad-clip). So compute the rank from the GLOBAL expert count and take this rank's
+    ``[offset : offset+E_local]`` expert block at forward time:
+      * lora_A ``[r*E_global, in]`` expert-major  -> rows ``[offset*r : (offset+E_local)*r]``
+      * lora_B ``[out, r*E_global]`` rank-major    -> reshape ``[out, r, E_global]``, take experts.
+    Non-EP modules (E_local == E_global) are a no-op. Returns ``(A, B, E_local, rank)``."""
+    e_local = experts.num_experts
+    e_global = getattr(experts, "num_experts_global", e_local)
+    rank = lora_A.shape[0] // e_global
+    if e_global == e_local:
+        return lora_A, lora_B, e_local, rank
+    offset = getattr(experts, "local_expert_offset", 0)
+    a = lora_A[offset * rank : (offset + e_local) * rank, :]
+    out = lora_B.shape[0]
+    b = lora_B.reshape(out, rank, e_global)[:, :, offset : offset + e_local].reshape(
+        out, rank * e_local
+    )
+    return a, b, e_local, rank
 
 
 def _get_base_param(param):

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts.py
@@ -582,6 +582,71 @@ def scattermoe_experts_forward(
     return output
 
 
+def _grouped_fp4_ep_maybe_tiled(
+    hidden,
+    idx,
+    wts,
+    gu_base,
+    dn_base,
+    gup_lora,
+    down_lora,
+    limit,
+    mode,
+    act_type,
+    recipe,
+    cache,
+    prefer_fp8_dx,
+):
+    """Run the grouped-fp4 expert GEMM, optionally TILED over the dispatched-token (sequence) dim.
+
+    The grouped path stores ``gu[Mt,2I]`` + ``h[Mt,I]`` for backward (the activation-memory cost).
+    With ``AXOLOTL_EP_EXPERT_SHARD_TOKENS=T`` set, slice the dispatched tokens into T-row chunks and
+    checkpoint each chunk (recompute its forward in backward) so peak saved activation is one chunk's
+    intermediates, not all of Mt — trading ~1 extra forward/chunk for memory. The frozen-weight mxfp4
+    requant ``cache`` is shared across chunks (and across the recompute), so weights are quantized once.
+    T<=0 or T>=N keeps the single un-tiled call. Chunks own disjoint token rows so the per-chunk [N_c,H]
+    outputs concatenate back in order."""
+    import os as _os_t
+
+    from .grouped_train import grouped_fp4_moe_train
+
+    def _call(h_c, i_c, w_c):
+        return grouped_fp4_moe_train(
+            h_c,
+            i_c,
+            w_c,
+            gu_base,
+            dn_base,
+            gup_lora,
+            down_lora,
+            limit,
+            mode,
+            act_type=act_type,
+            weight_recipe=recipe,
+            mxfp4_cache=cache,
+            prefer_fp8_dx=prefer_fp8_dx,
+        )
+
+    shard = int(_os_t.environ.get("AXOLOTL_EP_EXPERT_SHARD_TOKENS", "0") or 0)
+    n = hidden.size(0)
+    if shard <= 0 or n <= shard:
+        return _call(hidden, idx, wts)
+
+    import torch.utils.checkpoint as _ckpt
+
+    outs = [
+        _ckpt.checkpoint(
+            _call,
+            hidden[s : s + shard],
+            idx[s : s + shard],
+            wts[s : s + shard],
+            use_reentrant=False,
+        )
+        for s in range(0, n, shard)
+    ]
+    return torch.cat(outs, dim=0)
+
+
 def scattermoe_experts_forward_ep(
     self,
     hidden_states: torch.Tensor,
@@ -602,6 +667,53 @@ def scattermoe_experts_forward_ep(
     weighted token-combine done via ``index_add_``.
     """
     _check_supported_layout(self)
+
+    # Prefer the grouped NVFP4 GEMM (the same backend the non-EP forward uses) over the triton
+    # scatter2scatter LoRA kernel: it's faster AND has no Triton autotune, so there's no per-rank
+    # autotune-timing skew to trip DeepEP's combine timeout (which is why the scatter2scatter path
+    # needed AXOLOTL_EP_SINGLE_CONFIG). grouped_fp4_moe_train tolerates the DeepEP -1 sentinels
+    # (remote-routed slots are dropped). Falls through to scatter2scatter for non-NVFP4 / mode-off /
+    # no-LoRA layouts.
+    _gup_lora_g, _down_lora_g = None, None
+    _sm_lora_g = getattr(self, "_scattermoe_lora", None)
+    if _sm_lora_g:
+        _gup_lora_g = _sm_lora_g.get("gate_up_proj")
+        _down_lora_g = _sm_lora_g.get("down_proj")
+    elif _has_peft_wrapper(self):
+        _, _gup_lora_g, _down_lora_g = _unwrap_experts_lora(self)
+
+    _fp4_grouped_mode_g = RUNTIME.fp4_grouped_mode
+    if (
+        _fp4_grouped_mode_g is not None
+        and _gup_lora_g is not None
+        and _down_lora_g is not None
+    ):
+        _gu_base_g = _get_base_param(self.gate_up_proj)
+        _dn_base_g = _get_base_param(self.down_proj)
+        if is_nvfp4_param(_gu_base_g):
+            from .grouped_train import grouped_fp4_available
+
+            if grouped_fp4_available(_fp4_grouped_mode_g):
+                _recipe_g = lambda: (  # noqa: E731
+                    _get_base_param(self.gate_up_proj),
+                    _get_base_param(self.down_proj),
+                )
+                _cache_g = self.__dict__.setdefault("_dg_mxfp4_cache", {})
+                return _grouped_fp4_ep_maybe_tiled(
+                    hidden_states,
+                    top_k_index,
+                    top_k_weights.to(hidden_states.dtype),
+                    _gu_base_g,
+                    _dn_base_g,
+                    _gup_lora_g,
+                    _down_lora_g,
+                    getattr(self, "limit", None),
+                    _fp4_grouped_mode_g,
+                    _detect_act_type(self),
+                    _recipe_g,
+                    _cache_g,
+                    RUNTIME.fp4_dx_prefer_fp8,
+                )
 
     N = hidden_states.size(0)
     K = top_k_index.shape[1]

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts_lora_fastpath.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts_lora_fastpath.py
@@ -82,12 +82,19 @@ def patch_paramwrapper_fastpath() -> None:
             lora_A, lora_B, scaling = get_lora_params_from_wrapper(wrapper)
             if lora_A is None or num_experts is None:
                 continue
-            rank = lora_A.shape[0] // num_experts
+            # Under EP the base is sliced to E_local experts but the adapter stays a single global
+            # tensor over E_global experts; take THIS rank's local-expert block and the true LoRA
+            # rank so the fused kernel reads the right experts. No-op when not EP-sharded.
+            from .experts import _ep_local_expert_lora
+
+            lora_A, lora_B, num_experts_local, rank = _ep_local_expert_lora(
+                lora_A, lora_B, base
+            )
             # PEFT keeps LoRA fp32; cast to activation dtype (grads still route to the fp32 params).
             lora_A = lora_A.to(x.dtype)
             lora_B = lora_B.to(x.dtype)
             sm_lora[name] = _convert_smoe_lora(
-                lora_A, lora_B, num_experts, rank, scaling
+                lora_A, lora_B, num_experts_local, rank, scaling
             )
 
         base._scattermoe_lora = sm_lora

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts_lora_fastpath.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/experts_lora_fastpath.py
@@ -20,11 +20,18 @@ the wrapper, fuse the LoRA), bringing the experts-interface path to parity.
 
 from __future__ import annotations
 
+# Implementations whose experts forward consumes ``module._scattermoe_lora`` (the fused
+# per-row LoRA kernel). ``deep_ep_scattermoe`` is the EP composite: its ``_scattermoe_local``
+# stage calls ``scattermoe_experts_forward_ep``, which reads the same attribute — so the
+# fastpath must engage under EP too, else the LoRA falls back to PEFT's parametrize merge
+# (which can't add a full-expert delta onto the EP-sharded weight).
+_SCATTERMOE_IMPLS = frozenset({"scattermoe", "deep_ep_scattermoe"})
+
 
 def _is_scattermoe_experts(module) -> bool:
     cfg = getattr(module, "config", None)
     impl = getattr(cfg, "_experts_implementation", None)
-    return impl == "scattermoe" and hasattr(module, "gate_up_proj")
+    return impl in _SCATTERMOE_IMPLS and hasattr(module, "gate_up_proj")
 
 
 def patch_paramwrapper_fastpath() -> None:

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/grouped_train.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/grouped_train.py
@@ -26,6 +26,7 @@ LOG = get_logger(__name__)
 
 _BACKEND_LOGGED = False  # one-time log of the resolved base-GEMM backend
 
+
 # thin compat wrapper over the centralized runtime module. grouped_backend (cfg.moe_grouped_backend):
 # None/"auto" = capability auto-select; marlin|cutlass|deepgemm = force if available (else warn +
 # auto); "dequant" = force the chunked-dequant fallback.
@@ -358,6 +359,7 @@ class _GroupedExperts(torch.autograd.Function):
         tile = (
             x.size(0) // m_indices.numel()
         )  # routing pad granularity (128 cutlass, 64 marlin)
+
         d_dn = d_dn.contiguous().to(x.dtype)
 
         if ctx.bwd_marlin is not None:

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/grouped_train.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/grouped_train.py
@@ -521,9 +521,19 @@ def grouped_fp4_moe_train(
     else:
         tile = TILE
     flat = idx.reshape(-1)
+    # The DeepEP local path tags remote-routed slots with -1; drop them (bincount/grouping require
+    # expert ids >= 0, and a dropped slot must contribute nothing to its token — correct, since that
+    # (token, slot) is handled on the rank that owns the expert). No-op for the non-EP path (no -1).
+    _tok = torch.arange(N, device=dev).repeat_interleave(idx.size(1))
+    _wf = wts.reshape(-1)
+    if (flat < 0).any():
+        keep = flat >= 0
+        flat = flat[keep]
+        _tok = _tok[keep]
+        _wf = _wf[keep]
     order = flat.argsort()
-    rep = torch.arange(N, device=dev).repeat_interleave(idx.size(1))[order]
-    wflat = wts.reshape(-1)[order]
+    rep = _tok[order]
+    wflat = _wf[order]
     exp_sorted = flat[order]
     counts = torch.bincount(flat, minlength=E)
     ptiles = (counts + tile - 1) // tile

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
@@ -12,8 +12,6 @@ reduce to plain grouped Gram products: dA[g] = scaling * YB_g^T @ X_g,
 dB[g] = scaling * DY_g^T @ XA_g (reduction over the group's tokens).
 """
 
-from itertools import product
-
 import torch
 import triton
 import triton.language as tl
@@ -23,18 +21,17 @@ from .lora_ops import _block_r_for_rank, _bucket_m
 
 
 def _grouped_gram_configs():
-    configs = []
-    for block_wide, block_m, warps, stages in product(
-        [32, 64, 128, 256], [32, 64, 128], [4, 8], [3, 4]
-    ):
-        configs.append(
-            triton.Config(
-                {"BLOCK_WIDE": block_wide, "BLOCK_M": block_m},
-                num_warps=warps,
-                num_stages=stages,
-            )
+    # TEMP (GLM DeepEP e2e bring-up): collapsed to a single config so the autotune sweep is
+    # instant — per-rank sweep-time skew otherwise desyncs ranks and trips DeepEP's combine
+    # barrier. Restore the full search (and revisit per-shape tuning) once EP is verified e2e.
+    return [
+        triton.Config(
+            {"BLOCK_WIDE": 128, "BLOCK_M": 128},
+            num_warps=4,
+            num_stages=3,
+            num_ctas=1,
         )
-    return configs
+    ]
 
 
 @triton.autotune(configs=_grouped_gram_configs(), key=["M_BUCKET", "WIDE", "RANK_IS_I"])

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/grouped_gram.py
@@ -20,18 +20,46 @@ from . import lora_ops
 from .lora_ops import _block_r_for_rank, _bucket_m
 
 
+def _device_shared_mem_optin() -> int:
+    """Opt-in max dynamic shared memory per block for the current CUDA device (bytes). Returns a
+    large sentinel when CUDA is unavailable so the big-SMEM config is chosen by default."""
+    try:
+        if torch.cuda.is_available():
+            return torch.cuda.get_device_properties(
+                torch.cuda.current_device()
+            ).shared_memory_per_block_optin
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return 1 << 30
+
+
+# The large tile (BLOCK_M=128, BLOCK_WIDE=128, num_stages=3) needs ~144 KiB of shared memory per
+# block: it fits sm_80 (A100, ~163 KiB) and sm_90/sm_100 (H100/B200, ~228 KiB) but NOT sm_89 (L40S)
+# or consumer sm_120 (RTX 6000 / 5090, ~99 KiB), where Triton raises OutOfResources.
+_GRAM_LARGE_CONFIG_SMEM = 147456  # bytes
+
+
 def _grouped_gram_configs():
-    # TEMP (GLM DeepEP e2e bring-up): collapsed to a single config so the autotune sweep is
-    # instant — per-rank sweep-time skew otherwise desyncs ranks and trips DeepEP's combine
-    # barrier. Restore the full search (and revisit per-shape tuning) once EP is verified e2e.
-    return [
-        triton.Config(
+    # ONE config sized to the device's shared memory. A single config keeps the autotune "sweep"
+    # instant — sweeping across configs re-times per rank at scattered layers and trips DeepEP's
+    # combine barrier (why this isn't a full per-shape search). Big-SMEM GPUs (H100/B200/A100) run
+    # the larger tile; small-SMEM GPUs (L40S / RTX 6000 / 5090) run a halved BLOCK_WIDE + double
+    # buffering that fits ~99 KiB (<= ~64 KiB even at BLOCK_R=128) instead of OOM-ing.
+    if _device_shared_mem_optin() >= _GRAM_LARGE_CONFIG_SMEM:
+        cfg = triton.Config(
             {"BLOCK_WIDE": 128, "BLOCK_M": 128},
             num_warps=4,
             num_stages=3,
             num_ctas=1,
         )
-    ]
+    else:
+        cfg = triton.Config(
+            {"BLOCK_WIDE": 64, "BLOCK_M": 128},
+            num_warps=4,
+            num_stages=2,
+            num_ctas=1,
+        )
+    return [cfg]
 
 
 @triton.autotune(configs=_grouped_gram_configs(), key=["M_BUCKET", "WIDE", "RANK_IS_I"])

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -58,10 +58,16 @@ def _next_power_of_2(n: int) -> int:
 # real M (loop bounds + masks); only the @triton.autotune key is bucketed so
 # that varying seqlens/routing don't keep invalidating the cache.
 _M_BUCKET_GRANULARITY = 1024
+# Large-M / expert-parallel regime: bucket coarsely so per-rank token-count variation (DeepEP
+# dispatch is imbalanced) collapses to ONE autotune key. Otherwise ranks land on different
+# M_BUCKETs, re-autotune at scattered layers, and the resulting per-rank timing skew trips DeepEP's
+# combine barrier. The kernel still runs on the real M; only the @triton.autotune key is bucketed.
+_M_BUCKET_COARSE = 131072
+_M_BUCKET_COARSE_THRESHOLD = 16384
 
 
 def _bucket_m(m: int) -> int:
-    g = _M_BUCKET_GRANULARITY
+    g = _M_BUCKET_COARSE if m >= _M_BUCKET_COARSE_THRESHOLD else _M_BUCKET_GRANULARITY
     return ((m + g - 1) // g) * g
 
 
@@ -2505,14 +2511,21 @@ def _compute_expert_block_lora_mxfp4(
 
 
 def _scatter2scatter_lora_mx_configs():
-    """Forward MX kernel configs. BLOCK_K must be a multiple of MX_BLOCK_SIZE."""
+    """Forward MX kernel configs. BLOCK_K must be a multiple of MX_BLOCK_SIZE.
+
+    ``num_stages=2`` is included: a single-GPU microbench found it optimal for the GLM expert
+    shapes on sm90, and it was absent from the original [3,4,5] search. For recognized
+    (arch, shape) profiles, :func:`_prune_fwd_mx_configs` narrows this full matrix to a small
+    pre-tuned subset (see ``_FWD_MX_PROFILES``); all other hardware/shapes keep the full
+    SMEM/register-pruned search.
+    """
     configs = []
     for block_m, block_n, block_k, warps, stages in product(
         [32, 64, 128],
         [32, 64],
         [32, 64, 128],  # all multiples of MX_BLOCK_SIZE=32
         [4, 8],
-        [3, 4, 5],
+        [2, 3, 4, 5],
     ):
         configs.append(
             triton.Config(
@@ -2522,6 +2535,64 @@ def _scatter2scatter_lora_mx_configs():
             )
         )
     return configs
+
+
+# Pre-tuned forward-MX config subsets for known (GPU arch, expert-GEMM shape) profiles. Emitting a
+# small *measured* subset instead of running the full autotune avoids per-rank sweep-time skew under
+# expert parallelism (DeepEP) — where each rank's recv-token count lands on a different M_BUCKET, so
+# a large per-rank sweep desyncs ranks and trips DeepEP's combine barrier. Any arch/shape not in the
+# table keeps the full SMEM/register-pruned search. spec = (BLOCK_M, BLOCK_N, BLOCK_K, warps, stages).
+_GLM_MX_SUBSET = [
+    (
+        128,
+        64,
+        32,
+        4,
+        2,
+    ),  # H200/sm90 microbench winner (invariant over M_BUCKET 32k-237k)
+    (128, 32, 64, 4, 2),  # near-tie alternate
+    (128, 32, 64, 8, 3),  # robust fallback within the stock search space
+    (128, 64, 64, 4, 2),  # neighbor
+]
+_FWD_MX_PROFILES = {
+    # sm90 (H200), GLM-5.2 expert GEMMs: gate_up (N=4096, K=6144), down (N=6144, K=2048).
+    (9, 0): {(4096, 6144): _GLM_MX_SUBSET, (6144, 2048): _GLM_MX_SUBSET},
+}
+
+
+def _profile_fwd_mx_configs(configs, meta):
+    """If the running GPU + this kernel's (N, K) match a known profile and M is in the tuned
+    (large) regime, return the pre-measured config subset (filtered from ``configs``). Else None.
+
+    ``meta`` is the kernel's compile-time kwargs (N, K, M_BUCKET, ...) that Triton passes to the
+    ``early_config_prune`` hook — the constexpr values are NOT in ``named_args`` (pointers/strides)."""
+    try:
+        cap = torch.cuda.get_device_capability()
+    except Exception:  # pragma: no cover
+        return None
+    table = _FWD_MX_PROFILES.get(cap)
+    if not table:
+        return None
+    specs = table.get((meta.get("N"), meta.get("K")))
+    mb = meta.get("M_BUCKET")
+    if (
+        not specs or mb is None or mb < 16384
+    ):  # only the large-M EP regime this was tuned for
+        return None
+    want = set(specs)
+    sel = [
+        c
+        for c in configs
+        if (
+            c.kwargs["BLOCK_M"],
+            c.kwargs["BLOCK_N"],
+            c.kwargs["BLOCK_K"],
+            c.num_warps,
+            c.num_stages,
+        )
+        in want
+    ]
+    return sel or None
 
 
 def _prune_fwd_mx_configs(configs, named_args, **kwargs):
@@ -2536,6 +2607,12 @@ def _prune_fwd_mx_configs(configs, named_args, **kwargs):
     the conservative full-tile accounting in ``_prune_dX_mx_configs``.
     Also require BLOCK_K % MX_BLOCK_SIZE == 0.
     """
+    # Known (arch, shape) profile -> emit the small pre-tuned subset, skipping the full sweep.
+    # N/K/M_BUCKET are constexpr -> they're in **kwargs, not named_args (pointers/strides).
+    profiled = _profile_fwd_mx_configs(configs, kwargs)
+    if profiled is not None:
+        return profiled
+
     smem_cap = _get_smem_capacity()
     block_r = named_args.get("BLOCK_R", 64)
 
@@ -2997,14 +3074,33 @@ def _compute_expert_block_lora_dX_mxfp4(
 
 def _scatter2scatter_lora_dX_mx_configs():
     """dX MX kernel configs. BLOCK_K must be a multiple of MX_BLOCK_SIZE
-    because scales broadcast within MX_BLOCK_SIZE-element K-blocks."""
+    because scales broadcast within MX_BLOCK_SIZE-element K-blocks.
+
+    The grid is deliberately conservative: the largest configs (BLOCK_M=128 /
+    BLOCK_K=128 / BLOCK_N=64 / num_stages=5) only fit on big-SMEM GPUs (sm90's
+    228 KB) and at least one of them issues an out-of-bounds access in the
+    grouped (expert-parallel) backward there — while the SMEM *estimate* used to
+    prune is too loose to exclude it reliably. Restricting the search space to
+    the validated low-resource configs keeps the kernel correct on every arch;
+    the dX (backward) path is far less autotune-sensitive than the forward.
+    ``AXOLOTL_MX_DX_SAFE_CONFIG`` pins a single config as an escape hatch."""
+    import os
+
+    if os.environ.get("AXOLOTL_MX_DX_SAFE_CONFIG"):
+        return [
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_K": 32, "BLOCK_N": 32},
+                num_stages=3,
+                num_warps=4,
+            )
+        ]
     configs = []
     for block_m, block_k, block_n, warps, stages in product(
-        [32, 64, 128],
-        [32, 64, 128],  # all multiples of MX_BLOCK_SIZE=32
         [32, 64],
+        [32, 64],  # all multiples of MX_BLOCK_SIZE=32
+        [32],
         [4, 8],
-        [3, 4, 5],
+        [2, 3],
     ):
         configs.append(
             triton.Config(
@@ -3016,9 +3112,63 @@ def _scatter2scatter_lora_dX_mx_configs():
     return configs
 
 
+# dX MX configs needing more shared memory than this are excluded from autotune even on
+# GPUs that physically have more (e.g. sm90's 228 KB). The larger configs are only reachable
+# on those GPUs, were never exercised on the 100 KB-class GPUs this kernel was validated on,
+# and at least one of them issues an out-of-bounds access on sm90 in the grouped (EP) layout.
+# Capping to the validated budget keeps autotune among known-good configs across all arches.
+_DX_MX_VALIDATED_SMEM = 101_376  # 99 KB — sm120 / Ada / sm89 opt-in budget
+
+
+# Pre-tuned dX-MX subsets for known (arch, shape) profiles — see _FWD_MX_PROFILES for the rationale.
+# spec = (BLOCK_M, BLOCK_K, BLOCK_N, warps, stages).
+_GLM_DX_MX_SUBSET = [
+    (32, 64, 32, 4, 2),  # H200/sm90 microbench winner
+    (64, 64, 32, 4, 2),  # larger BLOCK_M
+    (32, 32, 32, 4, 2),  # smaller BLOCK_K
+    (64, 32, 32, 8, 3),  # fallback
+]
+_DX_MX_PROFILES = {
+    (9, 0): {(4096, 6144): _GLM_DX_MX_SUBSET, (6144, 2048): _GLM_DX_MX_SUBSET},
+}
+
+
+def _profile_dX_mx_configs(configs, meta):
+    """Known GPU arch + (N, K) + large M -> pre-measured dX subset (filtered from ``configs``)."""
+    try:
+        cap = torch.cuda.get_device_capability()
+    except Exception:  # pragma: no cover
+        return None
+    table = _DX_MX_PROFILES.get(cap)
+    if not table:
+        return None
+    specs = table.get((meta.get("N"), meta.get("K")))
+    mb = meta.get("M_BUCKET")
+    if not specs or mb is None or mb < 16384:
+        return None
+    want = set(specs)
+    sel = [
+        c
+        for c in configs
+        if (
+            c.kwargs["BLOCK_M"],
+            c.kwargs["BLOCK_K"],
+            c.kwargs["BLOCK_N"],
+            c.num_warps,
+            c.num_stages,
+        )
+        in want
+    ]
+    return sel or None
+
+
 def _prune_dX_mx_configs(configs, named_args, **kwargs):
     """Prune dX MX configs by SMEM and register pressure (MX-aware)."""
-    smem_cap = _get_smem_capacity()
+    profiled = _profile_dX_mx_configs(configs, kwargs)
+    if profiled is not None:
+        return profiled
+
+    smem_cap = min(_get_smem_capacity(), _DX_MX_VALIDATED_SMEM)
     block_r = named_args.get("BLOCK_R", 64)
 
     scored = []

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/marlin_w4a16/backend.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/marlin_w4a16/backend.py
@@ -69,6 +69,30 @@ def _build_base_scatter(dev: torch.device) -> torch.Tensor:
     return lut
 
 
+def _marlin_cache_under_fsdp(device) -> bool:
+    """Whether to persist marlin-prepped experts in the per-layer module cache under FSDP.
+
+    DEFAULT: NO. The per-layer cache holds each layer's gathered (un-sharded) marlin experts, so it
+    accumulates the whole model across depth (~0.6 GiB/proj × 2 × num_layers — e.g. ~94 GiB for GLM-5.2)
+    on top of the resident sharded model → OOM. Profiled: a layer's marlin re-prep is only a ~17 GiB
+    transient that frees immediately, so re-prepping every forward is far cheaper than caching, and the
+    per-layer MoE fwd+bwd peak is ~17 GiB — fits easily beside the ~60 GiB resident shard.
+
+    OPT-IN for roomy GPUs (e.g. B200, or small models) where the full cache fits: set
+    ``AXOLOTL_MARLIN_CACHE_MIN_FREE_GB=<N>`` to cache while ≥ N GiB VRAM is free (``0`` = always cache).
+    Unset → never cache under FSDP."""
+    import os
+
+    val = os.environ.get("AXOLOTL_MARLIN_CACHE_MIN_FREE_GB")
+    if val is None:
+        return False
+    try:
+        free, _ = torch.cuda.mem_get_info(device)
+    except Exception:  # pylint: disable=broad-except
+        return True
+    return free > float(val) * (1024**3)
+
+
 def _cached_prep(nv, size_n, size_k, ext, cache, key):
     """Prep one NVFP4 weight -> Marlin layout, cached (experts are frozen). Prefer a persistent
     module-level ``cache`` dict keyed by ``key`` — under FSDP2 the gathered param is a fresh tensor
@@ -79,6 +103,11 @@ def _cached_prep(nv, size_n, size_k, ext, cache, key):
     key+"_bwd" for the fused backward dequant, then frees nv.qdata to drop the duplicate 4-bit copy.
     Under FSDP the gathered param is fresh each step so weight_recipe() re-gathers it anyway; skips
     the free when distributed is active."""
+    import torch.distributed as dist
+
+    _is_distributed = (
+        dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1
+    )
     bwd_key = key + "_bwd"
     if cache is not None and key in cache:
         return cache[key]
@@ -98,39 +127,46 @@ def _cached_prep(nv, size_n, size_k, ext, cache, key):
             torch.bfloat16,
             ext.gptq_marlin_repack,
         )
-        try:
-            nv._marlin_w4a16 = cached
-        except (AttributeError, RuntimeError):
-            pass
-    if cache is not None:
+        # Stash the full-layer marlin weight on the gathered tensor ONLY single-GPU. Under FSDP2 the
+        # gathered param is a fresh tensor every forward AND every backward recompute, so this attr
+        # never produces a cache hit — it only pins ~9 GiB/proj alive on each layer's gathered tensor,
+        # and during the backward sweep FSDP keeps several layers' gathered tensors live at once →
+        # the marlin weights accumulate across depth and OOM (bypassing the module-cache guard below).
+        if not _is_distributed:
+            try:
+                nv._marlin_w4a16 = cached
+            except (AttributeError, RuntimeError):
+                pass
+    if cache is not None and not _is_distributed:
+        # Single-GPU: persist the marlin weight and drop the duplicate 4-bit qdata.
         cache[key] = cached
         if qdata_fresh and bwd_key not in cache:
-            import torch.distributed as dist
-
-            _is_distributed = (
-                dist.is_available()
-                and dist.is_initialized()
-                and dist.get_world_size() > 1
-            )
-            if not _is_distributed:
-                E, dev = nv.qdata.size(0), nv.qdata.device
-                # Reference (don't clone) the original scales for the backward dequant: the
-                # marlin scales subsample [:, 1::2] so they're lossy and unusable for backward.
-                # Single-GPU: nv.scale stays live on the frozen param, so a clone just dups ~1.3 GiB.
-                # _pt may return .expand() with stride(0)==0; Triton needs a real stride.
-                pt_bwd = _pt(nv, E, dev)
-                if pt_bwd.stride(0) == 0:
-                    pt_bwd = pt_bwd.contiguous()
-                cache[bwd_key] = (nv.scale, pt_bwd, E, size_n, size_k)
-                # 3-D [E, N, 0] placeholder (not flat empty(0)): NVFP4Tensor clone/save needs
-                # ndim==3, and numel()==0 still routes through the marlin qdata-free paths.
-                try:
-                    _N = nv.qdata.size(1)
-                    nv.qdata.data = torch.empty(
-                        (E, _N, 0), dtype=nv.qdata.dtype, device=dev
-                    )
-                except (AttributeError, RuntimeError):
-                    pass
+            E, dev = nv.qdata.size(0), nv.qdata.device
+            # Reference (don't clone) the original scales for the backward dequant: the
+            # marlin scales subsample [:, 1::2] so they're lossy and unusable for backward.
+            # Single-GPU: nv.scale stays live on the frozen param, so a clone just dups ~1.3 GiB.
+            # _pt may return .expand() with stride(0)==0; Triton needs a real stride.
+            pt_bwd = _pt(nv, E, dev)
+            if pt_bwd.stride(0) == 0:
+                pt_bwd = pt_bwd.contiguous()
+            cache[bwd_key] = (nv.scale, pt_bwd, E, size_n, size_k)
+            # 3-D [E, N, 0] placeholder (not flat empty(0)): NVFP4Tensor clone/save needs
+            # ndim==3, and numel()==0 still routes through the marlin qdata-free paths.
+            try:
+                _N = nv.qdata.size(1)
+                nv.qdata.data = torch.empty(
+                    (E, _N, 0), dtype=nv.qdata.dtype, device=dev
+                )
+            except (AttributeError, RuntimeError):
+                pass
+    elif cache is not None and _marlin_cache_under_fsdp(nv.qdata.device):
+        # FSDP2: the gathered weight is a fresh, transient tensor per forward (meant to reshard), so
+        # persisting its marlin copy for EVERY layer re-materializes the whole un-sharded model on
+        # each rank — OOMing large checkpoints. The cache is still a real perf win (no re-repacking
+        # 256 experts/forward) when VRAM is roomy, so cache only while there's headroom; once it
+        # tightens, fall through to per-forward re-prep (the transient ``_marlin_w4a16`` attr handles
+        # in-forward reuse and dies on reshard). Don't free qdata here — backward re-gathers it.
+        cache[key] = cached
     return cached
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/marlin_w4a16/prep.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/marlin_w4a16/prep.py
@@ -46,13 +46,15 @@ def marlin_permute_scales(s, size_k, size_n, group_size, is_a_8bit=False):
 def _nvfp4_compute_scale_factor(marlin_scales, a_dtype=None):
     if a_dtype is not None and a_dtype == torch.half:
         return 1.0
-    ws_float = marlin_scales.float() * (2**7)
-    nonzero_mask = ws_float > 0
-    if nonzero_mask.any():
-        max_val = ws_float[nonzero_mask].max()
-        if max_val < 448 * (2**7):
-            sf = (448 * (2**7) / max_val).log2().floor().exp2()
-            return sf.item()
+    # Value-identical, memory-cheap form of vllm's `ws_float[ws_float>0].max()`: the max of the
+    # positive entries equals the overall amax whenever any positive exists. Computing amax in the
+    # native (bf16) dtype avoids materializing a full float copy AND a boolean-index copy of the
+    # [E,N,K/16] scales (~9 GiB at GLM-5.2 dims) — that copy OOMed the gradient-checkpoint backward
+    # recompute. bf16 amax selects the exact max element; the *128 scaling is then a scalar float op.
+    max_val = marlin_scales.amax().float() * (2**7)
+    if max_val > 0 and max_val < 448 * (2**7):
+        sf = (448 * (2**7) / max_val).log2().floor().exp2()
+        return sf.item()
     return 1.0
 
 

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
@@ -144,7 +144,7 @@ def inspect_nvfp4_layout(repo_id: str) -> dict:
     routed_re = re.compile(r"\.experts\.\d+\.([A-Za-z_][A-Za-z0-9_]*)$")
     layer_re = re.compile(r"^.*?layers\.\d+\.")
     routed_projs: list[str] = []
-    routed_sample: dict[str, tuple] = {}
+    routed_sample: dict[str, tuple | None] = {}
     nonrouted: dict[str, dict] = {}
     qdata_names: set[str] = set()
     per_tensor_names: set[str] = set()

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
@@ -62,6 +62,176 @@ def _shard_open(repo_id: str, shard: str):
     return safe_open(_resolve_repo_file(repo_id, shard), framework="pt")
 
 
+def _safetensors_metadata(repo_id: str) -> dict[str, tuple[str, tuple[int, ...]]]:
+    """Return ``{tensor_name: (dtype_str, shape)}`` for every checkpoint tensor, read from the
+    safetensors *headers* only (no weight download). Works for a hub repo or a local snapshot dir.
+    """
+    if os.path.isdir(repo_id):
+        from safetensors import safe_open
+
+        out: dict[str, tuple[str, tuple[int, ...]]] = {}
+        index = os.path.join(repo_id, "model.safetensors.index.json")
+        if os.path.exists(index):
+            shards = sorted(set(_load_index(repo_id).values()))
+        else:  # single-file checkpoint
+            shards = ["model.safetensors"]
+        for shard in shards:
+            with safe_open(os.path.join(repo_id, shard), framework="pt") as f:
+                for name in f.keys():
+                    sl = f.get_slice(name)
+                    out[name] = (sl.get_dtype(), tuple(sl.get_shape()))
+        return out
+
+    from huggingface_hub import HfApi
+
+    meta = HfApi().get_safetensors_metadata(repo_id)
+    out = {}
+    for fmeta in meta.files_metadata.values():
+        for name, tinfo in fmeta.tensors.items():
+            out[name] = (str(tinfo.dtype), tuple(tinfo.shape))
+    return out
+
+
+# Known per-module leaf names across NVFP4 export conventions. The packed 4-bit weight is the
+# robust NVFP4 signal (uint8 qdata) — distinguishing NVFP4 from FP8 (which also carries a
+# ``weight_scale`` but stores an fp8 weight, not uint8). Names differ by exporter:
+#   modelopt          : weight        / weight_scale / weight_scale_2
+#   compressed-tensors: weight_packed / weight_scale / weight_global_scale
+_QDATA_LEAVES = ("weight", "weight_packed")
+_GROUP_SCALE_LEAVES = ("weight_scale",)
+_PER_TENSOR_LEAVES = ("weight_scale_2", "weight_global_scale")
+_ALL_LEAVES = (
+    "weight_scale_2",
+    "weight_global_scale",
+    "weight_scale",
+    "weight_packed",
+    "weight",
+    "input_scale",
+    "input_global_scale",
+)
+
+
+def inspect_nvfp4_layout(repo_id: str) -> dict:
+    """Detect a checkpoint's NVFP4 layout from its safetensors headers — no layout assumptions.
+
+    A module is treated as **NVFP4** only when it has a *packed* 4-bit weight (uint8 qdata, under
+    ``weight`` or ``weight_packed``) plus a group ``weight_scale`` — this distinguishes NVFP4 from
+    FP8 modules (which also carry a ``weight_scale`` but store an fp8, not uint8, weight) so a mixed
+    NVFP4+FP8 checkpoint is classified correctly. The NVFP4 modules are split into:
+      * ``routed_projs``  — proj names under ``...experts.<int>.<proj>`` (fused into 3D expert params),
+      * ``nonrouted_suffixes`` — layer-relative paths of every other NVFP4 linear THIS checkpoint
+        quantizes (shared experts, dense MLPs, ...),
+    plus the detected key ``naming`` (``modelopt`` vs ``compressed-tensors`` vs ``mixed``) so the
+    caller can tell whether its converters (which assume modelopt ``weight``/``weight_scale_2``)
+    apply. Everything is derived from the headers; differing exports are described, not assumed.
+    """
+    import re
+
+    meta = _safetensors_metadata(repo_id)
+    bases: dict[str, dict[str, tuple[str, tuple[int, ...]]]] = {}
+    for name, dt_shape in meta.items():
+        for leaf in _ALL_LEAVES:
+            if name.endswith("." + leaf):
+                bases.setdefault(name[: -len(leaf) - 1], {})[leaf] = dt_shape
+                break
+
+    def _qdata(parts):
+        for leaf in _QDATA_LEAVES:
+            if leaf in parts and parts[leaf][0] == "U8":
+                return leaf
+        return None
+
+    routed_re = re.compile(r"\.experts\.\d+\.([A-Za-z_][A-Za-z0-9_]*)$")
+    layer_re = re.compile(r"^.*?layers\.\d+\.")
+    routed_projs: list[str] = []
+    routed_sample: dict[str, tuple] = {}
+    nonrouted: dict[str, dict] = {}
+    qdata_names: set[str] = set()
+    per_tensor_names: set[str] = set()
+    for base, parts in bases.items():
+        qd = _qdata(parts)
+        is_nvfp4 = qd is not None and any(g in parts for g in _GROUP_SCALE_LEAVES)
+        if not is_nvfp4:  # bf16 (excluded) or fp8 module — not NVFP4
+            continue
+        qdata_names.add(qd)
+        for leaf in _PER_TENSOR_LEAVES:
+            if leaf in parts:
+                per_tensor_names.add(leaf)
+        m = routed_re.search(base)
+        if m:
+            proj = m.group(1)
+            if proj not in routed_projs:
+                routed_projs.append(proj)
+                routed_sample[proj] = parts.get(qd)
+        else:
+            nonrouted.setdefault(layer_re.sub("", base), parts)
+
+    modelopt = qdata_names <= {"weight"} and per_tensor_names <= {"weight_scale_2"}
+    ct = qdata_names <= {"weight_packed"} and per_tensor_names <= {
+        "weight_global_scale"
+    }
+    naming = (
+        "modelopt" if modelopt else ("compressed-tensors" if ct else "mixed/unknown")
+    )
+
+    return {
+        "routed_present": bool(routed_projs),
+        "routed_projs": sorted(routed_projs),
+        "routed_sample_shapes": routed_sample,
+        "nonrouted_suffixes": sorted(nonrouted),
+        "nonrouted_sample_shapes": nonrouted,
+        "qdata_names": sorted(qdata_names),
+        "per_tensor_names": sorted(per_tensor_names),
+        "naming": naming,
+    }
+
+
+def fuse_nvfp4_experts(projs: list[dict], *, block_size: int = 16, dtype=None):
+    """Shared NVFP4-expert fusion core (one implementation for every load path).
+
+    ``projs`` is the ordered list of projections to fuse on the N (row) axis — one entry for a
+    single proj (``down``), two for a fused ``gate_up`` — each a dict of per-expert lists::
+
+        {"qd": [E uint8 [N, K/2]], "sc": [E e4m3 [N, K/16]], "pts": [E f32 scalar]}
+
+    Returns a torchao ``NVFP4Tensor`` ``[E, ΣN, K/2]``. The fused tensor carries ONE per-expert
+    per-tensor scale (``pts``), so when the projections export different ``pts`` the ratio is
+    folded into the later proj's group scale (dequant = qdata · group_scale · per_tensor_scale, so
+    this is exact up to e4m3 rounding) rather than silently dropping it. Used by both the
+    ``WeightConverter`` (modelopt skeleton load) and the post-load scale-attach path so the fusion
+    + scale reconciliation live in exactly one place.
+    """
+    import torch as _torch
+
+    NVFP4Tensor = _nvfp4_cls()
+    if NVFP4Tensor is None:
+        raise RuntimeError("torchao NVFP4Tensor not available")
+    dtype = dtype or _torch.bfloat16
+
+    pts0 = _torch.stack([t.to(_torch.float32) for t in projs[0]["pts"]]).view(-1, 1, 1)
+    qdatas, scales = [], []
+    for i, p in enumerate(projs):
+        qd = _torch.stack(list(p["qd"]), dim=0)  # [E, N, K/2]
+        sc = _torch.stack(list(p["sc"]), dim=0)  # [E, N, K/16]
+        if i > 0:
+            pts_i = _torch.stack([t.to(_torch.float32) for t in p["pts"]]).view(
+                -1, 1, 1
+            )
+            if not _torch.allclose(pts_i, pts0):
+                sc = (sc.to(_torch.float32) * (pts_i / pts0)).to(_torch.float8_e4m3fn)
+                LOG.warning(
+                    "fuse_nvfp4_experts: proj #%d per-tensor scale differs from the first; "
+                    "folded the ratio into its group scale (max %.4g)",
+                    i,
+                    (pts_i / pts0).max().item(),
+                )
+        qdatas.append(qd)
+        scales.append(sc)
+    qdata = qdatas[0] if len(qdatas) == 1 else _torch.cat(qdatas, dim=1)
+    scale = scales[0] if len(scales) == 1 else _torch.cat(scales, dim=1)
+    return NVFP4Tensor(qdata, scale, block_size, dtype, per_tensor_scale=pts0)
+
+
 # Per-architecture checkpoint naming for the unfused per-expert NVFP4 tensors.
 # base_fmt formats with (layer, e, proj); gate_up/down are the proj names fused
 # (gate_up = cat on the N/row axis in this order; down is single).
@@ -91,11 +261,11 @@ def _detect_scheme(wmap):
 
 
 def _build_expert_nvfp4(repo_id, wmap, base_fmt, layer, projs, n_experts, device):
-    """Rebuild fused qdata + E4M3 block scale + per-tensor scale for all experts of one
-    fused projection straight from the raw checkpoint (no dependence on transformers' own
-    fusion). Fused on the N (row) axis: qdata [E, sumN, K/2] uint8, scale [E, sumN, K/16]
-    E4M3, per_tensor scalar."""
-    qd_proj, sc_proj, pts_list = [[] for _ in projs], [[] for _ in projs], []
+    """Rebuild a fused NVFP4Tensor for one expert projection group straight from the raw
+    checkpoint (no dependence on transformers' own fusion), reading every proj's per-expert qdata,
+    E4M3 block scale and per-tensor scale, then delegating the stack/concat/scale-reconcile to the
+    shared :func:`fuse_nvfp4_experts` core. Returns an ``NVFP4Tensor`` ``[E, ΣN, K/2]`` on ``device``."""
+    proj_parts = [{"qd": [], "sc": [], "pts": []} for _ in projs]
     opened: dict[str, object] = {}
     for e in range(n_experts):
         for pi, proj in enumerate(projs):
@@ -104,17 +274,12 @@ def _build_expert_nvfp4(repo_id, wmap, base_fmt, layer, projs, n_experts, device
             f = opened.get(shard) or opened.setdefault(
                 shard, _shard_open(repo_id, shard)
             )
-            qd_proj[pi].append(f.get_tensor(f"{base}.weight"))
-            sc_proj[pi].append(f.get_tensor(f"{base}.weight_scale"))
-            if pi == 0:  # gate/up share weight_scale_2; one per expert
-                pts_list.append(
-                    f.get_tensor(f"{base}.weight_scale_2").to(torch.float32)
-                )
-    qdata = torch.cat([torch.stack(q, 0) for q in qd_proj], dim=1).to(device)
-    scale = torch.cat([torch.stack(s, 0) for s in sc_proj], dim=1).to(device)
-    # Per-expert weight_scale_2 stacked to [E,1,1], not expert-0's scalar broadcast to all experts.
-    pts = torch.stack(pts_list).view(-1, 1, 1).to(device)
-    return qdata, scale, pts
+            proj_parts[pi]["qd"].append(f.get_tensor(f"{base}.weight").to(device))
+            proj_parts[pi]["sc"].append(f.get_tensor(f"{base}.weight_scale").to(device))
+            proj_parts[pi]["pts"].append(
+                f.get_tensor(f"{base}.weight_scale_2").to(torch.float32).to(device)
+            )
+    return fuse_nvfp4_experts(proj_parts)
 
 
 def attach_nvfp4_expert_scales(model: nn.Module, repo_id: str) -> int:
@@ -156,18 +321,14 @@ def attach_nvfp4_expert_scales(model: nn.Module, repo_id: str) -> int:
         if base_fmt.format(layer=layer, e=0, proj=projs_gu[0]) + ".weight" not in wmap:
             continue
         E = gup.shape[0]
-        gqd, gscale, gpts = _build_expert_nvfp4(
-            repo_id, wmap, base_fmt, layer, projs_gu, E, gup.device
-        )
-        dqd, dscale, dpts = _build_expert_nvfp4(
-            repo_id, wmap, base_fmt, layer, projs_dn, E, dn.device
-        )
         mod.gate_up_proj = nn.Parameter(
-            NVFP4Tensor(gqd, gscale, 16, torch.bfloat16, per_tensor_scale=gpts),
+            _build_expert_nvfp4(
+                repo_id, wmap, base_fmt, layer, projs_gu, E, gup.device
+            ),
             requires_grad=False,
         )
         mod.down_proj = nn.Parameter(
-            NVFP4Tensor(dqd, dscale, 16, torch.bfloat16, per_tensor_scale=dpts),
+            _build_expert_nvfp4(repo_id, wmap, base_fmt, layer, projs_dn, E, dn.device),
             requires_grad=False,
         )
         # Drop the stale FP8 scale params the quantizer created for these experts

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_moe_loading.py
@@ -208,12 +208,18 @@ def fuse_nvfp4_experts(projs: list[dict], *, block_size: int = 16, dtype=None):
         raise RuntimeError("torchao NVFP4Tensor not available")
     dtype = dtype or _torch.bfloat16
 
+    # cpu_ram_efficient_loading runs the converter once on META placeholders (shape inference) and
+    # again on the real tensors on rank 0. On meta the scale-reconciliation value ops (`allclose`,
+    # `.item()`) can't run, so skip them — only the OUTPUT SHAPE matters on the meta pass, and the
+    # stack/cat below produce correctly-shaped meta tensors regardless.
+    is_meta = bool(projs[0]["qd"]) and projs[0]["qd"][0].is_meta
+
     pts0 = _torch.stack([t.to(_torch.float32) for t in projs[0]["pts"]]).view(-1, 1, 1)
     qdatas, scales = [], []
     for i, p in enumerate(projs):
         qd = _torch.stack(list(p["qd"]), dim=0)  # [E, N, K/2]
         sc = _torch.stack(list(p["sc"]), dim=0)  # [E, N, K/16]
-        if i > 0:
+        if i > 0 and not is_meta:
             pts_i = _torch.stack([t.to(_torch.float32) for t in p["pts"]]).view(
                 -1, 1, 1
             )
@@ -230,6 +236,43 @@ def fuse_nvfp4_experts(projs: list[dict], *, block_size: int = 16, dtype=None):
     qdata = qdatas[0] if len(qdatas) == 1 else _torch.cat(qdatas, dim=1)
     scale = scales[0] if len(scales) == 1 else _torch.cat(scales, dim=1)
     return NVFP4Tensor(qdata, scale, block_size, dtype, per_tensor_scale=pts0)
+
+
+def patch_nvfp4_tensor_meta_ops() -> None:
+    """Register ``zeros_like`` / ``empty_like`` / ``new_zeros`` on torchao's NVFP4Tensor.
+
+    FSDP2's ``cpu_ram_efficient_loading`` keeps non-rank-0 params on ``meta`` and materializes the
+    receive buffers with ``zeros_like`` / ``empty_like`` before scattering rank 0's shards. torchao
+    doesn't implement those for NVFP4Tensor (only matmul / view / slice / copy), so a 4-bit expert
+    param hits 'unimplemented operator'. Each just applies the op to the packed data + scales and
+    rebuilds the tensor, preserving block_size / dtype / per-tensor scale. Idempotent."""
+    import torch as _torch
+
+    NVFP4Tensor = _nvfp4_cls()
+    if NVFP4Tensor is None or getattr(NVFP4Tensor, "_axolotl_meta_ops", False):
+        return
+    from torchao.utils import return_and_correct_aliasing
+
+    aten = _torch.ops.aten
+
+    @NVFP4Tensor.implements([aten.zeros_like.default, aten.empty_like.default])
+    def _nvfp4_like(func, types, args, kwargs):
+        # FSDP2 passes device / pin_memory / memory_format; forward them to the packed data + scale
+        # tensors. dtype/layout would break the int-packed payload, so drop them.
+        passthru = {
+            k: v
+            for k, v in kwargs.items()
+            if k in ("device", "pin_memory", "memory_format")
+        }
+        out = args[0]._apply_fn_to_data(lambda x: func(x, **passthru))
+        return return_and_correct_aliasing(func, args, kwargs, out)
+
+    @NVFP4Tensor.implements([aten.new_zeros.default])
+    def _nvfp4_new_zeros(func, types, args, kwargs):
+        out = args[0]._apply_fn_to_data(lambda x: _torch.zeros_like(x))
+        return return_and_correct_aliasing(func, args, kwargs, out)
+
+    NVFP4Tensor._axolotl_meta_ops = True
 
 
 # Per-architecture checkpoint naming for the unfused per-expert NVFP4 tensors.
@@ -357,6 +400,86 @@ def attach_nvfp4_expert_scales(model: nn.Module, repo_id: str) -> int:
             scheme_name,
         )
     return fixed
+
+
+def direct_load_nvfp4_experts(model, repo_id: str, routed_projs: list[str]) -> int:
+    """FAST routed-expert load that BYPASSES transformers' conversion loader.
+
+    Transformers' loader spends ~7 min on GLM-5.2 iterating/matching ~240k per-expert source tensors
+    through its Python machinery; a DIRECT read+fuse of the same experts is ~25s (profiled). This
+    reads each MoE layer's routed-expert ``weight``(uint8)/``weight_scale``(fp8)/``weight_scale_2``
+    components straight from the safetensors (native dtype) and fuses them into the 3D NVFP4 expert
+    params, mirroring :class:`Nvfp4ExpertsDeserialize` but without the per-tensor loader overhead.
+
+    Only the LOCAL-RANK-0 process materializes (others stay meta for the FSDP broadcast). Requires the
+    routed converters to be SKIPPED at registration (so transformers leaves the fused params unfilled).
+    Returns the number of fused params filled. Safe no-op on non-rank0 / no routed experts.
+    """
+    import os
+    import re
+
+    import torch
+
+    if str(os.environ.get("LOCAL_RANK", "0")) not in ("0", ""):
+        return 0
+    if not routed_projs:
+        return 0
+    NVFP4Tensor = _nvfp4_cls()
+    if NVFP4Tensor is None:
+        return 0
+    wmap = _load_index(repo_id)
+    # per-layer expert count, from the index (no reads): count ...experts.<e>.<proj0>.weight keys.
+    proj0 = routed_projs[0]
+    layer_E: dict[int, int] = {}
+    pat = re.compile(
+        r"\.layers\.(\d+)\.mlp\.experts\.(\d+)\." + re.escape(proj0) + r"\.weight$"
+    )
+    for key in wmap:
+        m = pat.search(key)
+        if m:
+            L, e = int(m.group(1)), int(m.group(2))
+            layer_E[L] = max(layer_E.get(L, 0), e + 1)
+
+    handles: dict[str, object] = {}
+
+    def gt(key):
+        sh = wmap[key]
+        if sh not in handles:
+            handles[sh] = _shard_open(repo_id, sh)
+        return handles[sh].get_tensor(key)  # native dtype (uint8/fp8/fp32)
+
+    fused_map = (
+        ("gate_up_proj", ["gate_proj", "up_proj"]),
+        ("down_proj", ["down_proj"]),
+    )
+    n = 0
+    for mod_name, mod in model.named_modules():
+        if not (hasattr(mod, "gate_up_proj") and hasattr(mod, "down_proj")):
+            continue
+        m = re.search(r"\.layers\.(\d+)\.", "." + mod_name)
+        if m is None:
+            continue
+        L = int(m.group(1))
+        if L not in layer_E:
+            continue
+        E = layer_E[L]
+        base = f"model.layers.{L}.mlp.experts"
+        for fused, parts in fused_map:
+            sel = [p for p in parts if p in routed_projs]
+            if not sel:
+                continue
+            projs = [
+                {
+                    "qd": [gt(f"{base}.{e}.{p}.weight") for e in range(E)],
+                    "sc": [gt(f"{base}.{e}.{p}.weight_scale") for e in range(E)],
+                    "pts": [gt(f"{base}.{e}.{p}.weight_scale_2") for e in range(E)],
+                }
+                for p in sel
+            ]
+            nvfp4 = fuse_nvfp4_experts(projs)
+            setattr(mod, fused, torch.nn.Parameter(nvfp4, requires_grad=False))
+            n += 1
+    return n
 
 
 if __name__ == "__main__":  # local self-consistency test on real layer-0 data

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
@@ -192,7 +192,7 @@ def patch_conversion_loader_rank0_only() -> None:
         _stats["real"] += 1
         return _orig(tensor, device=device, dtype=dtype)
 
-    _patched_materialize_copy._axolotl_rank0_patched = True
+    _patched_materialize_copy._axolotl_rank0_patched = True  # type: ignore[attr-defined]
     cml._materialize_copy = _patched_materialize_copy
     LOG.info(
         "Patched transformers core_model_loading._materialize_copy for rank0-only loading "

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
@@ -44,6 +44,153 @@ def _nvfp4_cls():
         return None
 
 
+def _nonrank0_meta_load() -> bool:
+    """True when cpu_ram_efficient broadcast loading wants this rank to stay on meta.
+
+    The safetensors are mmap'd, so a converter that calls ``torch.stack`` on the checkpoint
+    tensors copies real data into RAM on EVERY rank — violating the rank0-only contract and
+    blowing CPU RAM up by the world size. On non-local-rank-0 we instead emit correctly-shaped
+    META params; FSDP's ``fsdp2_load_full_state_dict`` then broadcasts rank 0's real weights.
+    (With the ``_materialize_copy`` patch active the converter already receives meta inputs; this
+    stays as a defensive second gate.)"""
+    return _is_nonrank0_process()
+
+
+def _to_meta(t):
+    import torch as _torch
+
+    return _torch.empty(t.shape, dtype=t.dtype, device="meta")
+
+
+def _is_nonrank0_process() -> bool:
+    """True on every process except local-rank-0 of the node.
+
+    torchrun always exports ``LOCAL_RANK``; we key off it directly rather than transformers'
+    ``is_fsdp_enabled()`` because that ALSO requires ``ACCELERATE_USE_FSDP`` /
+    ``FSDP_CPU_RAM_EFFICIENT_LOADING`` in the env, which ``axolotl train`` does NOT set at
+    ``from_pretrained`` time — so transformers' own rank0-gate is dormant during the load. ``-1``
+    (unset) means a single non-distributed process → load normally."""
+    import os
+
+    return int(os.environ.get("LOCAL_RANK", "-1")) > 0
+
+
+def patch_conversion_loader_rank0_only() -> None:
+    """Make transformers' conversion-based loader load rank0-only (for FSDP cpu_ram_efficient).
+
+    transformers' new ``core_model_loading`` loader (engaged whenever a ``conversion_mapping`` is
+    registered — i.e. our NVFP4 converters) materializes every tensor on every rank: it only shards
+    per-rank when a ``tp_plan`` is set, and otherwise has NO rank gating. Under FSDP that loads the
+    full model on all ``world_size`` ranks → an N× CPU-RAM blowup that OOMs large models. (And even
+    the legacy gate it would mirror is dormant here — see :func:`_is_nonrank0_process`.)
+
+    On non-local-rank-0 return a META tensor from ``_materialize_copy`` so only rank 0 holds real
+    weights; ``fsdp2_load_full_state_dict`` then broadcasts them. The mmap'd slice read still happens
+    (cheap, shared OS page cache) but the copy is dropped to meta, so non-rank-0 never accumulates.
+    Install ONLY when cpu_ram_efficient broadcast loading is active, else it would starve DDP ranks
+    that each need their own real weights. Idempotent."""
+    import os
+
+    import torch as _torch
+    import transformers.core_model_loading as cml
+
+    # transformers caps the conversion-loader ThreadPoolExecutor at min(4, cpu_count). Measured NOT
+    # to help GLM-5.2 load time (the bottleneck is the SERIAL main-thread converter/match loop over
+    # ~240k source tensors, not the materialize I/O — disk is fast NVMe). Left as an explicit opt-in
+    # (AXOLOTL_LOAD_WORKERS=<n>) in case it helps on a slow-disk/network box; no default change.
+    try:
+        _w = int(os.environ.get("AXOLOTL_LOAD_WORKERS", "0") or 0)
+        if _w > getattr(cml, "GLOBAL_WORKERS", 4):
+            cml.GLOBAL_WORKERS = _w
+            LOG.info("Raised transformers conversion-loader workers to %d", _w)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    if getattr(cml._materialize_copy, "_axolotl_rank0_patched", False):
+        return
+
+    _orig = cml._materialize_copy
+
+    # safetensors dtype-string -> torch dtype, for building meta tensors without reading the slice.
+    _ST_DTYPE = {
+        "F64": _torch.float64,
+        "F32": _torch.float32,
+        "F16": _torch.float16,
+        "BF16": _torch.bfloat16,
+        "F8_E4M3": _torch.float8_e4m3fn,
+        "F8_E5M2": _torch.float8_e5m2,
+        "I64": _torch.int64,
+        "I32": _torch.int32,
+        "I16": _torch.int16,
+        "I8": _torch.int8,
+        "U8": _torch.uint8,
+        "BOOL": _torch.bool,
+    }
+
+    def _meta_from_slice(tensor, dtype):
+        """Build a meta tensor matching what ``_orig`` WOULD return, without reading from disk."""
+        if not (hasattr(tensor, "get_shape") and hasattr(tensor, "get_dtype")):
+            return None
+        out_dtype = dtype if dtype is not None else _ST_DTYPE.get(tensor.get_dtype())
+        if out_dtype is None:
+            return None
+        return _torch.empty(tensor.get_shape(), dtype=out_dtype, device="meta")
+
+    _stats = {"meta": 0, "real": 0, "fallback": 0, "logged": False}
+
+    def _dbg(msg):
+        import sys
+
+        print(
+            f"[MATCOPY rank={os.environ.get('LOCAL_RANK', '?')}] {msg}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    def _patched_materialize_copy(tensor, device=None, dtype=None):
+        # dtype-aware: load the RAW NVFP4 components (uint8 qdata / fp8 e4m3|e5m2 scales) at their
+        # native dtype instead of the bf16 skeleton dtype. modelopt is an unrecognized quantizer so
+        # transformers' own native-dtype branch (hf_quantizer.pre_quantized) never fires and it casts
+        # everything to bf16 — doubling the bytes of the largest (uint8) expert tensors and adding a
+        # cast the converter's _recast_weight/_recast_scale would just undo. Applied before the
+        # rank0/meta split so both produce the same native dtype. (F32/F16/BF16 sources unaffected.)
+        if dtype is not None and hasattr(tensor, "get_dtype"):
+            _st = tensor.get_dtype()
+            if _st == "U8" or _st.startswith("F8"):
+                dtype = None
+        nonrank0 = _is_nonrank0_process()
+        if not _stats["logged"]:
+            _dbg(f"first call: nonrank0={nonrank0} slice_type={type(tensor).__name__}")
+            _stats["logged"] = True
+        # Non-rank-0: never touch the data — produce a same-shape/dtype META tensor so the slice is
+        # never read into RAM (reading-then-discarding leaves glibc holding the freed pages).
+        if nonrank0:
+            meta = _meta_from_slice(tensor, dtype)
+            if meta is not None:
+                _stats["meta"] += 1
+                if _stats["meta"] % 2000 == 0:
+                    _dbg(f"meta={_stats['meta']} fallback={_stats['fallback']}")
+                return meta
+            # Fallback (unknown slice type): read then drop to meta — correctness over memory.
+            _stats["fallback"] += 1
+            if _stats["fallback"] % 500 == 0:
+                _dbg(
+                    f"FALLBACK count={_stats['fallback']} type={type(tensor).__name__}"
+                )
+            out = _orig(tensor, device=device, dtype=dtype)
+            return _torch.empty(out.shape, dtype=out.dtype, device="meta")
+        _stats["real"] += 1
+        return _orig(tensor, device=device, dtype=dtype)
+
+    _patched_materialize_copy._axolotl_rank0_patched = True
+    cml._materialize_copy = _patched_materialize_copy
+    LOG.info(
+        "Patched transformers core_model_loading._materialize_copy for rank0-only loading "
+        "(LOCAL_RANK=%s)",
+        os.environ.get("LOCAL_RANK", "-1"),
+    )
+
+
 class Nvfp4ExpertsDeserialize:
     """ConversionOps that fuses per-expert NVFP4 tensors into a single NVFP4Tensor.
 
@@ -84,6 +231,18 @@ class Nvfp4ExpertsDeserialize:
         else:
             proj = "gate_up_proj"
 
+        # cpu_ram_efficient_loading: only local-rank-0 materializes; others stay on meta and get
+        # filled by the FSDP broadcast. Drop the mmap'd checkpoint data to meta BEFORE fusing.
+        if _nonrank0_meta_load():
+            input_dict = {
+                k: (
+                    [_to_meta(t) for t in v]
+                    if isinstance(v, (list, tuple))
+                    else _to_meta(v)
+                )
+                for k, v in input_dict.items()
+            }
+
         def _find(pat_suffix: str) -> list[torch.Tensor]:
             """Find the tensor list for a source pattern that ends with pat_suffix."""
             for key, tensors in input_dict.items():
@@ -123,6 +282,7 @@ class Nvfp4ExpertsDeserialize:
         nvfp4 = fuse_nvfp4_experts(projs)
 
         module, _ = get_module_from_name(model, full_layer_name)
+
         setattr(module, proj, nn.Parameter(nvfp4, requires_grad=False))
 
         if missing_keys is not None:
@@ -185,17 +345,27 @@ class Nvfp4LinearDequantize:
                 f"input_dict keys: {list(input_dict.keys())}"
             )
 
-        # spawn_materialize casts checkpoint tensors to the skeleton dtype (bf16); recast the
-        # raw uint8 qdata / e4m3 scale back (both roundtrip exactly through bf16).
         w = _one(".weight")
-        qdata = w if w.dtype == torch.uint8 else w.to(torch.int32).to(torch.uint8)
-        sc = _one(".weight_scale")
-        scale = sc if sc.dtype == torch.float8_e4m3fn else sc.to(torch.float8_e4m3fn)
-        pts = _one(".weight_scale_2").to(torch.float32).view(1, 1)
 
-        weight = NVFP4Tensor(
-            qdata, scale, 16, torch.bfloat16, per_tensor_scale=pts
-        ).dequantize(torch.bfloat16)
+        # cpu_ram_efficient_loading: non-local-rank-0 stays on meta (FSDP broadcasts rank 0's
+        # weights). qdata is packed [out, in/2] uint8 -> dequantized weight is [out, in] bf16.
+        if _nonrank0_meta_load():
+            weight = torch.empty(
+                (w.shape[0], w.shape[1] * 2), dtype=torch.bfloat16, device="meta"
+            )
+        else:
+            # spawn_materialize casts checkpoint tensors to the skeleton dtype (bf16); recast the
+            # raw uint8 qdata / e4m3 scale back (both roundtrip exactly through bf16).
+            qdata = w if w.dtype == torch.uint8 else w.to(torch.int32).to(torch.uint8)
+            sc = _one(".weight_scale")
+            scale = (
+                sc if sc.dtype == torch.float8_e4m3fn else sc.to(torch.float8_e4m3fn)
+            )
+            pts = _one(".weight_scale_2").to(torch.float32).view(1, 1)
+
+            weight = NVFP4Tensor(
+                qdata, scale, 16, torch.bfloat16, per_tensor_scale=pts
+            ).dequantize(torch.bfloat16)
 
         module, param_name = get_module_from_name(model, full_layer_name)
         setattr(module, param_name, nn.Parameter(weight, requires_grad=False))

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
@@ -13,12 +13,10 @@ the ``Gemma4TextExperts`` module — exactly like ``Mxfp4Deserialize`` does for
 MXFP4.  ``is_nvfp4_param(param)`` returns ``True`` on the result, activating
 the scattermoe fused NVFP4 path.
 
-The fusion logic mirrors ``nvfp4_moe_loading._build_expert_nvfp4`` exactly:
-  gate_up qdata  = stack-experts then cat([gate, up], dim=1)  → [E, 2*I, H/2] uint8
-  gate_up scale  = same                                        → [E, 2*I, H/16] e4m3
-  gate_up pts    = scalar (shared between gate and up)
-  down qdata     = stack-experts                               → [E, H, I/2] uint8
-  down scale     = stack-experts                               → [E, H, I/16] e4m3
+The fusion itself (stack experts, cat gate/up on the N axis, reconcile the per-tensor scales)
+is the shared ``nvfp4_moe_loading.fuse_nvfp4_experts`` core, so the WeightConverter (modelopt
+skeleton load) and the post-load scale-attach path use one implementation instead of duplicating
+the NVFP4-expert math.
 
 Registration is done via ``transformers.conversion_mapping.register_checkpoint_conversion_mapping``
 — no site-packages edits.  The registration helper is gated: call it only when
@@ -77,12 +75,9 @@ class Nvfp4ExpertsDeserialize:
     ) -> dict[str, Any]:
         from transformers.quantizers.quantizers_utils import get_module_from_name
 
-        NVFP4Tensor = _nvfp4_cls()
-        if NVFP4Tensor is None:
-            raise RuntimeError(
-                "torchao.prototype.mx_formats.nvfp4_tensor.NVFP4Tensor not found; "
-                "install torchao with NVFP4 support"
-            )
+        from axolotl.integrations.kernels.libs.scattermoe_lora.nvfp4_moe_loading import (
+            fuse_nvfp4_experts,
+        )
 
         if full_layer_name is None or "gate_up_proj" not in full_layer_name:
             proj = "down_proj"
@@ -112,36 +107,20 @@ class Nvfp4ExpertsDeserialize:
                 return t.to(torch.float8_e4m3fn)
             return t
 
+        def _proj_parts(proj_name: str) -> dict:
+            return {
+                "qd": [_recast_weight(t) for t in _find(f"{proj_name}.weight")],
+                "sc": [_recast_scale(t) for t in _find(f"{proj_name}.weight_scale")],
+                "pts": list(_find(f"{proj_name}.weight_scale_2")),
+            }
+
+        # gate/up fuse on the N axis (each ships its own per-tensor scale, reconciled in the core);
+        # down is a single projection. Fusion + scale reconciliation live in fuse_nvfp4_experts.
         if proj == "gate_up_proj":
-            gate_w = [_recast_weight(t) for t in _find("gate_proj.weight")]
-            up_w = [_recast_weight(t) for t in _find("up_proj.weight")]
-            gate_sc = [_recast_scale(t) for t in _find("gate_proj.weight_scale")]
-            up_sc = [_recast_scale(t) for t in _find("up_proj.weight_scale")]
-            pts_list = _find("gate_proj.weight_scale_2")
-
-            gate_qd = torch.stack(gate_w, dim=0)  # [E, I, H/2]
-            up_qd = torch.stack(up_w, dim=0)  # [E, I, H/2]
-            qdata = torch.cat([gate_qd, up_qd], dim=1)  # [E, 2I, H/2]
-            del gate_qd, up_qd
-
-            gate_s = torch.stack(gate_sc, dim=0)  # [E, I, H/16]
-            up_s = torch.stack(up_sc, dim=0)  # [E, I, H/16]
-            scale = torch.cat([gate_s, up_s], dim=1)  # [E, 2I, H/16]
-            del gate_s, up_s
-
-            # Per-expert weight_scale_2 stacked to [E,1,1] (gate/up share it), not expert-0's scalar.
-            pts = torch.stack([t.to(torch.float32) for t in pts_list]).view(-1, 1, 1)
-
-        else:  # down_proj
-            down_w = [_recast_weight(t) for t in _find("down_proj.weight")]
-            down_sc = [_recast_scale(t) for t in _find("down_proj.weight_scale")]
-            pts_list = _find("down_proj.weight_scale_2")
-
-            qdata = torch.stack(down_w, dim=0)  # [E, H, I/2]
-            scale = torch.stack(down_sc, dim=0)  # [E, H, I/16]
-            pts = torch.stack([t.to(torch.float32) for t in pts_list]).view(-1, 1, 1)
-
-        nvfp4 = NVFP4Tensor(qdata, scale, 16, torch.bfloat16, per_tensor_scale=pts)
+            projs = [_proj_parts("gate_proj"), _proj_parts("up_proj")]
+        else:
+            projs = [_proj_parts("down_proj")]
+        nvfp4 = fuse_nvfp4_experts(projs)
 
         module, _ = get_module_from_name(model, full_layer_name)
         setattr(module, proj, nn.Parameter(nvfp4, requires_grad=False))
@@ -154,7 +133,7 @@ class Nvfp4ExpertsDeserialize:
         LOG.debug(
             "Nvfp4ExpertsDeserialize: set %s as NVFP4Tensor [%s]",
             full_layer_name,
-            list(qdata.shape),
+            list(nvfp4.shape),
         )
         return {}
 
@@ -164,6 +143,105 @@ class Nvfp4ExpertsDeserialize:
         from transformers.core_model_loading import _IdentityOp
 
         return _IdentityOp()
+
+
+class Nvfp4LinearDequantize:
+    """ConversionOps that dequantizes one NVFP4 ``nn.Linear`` weight to bf16 in place.
+
+    Consumes a single module's NVFP4 triple — ``weight`` (uint8 qdata ``[out, in/2]``),
+    ``weight_scale`` (e4m3 group-16 ``[out, in/16]``), ``weight_scale_2`` (per-tensor scalar) —
+    and assigns ``dequantize(NVFP4Tensor(...))`` to the target ``.weight`` param. Used for whatever
+    non-routed linears a given checkpoint quantizes (the caller decides which, from the index);
+    this op makes no assumption about which modules those are. ``input_dict`` holds the three
+    source tensors (each a 1-element list under a non-wildcard source pattern); ``full_layer_name``
+    is the target ``....weight``.
+    """
+
+    def convert(
+        self,
+        input_dict: dict[str, Any],
+        source_patterns: list[str] | None = None,
+        target_patterns: list[str] | None = None,
+        full_layer_name: str | None = None,
+        model: nn.Module | None = None,
+        missing_keys: set | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        from transformers.quantizers.quantizers_utils import get_module_from_name
+
+        NVFP4Tensor = _nvfp4_cls()
+        if NVFP4Tensor is None:
+            raise RuntimeError(
+                "torchao.prototype.mx_formats.nvfp4_tensor.NVFP4Tensor not found; "
+                "install torchao with NVFP4 support"
+            )
+
+        def _one(pat_suffix: str) -> torch.Tensor:
+            for key, val in input_dict.items():
+                if key.endswith(pat_suffix):
+                    return val[0] if isinstance(val, (list, tuple)) else val
+            raise KeyError(
+                f"Nvfp4LinearDequantize: could not find '{pat_suffix}' in "
+                f"input_dict keys: {list(input_dict.keys())}"
+            )
+
+        # spawn_materialize casts checkpoint tensors to the skeleton dtype (bf16); recast the
+        # raw uint8 qdata / e4m3 scale back (both roundtrip exactly through bf16).
+        w = _one(".weight")
+        qdata = w if w.dtype == torch.uint8 else w.to(torch.int32).to(torch.uint8)
+        sc = _one(".weight_scale")
+        scale = sc if sc.dtype == torch.float8_e4m3fn else sc.to(torch.float8_e4m3fn)
+        pts = _one(".weight_scale_2").to(torch.float32).view(1, 1)
+
+        weight = NVFP4Tensor(
+            qdata, scale, 16, torch.bfloat16, per_tensor_scale=pts
+        ).dequantize(torch.bfloat16)
+
+        module, param_name = get_module_from_name(model, full_layer_name)
+        setattr(module, param_name, nn.Parameter(weight, requires_grad=False))
+        if missing_keys is not None:
+            missing_keys.discard(full_layer_name)
+        module._is_hf_initialized = True
+        return {}
+
+    @property
+    def reverse_op(self):
+        from transformers.core_model_loading import _IdentityOp
+
+        return _IdentityOp()
+
+
+def _nvfp4_linear_dequant_converter(target_weight: str):
+    """A WeightConverter that dequantizes one NVFP4 linear (``<target_weight>``) to bf16.
+
+    ``target_weight`` is the distinctive suffix of the linear's ``.weight`` param (e.g.
+    ``"shared_experts.gate_proj.weight"``). The three source patterns claim the NVFP4 triple so
+    none lands UNEXPECTED; longest-suffix-first so ``.weight`` doesn't steal ``.weight_scale*``.
+    """
+    from transformers.core_model_loading import WeightConverter
+
+    base = target_weight[: -len(".weight")]
+    return WeightConverter(
+        source_patterns=[
+            f"{base}.weight_scale_2",
+            f"{base}.weight_scale",
+            f"{base}.weight",
+        ],
+        target_patterns=target_weight,
+        operations=[Nvfp4LinearDequantize()],
+    )
+
+
+def nonrouted_dequant_converters(nonrouted_suffixes: list[str]) -> list:
+    """Dequant converters for the non-routed NVFP4 linears a checkpoint actually quantizes.
+
+    ``nonrouted_suffixes`` are the layer-relative module paths detected from the safetensors
+    index (e.g. ``"mlp.shared_experts.gate_proj"``, ``"mlp.gate_proj"``) — NOT hardcoded — each
+    pointing at a ``.weight`` to dequantize to bf16. Empty list -> no converters (e.g. a
+    checkpoint that leaves all non-routed linears bf16)."""
+    return [
+        _nvfp4_linear_dequant_converter(f"{suf}.weight") for suf in nonrouted_suffixes
+    ]
 
 
 def nvfp4_experts_weight_converters() -> list:
@@ -185,8 +263,8 @@ def nvfp4_experts_weight_converters() -> list:
     # and steal those keys unless the more specific suffixes appear first.
     gate_up_converter = WeightConverter(
         source_patterns=[
-            # gate and up each ship their own weight_scale_2 scalar; claim BOTH so neither
-            # lands as an UNEXPECTED key (the op only reads the first; they're identical).
+            # gate and up each ship their own weight_scale_2 scalar; claim BOTH so neither lands
+            # as an UNEXPECTED key (the op reconciles them — equal in practice, folded if not).
             "experts.*.gate_proj.weight_scale_2",
             "experts.*.up_proj.weight_scale_2",
             "experts.*.gate_proj.weight_scale",
@@ -211,24 +289,49 @@ def nvfp4_experts_weight_converters() -> list:
     return [gate_up_converter, down_converter]
 
 
-def register_gemma4_nvfp4_converters() -> None:
-    """Seed the transformers conversion_mapping cache with NVFP4 expert converters
-    for ``gemma4_text``.
+def register_nvfp4_expert_converters(
+    model_type: str, include_routed: bool = True, extra: list | None = None
+) -> None:
+    """Seed the transformers conversion_mapping cache with NVFP4 converters for ``model_type``.
 
-    Safe to call multiple times (idempotent via overwrite=True on re-entry).
-    Does not touch DSV4, bf16 gemma4, or any other model type.
+    The routed-expert converters (``Nvfp4ExpertsDeserialize`` + the ``experts.*.{proj}.weight*``
+    source patterns) fuse per-expert ``gate/up/down`` into the model's 3D expert params; they are
+    registered when ``include_routed`` (gate this on the checkpoint actually exporting per-expert
+    NVFP4). ``extra`` carries any per-checkpoint non-routed dequant converters (built from the
+    detected index layout). The only per-model knob is which ``model_type`` the loader looks the
+    mapping up under. Safe to call repeatedly (idempotent via overwrite on re-entry).
     """
     from transformers.conversion_mapping import register_checkpoint_conversion_mapping
 
-    converters = nvfp4_experts_weight_converters()
+    converters = (nvfp4_experts_weight_converters() if include_routed else []) + list(
+        extra or []
+    )
+    if not converters:
+        return
     try:
-        register_checkpoint_conversion_mapping("gemma4_text", converters)
+        register_checkpoint_conversion_mapping(model_type, converters)
     except ValueError:
         # Already registered; overwrite to keep converters fresh.
-        register_checkpoint_conversion_mapping(
-            "gemma4_text", converters, overwrite=True
-        )
+        register_checkpoint_conversion_mapping(model_type, converters, overwrite=True)
 
     LOG.info(
-        "Registered gemma4_text NVFP4 expert WeightConverters in transformers conversion_mapping"
+        "Registered %s NVFP4 WeightConverters (%d) in transformers conversion_mapping",
+        model_type,
+        len(converters),
+    )
+
+
+def register_gemma4_nvfp4_converters() -> None:
+    """Register NVFP4 expert converters for ``gemma4_text`` (see register_nvfp4_expert_converters)."""
+    register_nvfp4_expert_converters("gemma4_text")
+
+
+def register_nvfp4_converters_for_layout(model_type: str, layout: dict) -> None:
+    """Register NVFP4 converters built from a detected checkpoint ``layout`` (see
+    :func:`...nvfp4_moe_loading.inspect_nvfp4_layout`): routed experts fused into packed
+    NVFP4Tensor (when present), and each detected non-routed NVFP4 linear dequantized to bf16."""
+    register_nvfp4_expert_converters(
+        model_type,
+        include_routed=layout.get("routed_present", False),
+        extra=nonrouted_dequant_converters(layout.get("nonrouted_suffixes", [])),
     )

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
@@ -44,6 +44,13 @@ def _nvfp4_cls():
         return None
 
 
+# Set True only by patch_conversion_loader_rank0_only() (installed solely under FSDP
+# cpu_ram_efficient_loading). Gates the converter meta-load so non-rank-0 stays on meta ONLY when the
+# FSDP broadcast will later fill it — otherwise (e.g. DDP, or the example without the flag) every rank
+# loads real weights as normal.
+_RANK0_ONLY_ACTIVE = False
+
+
 def _nonrank0_meta_load() -> bool:
     """True when cpu_ram_efficient broadcast loading wants this rank to stay on meta.
 
@@ -53,7 +60,7 @@ def _nonrank0_meta_load() -> bool:
     META params; FSDP's ``fsdp2_load_full_state_dict`` then broadcasts rank 0's real weights.
     (With the ``_materialize_copy`` patch active the converter already receives meta inputs; this
     stays as a defensive second gate.)"""
-    return _is_nonrank0_process()
+    return _RANK0_ONLY_ACTIVE and _is_nonrank0_process()
 
 
 def _to_meta(t):
@@ -89,6 +96,9 @@ def patch_conversion_loader_rank0_only() -> None:
     (cheap, shared OS page cache) but the copy is dropped to meta, so non-rank-0 never accumulates.
     Install ONLY when cpu_ram_efficient broadcast loading is active, else it would starve DDP ranks
     that each need their own real weights. Idempotent."""
+    global _RANK0_ONLY_ACTIVE
+    _RANK0_ONLY_ACTIVE = True
+
     import os
 
     import torch as _torch

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -317,6 +317,13 @@ class PatchManager:
 
             patch_initialize_missing_keys_for_fsdp()
 
+            if self.cfg.fsdp_config.cpu_ram_efficient_loading:
+                from axolotl.monkeypatch.accelerate.fsdp2 import (
+                    patch_move_missing_keys_meta_for_fsdp,
+                )
+
+                patch_move_missing_keys_meta_for_fsdp()
+
         if self.cfg.context_parallel_size > 1 or (
             self.cfg.fsdp_config and str(self.cfg.fsdp_version) == "2"
         ):

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -317,7 +317,14 @@ class PatchManager:
 
             patch_initialize_missing_keys_for_fsdp()
 
-            if self.cfg.fsdp_config.cpu_ram_efficient_loading:
+            # Only for adapter (frozen-base) runs: this patch leaves non-rank-0 base params on meta
+            # (FSDP broadcasts rank-0's weights into them), which avoids world_size× CPU
+            # materialization of large unrecognized-quantizer (NVFP4-modelopt) checkpoints. Those are
+            # always trained with a frozen base, so no base optimizer state exists. For a FULL
+            # fine-tune the base params DO carry optimizer state, and leaving them on meta deadlocks
+            # the FSDP2 optimizer-state all-gather at checkpoint save (rank-0 real DTensors vs
+            # non-rank-0 meta) — so fall back to the stock materialize-to-cpu path there.
+            if self.cfg.fsdp_config.cpu_ram_efficient_loading and self.cfg.adapter:
                 from axolotl.monkeypatch.accelerate.fsdp2 import (
                     patch_move_missing_keys_meta_for_fsdp,
                 )

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -246,9 +246,14 @@ def fsdp2_load_full_state_dict(
             # (all-experts) adapter (4096-row lora_A etc.). The generic broadcast below would mismatch
             # sizes (rank-0 sends the global tensor, receivers allocate the E_local size) and replicate
             # rank-0's experts onto ranks owning a different ep-slice. Broadcast rank-0's global adapter
-            # (a consistent shape on every rank), then slice THIS rank's ep-chunk (dim 0 for lora_A's
-            # expert-major rows, dim 1 for lora_B's rank-major columns) and its dp_shard, and from_local.
-            from torch.distributed.tensor import DTensor, Shard
+            # (a consistent shape on every rank), then slice THIS rank's ep-experts + dp_shard and
+            # from_local. The ep slice is expert-aware (lora_B's experts are not contiguous in its flat
+            # r*E dim), so it mirrors shard_expert_lora rather than a plain chunk.
+            from torch.distributed.tensor import DTensor
+
+            from axolotl.integrations.expert_parallel.shard import (
+                ep_adapter_load_local_shard,
+            )
 
             mesh = sharded_meta_param.device_mesh
             placements = sharded_meta_param.placements
@@ -264,13 +269,19 @@ def fsdp2_load_full_state_dict(
                 g = torch.empty(gshape, device=dev, dtype=sharded_meta_param.dtype)
             dist.broadcast(g, src=0)
             ep_coord = min(dist.get_process_group_ranks(mesh.get_group())) // dp_size
-            local = g.chunk(ep_size, dim=ep_dim)[ep_coord]
             dp_rank = dist.get_group_rank(mesh.get_group(), dist.get_rank())
-            for _p in placements:
-                if isinstance(_p, Shard):
-                    local = local.chunk(dp_size, dim=_p.dim)[dp_rank]
+            local = ep_adapter_load_local_shard(
+                g,
+                ep_dim,
+                model._ep_num_experts_global,
+                ep_coord,
+                ep_size,
+                placements,
+                dp_size,
+                dp_rank,
+            )
             sharded_param = DTensor.from_local(
-                local.contiguous(), mesh, placements, run_check=False
+                local, mesh, placements, run_check=False
             )
         elif hasattr(sharded_meta_param, "device_mesh"):
             # GLOBAL broadcast of rank-0's full tensor, then slice this rank's local shard and wrap via

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -670,12 +670,11 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     # SAME experts (cp shards the sequence, not the experts), so FSDP-shard them on cp and let the MoE
     # forward all-gather — otherwise each rank keeps its full ep-group slice (e.g. 64 experts at ep=4)
     # and OOMs on the first forward's all-gather.
-    _ep_shard_axis = None
-    if mesh is not None and "ep" in getattr(mesh, "mesh_dim_names", ()):
-        if "dp_shard" in mesh.mesh_dim_names:
-            _ep_shard_axis = "dp_shard"
-        elif "cp" in mesh.mesh_dim_names:
-            _ep_shard_axis = "cp"
+    from axolotl.integrations.expert_parallel.plugin import expert_shard_axis
+
+    _ep_shard_axis = expert_shard_axis(
+        getattr(mesh, "mesh_dim_names", None) if mesh is not None else None
+    )
     if _ep_shard_axis is not None:
         from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
         from axolotl.integrations.expert_parallel.shard import shard_expert_lora

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -122,9 +122,44 @@ def fsdp2_load_full_state_dict(
 
     start_time = time.time()
 
+    # EP-sharded expert params hold RANK-SPECIFIC content (each rank owns experts
+    # [r*E_local, (r+1)*E_local)). The default rank0-authoritative load below would broadcast
+    # rank 0's shard to every rank, replicating experts[0:E_local] everywhere and silently
+    # destroying expert parallelism. shard_expert_weights() already scattered the correct shard
+    # to every rank BEFORE the model was moved to meta, so each rank's own `full_sd` entry is
+    # already correct — load it locally with no cross-rank broadcast. Match via the `.experts.`
+    # infix (excludes `shared_experts`, survives the `_checkpoint_wrapped_module` infix) tied to
+    # the propagated DDP-ignore list.
+    _ep_ignore = getattr(model, "_ddp_params_and_buffers_to_ignore", None) or []
+    _ep_tails = tuple(
+        sorted({"." + n.split(".experts.", 1)[1] for n in _ep_ignore if ".experts." in n})
+    )
+
+    def _is_ep_expert_param(name: str) -> bool:
+        return bool(_ep_tails) and ".experts." in name and name.endswith(_ep_tails)
+
     meta_sharded_sd = model.state_dict()
     sharded_sd = {}
     for param_name, sharded_meta_param in meta_sharded_sd.items():
+        # Pure-EP: the EP-sharded experts are excluded from the FSDP wrap (ignored_params), so they
+        # stay PLAIN per-rank meta params here. shard_expert_weights already scattered each rank's
+        # correct [E_local] slice before the meta move, so each rank's own `full_sd` entry is right —
+        # load it locally with NO rank-0 broadcast (which would replicate experts[0:E_local]). Only
+        # applies when the param is plain (not a DTensor); EP×dp_shard composition keeps them as
+        # DTensors loaded via the mesh path below.
+        if _is_ep_expert_param(param_name) and not hasattr(
+            sharded_meta_param, "device_mesh"
+        ):
+            own = full_sd[param_name]
+            own = own.to(torch.device("cuda"))
+            if offload_to_cpu:
+                own = own.cpu()
+            sharded_sd[param_name] = nn.Parameter(
+                own, requires_grad=sharded_meta_param.requires_grad
+            )
+            full_sd[param_name] = None
+            continue
+
         nvfp4_cls = _nvfp4_local_tensor_cls(sharded_meta_param)
 
         full_tensor = None
@@ -533,6 +568,29 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         model._ep_lora_group = mesh["ep"].get_group()
         shard_expert_lora(model, mesh["ep"].size())
         ExpertParallelPlugin.fully_shard_experts(model, mesh["dp_shard"], fsdp2_kwargs)
+    elif getattr(model, "_ddp_params_and_buffers_to_ignore", None):
+        # Pure EP (ep_size == world_size): no ep×dp_shard mesh is built, so the experts were
+        # manually EP-sharded (shard_expert_weights scattered each rank's real [E_local] slice) but
+        # there is NO dp_shard axis to FSDP them onto. Left to the outer fully_shard(mesh=None) they
+        # would be re-sharded on the flat world mesh and replicated from rank 0, destroying EP. Exclude
+        # the EP-sharded expert base params from the FSDP wrap entirely so each rank keeps its own
+        # [E_local] slice as a plain param; fsdp2_load_full_state_dict restores them per-rank.
+        ep_ignored = {
+            p
+            for n, p in model.named_parameters()
+            if ".experts." in n
+            and ".shared_experts." not in n
+            and n.rsplit(".", 1)[-1]
+            in ("gate_up_proj", "down_proj", "gate_up_proj_bias", "down_proj_bias")
+        }
+        if ep_ignored:
+            fsdp2_kwargs["ignored_params"] = set(
+                fsdp2_kwargs.get("ignored_params") or set()
+            ) | ep_ignored
+            LOG.info(
+                f"expert_parallel (pure EP): excluded {len(ep_ignored)} EP-sharded expert "
+                "param(s) from the FSDP wrap (kept as plain per-rank slices)."
+            )
 
     auto_wrap_policy = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
     log_bias_dtype_mismatch = False

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -889,7 +889,12 @@ def patch_move_missing_keys_meta_for_fsdp():
     non-rank-0 rank → ``world_size``× CPU RAM → OOM. axolotl's ``fsdp2_prepare_model`` immediately
     does ``model.to("meta")`` then broadcasts rank 0's weights, so the materialized params are
     pure waste. Keep params on meta (FSDP fills them); only buffers — computed in ``__init__`` and
-    not broadcast — get real CPU storage."""
+    not broadcast — get real CPU storage.
+
+    Caller MUST restrict this to frozen-base (adapter) runs: leaving base params on meta on
+    non-rank-0 deadlocks the FSDP2 optimizer-state all-gather at checkpoint save for a FULL
+    fine-tune (rank-0 real DTensors vs non-rank-0 meta). LoRA/qLoRA carry no base optimizer state,
+    so the gather never touches these params."""
     from transformers import PreTrainedModel
     from transformers.integrations import (
         is_deepspeed_zero3_enabled,

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -55,18 +55,22 @@ def _broadcast_nvfp4_param(sharded_meta_param, full_nvfp4, is_main, device, nvfp
         group = mesh.get_group()
         world = dist.get_world_size(group)
         p0 = placements[0] if len(placements) == 1 else None
+        # Direct per-shard scatter on the param's mesh group — the full WORLD (pure data-parallel) OR a
+        # dp_shard/cp SUBGROUP (EP composition). Source is the group's rank-0 (== the is_main rank set by
+        # the caller). Avoids distribute_tensor, which deadlocks scattering from src_data_rank=0 on a
+        # sub-mesh. Falls back to distribute_tensor only for non-Shard(0)/uneven placements.
         if (
             p0 is not None
             and getattr(p0, "dim", None) == 0
             and ref_local.shape[0] * world == e_global
-            and world == dist.get_world_size()
         ):
+            src_rank = dist.get_process_group_ranks(group)[0]
             local = torch.empty_like(ref_local, device=device)
             chunks = None
             if is_main:
                 full = getattr(full_nvfp4, name)
                 chunks = [c.contiguous().to(device) for c in full.chunk(world, dim=0)]
-            dist.scatter(local, scatter_list=chunks, src=0, group=group)
+            dist.scatter(local, scatter_list=chunks, src=src_rank, group=group)
             del chunks
             return local
         # Fallback: generic distribute_tensor (uneven / replicate / sub-group).
@@ -103,6 +107,38 @@ def _broadcast_nvfp4_param(sharded_meta_param, full_nvfp4, is_main, device, nvfp
     return DTensor.from_local(local_nvfp4, mesh, placements, run_check=False)
 
 
+def _ep_expert_from_local(sharded_meta_param, full_local, nvfp4_cls):
+    """Build an EP-sharded NVFP4 expert DTensor from THIS rank's already-correct local copy — NO
+    collective. shard_expert_weights scattered each rank its ep-group's full ``[E_local]`` NVFP4
+    (``full_local``); slice this rank's dp-axis shard (``[E_local // dp]`` at its position in the
+    mesh group) and wrap it with ``from_local``. Used instead of a per-subgroup scatter, which
+    deadlocks against the interleaved full-mesh non-expert loads (the receiver ranks race ahead of
+    the source ranks)."""
+    from torch.distributed.tensor import DTensor
+
+    mesh = sharded_meta_param.device_mesh
+    placements = sharded_meta_param.placements
+    local_meta = sharded_meta_param._local_tensor
+    dev = mesh.device_type
+    e_dp = local_meta.qdata.shape[0]  # this rank's dp-local expert count
+    dp_rank = dist.get_group_rank(mesh.get_group(), dist.get_rank())
+    s = slice(dp_rank * e_dp, (dp_rank + 1) * e_dp)
+    qd = full_local.qdata[s].to(dev)
+    sc = full_local.scale[s].to(dev)
+    pts = getattr(full_local, "per_tensor_scale", None)
+    local_pts = None
+    if pts is not None:
+        local_pts = (
+            pts[s].to(dev)
+            if (pts.dim() >= 1 and pts.shape[0] == full_local.qdata.shape[0])
+            else pts.to(dev)
+        )
+    local_nv = nvfp4_cls(
+        qd, sc, local_meta.block_size, local_meta.dtype, per_tensor_scale=local_pts
+    )
+    return DTensor.from_local(local_nv, mesh, placements, run_check=False)
+
+
 def fsdp2_load_full_state_dict(
     _accelerator, model: torch.nn.Module, full_sd: dict, offload_to_cpu: bool = False
 ):
@@ -115,8 +151,6 @@ def fsdp2_load_full_state_dict(
             The model to load the state dict into, expected to be on meta device or a VRAM spike can occur
         full_sd (`dict`): The full state dict to load, can only be on rank 0
     """
-    from torch.distributed.tensor import distribute_tensor
-
     LOG.info("Broadcasting full state dict to all ranks...")
     import time
 
@@ -140,6 +174,7 @@ def fsdp2_load_full_state_dict(
 
     meta_sharded_sd = model.state_dict()
     sharded_sd = {}
+
     for param_name, sharded_meta_param in meta_sharded_sd.items():
         # Pure-EP: the EP-sharded experts are excluded from the FSDP wrap (ignored_params), so they
         # stay PLAIN per-rank meta params here. shard_expert_weights already scattered each rank's
@@ -172,37 +207,103 @@ def fsdp2_load_full_state_dict(
             # NVFP4Tensor params can't go through distribute_tensor (c10d.scatter_ unimplemented on
             # the subclass); scatter their plain qdata/scale/per_tensor_scale components instead.
             device_mesh = sharded_meta_param.device_mesh
-            full_nvfp4 = full_sd[param_name] if _accelerator.is_main_process else None
-            sharded_param = _broadcast_nvfp4_param(
-                sharded_meta_param,
-                full_nvfp4,
-                _accelerator.is_main_process,
-                device_mesh.device_type,
-                nvfp4_cls,
+            # Source each NVFP4 expert from its OWN mesh-group's rank-0, not the global rank 0. Under
+            # EP×dp_shard / EP×cp composition the experts live on a dp_shard SUBGROUP mesh, and
+            # shard_expert_weights scattered each rank its ep-group's real slice — so the subgroup's
+            # rank-0 holds the data (global rank 0 is outside ep-groups 1..N's subgroups). For full-world
+            # params the subgroup rank-0 IS global rank 0, so this reduces to is_main_process.
+            if _is_ep_expert_param(param_name):
+                # EP-sharded NVFP4 experts: shard_expert_weights already scattered THIS rank its
+                # ep-group's full [E_local] NVFP4 into full_sd. Build the DTensor by slicing the dp-axis
+                # shard out of that local copy and wrapping it with from_local — NO collective. The
+                # per-subgroup scatter (any flavor) deadlocks because it interleaves with the full-mesh
+                # non-expert loads, racing the receiver ranks ahead of the source ranks; from_local
+                # sidesteps every collective.
+                sharded_param = _ep_expert_from_local(
+                    sharded_meta_param, full_sd[param_name], nvfp4_cls
+                )
+            else:
+                # Non-EP NVFP4 on the full data-parallel mesh: only rank 0 has data -> scatter from it.
+                full_nvfp4 = (
+                    full_sd[param_name] if _accelerator.is_main_process else None
+                )
+                sharded_param = _broadcast_nvfp4_param(
+                    sharded_meta_param,
+                    full_nvfp4,
+                    _accelerator.is_main_process,
+                    device_mesh.device_type,
+                    nvfp4_cls,
+                )
+        elif (
+            ".experts." in param_name
+            and (".lora_A." in param_name or ".lora_B." in param_name)
+            and hasattr(sharded_meta_param, "device_mesh")
+            and dist.get_world_size(sharded_meta_param.device_mesh.get_group())
+            < dist.get_world_size()
+        ):
+            # EP×dp_shard/cp composition: the routed-expert LoRA adapter lives on a dp_shard SUBGROUP
+            # mesh and holds only THIS ep-group's E_local experts, but full_sd carries the GLOBAL
+            # (all-experts) adapter (4096-row lora_A etc.). The generic broadcast below would mismatch
+            # sizes (rank-0 sends the global tensor, receivers allocate the E_local size) and replicate
+            # rank-0's experts onto ranks owning a different ep-slice. Broadcast rank-0's global adapter
+            # (a consistent shape on every rank), then slice THIS rank's ep-chunk (dim 0 for lora_A's
+            # expert-major rows, dim 1 for lora_B's rank-major columns) and its dp_shard, and from_local.
+            from torch.distributed.tensor import DTensor, Shard
+
+            mesh = sharded_meta_param.device_mesh
+            placements = sharded_meta_param.placements
+            dp_size = mesh.size()
+            ep_size = dist.get_world_size() // dp_size
+            ep_dim = 0 if ".lora_A." in param_name else 1
+            dev = mesh.device_type
+            gshape = list(sharded_meta_param.size())
+            gshape[ep_dim] *= ep_size
+            if _accelerator.is_main_process:
+                g = full_tensor.to(dev)
+            else:
+                g = torch.empty(gshape, device=dev, dtype=sharded_meta_param.dtype)
+            dist.broadcast(g, src=0)
+            ep_coord = min(dist.get_process_group_ranks(mesh.get_group())) // dp_size
+            local = g.chunk(ep_size, dim=ep_dim)[ep_coord]
+            dp_rank = dist.get_group_rank(mesh.get_group(), dist.get_rank())
+            for _p in placements:
+                if isinstance(_p, Shard):
+                    local = local.chunk(dp_size, dim=_p.dim)[dp_rank]
+            sharded_param = DTensor.from_local(
+                local.contiguous(), mesh, placements, run_check=False
             )
         elif hasattr(sharded_meta_param, "device_mesh"):
+            # GLOBAL broadcast of rank-0's full tensor, then slice this rank's local shard and wrap via
+            # from_local. distribute_tensor (src_data_rank=0) and per-mesh scatters DEADLOCK or fail on
+            # EP-composition: experts/non-experts live on dp_shard SUBGROUP meshes that exclude global
+            # rank 0, but under cpu_ram_efficient only rank 0 has data — so neither a sub-mesh scatter
+            # (no source in the subgroup) nor distribute_tensor (receivers race the stalled source) works.
+            # A global broadcast has every rank participate (no desync), and the slice+from_local needs
+            # no further collective. Equivalent result to distribute_tensor for the full DP mesh, so the
+            # non-EP path is unchanged.
+            from torch.distributed.tensor import DTensor, Shard
+
             device_mesh = sharded_meta_param.device_mesh
+            _pl = sharded_meta_param.placements
             if _accelerator.is_main_process:
-                full_tensor = full_tensor.to(device_mesh.device_type)
+                _full = full_tensor.to(device_mesh.device_type)
             else:
-                full_tensor = torch.empty(
+                _full = torch.empty(
                     sharded_meta_param.size(),
                     device=device_mesh.device_type,
                     dtype=sharded_meta_param.dtype,
                 )
-            sharded_param = distribute_tensor(
-                full_tensor,
-                device_mesh,
-                sharded_meta_param.placements,
-                src_data_rank=0,
+            dist.broadcast(_full, src=0)
+            _grp = device_mesh.get_group()
+            _lr = dist.get_group_rank(_grp, dist.get_rank())
+            _w = dist.get_world_size(_grp)
+            _local = _full
+            for _p in _pl:
+                if isinstance(_p, Shard):
+                    _local = _local.chunk(_w, dim=_p.dim)[_lr]
+            sharded_param = DTensor.from_local(
+                _local.contiguous(), device_mesh, _pl, run_check=False
             )
-            # Clone the local shard to allow full_tensor to be freed.
-            if (
-                sharded_param._local_tensor.untyped_storage().size()
-                > sharded_param._local_tensor.nelement()
-                * sharded_param._local_tensor.element_size()
-            ):
-                sharded_param = sharded_param.clone()
         else:
             # Non-sharded parameters
             if _accelerator.is_main_process:
@@ -553,11 +654,18 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
 
     # EP+FSDP: pre-wrap experts on `dp_shard` before the outer auto-wrap so
     # the walker skips them. See `expert_parallel/README.md`.
-    if (
-        mesh is not None
-        and "ep" in getattr(mesh, "mesh_dim_names", ())
-        and "dp_shard" in mesh.mesh_dim_names
-    ):
+    # EP composition shards the experts on the non-ep axis so they don't sit replicated per rank. With
+    # dp_shard that's the data axis; with pure EP×cp (no dp_shard) the cp ranks of an ep-group hold the
+    # SAME experts (cp shards the sequence, not the experts), so FSDP-shard them on cp and let the MoE
+    # forward all-gather — otherwise each rank keeps its full ep-group slice (e.g. 64 experts at ep=4)
+    # and OOMs on the first forward's all-gather.
+    _ep_shard_axis = None
+    if mesh is not None and "ep" in getattr(mesh, "mesh_dim_names", ()):
+        if "dp_shard" in mesh.mesh_dim_names:
+            _ep_shard_axis = "dp_shard"
+        elif "cp" in mesh.mesh_dim_names:
+            _ep_shard_axis = "cp"
+    if _ep_shard_axis is not None:
         from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
         from axolotl.integrations.expert_parallel.shard import shard_expert_lora
 
@@ -567,7 +675,9 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         # save time can pick up a stale/size-1 mesh).
         model._ep_lora_group = mesh["ep"].get_group()
         shard_expert_lora(model, mesh["ep"].size())
-        ExpertParallelPlugin.fully_shard_experts(model, mesh["dp_shard"], fsdp2_kwargs)
+        ExpertParallelPlugin.fully_shard_experts(
+            model, mesh[_ep_shard_axis], fsdp2_kwargs
+        )
     elif getattr(model, "_ddp_params_and_buffers_to_ignore", None):
         # Pure EP (ep_size == world_size): no ep×dp_shard mesh is built, so the experts were
         # manually EP-sharded (shard_expert_weights scattered each rank's real [E_local] slice) but

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -166,7 +166,9 @@ def fsdp2_load_full_state_dict(
     # the propagated DDP-ignore list.
     _ep_ignore = getattr(model, "_ddp_params_and_buffers_to_ignore", None) or []
     _ep_tails = tuple(
-        sorted({"." + n.split(".experts.", 1)[1] for n in _ep_ignore if ".experts." in n})
+        sorted(
+            {"." + n.split(".experts.", 1)[1] for n in _ep_ignore if ".experts." in n}
+        )
     )
 
     def _is_ep_expert_param(name: str) -> bool:
@@ -280,9 +282,7 @@ def fsdp2_load_full_state_dict(
                 dp_size,
                 dp_rank,
             )
-            sharded_param = DTensor.from_local(
-                local, mesh, placements, run_check=False
-            )
+            sharded_param = DTensor.from_local(local, mesh, placements, run_check=False)
         elif hasattr(sharded_meta_param, "device_mesh"):
             # GLOBAL broadcast of rank-0's full tensor, then slice this rank's local shard and wrap via
             # from_local. distribute_tensor (src_data_rank=0) and per-mesh scatters DEADLOCK or fail on
@@ -704,9 +704,9 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             in ("gate_up_proj", "down_proj", "gate_up_proj_bias", "down_proj_bias")
         }
         if ep_ignored:
-            fsdp2_kwargs["ignored_params"] = set(
-                fsdp2_kwargs.get("ignored_params") or set()
-            ) | ep_ignored
+            fsdp2_kwargs["ignored_params"] = (
+                set(fsdp2_kwargs.get("ignored_params") or set()) | ep_ignored
+            )
             LOG.info(
                 f"expert_parallel (pure EP): excluded {len(ep_ignored)} EP-sharded expert "
                 "param(s) from the FSDP wrap (kept as plain per-rank slices)."

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -20,6 +20,89 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 
+def _nvfp4_local_tensor_cls(p):
+    """Return the NVFP4Tensor class if ``p`` is a DTensor whose local shard is an NVFP4Tensor."""
+    try:
+        from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+    except ImportError:
+        return None
+    lt = getattr(p, "_local_tensor", None)
+    return NVFP4Tensor if isinstance(lt, NVFP4Tensor) else None
+
+
+def _broadcast_nvfp4_param(sharded_meta_param, full_nvfp4, is_main, device, nvfp4_cls):
+    """Scatter rank-0's full NVFP4Tensor expert param to each rank's shard.
+
+    ``distribute_tensor`` calls ``c10d.scatter_``, which torchao's NVFP4Tensor doesn't implement.
+    Instead scatter the PLAIN component tensors (qdata uint8, scale e4m3, per_tensor_scale fp32 — all
+    collective-capable) along the same Shard placement, then rebuild a local NVFP4Tensor shard and
+    wrap it back into a DTensor matching the sharded model param."""
+    from torch.distributed.tensor import DTensor, distribute_tensor
+
+    mesh = sharded_meta_param.device_mesh
+    placements = sharded_meta_param.placements
+    local_meta = sharded_meta_param._local_tensor
+    e_global = sharded_meta_param.shape[0]
+    block_size = local_meta.block_size
+    dtype = local_meta.dtype
+
+    def _scatter_component(name, ref_local):
+        # Direct per-shard scatter: send each rank ONLY its dim-0 (expert-axis) shard. Avoids the
+        # full-global placeholder that non-rank0 otherwise allocates (256 experts to receive 32),
+        # the generic distribute_tensor path, and its trailing .clone(). Valid for the common
+        # Shard(0) + even-division + full-world mesh (GLM-5.2: 256 experts / 8 ranks); falls back to
+        # distribute_tensor for anything else (uneven, replicate, sub-group meshes).
+        group = mesh.get_group()
+        world = dist.get_world_size(group)
+        p0 = placements[0] if len(placements) == 1 else None
+        if (
+            p0 is not None
+            and getattr(p0, "dim", None) == 0
+            and ref_local.shape[0] * world == e_global
+            and world == dist.get_world_size()
+        ):
+            local = torch.empty_like(ref_local, device=device)
+            chunks = None
+            if is_main:
+                full = getattr(full_nvfp4, name)
+                chunks = [c.contiguous().to(device) for c in full.chunk(world, dim=0)]
+            dist.scatter(local, scatter_list=chunks, src=0, group=group)
+            del chunks
+            return local
+        # Fallback: generic distribute_tensor (uneven / replicate / sub-group).
+        gshape = (e_global,) + tuple(ref_local.shape[1:])
+        if is_main:
+            full = getattr(full_nvfp4, name).to(device)
+        else:
+            full = torch.empty(gshape, device=device, dtype=ref_local.dtype)
+        dt = distribute_tensor(full, mesh, placements, src_data_rank=0)
+        return dt._local_tensor.clone()
+
+    local_qdata = _scatter_component("qdata", local_meta.qdata)
+    local_scale = _scatter_component("scale", local_meta.scale)
+
+    local_pts = None
+    pts_ref = getattr(local_meta, "per_tensor_scale", None)
+    if pts_ref is not None:
+        if pts_ref.dim() >= 1 and pts_ref.shape[0] == local_meta.qdata.shape[0]:
+            # per-expert scale shards along dim 0 like qdata/scale
+            local_pts = _scatter_component("per_tensor_scale", pts_ref)
+        else:
+            # replicated scalar — plain broadcast
+            if is_main:
+                local_pts = full_nvfp4.per_tensor_scale.to(device)
+            else:
+                local_pts = torch.empty(
+                    pts_ref.shape, device=device, dtype=pts_ref.dtype
+                )
+            dist.broadcast(local_pts, src=0)
+
+    local_nvfp4 = nvfp4_cls(
+        local_qdata, local_scale, block_size, dtype, per_tensor_scale=local_pts
+    )
+    return DTensor.from_local(local_nvfp4, mesh, placements, run_check=False)
+
+
 def fsdp2_load_full_state_dict(
     _accelerator, model: torch.nn.Module, full_sd: dict, offload_to_cpu: bool = False
 ):
@@ -42,12 +125,27 @@ def fsdp2_load_full_state_dict(
     meta_sharded_sd = model.state_dict()
     sharded_sd = {}
     for param_name, sharded_meta_param in meta_sharded_sd.items():
+        nvfp4_cls = _nvfp4_local_tensor_cls(sharded_meta_param)
+
         full_tensor = None
-        if _accelerator.is_main_process:
+        # Skip the dtype cast for NVFP4 (its components are scattered raw, not cast to bf16).
+        if _accelerator.is_main_process and nvfp4_cls is None:
             full_tensor = full_sd[param_name]
             full_tensor = full_tensor.to(sharded_meta_param.dtype)
 
-        if hasattr(sharded_meta_param, "device_mesh"):
+        if nvfp4_cls is not None:
+            # NVFP4Tensor params can't go through distribute_tensor (c10d.scatter_ unimplemented on
+            # the subclass); scatter their plain qdata/scale/per_tensor_scale components instead.
+            device_mesh = sharded_meta_param.device_mesh
+            full_nvfp4 = full_sd[param_name] if _accelerator.is_main_process else None
+            sharded_param = _broadcast_nvfp4_param(
+                sharded_meta_param,
+                full_nvfp4,
+                _accelerator.is_main_process,
+                device_mesh.device_type,
+                nvfp4_cls,
+            )
+        elif hasattr(sharded_meta_param, "device_mesh"):
             device_mesh = sharded_meta_param.device_mesh
             if _accelerator.is_main_process:
                 full_tensor = full_tensor.to(device_mesh.device_type)
@@ -360,7 +458,10 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
 
     # Disable memory pinning if requested
     offload_to_cpu = isinstance(fsdp2_plugin.cpu_offload, CPUOffloadPolicy)
-    if offload_to_cpu and os.environ.get("FSDP_CPU_OFFLOAD_PIN_MEMORY", "") == "false":
+    if (
+        offload_to_cpu
+        and os.environ.get("FSDP_CPU_OFFLOAD_PIN_MEMORY", "").lower() == "false"
+    ):
         fsdp2_plugin.cpu_offload.pin_memory = False
 
     fsdp2_kwargs = {
@@ -423,7 +524,14 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         and "dp_shard" in mesh.mesh_dim_names
     ):
         from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
+        from axolotl.integrations.expert_parallel.shard import shard_expert_lora
 
+        # Realign target_parameters expert LoRA with the EP-sharded weights before
+        # FSDP wraps the experts (PEFT sized it for the global expert count). Stash the
+        # exact ep group so the save path gathers across the same axis (re-resolving at
+        # save time can pick up a stale/size-1 mesh).
+        model._ep_lora_group = mesh["ep"].get_group()
+        shard_expert_lora(model, mesh["ep"].size())
         ExpertParallelPlugin.fully_shard_experts(model, mesh["dp_shard"], fsdp2_kwargs)
 
     auto_wrap_policy = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
@@ -591,6 +699,84 @@ def patch_initialize_missing_keys_for_fsdp():
 
     PreTrainedModel._initialize_missing_keys = _patched_initialize_missing_keys
     PreTrainedModel._initialize_missing_keys._axolotl_patched = True
+
+
+def patch_move_missing_keys_meta_for_fsdp():
+    """Stop transformers materializing the FULL model on every non-rank-0 rank during load.
+
+    ``_move_missing_keys_from_meta_to_device`` has a branch ``is_fsdp_enabled() and not
+    is_local_dist_rank_0() and not is_quantized`` that moves EVERY meta parameter to real CPU
+    storage (``torch.zeros_like(param, device="cpu")``). For an unrecognized-quantizer checkpoint
+    (NVFP4-modelopt → ``is_quantized=False``) on a large model, that puts the whole model on each
+    non-rank-0 rank → ``world_size``× CPU RAM → OOM. axolotl's ``fsdp2_prepare_model`` immediately
+    does ``model.to("meta")`` then broadcasts rank 0's weights, so the materialized params are
+    pure waste. Keep params on meta (FSDP fills them); only buffers — computed in ``__init__`` and
+    not broadcast — get real CPU storage."""
+    from transformers import PreTrainedModel
+    from transformers.integrations import (
+        is_deepspeed_zero3_enabled,
+        is_fsdp_enabled,
+    )
+    from transformers.modeling_utils import (
+        _load_parameter_into_model,
+        get_device,
+        is_local_dist_rank_0,
+    )
+
+    if getattr(
+        PreTrainedModel._move_missing_keys_from_meta_to_device,
+        "_axolotl_patched",
+        False,
+    ):
+        return
+
+    def _patched_move_missing_keys(
+        self, missing_keys, device_map, device_mesh, hf_quantizer
+    ):
+        is_quantized = hf_quantizer is not None
+        if is_deepspeed_zero3_enabled() and not is_quantized:
+            return
+
+        if is_fsdp_enabled() and not is_local_dist_rank_0() and not is_quantized:
+            # Params: leave on meta — FSDP broadcasts rank 0's real weights into them. (Upstream
+            # materialized them all to cpu zeros here, OOMing large models.) Buffers still need real
+            # storage, but they are small.
+            for key, buffer in self.named_buffers():
+                if buffer.is_meta:
+                    value = torch.zeros_like(buffer, device="cpu")
+                    _load_parameter_into_model(self, key, value)
+            return
+
+        for key in missing_keys - self.all_tied_weights_keys.keys():
+            param = self.get_parameter_or_buffer(key)
+            param_device = get_device(device_map, key, valid_torch_device=True)
+            value = torch.empty_like(param, device=param_device)
+            if device_mesh is not None:
+                from transformers.modeling_utils import shard_and_distribute_module
+
+                shard_and_distribute_module(
+                    self,
+                    value,
+                    param,
+                    key,
+                    None,
+                    False,
+                    device_mesh.get_local_rank(),
+                    device_mesh,
+                )
+            else:
+                _load_parameter_into_model(self, key, value)
+        for key, buffer in self.named_non_persistent_buffers():
+            buffer_device = get_device(device_map, key, valid_torch_device=True)
+            value = torch.empty_like(buffer, device=buffer_device)
+            _load_parameter_into_model(self, key, value)
+
+    PreTrainedModel._move_missing_keys_from_meta_to_device = _patched_move_missing_keys
+    PreTrainedModel._move_missing_keys_from_meta_to_device._axolotl_patched = True
+    LOG.info(
+        "Patched transformers _move_missing_keys_from_meta_to_device: non-rank-0 params stay "
+        "on meta (FSDP broadcast fills them) instead of full-model CPU materialization"
+    )
 
 
 def patch_accelerate_fsdp2():

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -284,37 +284,37 @@ def fsdp2_load_full_state_dict(
             )
             sharded_param = DTensor.from_local(local, mesh, placements, run_check=False)
         elif hasattr(sharded_meta_param, "device_mesh"):
-            # GLOBAL broadcast of rank-0's full tensor, then slice this rank's local shard and wrap via
-            # from_local. distribute_tensor (src_data_rank=0) and per-mesh scatters DEADLOCK or fail on
-            # EP-composition: experts/non-experts live on dp_shard SUBGROUP meshes that exclude global
-            # rank 0, but under cpu_ram_efficient only rank 0 has data — so neither a sub-mesh scatter
-            # (no source in the subgroup) nor distribute_tensor (receivers race the stalled source) works.
-            # A global broadcast has every rank participate (no desync), and the slice+from_local needs
-            # no further collective. Equivalent result to distribute_tensor for the full DP mesh, so the
-            # non-EP path is unchanged.
-            from torch.distributed.tensor import DTensor, Shard
+            # Generic sharded params (the whole non-EP model, and EP composition's NON-expert weights)
+            # live on a FULL mesh that includes global rank 0, so distribute_tensor(src_data_rank=0)
+            # broadcasts rank-0's data and shards it correctly — including FSDP's padding for uneven
+            # sizes, which a manual chunk + from_local gets wrong (it builds a DTensor with the raw
+            # global size and mismatches the model param). EP-composition's rank-0-EXCLUDING subgroup
+            # params (experts, and the routed-expert LoRA adapter) are handled by their own branches
+            # above, so they never reach here.
+            from torch.distributed.tensor import distribute_tensor
 
             device_mesh = sharded_meta_param.device_mesh
-            _pl = sharded_meta_param.placements
             if _accelerator.is_main_process:
-                _full = full_tensor.to(device_mesh.device_type)
+                full_tensor = full_tensor.to(device_mesh.device_type)
             else:
-                _full = torch.empty(
+                full_tensor = torch.empty(
                     sharded_meta_param.size(),
                     device=device_mesh.device_type,
                     dtype=sharded_meta_param.dtype,
                 )
-            dist.broadcast(_full, src=0)
-            _grp = device_mesh.get_group()
-            _lr = dist.get_group_rank(_grp, dist.get_rank())
-            _w = dist.get_world_size(_grp)
-            _local = _full
-            for _p in _pl:
-                if isinstance(_p, Shard):
-                    _local = _local.chunk(_w, dim=_p.dim)[_lr]
-            sharded_param = DTensor.from_local(
-                _local.contiguous(), device_mesh, _pl, run_check=False
+            sharded_param = distribute_tensor(
+                full_tensor,
+                device_mesh,
+                sharded_meta_param.placements,
+                src_data_rank=0,
             )
+            # Clone the local shard to allow full_tensor to be freed.
+            if (
+                sharded_param._local_tensor.untyped_storage().size()
+                > sharded_param._local_tensor.nelement()
+                * sharded_param._local_tensor.element_size()
+            ):
+                sharded_param = sharded_param.clone()
         else:
             # Non-sharded parameters
             if _accelerator.is_main_process:

--- a/src/axolotl/monkeypatch/accelerate/parallelism_config.py
+++ b/src/axolotl/monkeypatch/accelerate/parallelism_config.py
@@ -243,8 +243,10 @@ def _ep_aware_clip_grad_norm(parameters, max_norm, norm_type=2.0):
 
 def patch_clip_grad_norm_for_ep():
     """Replace `Accelerator.clip_grad_norm_` with the EP-aware version when
-    the active parallelism includes both `ep` and `dp_shard` (i.e., the
-    FSDP+EP composition produces multi-mesh DTensor grads).
+    the active parallelism composes `ep` with `dp_shard` and/or `cp` (i.e., the
+    FSDP+EP composition produces multi-mesh DTensor grads — the experts shard on
+    the dp_shard/cp subgroup, the non-experts on the flattened dp_shard_cp mesh,
+    so the stock `clip_grad_norm_` can't stack their per-param norms together).
     """
     from accelerate import Accelerator
 
@@ -257,7 +259,10 @@ def patch_clip_grad_norm_for_ep():
         if (
             pc is not None
             and getattr(pc, "ep_enabled", False)
-            and getattr(pc, "dp_shard_enabled", False)
+            and (
+                getattr(pc, "dp_shard_enabled", False)
+                or getattr(pc, "cp_enabled", False)
+            )
         ):
             self.unscale_gradients()
             params = list(parameters)

--- a/src/axolotl/monkeypatch/multipack.py
+++ b/src/axolotl/monkeypatch/multipack.py
@@ -40,6 +40,7 @@ SUPPORTED_MULTIPACK_MODEL_TYPES = [
     "glm",
     "glm4",
     "glm4_moe",
+    "glm_moe_dsa",
     "smollm3",
     "granite",
     "granitemoe",

--- a/src/axolotl/monkeypatch/ring_attn/patch.py
+++ b/src/axolotl/monkeypatch/ring_attn/patch.py
@@ -219,7 +219,12 @@ def update_ring_attn_params(position_ids: torch.Tensor | None):
     Args:
         position_ids: Optional tensor of position IDs (for sample packed data).
     """
-    from ring_flash_attn import update_ring_flash_attn_params
+    try:
+        from ring_flash_attn import update_ring_flash_attn_params
+    except ImportError:
+        # No ring attention was substituted (e.g. the GLM DSA kernels own context-parallel attention
+        # and derive their own cu_seqlens from position_ids), so there is nothing to update here.
+        return
 
     cu_seqlens, _ = get_cu_seqlens_from_pos_ids(position_ids)
     cu_seqlens = cu_seqlens.squeeze().to(device=torch.cuda.current_device())

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -293,6 +293,29 @@ def save_trained_model(
             # final model weights have already been saved by `ReLoRACallback.on_train_end`
             return
 
+    # EP-sharded expert LoRA: the adapter is split across the EP axis, so the normal
+    # FSDP/PEFT save would persist only the local rank's experts. Gather across EP and
+    # write a complete adapter.
+    if cfg.adapter and (getattr(cfg, "expert_parallel_size", 1) or 1) > 1:
+        from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
+        from axolotl.integrations.expert_parallel.shard import save_ep_lora_adapter
+
+        ep_group = ExpertParallelPlugin._resolve_ep_group(cfg)
+        if save_ep_lora_adapter(model, cfg.output_dir, ep_group):
+            return
+
+    # FSDP2 (no EP) LoRA: the DCP sharded save fails ("Failed to validate global plan") on the
+    # frozen NVFP4 base DTensors, so gather just the adapter and write it directly.
+    if (
+        cfg.adapter
+        and (trainer.is_fsdp_enabled or cfg.fsdp_config)
+        and str(cfg.fsdp_version) == "2"
+    ):
+        from axolotl.integrations.expert_parallel.shard import save_fsdp2_lora_adapter
+
+        if save_fsdp2_lora_adapter(model, cfg.output_dir):
+            return
+
     if trainer.is_fsdp_enabled or cfg.fsdp_config:
         if cfg.fsdp_config or cfg.fsdp:
             if cfg.fsdp_config.final_state_dict_type:
@@ -341,9 +364,10 @@ def save_trained_model(
             ) as config_file_io:
                 # read the model config as an OrderedDict
                 config = json.load(config_file_io, object_pairs_hook=OrderedDict)
-                config["architectures"] = [
-                    name.lstrip("FSDP") for name in config["architectures"]
-                ]
+                if config.get("architectures"):
+                    config["architectures"] = [
+                        name.lstrip("FSDP") for name in config["architectures"]
+                    ]
             # write the updated model config back
             with open(
                 os.path.join(cfg.output_dir, "config.json"), "w", encoding="utf-8"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1605,6 +1605,16 @@ class ComplexValidationMixin:
             self.context_parallel_size = self.sequence_parallel_degree
         if not self.context_parallel_size:
             self.context_parallel_size = 1
+        elif self.context_parallel_size > 1 and getattr(
+            self, "use_glm_dsa_kernels", False
+        ):
+            # The GLM DSA kernels provide their own context-parallel attention (the sequence is sharded
+            # on the cp axis with a compressed-KV all-gather + per-rank q_offset), so the flash /
+            # ring_flash_attn stack the generic CP path below requires does not apply.
+            LOG.warning(
+                "context_parallel_size > 1 with use_glm_dsa_kernels: the DSA kernels handle context "
+                "parallelism (compressed-KV all-gather); skipping the flash/ring-attention requirement."
+            )
         elif self.context_parallel_size > 1:
             if not self.attn_uses_flash_lib:
                 raise ValueError(
@@ -1693,6 +1703,11 @@ class ComplexValidationMixin:
 
         if self.ring_attn_func is not None:
             self.ring_attn_func = RingAttnFunc(self.ring_attn_func)
+        elif getattr(self, "use_glm_dsa_kernels", False):
+            # The GLM DSA kernels own attention (including the context-parallel compressed-KV gather),
+            # so leave ring_attn_func None: the SP context manager still shards the sequence by chunking,
+            # but skips the ring_flash_attn substitution (which GLM doesn't use and isn't installed).
+            pass
         else:
             # Default ring attention function selection
             sample_packing = getattr(self, "sample_packing", False)

--- a/tests/core/test_quantized_lora_checkpoint_resume.py
+++ b/tests/core/test_quantized_lora_checkpoint_resume.py
@@ -1,0 +1,53 @@
+"""F4: FSDP2 + quantized-base LoRA checkpoints must stay resumable.
+
+The DCP sharded model save fails on the NVFP4/Float8 frozen base, so the trainer saves just the
+adapter — but it must STILL persist optimizer/scheduler/scaler/RNG and trainer_state so periodic
+checkpoints can resume. These bind ``AxolotlTrainer._save_checkpoint`` to a stub (no Trainer/GPU)
+and assert the resume artifacts are written after the adapter save.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from axolotl.core.trainers.base import AxolotlTrainer
+
+
+def _stub(tmp_path, *, save_only_model=False, should_save=True, adapter_handled=True):
+    return SimpleNamespace(
+        state=SimpleNamespace(global_step=5, save_to_json=MagicMock()),
+        args=SimpleNamespace(save_only_model=save_only_model, should_save=should_save),
+        _get_output_dir=lambda trial=None: str(tmp_path),
+        _save_fsdp2_quantized_lora_adapter=MagicMock(return_value=adapter_handled),
+        _save_optimizer_and_scheduler=MagicMock(),
+        _save_scaler=MagicMock(),
+        _save_rng_state=MagicMock(),
+    )
+
+
+def test_quantized_lora_checkpoint_persists_resume_state(tmp_path):
+    stub = _stub(tmp_path)
+    out = AxolotlTrainer._save_checkpoint(stub, model=object(), trial=None)
+    assert out is None
+    stub._save_fsdp2_quantized_lora_adapter.assert_called_once()
+    # the F4 fix: optimizer/scheduler/scaler/RNG + trainer_state all written (resumable)
+    stub._save_optimizer_and_scheduler.assert_called_once()
+    stub._save_scaler.assert_called_once()
+    stub._save_rng_state.assert_called_once()
+    stub.state.save_to_json.assert_called_once()
+
+
+def test_save_only_model_skips_optimizer_but_writes_trainer_state(tmp_path):
+    stub = _stub(tmp_path, save_only_model=True)
+    AxolotlTrainer._save_checkpoint(stub, model=object(), trial=None)
+    stub._save_optimizer_and_scheduler.assert_not_called()
+    stub._save_rng_state.assert_not_called()
+    stub.state.save_to_json.assert_called_once()  # trainer_state still written for resume bookkeeping
+
+
+def test_resume_state_failure_keeps_adapter_and_does_not_raise(tmp_path):
+    # If an FSDP2 resume-artifact save raises, keep the (already-written) adapter rather than aborting.
+    stub = _stub(tmp_path)
+    stub._save_optimizer_and_scheduler = MagicMock(side_effect=RuntimeError("dcp optim fail"))
+    out = AxolotlTrainer._save_checkpoint(stub, model=object(), trial=None)
+    assert out is None  # did not raise
+    stub._save_fsdp2_quantized_lora_adapter.assert_called_once()

--- a/tests/core/test_quantized_lora_checkpoint_resume.py
+++ b/tests/core/test_quantized_lora_checkpoint_resume.py
@@ -47,7 +47,9 @@ def test_save_only_model_skips_optimizer_but_writes_trainer_state(tmp_path):
 def test_resume_state_failure_keeps_adapter_and_does_not_raise(tmp_path):
     # If an FSDP2 resume-artifact save raises, keep the (already-written) adapter rather than aborting.
     stub = _stub(tmp_path)
-    stub._save_optimizer_and_scheduler = MagicMock(side_effect=RuntimeError("dcp optim fail"))
+    stub._save_optimizer_and_scheduler = MagicMock(
+        side_effect=RuntimeError("dcp optim fail")
+    )
     out = AxolotlTrainer._save_checkpoint(stub, model=object(), trial=None)
     assert out is None  # did not raise
     stub._save_fsdp2_quantized_lora_adapter.assert_called_once()

--- a/tests/e2e/integrations/test_scattermoe_lora_olmoe.py
+++ b/tests/e2e/integrations/test_scattermoe_lora_olmoe.py
@@ -106,6 +106,32 @@ requires_cuda = pytest.mark.skipif(
 )
 
 
+def _max_shared_memory_optin() -> int:
+    if not torch.cuda.is_available():
+        return 0
+    return torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).shared_memory_per_block_optin
+
+
+# The fused LoRA weight-grad kernel (grouped_gram) runs a single large autotune config
+# (BLOCK_M=128, BLOCK_WIDE=128, num_stages=3) pinned for the GLM DeepEP path — a single config
+# avoids per-rank re-autotune skew tripping DeepEP's combine barrier. It needs ~144 KiB of shared
+# memory/block, which big-SMEM GPUs (sm_80 A100 ~163 KiB, sm_90 H100 ~228 KiB) provide but sm_89
+# (L40S) and consumer Blackwell (sm_120 Max-Q, ~99 KiB) do not — Triton raises OutOfResources.
+# Gate the backward test on the device actually having enough shared memory.
+_GRAM_KERNEL_SHARED_MEM = 147456  # bytes; the kernel's largest (only) config
+
+requires_gram_kernel_shared_memory = pytest.mark.skipif(
+    _max_shared_memory_optin() < _GRAM_KERNEL_SHARED_MEM,
+    reason=(
+        "scattermoe_lora grouped_gram backward kernel needs "
+        f"{_GRAM_KERNEL_SHARED_MEM} bytes shared memory/block "
+        f"(device optin max is {_max_shared_memory_optin()})"
+    ),
+)
+
+
 def make_olmoe_config(use_full=False):
     cfg = dict(FULL_OLMOE_CONFIG if use_full else SMALL_OLMOE_CONFIG)
     cfg["experts_implementation"] = "grouped_mm"
@@ -764,6 +790,7 @@ class TestOLMoEPeftLoRAForward:
 
 
 @requires_cuda
+@requires_gram_kernel_shared_memory
 class TestOLMoEPeftLoRABackward:
     """Backward gradients through scattermoe_lora vs pure-PyTorch reference."""
 

--- a/tests/e2e/integrations/test_scattermoe_lora_olmoe.py
+++ b/tests/e2e/integrations/test_scattermoe_lora_olmoe.py
@@ -106,32 +106,6 @@ requires_cuda = pytest.mark.skipif(
 )
 
 
-def _max_shared_memory_optin() -> int:
-    if not torch.cuda.is_available():
-        return 0
-    return torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).shared_memory_per_block_optin
-
-
-# The fused LoRA weight-grad kernel (grouped_gram) runs a single large autotune config
-# (BLOCK_M=128, BLOCK_WIDE=128, num_stages=3) pinned for the GLM DeepEP path — a single config
-# avoids per-rank re-autotune skew tripping DeepEP's combine barrier. It needs ~144 KiB of shared
-# memory/block, which big-SMEM GPUs (sm_80 A100 ~163 KiB, sm_90 H100 ~228 KiB) provide but sm_89
-# (L40S) and consumer Blackwell (sm_120 Max-Q, ~99 KiB) do not — Triton raises OutOfResources.
-# Gate the backward test on the device actually having enough shared memory.
-_GRAM_KERNEL_SHARED_MEM = 147456  # bytes; the kernel's largest (only) config
-
-requires_gram_kernel_shared_memory = pytest.mark.skipif(
-    _max_shared_memory_optin() < _GRAM_KERNEL_SHARED_MEM,
-    reason=(
-        "scattermoe_lora grouped_gram backward kernel needs "
-        f"{_GRAM_KERNEL_SHARED_MEM} bytes shared memory/block "
-        f"(device optin max is {_max_shared_memory_optin()})"
-    ),
-)
-
-
 def make_olmoe_config(use_full=False):
     cfg = dict(FULL_OLMOE_CONFIG if use_full else SMALL_OLMOE_CONFIG)
     cfg["experts_implementation"] = "grouped_mm"
@@ -790,7 +764,6 @@ class TestOLMoEPeftLoRAForward:
 
 
 @requires_cuda
-@requires_gram_kernel_shared_memory
 class TestOLMoEPeftLoRABackward:
     """Backward gradients through scattermoe_lora vs pure-PyTorch reference."""
 

--- a/tests/integrations/kernels/glm_dsa/test_dsa_attention_eager.py
+++ b/tests/integrations/kernels/glm_dsa/test_dsa_attention_eager.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""End-to-end correctness: our DSA-kernel attention path == HuggingFace eager GlmMoeDsaAttention.
+
+The patched ``_glm_dsa_attention_forward`` replaces the eager forward with the absorbed-MLA path
+(indexer top-k -> absorbed query -> sparse gather/dense over the compressed latent -> value
+projection). This asserts it numerically matches the stock eager module on identical weights/inputs,
+covering both the dense (topk >= seq) and sparse (topk < seq) regimes, with the stock and the fused
+indexer. Combined with test_mla_absorb_gather (gather == dense), the full eager->dense->gather chain
+is verified.
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+pytest.importorskip(
+    "transformers.models.glm_moe_dsa.modeling_glm_moe_dsa",
+    reason="glm_moe_dsa required",
+)
+from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (  # noqa: E402
+    GlmMoeDsaConfig,
+)
+from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (  # noqa: E402
+    GlmMoeDsaAttention,
+    GlmMoeDsaRotaryEmbedding,
+)
+
+from axolotl.integrations.kernels.libs.glm_dsa.patch import (  # noqa: E402
+    patch_glm_moe_dsa_attention,
+)
+
+DEV = "cuda"
+DT = torch.bfloat16
+
+
+def _build(index_topk, seed=0):
+    torch.manual_seed(seed)
+    cfg = GlmMoeDsaConfig(
+        hidden_size=512,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        q_lora_rank=256,
+        kv_lora_rank=512,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_topk=index_topk,
+        index_head_dim=128,
+        index_n_heads=2,
+        num_hidden_layers=1,
+    )
+    cfg._attn_implementation = "eager"
+    attn = GlmMoeDsaAttention(cfg, layer_idx=0).to(DEV, DT).eval()
+    rope = GlmMoeDsaRotaryEmbedding(cfg).to(DEV)
+    return cfg, attn, rope
+
+
+@pytest.mark.parametrize("S,index_topk", [(64, 16), (48, 128)], ids=["sparse", "dense"])
+@pytest.mark.parametrize(
+    "use_fused_indexer", [False, True], ids=["eager_idx", "fused_idx"]
+)
+def test_dsa_attention_matches_hf_eager(S, index_topk, use_fused_indexer):
+    cfg, attn, rope = _build(index_topk)
+    B = 1
+    hidden = torch.randn(B, S, cfg.hidden_size, device=DEV, dtype=DT)
+    position_ids = torch.arange(S, device=DEV).unsqueeze(0)
+    cos, sin = rope(hidden, position_ids)
+    pe = (cos, sin)
+
+    import torch.nn as nn
+
+    with torch.no_grad():
+        out_eager = attn(hidden, pe, None, position_ids=position_ids)[0]
+        wrapper = nn.Module()
+        wrapper.add_module("a", attn)
+        assert (
+            patch_glm_moe_dsa_attention(wrapper, use_fused_indexer=use_fused_indexer)
+            == 1
+        )
+        out_kernel = attn(hidden, pe, None, position_ids=position_ids)[0]
+
+    assert torch.isfinite(out_kernel).all()
+    err = (out_eager.float() - out_kernel.float()).abs().max().item()
+    scale = out_eager.float().abs().max().item() + 1e-6
+    assert err / scale < 5e-2, f"rel err {err / scale:.4g} (abs {err:.4g})"

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -12,6 +12,7 @@
    on sm90 (so autotune never trials the rest) while leaving other archs to normal SMEM pruning.
 """
 
+import os
 from unittest import mock
 
 import torch
@@ -90,3 +91,55 @@ def test_sm90_bwd_prune_collapses_to_single_config():
         assert len(kept_sm120) > 1, (
             "non-sm90 keeps the full SMEM-pruned grid for autotuning"
         )
+
+
+def test_gather_supported_sm90_sm120_and_disable_override():
+    """The sparse gather is enabled on sm90 (Hopper) and sm120; unlisted archs fall back to dense;
+    ``GLM_DSA_DISABLE_GATHER`` forces dense everywhere."""
+    from axolotl.integrations.kernels.libs.glm_dsa import dispatch as D
+
+    dev = torch.device("cuda:0")
+    for cap, expected in [
+        ((9, 0), True),
+        ((12, 0), True),
+        ((8, 0), False),
+        ((10, 0), False),
+    ]:
+        D._GATHER_OK.clear()
+        with mock.patch.object(torch.cuda, "get_device_capability", return_value=cap):
+            assert D._gather_supported(dev) is expected, f"cap {cap}"
+    D._GATHER_OK.clear()
+    with mock.patch.dict(os.environ, {"GLM_DSA_DISABLE_GATHER": "1"}):
+        with mock.patch.object(
+            torch.cuda, "get_device_capability", return_value=(9, 0)
+        ):
+            assert D._gather_supported(dev) is False  # override wins
+
+
+def test_mla_attn_routes_to_gather_under_packing_and_forwards_seq():
+    """Above the crossover the sparse gather is used EVEN under sample packing (it is doc-aware), and
+    ``seq_q``/``seq_k`` are forwarded to it; when the gather is unsupported, dense is used."""
+    from axolotl.integrations.kernels.libs.glm_dsa import dispatch as D
+
+    qa = torch.zeros(1, 4, 8, 576)
+    ks = torch.zeros(1, 8, 576)
+    idx = torch.zeros(1, 8, 4, dtype=torch.int64)
+    seq = torch.zeros(1, 8, dtype=torch.int64)
+
+    with (
+        mock.patch.object(D, "mla_absorb_attn", return_value="GATHER") as mg,
+        mock.patch.object(D, "dense_masked_out_latent", return_value="DENSE"),
+        mock.patch.object(D, "_gather_supported", return_value=True),
+        mock.patch.object(D, "calibrate_crossover", return_value=0),
+    ):
+        out = D.mla_attn(qa, ks, idx, 1.0, seq_q=seq, seq_k=seq)
+        assert out == "GATHER"  # packing no longer forces dense
+        # seq_q / seq_k forwarded as the last two positional args
+        assert mg.call_args.args[-2] is seq and mg.call_args.args[-1] is seq
+
+    with (
+        mock.patch.object(D, "dense_masked_out_latent", return_value="DENSE"),
+        mock.patch.object(D, "_gather_supported", return_value=False),
+        mock.patch.object(D, "calibrate_crossover", return_value=0),
+    ):
+        assert D.mla_attn(qa, ks, idx, 1.0, seq_q=seq, seq_k=seq) == "DENSE"

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -13,8 +13,10 @@
 """
 
 import os
+from types import SimpleNamespace
 from unittest import mock
 
+import pytest
 import torch
 
 from axolotl.integrations.expert_parallel.experts_fn import _apply_expert_capacity
@@ -143,3 +145,58 @@ def test_mla_attn_routes_to_gather_under_packing_and_forwards_seq():
         mock.patch.object(D, "calibrate_crossover", return_value=0),
     ):
         assert D.mla_attn(qa, ks, idx, 1.0, seq_q=seq, seq_k=seq) == "DENSE"
+
+
+def test_deep_ep_forward_applies_token_capacity():
+    """The capacity cap must actually be applied to the routing before the dispatch layout is built
+    (regression: the cap function existed but was never called)."""
+    from axolotl.integrations.expert_parallel import experts_fn as E
+
+    captured = {}
+
+    class _FakeBuf:
+        def get_dispatch_layout(self, topk_idx, e_global):
+            captured["topk"] = topk_idx.clone()
+            raise RuntimeError("stop")  # short-circuit the rest of the forward
+
+    ntok, K, e_global = 64, 2, 8
+    topk = torch.zeros(
+        ntok, K, dtype=torch.int64
+    )  # column 0 -> expert 0 for ALL tokens
+    topk[:, 1] = 1
+    w = torch.rand(ntok, K)
+    self_mod = SimpleNamespace(num_experts=e_global, num_experts_global=e_global)
+
+    E.set_token_capacity(4)
+    try:
+        with (
+            mock.patch.object(E, "get_buffer", return_value=_FakeBuf()),
+            mock.patch.object(E, "_get_valid_token_mask", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="stop"):
+                E._deep_ep_forward(
+                    self_mod, torch.zeros(ntok, 16), topk, w, kernel_name="eager"
+                )
+    finally:
+        E.set_token_capacity(None)
+
+    # expert 0 was requested by all 64 tokens; the cap must hold it to <= 4
+    assert int((captured["topk"] == 0).sum()) <= 4
+
+
+def test_mla_attn_skips_calibration_when_gather_unsupported():
+    """On an unsupported GPU mla_attn must NOT call calibrate_crossover (it would compile/run the
+    gather Triton path we are avoiding)."""
+    from axolotl.integrations.kernels.libs.glm_dsa import dispatch as D
+
+    qa = torch.zeros(1, 4, 8, 576)
+    ks = torch.zeros(1, 8, 576)
+    idx = torch.zeros(1, 8, 4, dtype=torch.int64)
+    calib = mock.MagicMock(return_value=0)
+    with (
+        mock.patch.object(D, "dense_masked_out_latent", return_value="DENSE"),
+        mock.patch.object(D, "_gather_supported", return_value=False),
+        mock.patch.object(D, "calibrate_crossover", calib),
+    ):
+        assert D.mla_attn(qa, ks, idx, 1.0) == "DENSE"
+    calib.assert_not_called()

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -200,3 +200,28 @@ def test_mla_attn_skips_calibration_when_gather_unsupported():
     ):
         assert D.mla_attn(qa, ks, idx, 1.0) == "DENSE"
     calib.assert_not_called()
+
+
+def test_cp_doc_ids_must_be_global_not_per_chunk():
+    """F2: under context parallelism the per-document ids must come from the GLOBAL position_ids, not
+    each rank's local chunk. Otherwise a document crossing a CP boundary gets different (and colliding)
+    ids per rank, which masks valid remote keys / allows cross-document attention."""
+    from axolotl.integrations.kernels.libs.glm_dsa.patch import (
+        _seq_idx_from_position_ids,
+    )
+
+    # doc B (positions 0,1,2,3) spans the cp=2 boundary at index 4 (S=4 queries per rank)
+    global_pos = torch.tensor([[0, 1, 0, 1, 2, 3, 0, 1]])
+    S = 4
+    global_ids = _seq_idx_from_position_ids(global_pos)
+    assert global_ids.tolist() == [[1, 1, 2, 2, 2, 2, 3, 3]]
+
+    # NEW (number docs on the global ids, then slice per rank): the boundary doc shares ONE id
+    r0, r1 = global_ids[:, 0:S], global_ids[:, S : 2 * S]
+    assert r0[0, -1].item() == r1[0, 0].item()  # doc B: rank0's last query == rank1's first query
+
+    # OLD (per-local-chunk cumsum): the same doc gets different ids across ranks, and ids collide
+    old_r0 = _seq_idx_from_position_ids(global_pos[:, 0:S])
+    old_r1 = _seq_idx_from_position_ids(global_pos[:, S : 2 * S])
+    assert old_r0[0, -1].item() != old_r1[0, 0].item()  # doc B inconsistent across ranks (the bug)
+    assert old_r1[0, 2].item() == old_r0[0, 0].item()  # doc C (rank1) collides with doc A (rank0)

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""CPU regression tests for two GLM-5.2 workarounds (no GPU needed):
+
+1. **Expert-capacity cap** (DeepEP #24): DeepEP's intranode combine deadlocks once one expert
+   receives too many tokens (the GLM router concentrates with depth). ``_apply_expert_capacity``
+   drops the lowest-weight excess (token,expert) assignments so no expert exceeds ``cap``.
+2. **sm90 backward-autotune prune** (#18): on Hopper the full bwd autotune grid trials a
+   nondeterministic invalid-PC (CUDA 718); ``_bwd_prune_sm90_safe`` must collapse to a single config
+   on sm90 (so autotune never trials the rest) while leaving other archs to normal SMEM pruning.
+"""
+
+from unittest import mock
+
+import torch
+
+from axolotl.integrations.expert_parallel.experts_fn import _apply_expert_capacity
+
+
+def test_expert_capacity_caps_tokens_per_expert():
+    # 6 tokens, top-2 -> 12 (token,expert) assignments, 3 experts. cap=2.
+    topk_idx = torch.tensor(
+        [[0, 1], [0, 2], [0, 1], [0, 2], [1, 2], [0, 1]], dtype=torch.int64
+    )
+    topk_w = torch.tensor(
+        [[0.9, 0.5], [0.8, 0.4], [0.7, 0.6], [0.3, 0.2], [0.95, 0.1], [0.55, 0.45]]
+    )
+    cap = 2
+    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap)
+
+    # every expert now has <= cap surviving assignments
+    for e in range(3):
+        assert int((out == e).sum()) <= cap, f"expert {e} exceeds cap"
+    # dropped slots are sentinelled to -1, and the number dropped is exactly the overflow
+    n_orig = int((topk_idx >= 0).sum())
+    n_kept = int((out >= 0).sum())
+    assert n_kept == n_orig - int((out == -1).sum())
+    # the HIGHEST-weight assignment to expert 0 (token4? no expert0 weights: 0.9,0.8,0.7,0.3,_,0.55)
+    # the two survivors for expert 0 must be the top-2 weights (0.9 @ tok0, 0.8 @ tok1)
+    surv0_tokens = (out[:, 0] == 0).nonzero().flatten().tolist() + (
+        out[:, 1] == 0
+    ).nonzero().flatten().tolist()
+    assert (
+        0 in surv0_tokens and 1 in surv0_tokens
+    )  # the two highest-weight expert-0 slots kept
+
+
+def test_expert_capacity_noop_when_under_cap():
+    topk_idx = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
+    topk_w = torch.tensor([[0.9, 0.1], [0.5, 0.5]])
+    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=8)
+    assert torch.equal(out, topk_idx)  # nothing dropped when every expert is under cap
+
+
+def test_expert_capacity_preserves_existing_sentinels():
+    topk_idx = torch.tensor([[0, -1], [0, 0]], dtype=torch.int64)
+    topk_w = torch.tensor([[0.9, 0.0], [0.8, 0.7]])
+    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=2)
+    assert out[0, 1] == -1  # pre-existing -1 untouched
+    assert int((out == 0).sum()) <= 2
+
+
+def _absorb():
+    import axolotl.integrations.kernels.libs.glm_dsa.attention_mla_absorb as M
+
+    return M
+
+
+def test_sm90_bwd_prune_collapses_to_single_config():
+    M = _absorb()
+    # mock the device SMEM so the base SMEM-prune keeps everything (CPU-only, deterministic)
+    with mock.patch(
+        "axolotl.integrations.kernels.libs.glm_dsa._autotune.max_smem",
+        return_value=1 << 30,
+    ):
+        with mock.patch.object(
+            torch.cuda, "get_device_capability", return_value=(9, 0)
+        ):
+            kept = M._bwd_prune_sm90_safe(M._ABSORB_CONFIGS, {}, DL=512, DR=64)
+        assert len(kept) == 1, (
+            "sm90 must collapse the bwd grid to one config (avoids invalid-PC)"
+        )
+
+        with mock.patch.object(
+            torch.cuda, "get_device_capability", return_value=(12, 0)
+        ):
+            kept_sm120 = M._bwd_prune_sm90_safe(M._ABSORB_CONFIGS, {}, DL=512, DR=64)
+        assert len(kept_sm120) > 1, (
+            "non-sm90 keeps the full SMEM-pruned grid for autotuning"
+        )

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -218,10 +218,16 @@ def test_cp_doc_ids_must_be_global_not_per_chunk():
 
     # NEW (number docs on the global ids, then slice per rank): the boundary doc shares ONE id
     r0, r1 = global_ids[:, 0:S], global_ids[:, S : 2 * S]
-    assert r0[0, -1].item() == r1[0, 0].item()  # doc B: rank0's last query == rank1's first query
+    assert (
+        r0[0, -1].item() == r1[0, 0].item()
+    )  # doc B: rank0's last query == rank1's first query
 
     # OLD (per-local-chunk cumsum): the same doc gets different ids across ranks, and ids collide
     old_r0 = _seq_idx_from_position_ids(global_pos[:, 0:S])
     old_r1 = _seq_idx_from_position_ids(global_pos[:, S : 2 * S])
-    assert old_r0[0, -1].item() != old_r1[0, 0].item()  # doc B inconsistent across ranks (the bug)
-    assert old_r1[0, 2].item() == old_r0[0, 0].item()  # doc C (rank1) collides with doc A (rank0)
+    assert (
+        old_r0[0, -1].item() != old_r1[0, 0].item()
+    )  # doc B inconsistent across ranks (the bug)
+    assert (
+        old_r1[0, 2].item() == old_r0[0, 0].item()
+    )  # doc C (rank1) collides with doc A (rank0)

--- a/tests/integrations/kernels/glm_dsa/test_mla_absorb_gather.py
+++ b/tests/integrations/kernels/glm_dsa/test_mla_absorb_gather.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Regression tests for the GLM-DSA absorbed-MLA sparse gather kernel.
+
+These guard two subtle, hard-won fixes:
+
+1. **Leading-all-masked-block softmax NaN.** The online-softmax running max ``m_i`` starts at
+   ``-inf``; a query whose *first* ``BN`` block of selected keys is entirely causally/doc-masked
+   keeps ``m_new == -inf``, so ``alpha = exp(m_i - m_new) = exp(-inf + inf) = NaN`` — *even though
+   the query has valid keys in later blocks*. This poisons the whole output. It surfaces at long
+   context (``topk`` >> a short query's causal positions) and is arch-independent. The kernel guards
+   it with ``m_safe = where(m_new == -inf, 0, m_new)`` (+ an ``l_i == 0`` division guard for
+   fully-masked rows). The reference is the dense path, which is always finite.
+
+2. **Var-len / document-aware masking under sample packing** (``seq_k[idx] == seq_q[s]``): the gather
+   must match the dense per-document mask so packing can use the sparse path.
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+from axolotl.integrations.kernels.libs.glm_dsa.attention_mla_absorb import (  # noqa: E402
+    mla_absorb_attn,
+)
+from axolotl.integrations.kernels.libs.glm_dsa.config import (  # noqa: E402
+    KV_LORA_RANK,
+    QK_ROPE_HEAD_DIM,
+)
+from axolotl.integrations.kernels.libs.glm_dsa.dispatch import (  # noqa: E402
+    dense_masked_out_latent,
+)
+
+DEV = "cuda"
+DQK = KV_LORA_RANK + QK_ROPE_HEAD_DIM  # 576 (512 + 64)
+
+
+def _causal_topk_future_first(B, S, Skv, TOPK, device, seed=0):
+    """Per query ``s`` select ``TOPK`` keys, ordering FUTURE (causally-invalid, ``> s``) positions
+    FIRST so the leading topk block(s) are entirely masked — the exact trigger for the running-max
+    NaN — while still including valid causal keys (and ``s`` itself) in later slots."""
+    idx = torch.empty(B, S, TOPK, dtype=torch.int32, device=device)
+    for s in range(S):
+        future = torch.arange(s + 1, Skv, device=device)
+        causal = torch.arange(0, s + 1, device=device)
+        pool = torch.cat([future, causal])  # future FIRST -> leading masked
+        if pool.numel() >= TOPK:
+            row = pool[:TOPK].clone()
+        else:
+            pad = causal[-1:].repeat(TOPK - pool.numel())
+            row = torch.cat([pool, pad])
+        row[-1] = s  # guarantee self (valid) present
+        idx[:, s, :] = row.to(torch.int32)
+    return idx
+
+
+@pytest.mark.parametrize("S,Skv,TOPK", [(64, 64, 48), (96, 96, 80)])
+def test_gather_leading_masked_block_is_finite_and_matches_dense(S, Skv, TOPK):
+    """The whole point: with leading masked blocks the gather must NOT NaN and must equal dense."""
+    torch.manual_seed(0)
+    B, H = 1, 16
+    q = torch.randn(B, H, S, DQK, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(B, Skv, DQK, device=DEV, dtype=torch.bfloat16)
+    idx = _causal_topk_future_first(B, S, Skv, TOPK, DEV)
+    scale = 1.0 / (DQK**0.5)
+
+    qg = q.clone().requires_grad_(True)
+    kg = k.clone().requires_grad_(True)
+    og = mla_absorb_attn(qg, kg, idx, scale, 0)
+    og.float().pow(2).mean().backward()
+
+    assert torch.isfinite(og).all(), (
+        "gather forward produced NaN/Inf on leading-masked-block input"
+    )
+    assert torch.isfinite(qg.grad).all(), "gather dq produced NaN/Inf"
+    assert torch.isfinite(kg.grad).all(), "gather dk produced NaN/Inf"
+
+    qd = q.clone().requires_grad_(True)
+    kd = k.clone().requires_grad_(True)
+    od = dense_masked_out_latent(qd, kd, idx, scale, 0)
+    od.float().pow(2).mean().backward()
+
+    # bf16 tensor-core tolerance
+    assert (og.float() - od.float()).abs().max().item() < 5e-2
+    assert (qg.grad.float() - qd.grad.float()).abs().max().item() < 5e-2
+
+
+def test_gather_fully_masked_query_is_finite():
+    """A query whose every selected key is in the future (zero valid causal keys) must yield a
+    finite (zero) row via the ``l_i == 0`` guard, not 0/0 = NaN."""
+    torch.manual_seed(1)
+    B, H, S, Skv, TOPK = 1, 8, 32, 32, 16
+    q = torch.randn(B, H, S, DQK, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(B, Skv, DQK, device=DEV, dtype=torch.bfloat16)
+    # causal-valid for everyone...
+    idx = torch.zeros(B, S, TOPK, dtype=torch.int32, device=DEV)
+    for s in range(S):
+        idx[:, s, :] = torch.randint(0, s + 1, (TOPK,), device=DEV, dtype=torch.int32)
+    # ...except query 5, whose every selected key is strictly future (invalid)
+    idx[:, 5, :] = torch.arange(6, 6 + TOPK, device=DEV, dtype=torch.int32).clamp_(
+        max=Skv - 1
+    )
+    out = mla_absorb_attn(q, k, idx, 1.0 / (DQK**0.5), 0)
+    assert torch.isfinite(out).all(), (
+        "fully-masked query produced NaN/Inf (0/0 not guarded)"
+    )
+
+
+def test_gather_docmask_matches_dense_under_packing():
+    """Doc-aware (var-len) gather must match the dense per-document mask: a query only attends keys
+    in its own document (``seq_k[idx] == seq_q[s]``).
+
+    NB: the dense reference de-duplicates selected keys (a boolean ``scatter_``) while the gather
+    sums each slot independently, so they only agree when ``idx`` has DISTINCT keys per query. We
+    build distinct causal keys and assert the exact match on queries with enough causal positions to
+    fill ``TOPK`` without padding; every query is still asserted finite.
+    """
+    torch.manual_seed(2)
+    B, H, S, Skv, TOPK = 1, 16, 64, 64, 16
+    q = torch.randn(B, H, S, DQK, device=DEV, dtype=torch.bfloat16)
+    k = torch.randn(B, Skv, DQK, device=DEV, dtype=torch.bfloat16)
+    seq = torch.zeros(B, S, dtype=torch.int32, device=DEV)
+    seq[:, S // 2 :] = 1  # two documents
+    seq_q, seq_k = seq, seq.clone()
+    # distinct causal topk (crosses the doc boundary so masking matters); short queries cycle their
+    # available causal keys (creates dups -> excluded from the exact comparison via ``no_dup``).
+    idx = torch.empty(B, S, TOPK, dtype=torch.int32, device=DEV)
+    no_dup = torch.zeros(S, dtype=torch.bool, device=DEV)
+    for s in range(S):
+        causal = torch.randperm(s + 1, device=DEV).to(torch.int32)
+        if causal.numel() >= TOPK:
+            idx[:, s, :] = causal[:TOPK]
+            no_dup[s] = True
+        else:
+            reps = (TOPK + causal.numel() - 1) // causal.numel()
+            idx[:, s, :] = causal.repeat(reps)[:TOPK]
+    scale = 1.0 / (DQK**0.5)
+
+    og = mla_absorb_attn(q.clone(), k.clone(), idx, scale, 0, seq_q, seq_k)
+    od = dense_masked_out_latent(q.clone(), k.clone(), idx, scale, 0, seq_q, seq_k)
+    assert torch.isfinite(og).all()
+    # exact agreement on the distinct-key (no-dup) queries only
+    masked = (og.float() - od.float())[:, :, no_dup, :].abs()
+    assert torch.isfinite(masked).all()
+    assert masked.max().item() < 5e-2
+    # doc mask must actually change the result vs causal-only (no seq)
+    on = mla_absorb_attn(q.clone(), k.clone(), idx, scale, 0)
+    assert (og.float() - on.float())[:, :, no_dup, :].abs().max().item() > 1e-2

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -785,3 +785,63 @@ class TestExpertShardAxis:
         # order in the tuple must not change the dp_shard preference
         assert expert_shard_axis(("ep", "cp", "dp_shard")) == "dp_shard"
         assert expert_shard_axis(("ep", "dp_shard", "cp")) == "dp_shard"
+
+
+class TestEpLoraSaveGating:
+    """save_ep_lora_adapter must EP-gather the routed-expert adapter ONLY when it was physically
+    sliced to E_local (EP×dp_shard/cp composition, where shard_expert_lora sets _ep_lora_sharded).
+    Pure EP keeps the adapter global, so gathering would duplicate every expert ep_size times. This
+    checks the discriminator the save relies on: shard_expert_lora flags + slices composition adapters,
+    and a non-sharded wrapper carries no flag (so the save leaves it as-is)."""
+
+    def _make_wrapper_model(self, e_global, ep_size, r, ep_rank=0):
+        e_local = e_global // ep_size
+
+        class _Experts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.num_experts_global = e_global
+                self.num_local_experts = e_local
+                self.local_expert_offset = ep_rank * e_local
+
+        class ParamWrapper(torch.nn.Module):  # name matches _is_param_wrapper's fallback check
+            def __init__(self):
+                super().__init__()
+                self.base_layer = _Experts()
+                self.lora_A = torch.nn.ModuleDict(
+                    {"default": torch.nn.Linear(5, e_global * r, bias=False)}
+                )
+                self.lora_B = torch.nn.ModuleDict(
+                    {"default": torch.nn.Linear(e_global * r, 7, bias=False)}
+                )
+
+        class _Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.wrapper = ParamWrapper()
+
+        return _Model()
+
+    def test_composition_slice_sets_flag(self):
+        from axolotl.integrations.expert_parallel.shard import shard_expert_lora
+
+        e_global, ep_size, r = 8, 2, 2
+        e_local = e_global // ep_size
+        m = self._make_wrapper_model(e_global, ep_size, r)
+        n = shard_expert_lora(m, ep_size)
+        assert n == 2  # lora_A + lora_B sliced
+        assert m.wrapper._ep_lora_sharded is True  # the gather discriminator the save reads
+        # sliced to E_local: gather (ep_size copies) is what reconstructs E_global
+        assert m.wrapper.lora_A["default"].weight.shape[0] == e_local * r
+        assert m.wrapper.lora_B["default"].weight.shape[1] == r * e_local
+
+    def test_pure_ep_wrapper_has_no_flag(self):
+        # Pure EP never runs shard_expert_lora -> no _ep_lora_sharded -> save_ep_lora_adapter must NOT
+        # EP-gather (the adapter is already global E_global).
+        m = self._make_wrapper_model(8, 2, 2)
+        assert getattr(m.wrapper, "_ep_lora_sharded", False) is False
+        # ep_size == 1 is a no-op and never flags either
+        from axolotl.integrations.expert_parallel.shard import shard_expert_lora
+
+        assert shard_expert_lora(m, 1) == 0
+        assert getattr(m.wrapper, "_ep_lora_sharded", False) is False

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -352,6 +352,44 @@ def _ep_topology_worker_expects_error(
         q.put((rank, err))
     finally:
         dist.destroy_process_group()
+
+
+def _ep_cp_topology_worker(rank, world_size, ep_size, cp_size, dp_shard_size, port, q):
+    """EP × CP (× dp_shard) topology probe: returns this rank's ep / cp / dp_shard group members."""
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    dist.init_process_group(
+        backend="gloo", rank=rank, world_size=world_size, timeout=timedelta(seconds=120)
+    )
+    try:
+        from types import SimpleNamespace
+
+        cfg = SimpleNamespace(
+            expert_parallel_size=ep_size,
+            dp_shard_size=dp_shard_size,
+            tensor_parallel_size=1,
+            context_parallel_size=cp_size,
+        )
+        ep_group = ExpertParallelPlugin._resolve_ep_group(cfg)
+        ep_ranks = sorted(dist.get_process_group_ranks(ep_group))
+        cp_group = ExpertParallelPlugin._resolve_cp_group(cfg)
+        cp_ranks = (
+            sorted(dist.get_process_group_ranks(cp_group))
+            if cp_group is not None
+            else None
+        )
+        mesh = ExpertParallelPlugin._device_mesh
+        dp_ranks = (
+            sorted(dist.get_process_group_ranks(mesh["dp_shard"].get_group()))
+            if mesh is not None and "dp_shard" in (mesh.mesh_dim_names or ())
+            else None
+        )
+        q.put((rank, ep_ranks, cp_ranks, dp_ranks))
+    finally:
+        dist.destroy_process_group()
+        ExpertParallelPlugin._device_mesh = None
         ExpertParallelPlugin._device_mesh = None
 
 
@@ -406,8 +444,47 @@ def _spawn_topology_check(world_size, ep_size, dp_shard_size):
     return sorted(results, key=lambda r: r[0])
 
 
+def _spawn_ep_cp_check(world_size, ep_size, cp_size, dp_shard_size=1):
+    ctx = mp.get_context("spawn")
+    q = ctx.Queue()
+    port = _find_free_port()
+    procs = [
+        ctx.Process(
+            target=_ep_cp_topology_worker,
+            args=(r, world_size, ep_size, cp_size, dp_shard_size, port, q),
+        )
+        for r in range(world_size)
+    ]
+    for p in procs:
+        p.start()
+    results = [q.get(timeout=120) for _ in range(world_size)]
+    for p in procs:
+        p.join(timeout=20)
+        assert p.exitcode == 0, f"worker exited with {p.exitcode}"
+    return sorted(results, key=lambda r: r[0])
+
+
 class TestMeshTopology:
     """The 4-rank EP+FSDP composition rank assignments."""
+
+    def test_world4_ep2_cp2_orthogonal(self):
+        """world=4, ep=2 × cp=2: experts shard on `ep`, sequence on `cp`. The two axes must be
+        orthogonal — every rank is in exactly one ep group and one cp group that intersect only at
+        that rank, and the groups tile the 4 ranks. (DeepEP not required — pure group topology.)"""
+        results = _spawn_ep_cp_check(world_size=4, ep_size=2, cp_size=2)
+        ep = {r: tuple(e) for r, e, c, d in results}
+        cp = {r: tuple(c) for r, e, c, d in results}
+        for r in range(4):
+            assert len(ep[r]) == 2 and len(cp[r]) == 2, (ep, cp)
+            assert set(ep[r]) & set(cp[r]) == {r}, (
+                r,
+                ep,
+                cp,
+            )  # orthogonal: meet only at self
+        assert len(set(ep.values())) == 2 and len(set(cp.values())) == 2, (ep, cp)
+        # union of all ep groups (and cp groups) tiles the world
+        assert set().union(*ep.values()) == {0, 1, 2, 3}
+        assert set().union(*cp.values()) == {0, 1, 2, 3}
 
     def test_world4_ep2_dp2_orthogonal(self):
         """At world=4 with ep=2 and dp_shard=2, EP groups must be strided

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -21,6 +21,7 @@ from axolotl.integrations.expert_parallel.experts_fn import (
     kernel_to_registered_name,
     register_all,
 )
+from axolotl.integrations.expert_parallel.plugin import expert_shard_axis
 from axolotl.integrations.expert_parallel.shard import (
     _detect_experts_modules,
     _slice_expert_lora_param,
@@ -757,3 +758,30 @@ class TestExpertAdapterLoadSharding:
         # correct loads ep-group 1's experts {4,5,6,7}; the naive chunk would not
         got = set(correct.reshape(out, r, e_local)[0, 0, :].long().tolist())
         assert got == {4, 5, 6, 7}
+
+
+class TestExpertShardAxis:
+    """`expert_shard_axis` picks the non-ep mesh axis the routed experts FSDP-shard on under EP
+    composition: dp_shard when present, else cp, else None (pure EP / no ep axis). Pure logic on the
+    mesh dim names — no dist / mesh object needed."""
+
+    @pytest.mark.parametrize(
+        "dim_names,expected",
+        [
+            (("ep", "dp_shard"), "dp_shard"),  # EP × dp_shard
+            (("ep", "cp"), "cp"),  # EP × cp
+            (("ep", "dp_shard", "cp"), "dp_shard"),  # both -> dp_shard preferred
+            (("ep",), None),  # pure EP at world_size: no secondary axis to pre-wrap on
+            (("dp_shard", "cp"), None),  # no ep axis -> not an EP composition
+            (("ep", "tp"), None),  # tp is not an expert-shard axis (EP×TP unsupported)
+            ((), None),
+            (None, None),
+        ],
+    )
+    def test_axis_selection(self, dim_names, expected):
+        assert expert_shard_axis(dim_names) == expected
+
+    def test_dp_shard_preferred_over_cp_regardless_of_order(self):
+        # order in the tuple must not change the dp_shard preference
+        assert expert_shard_axis(("ep", "cp", "dp_shard")) == "dp_shard"
+        assert expert_shard_axis(("ep", "dp_shard", "cp")) == "dp_shard"

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -23,6 +23,7 @@ from axolotl.integrations.expert_parallel.experts_fn import (
 )
 from axolotl.integrations.expert_parallel.shard import (
     _detect_experts_modules,
+    _slice_expert_lora_param,
     shard_expert_weights,
 )
 
@@ -544,3 +545,127 @@ class TestMeshTopology:
         for rank, err in results:
             assert err is not None, f"rank {rank} did not raise"
             assert "must equal" in err.lower() or "world_size" in err.lower(), err
+
+
+class TestExpertLoraSlicing:
+    """Routed-expert LoRA must be sliced so each EP rank gets ITS OWN experts' adapter blocks, and the
+    sliced shape must imply the TRUE LoRA rank ``r`` (= sliced_packed_dim // E_local), not ``r*ep_size``.
+
+    The pure-EP bug left the adapter global-sized while the base was E_local, so
+    ``_unwrap_experts_lora`` read ``rank = lora_A.shape[0] // E_local = r*ep_size`` and reshaped the
+    adapter into a scrambled expert/rank layout (harmless only at step 0, where lora_B == 0). These are
+    pure tensor-op checks of the slice math — no dist / FSDP / DeepEP / NVFP4 / model needed.
+    """
+
+    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
+    def test_lora_A_slice_picks_local_experts(self, e_global, ep_size, r):
+        # lora_A peft layout [E*r, in], expert-major: expert e owns rows [e*r:(e+1)*r]; tag rows = e.
+        e_local, in_features = e_global // ep_size, 5
+        full = torch.zeros(e_global * r, in_features)
+        for e in range(e_global):
+            full[e * r : (e + 1) * r] = float(e)
+        for ep_rank in range(ep_size):
+            start, end = ep_rank * e_local, (ep_rank + 1) * e_local
+            lin = torch.nn.Linear(in_features, e_global * r, bias=False)
+            lin.weight = torch.nn.Parameter(full.clone())
+            assert _slice_expert_lora_param(lin, 0, e_global, start, end) == r
+            sl = lin.weight.data
+            # the implied rank from the SLICED shape is the true r (the bug would give r*ep_size)
+            assert sl.shape[0] // e_local == r
+            tags = sl.reshape(e_local, r, in_features)[:, 0, 0].long()
+            assert torch.equal(tags, torch.arange(start, end))
+
+    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
+    def test_lora_B_slice_picks_local_experts(self, e_global, ep_size, r):
+        # lora_B peft layout [out, r*E], rank-major [out, r, E]; tag column (k, e) = e.
+        e_local, out_features = e_global // ep_size, 5
+        full = torch.zeros(out_features, r, e_global)
+        for e in range(e_global):
+            full[:, :, e] = float(e)
+        full = full.reshape(out_features, r * e_global)
+        for ep_rank in range(ep_size):
+            start, end = ep_rank * e_local, (ep_rank + 1) * e_local
+            lin = torch.nn.Linear(e_global * r, out_features, bias=False)
+            lin.weight = torch.nn.Parameter(full.clone())
+            assert _slice_expert_lora_param(lin, 1, e_global, start, end) == r
+            sl = lin.weight.data
+            assert sl.shape[1] // e_local == r
+            tags = sl.reshape(out_features, r, e_local)[0, 0, :].long()
+            assert torch.equal(tags, torch.arange(start, end))
+
+    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
+    def test_forward_slice_picks_local_experts_and_true_rank(self, e_global, ep_size, r):
+        """The FORWARD-time slice (used by the ParamWrapper fastpath and the _unwrap fallback) keeps
+        the adapter global and takes each rank's expert block at use time, reporting rank=r — NOT the
+        r*ep_size that the un-sliced global adapter would imply (the actual pure-EP bug path)."""
+        from types import SimpleNamespace
+
+        from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (
+            _ep_local_expert_lora,
+        )
+
+        e_local, in_f, out_f = e_global // ep_size, 5, 7
+        A = torch.zeros(e_global * r, in_f)
+        for e in range(e_global):
+            A[e * r : (e + 1) * r] = float(e)
+        B = torch.zeros(out_f, r, e_global)
+        for e in range(e_global):
+            B[:, :, e] = float(e)
+        B = B.reshape(out_f, r * e_global)
+        for ep_rank in range(ep_size):
+            offset = ep_rank * e_local
+            experts = SimpleNamespace(
+                num_experts=e_local,
+                num_experts_global=e_global,
+                local_expert_offset=offset,
+            )
+            a, b, n_local, rank = _ep_local_expert_lora(A, B, experts)
+            assert n_local == e_local and rank == r
+            assert torch.equal(
+                a.reshape(e_local, r, in_f)[:, 0, 0].long(),
+                torch.arange(offset, offset + e_local),
+            )
+            assert torch.equal(
+                b.reshape(out_f, r, e_local)[0, 0, :].long(),
+                torch.arange(offset, offset + e_local),
+            )
+
+    def test_forward_slice_noop_when_not_ep_sharded(self):
+        from types import SimpleNamespace
+
+        from axolotl.integrations.kernels.libs.scattermoe_lora.experts import (
+            _ep_local_expert_lora,
+        )
+
+        a_in, b_in = torch.randn(8 * 2, 5), torch.randn(7, 2 * 8)
+        experts = SimpleNamespace(
+            num_experts=8, num_experts_global=8, local_expert_offset=0
+        )
+        a, b, n_local, rank = _ep_local_expert_lora(a_in, b_in, experts)
+        assert n_local == 8 and rank == 2
+        assert a is a_in and b is b_in  # no slice / copy when E_local == E_global
+
+    def test_ranks_reconstruct_global_adapter(self):
+        # All EP ranks' slices, concatenated on the expert axis, must rebuild the global adapter
+        # (no expert dropped or duplicated).
+        e_global, ep_size, r, in_features, out_features = 8, 2, 2, 5, 7
+        e_local = e_global // ep_size
+        A = torch.randn(e_global * r, in_features)
+        B = torch.randn(out_features, r * e_global)
+        a_pieces, b_pieces = [], []
+        for ep_rank in range(ep_size):
+            start, end = ep_rank * e_local, (ep_rank + 1) * e_local
+            la = torch.nn.Linear(in_features, e_global * r, bias=False)
+            la.weight = torch.nn.Parameter(A.clone())
+            _slice_expert_lora_param(la, 0, e_global, start, end)
+            a_pieces.append(la.weight.data)
+            lb = torch.nn.Linear(e_global * r, out_features, bias=False)
+            lb.weight = torch.nn.Parameter(B.clone())
+            _slice_expert_lora_param(lb, 1, e_global, start, end)
+            # rank-major [out, r, E_local] per rank -> stack on the expert axis
+            b_pieces.append(lb.weight.data.reshape(out_features, r, e_local))
+        assert torch.equal(torch.cat(a_pieces, dim=0), A)
+        assert torch.equal(
+            torch.cat(b_pieces, dim=2).reshape(out_features, r * e_global),
+            B.reshape(out_features, r, e_global).reshape(out_features, r * e_global),
+        )

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -559,7 +559,9 @@ class TestExpertLoraSlicing:
     pure tensor-op checks of the slice math — no dist / FSDP / DeepEP / NVFP4 / model needed.
     """
 
-    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
+    @pytest.mark.parametrize(
+        "e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)]
+    )
     def test_lora_A_slice_picks_local_experts(self, e_global, ep_size, r):
         # lora_A peft layout [E*r, in], expert-major: expert e owns rows [e*r:(e+1)*r]; tag rows = e.
         e_local, in_features = e_global // ep_size, 5
@@ -577,7 +579,9 @@ class TestExpertLoraSlicing:
             tags = sl.reshape(e_local, r, in_features)[:, 0, 0].long()
             assert torch.equal(tags, torch.arange(start, end))
 
-    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
+    @pytest.mark.parametrize(
+        "e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)]
+    )
     def test_lora_B_slice_picks_local_experts(self, e_global, ep_size, r):
         # lora_B peft layout [out, r*E], rank-major [out, r, E]; tag column (k, e) = e.
         e_local, out_features = e_global // ep_size, 5
@@ -595,8 +599,12 @@ class TestExpertLoraSlicing:
             tags = sl.reshape(out_features, r, e_local)[0, 0, :].long()
             assert torch.equal(tags, torch.arange(start, end))
 
-    @pytest.mark.parametrize("e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)])
-    def test_forward_slice_picks_local_experts_and_true_rank(self, e_global, ep_size, r):
+    @pytest.mark.parametrize(
+        "e_global,ep_size,r", [(8, 2, 2), (256, 8, 16), (16, 4, 3)]
+    )
+    def test_forward_slice_picks_local_experts_and_true_rank(
+        self, e_global, ep_size, r
+    ):
         """The FORWARD-time slice (used by the ParamWrapper fastpath and the _unwrap fallback) keeps
         the adapter global and takes each rank's expert block at use time, reporting rank=r — NOT the
         r*ep_size that the un-sliced global adapter would imply (the actual pure-EP bug path)."""
@@ -686,7 +694,9 @@ class TestExpertAdapterLoadSharding:
     @pytest.mark.parametrize(
         "e_global,ep_size,dp_size,r", [(8, 2, 2, 2), (256, 4, 2, 16), (16, 2, 1, 3)]
     )
-    def test_lora_A_load_shards_match_forward_slice(self, e_global, ep_size, dp_size, r):
+    def test_lora_A_load_shards_match_forward_slice(
+        self, e_global, ep_size, dp_size, r
+    ):
         from torch.distributed.tensor import Shard
 
         in_features, e_local = 5, e_global // ep_size
@@ -715,7 +725,9 @@ class TestExpertAdapterLoadSharding:
     @pytest.mark.parametrize(
         "e_global,ep_size,dp_size,r", [(8, 2, 2, 2), (256, 4, 2, 16), (16, 2, 1, 3)]
     )
-    def test_lora_B_load_shards_match_forward_slice(self, e_global, ep_size, dp_size, r):
+    def test_lora_B_load_shards_match_forward_slice(
+        self, e_global, ep_size, dp_size, r
+    ):
         from torch.distributed.tensor import Shard
 
         out_features, e_local = 6, e_global // ep_size
@@ -724,7 +736,9 @@ class TestExpertAdapterLoadSharding:
         for e in range(e_global):
             g[:, :, e] = float(e)
         g = g.reshape(out_features, r * e_global)
-        placements = (Shard(0),)  # FSDP shards dim 0 (out); the ep slice is on the expert axis
+        placements = (
+            Shard(0),
+        )  # FSDP shards dim 0 (out); the ep slice is on the expert axis
         for ep_coord in range(ep_size):
             shards = [
                 ep_adapter_load_local_shard(
@@ -751,7 +765,9 @@ class TestExpertAdapterLoadSharding:
         for e in range(e_global):
             g[:, :, e] = float(e)
         g = g.reshape(out, r * e_global)
-        correct = ep_adapter_load_local_shard(g, 1, e_global, 1, ep_size, (Shard(0),), 1, 0)
+        correct = ep_adapter_load_local_shard(
+            g, 1, e_global, 1, ep_size, (Shard(0),), 1, 0
+        )
         naive = g.chunk(ep_size, dim=1)[1]
         assert not torch.equal(correct, naive)
         e_local = e_global // ep_size
@@ -804,7 +820,9 @@ class TestEpLoraSaveGating:
                 self.num_local_experts = e_local
                 self.local_expert_offset = ep_rank * e_local
 
-        class ParamWrapper(torch.nn.Module):  # name matches _is_param_wrapper's fallback check
+        class ParamWrapper(
+            torch.nn.Module
+        ):  # name matches _is_param_wrapper's fallback check
             def __init__(self):
                 super().__init__()
                 self.base_layer = _Experts()
@@ -830,7 +848,9 @@ class TestEpLoraSaveGating:
         m = self._make_wrapper_model(e_global, ep_size, r)
         n = shard_expert_lora(m, ep_size)
         assert n == 2  # lora_A + lora_B sliced
-        assert m.wrapper._ep_lora_sharded is True  # the gather discriminator the save reads
+        assert (
+            m.wrapper._ep_lora_sharded is True
+        )  # the gather discriminator the save reads
         # sliced to E_local: gather (ep_size copies) is what reconstructs E_global
         assert m.wrapper.lora_A["default"].weight.shape[0] == e_local * r
         assert m.wrapper.lora_B["default"].weight.shape[1] == r * e_local

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -24,6 +24,7 @@ from axolotl.integrations.expert_parallel.experts_fn import (
 from axolotl.integrations.expert_parallel.shard import (
     _detect_experts_modules,
     _slice_expert_lora_param,
+    ep_adapter_load_local_shard,
     shard_expert_weights,
 )
 
@@ -669,3 +670,90 @@ class TestExpertLoraSlicing:
             torch.cat(b_pieces, dim=2).reshape(out_features, r * e_global),
             B.reshape(out_features, r, e_global).reshape(out_features, r * e_global),
         )
+
+
+class TestExpertAdapterLoadSharding:
+    """The cpu_ram_efficient load reconstructs each rank's local FSDP shard of the routed-expert LoRA
+    adapter from rank-0's broadcast GLOBAL (all-experts) adapter — the inverse of shard_expert_lora +
+    the dp/cp FSDP sharding (``ep_adapter_load_local_shard``). The ep slice must be EXPERT-aware:
+    lora_B's experts are the last axis of its ``[out, r, E]`` view (NOT contiguous in the flat ``r*E``
+    dim), so a plain chunk on dim 1 would load a rank-component instead of this ep-group's experts.
+    The 1-step e2e loss can't catch this (lora_B is zero-initialized — wrong zeros are still zeros); it
+    only bites a non-zero / resumed adapter. Pure tensor-op checks — no dist / FSDP / model needed.
+    """
+
+    @pytest.mark.parametrize(
+        "e_global,ep_size,dp_size,r", [(8, 2, 2, 2), (256, 4, 2, 16), (16, 2, 1, 3)]
+    )
+    def test_lora_A_load_shards_match_forward_slice(self, e_global, ep_size, dp_size, r):
+        from torch.distributed.tensor import Shard
+
+        in_features, e_local = 5, e_global // ep_size
+        # global lora_A [E_global*r, in], expert-major; expert e's row block tagged = e
+        g = torch.zeros(e_global * r, in_features)
+        for e in range(e_global):
+            g[e * r : (e + 1) * r] = float(e)
+        placements = (Shard(0),)  # FSDP shards dim 0
+        for ep_coord in range(ep_size):
+            shards = [
+                ep_adapter_load_local_shard(
+                    g, 0, e_global, ep_coord, ep_size, placements, dp_size, dp
+                )
+                for dp in range(dp_size)
+            ]
+            ep_full = torch.cat(shards, dim=0)  # gather this ep-group's dp shards
+            # == the forward E_local slice shard_expert_lora produces for this ep-group
+            start, end = ep_coord * e_local, (ep_coord + 1) * e_local
+            la = torch.nn.Linear(in_features, e_global * r, bias=False)
+            la.weight = torch.nn.Parameter(g.clone())
+            _slice_expert_lora_param(la, 0, e_global, start, end)
+            assert torch.equal(ep_full, la.weight.data)
+            tags = ep_full.reshape(e_local, r, in_features)[:, 0, 0].long()
+            assert torch.equal(tags, torch.arange(start, end))
+
+    @pytest.mark.parametrize(
+        "e_global,ep_size,dp_size,r", [(8, 2, 2, 2), (256, 4, 2, 16), (16, 2, 1, 3)]
+    )
+    def test_lora_B_load_shards_match_forward_slice(self, e_global, ep_size, dp_size, r):
+        from torch.distributed.tensor import Shard
+
+        out_features, e_local = 6, e_global // ep_size
+        # global lora_B [out, r*E] viewed [out, r, E]; column (k, e) tagged = e
+        g = torch.zeros(out_features, r, e_global)
+        for e in range(e_global):
+            g[:, :, e] = float(e)
+        g = g.reshape(out_features, r * e_global)
+        placements = (Shard(0),)  # FSDP shards dim 0 (out); the ep slice is on the expert axis
+        for ep_coord in range(ep_size):
+            shards = [
+                ep_adapter_load_local_shard(
+                    g, 1, e_global, ep_coord, ep_size, placements, dp_size, dp
+                )
+                for dp in range(dp_size)
+            ]
+            ep_full = torch.cat(shards, dim=0)  # gather the dp (out) shards back
+            start, end = ep_coord * e_local, (ep_coord + 1) * e_local
+            lb = torch.nn.Linear(e_global * r, out_features, bias=False)
+            lb.weight = torch.nn.Parameter(g.clone())
+            _slice_expert_lora_param(lb, 1, e_global, start, end)
+            assert torch.equal(ep_full, lb.weight.data)
+            tags = ep_full.reshape(out_features, r, e_local)[0, 0, :].long()
+            assert torch.equal(tags, torch.arange(start, end))
+
+    def test_lora_B_plain_chunk_would_load_wrong_experts(self):
+        # Documents the bug the expert-aware slice fixes: a naive chunk(ep_size, dim=1) loads a
+        # rank-component (all experts of one r-slice), not this ep-group's experts.
+        from torch.distributed.tensor import Shard
+
+        e_global, ep_size, r, out = 8, 2, 2, 6
+        g = torch.zeros(out, r, e_global)
+        for e in range(e_global):
+            g[:, :, e] = float(e)
+        g = g.reshape(out, r * e_global)
+        correct = ep_adapter_load_local_shard(g, 1, e_global, 1, ep_size, (Shard(0),), 1, 0)
+        naive = g.chunk(ep_size, dim=1)[1]
+        assert not torch.equal(correct, naive)
+        e_local = e_global // ep_size
+        # correct loads ep-group 1's experts {4,5,6,7}; the naive chunk would not
+        got = set(correct.reshape(out, r, e_local)[0, 0, :].long().tolist())
+        assert got == {4, 5, 6, 7}

--- a/tests/integrations/test_scattermoe_autotune_telemetry.py
+++ b/tests/integrations/test_scattermoe_autotune_telemetry.py
@@ -53,26 +53,28 @@ def _make_mock_lora_ops(
 
 @contextmanager
 def _inject_lora_ops(mock_module, name="scattermoe_lora_abc123.kernels.lora_ops"):
-    """Register ``mock_module`` under a ``lora_ops``-hint name in ``sys.modules`` and hide any
-    real lora_ops modules, so the sys.modules-scanning collector sees only the mock."""
-    hide = {n: None for n in _real_lora_ops_module_names()}
+    """Register ``mock_module`` under a ``lora_ops``-hint name in ``sys.modules`` and hide EVERY
+    real kernel module the collector scans, so the sys.modules-scanning collector sees only the
+    mock. Hiding just real ``lora_ops`` modules isn't enough: the collector also scans the
+    dsv4/glm_dsa/scattermoe kernel modules (``_KERNEL_MODULE_HINTS``), and when an earlier test in
+    the same process has autotuned one of those, its real cache otherwise leaks into the result."""
+    hide = {n: None for n in _real_scanned_kernel_module_names() if n != name}
     with patch.dict(sys.modules, {name: mock_module, **hide}):
         yield
 
 
-def _real_lora_ops_module_names():
-    """Return sys.modules keys that match the lora_ops discovery pattern.
+def _real_scanned_kernel_module_names():
+    """``sys.modules`` keys the collector would scan (any name matching its kernel-module hints).
 
-    Other tests in the same xdist worker may have loaded the *real*
-    lora_ops module.  We need to temporarily hide those entries so the
-    discovery test finds only the mock we inject.
+    Other tests in the same process may have imported/autotuned the *real* kernels (lora_ops,
+    dsv4, glm_dsa, ...). Hide every such entry so the discovery tests see only the injected mock.
     """
+    from axolotl.integrations.kernels.autotune_collector import _KERNEL_MODULE_HINTS
+
     return [
         name
         for name, mod in list(sys.modules.items())
-        if mod is not None
-        and "lora_ops" in name
-        and hasattr(mod, "_scatter2scatter_lora")
+        if mod is not None and any(h in name for h in _KERNEL_MODULE_HINTS)
     ]
 
 
@@ -173,7 +175,7 @@ class TestAutotuneCollector:
             collect_autotune_configs,
         )
 
-        hide = {n: None for n in _real_lora_ops_module_names()}
+        hide = {n: None for n in _real_scanned_kernel_module_names()}
         with patch.dict(sys.modules, hide):
             result = collect_autotune_configs()
         assert result == []
@@ -188,7 +190,7 @@ class TestAutotuneCollector:
 
         # Temporarily hide any real lora_ops modules that other tests in
         # the same xdist worker may have loaded, so only our mock is found.
-        real_names = _real_lora_ops_module_names()
+        real_names = _real_scanned_kernel_module_names()
         hide_patch = {name: None for name in real_names}
 
         with patch.dict(sys.modules, {alt_name: mock_lora_ops, **hide_patch}):

--- a/tests/test_glm_dsa_cp_validation.py
+++ b/tests/test_glm_dsa_cp_validation.py
@@ -1,0 +1,74 @@
+"""Validation tests for the GLM DSA kernels' context-parallel exemptions.
+
+``context_parallel_size > 1`` normally requires flash attention + ``ring_flash_attn``. The GLM DSA
+kernels own context-parallel attention (compressed-KV all-gather + per-rank ``q_offset``), so when
+``use_glm_dsa_kernels`` is set the validator skips that requirement and leaves ``ring_attn_func`` None
+(the SP context manager still shards the sequence by chunking). These are config-validation checks only
+-- no GPU / dist / model needed. ``ring_flash_attn`` is intentionally NOT mocked here: the DSA path must
+validate without it installed.
+"""
+
+import pytest
+
+from axolotl.utils.config import prepare_plugins, validate_config
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_manager():
+    # prepare_plugins registers into the PluginManager singleton; reset around each test so the kernels
+    # plugin neither leaks out to other tests nor inherits another test's registered plugins.
+    from axolotl.integrations.base import PluginManager
+
+    PluginManager._instance = None
+    yield
+    PluginManager._instance = None
+
+
+def _cfg(**extra):
+    return DictDefault(
+        base_model="HuggingFaceTB/SmolLM2-135M",
+        learning_rate=1e-3,
+        datasets=[{"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"}],
+        micro_batch_size=1,
+        gradient_accumulation_steps=1,
+        sequence_len=2048,
+        **extra,
+    )
+
+
+class TestGlmDsaContextParallelValidation:
+    """The use_glm_dsa_kernels exemptions in check_context_parallel_size / validate_ring_attn_func."""
+
+    def test_dsa_cp_skips_flash_and_ring_requirement(self, monkeypatch):
+        """use_glm_dsa_kernels + context_parallel_size>1 validates WITHOUT flash attention and WITHOUT
+        ring_flash_attn installed -- the DSA kernels own CP attention."""
+        monkeypatch.setenv("WORLD_SIZE", "4")
+        cfg = _cfg(
+            plugins=["axolotl.integrations.kernels.KernelsPlugin"],
+            use_glm_dsa_kernels=True,
+            context_parallel_size=2,
+        )
+        prepare_plugins(cfg)
+        out = validate_config(cfg)  # must not raise (no flash, no ring_flash_attn)
+        # ring attention is NOT substituted: ring_attn_func stays None so the SP context manager only
+        # shards the sequence (register_ring_attn skips the ring_flash_attn import when it is None).
+        assert out.ring_attn_func is None
+
+    def test_cp_without_dsa_still_requires_flash(self, monkeypatch):
+        """The exemption is scoped to use_glm_dsa_kernels -- plain CP still demands flash attention."""
+        monkeypatch.setenv("WORLD_SIZE", "4")
+        cfg = _cfg(context_parallel_size=2)  # no DSA kernels, no flash_attention
+        with pytest.raises(Exception, match="(?i)flash attention"):
+            validate_config(cfg)
+
+    def test_dsa_without_cp_leaves_ring_attn_func_none(self, monkeypatch):
+        """use_glm_dsa_kernels with context_parallel_size 1 is a no-op for the CP validators."""
+        monkeypatch.setenv("WORLD_SIZE", "1")
+        cfg = _cfg(
+            plugins=["axolotl.integrations.kernels.KernelsPlugin"],
+            use_glm_dsa_kernels=True,
+        )
+        prepare_plugins(cfg)
+        out = validate_config(cfg)
+        assert out.ring_attn_func is None


### PR DESCRIPTION
## Summary

Adds support for fine-tuning **GLM-5.2** (`glm_moe_dsa` — the DeepSeek-V3.2 sparse-MLA / DSA lineage: 78 layers, 256 routed experts top-8 + 1 shared, MLA attention with a Lightning-Indexer top-k token selector) from its **NVFP4 (modelopt)** checkpoint on multi-GPU FSDP2, including DeepEP **expert parallelism** and its **2D composition** with data and context parallelism.

Requires the `deep_ep` package for the EP path. Config: `examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml`.

## What this adds

- **DSA attention kernels** (`use_glm_dsa_kernels`) — MLA weight-absorption attention (fwd + bwd + varlen) + head-batched sparse top-k gather + fused Lightning-Indexer, replacing the dense `[B,S,T]`-mask SDPA path. A length-aware dispatcher falls back to dense below the sparse crossover; routers kept fp32.
- **NVFP4 modelopt loading** — dtype-aware weight converter + rank0-only/meta load + broadcast so the ~250 GB 4-bit experts load on 8×H200 / 2×B200 without an OOM spike.
- **Expert parallelism (DeepEP)** — intranode dispatch/combine all-to-all, a fixed-threshold expert-capacity cap that guards the NVLink combine, and routed-expert LoRA via scattermoe (3D `target_parameters` LoRA + fused 4-bit grouped NVFP4 GEMM).
- **EP 2D composition** — `EP × dp_shard` and `EP × cp` (see below).
- **LoRA save** under FSDP2 + quantized base (intermediate checkpoints + final adapter), bypassing the DCP planner which can't validate NVFP4 tensor-subclass DTensors.

## Expert-parallel 2D composition

Previously only pure EP (`expert_parallel_size == world_size`) trained. This composes EP with the other axes (`ep * dp_shard * cp == world_size`):

- **EP × dp_shard** — experts shard on `ep` and FSDP-shard across each ep-group's `dp_shard` ranks; non-experts shard on the full `dp_shard_cp` mesh.
- **EP × cp** — the sequence shards on `cp` (the DSA attention all-gathers only the 576-wide compressed KV on that axis), and the experts FSDP-shard across each ep-group's `cp` ranks so they don't sit replicated per rank. The DSA kernels own the context-parallel attention, so this needs no `ring_flash_attn`.

Load/runtime fixes this required:

- **Routed-expert LoRA load**: under `cpu_ram_efficient_loading` the adapter is a DTensor on a `dp_shard`/`cp` subgroup but `full_sd` holds the *global* (all-experts) adapter. Broadcast rank-0's global adapter (a consistent shape on every rank), then slice each rank's ep-experts + dp/cp shard — the generic broadcast mismatched the `E_local` size and replicated rank-0's experts onto ranks owning a different ep-slice. The `lora_B` slice is **expert-aware** (its experts are the last axis of the `[out, r, E]` view, not contiguous in the packed `r*E` dim).
- **Expert sharding axis**: shard experts on `cp` when there is no `dp_shard`, else `EP × cp` OOMs holding the full ep-group expert slice per rank on the first forward's all-gather.
- **Grad clipping**: use the EP-aware, mesh-agnostic `clip_grad_norm_` whenever `ep` composes with `dp_shard` or `cp` (experts and non-experts live on different meshes, which the stock clip can't stack).

## Verification (8×H200, seq 2048, 1 step)

Loss/grad parity across the EP modes (within step-0 noise; CP logged-loss differs slightly per the SP-Trainer note):

| Mode | Loss |
|---|---|
| pure-EP (`ep=8`) | 1.396 |
| `EP × dp_shard` (`ep=4, dp_shard=2`) | 1.396 |
| `EP × cp` (`ep=4, cp=2`) | 1.483 |

Longer-context, grad_norm, and per-GPU memory results are in the individual commit messages.

## Tests

- `tests/integrations/kernels/glm_dsa/` — DSA absorb/gather attention matches HF eager `GlmMoeDsaAttention` and the dense reference; fully-masked-block softmax guard; expert-capacity cap; sm90 bwd-config prune.
- `tests/integrations/test_expert_parallel.py` — mesh topology (`ep×cp`, `ep×dp`), forward **and** load-time LoRA slicing (`lora_A`/`lora_B` shards vs the forward slice, with the `lora_B`-expert-aware regression check), and `expert_shard_axis` selection.
- `tests/test_glm_dsa_cp_validation.py` — the `use_glm_dsa_kernels` context-parallel validation exemptions (CP without flash/`ring_flash_attn`).

Draft for review of the description/scope before requesting reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.2 DSA kernel support, including fused sparse attention paths, context-parallel handling, and a new training config for NVFP4 LoRA runs.
  * Added improved expert-parallel LoRA saving/loading so adapters can be restored correctly across sharded training setups.
  * Expanded support for expert-parallel routing controls, including token-cap limits and padding-token masking.

* **Bug Fixes**
  * Improved checkpoint saving for quantized LoRA models under sharded training.
  * Fixed activation offloading and expert-parallel synchronization issues.
  * Refined validation so GLM DSA works with context parallelism without requiring ring attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->