### PR TITLE
fix: auto-detect EOT token from chat template when eos_token is absent (Gemma)

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -355,8 +355,28 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 and "eos_token" not in self.prompter.chat_template
             ):
                 LOG.warning(
-                    f"EOS token '{self.tokenizer.eos_token}' not found in chat_template. Please check if your template/EOS token is correct."
+                    f"EOS token '{self.tokenizer.eos_token}' not found in "
+                    "chat_template; the turn terminator won't be trained with the "
+                    "default eot_tokens. Attempting to auto-detect the actual EOT "
+                    "token from the rendered template. Set `eot_tokens` explicitly "
+                    "to suppress this detection and control the behaviour."
                 )
+                detected = self._detect_eot_from_template()
+                if detected:
+                    LOG.info(
+                        f"Auto-detected EOT tokens from template rendering: {detected}. "
+                        "These will be used instead of eos_token. Set `eot_tokens` "
+                        "explicitly if you want different behaviour."
+                    )
+                    self.eot_tokens = detected
+                else:
+                    LOG.warning(
+                        "Could not auto-detect EOT token from template. "
+                        "The turn terminator will not be trained. "
+                        "Set `eot_tokens` to the template's turn-ending token "
+                        "(e.g. '<end_of_turn>' for Gemma)."
+                    )
+                    self.eot_tokens = []
             return
 
         # Create a new list to store tokens that should be kept
@@ -397,6 +417,57 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
                 f"eot_tokens: {self.eot_tokens}"
                 f"eos_token: {self.tokenizer.eos_token}"
             )
+
+    def _detect_eot_from_template(self) -> list[str]:
+        """
+        Render the chat template with a sentinel assistant turn and find tokens
+        that appear immediately after the assistant content but are not the EOS
+        token. These are candidates for the real end-of-turn (EOT) token.
+
+        Returns a list of detected EOT token strings (may be empty if detection
+        fails or no suitable token is found).
+        """
+        _SENTINEL = "SENTINEL_XYZ_DO_NOT_USE"
+        dummy_conv = [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "content": _SENTINEL},
+        ]
+        try:
+            full_ids = list(
+                self.tokenizer.apply_chat_template(
+                    dummy_conv,
+                    tokenize=True,
+                    add_generation_prompt=False,
+                    chat_template=self.prompter.chat_template,
+                )
+            )
+            sentinel_ids = list(
+                self.tokenizer.encode(_SENTINEL, add_special_tokens=False)
+            )
+            if not sentinel_ids:
+                return []
+
+            sentinel_len = len(sentinel_ids)
+            for start_pos in range(len(full_ids) - sentinel_len + 1):
+                if full_ids[start_pos : start_pos + sentinel_len] == sentinel_ids:
+                    eot_tokens = []
+                    for token_id in full_ids[start_pos + sentinel_len :]:
+                        if token_id == self.tokenizer.eos_token_id:
+                            break
+                        token_str = self.tokenizer.decode(
+                            [token_id], skip_special_tokens=False
+                        )
+                        # Stop at pure-whitespace tokens (e.g. '\n' after <end_of_turn>)
+                        if not token_str.strip():
+                            break
+                        eot_tokens.append(token_str)
+                    return eot_tokens
+        except Exception:  # pylint: disable=broad-except
+            LOG.debug(
+                "Failed to auto-detect EOT token from template rendering",
+                exc_info=True,
+            )
+        return []
 
     @property
     def supports_batched(self) -> bool:

--- a/tests/prompt_strategies/test_gemma_eot_autodetect.py
+++ b/tests/prompt_strategies/test_gemma_eot_autodetect.py
@@ -1,0 +1,198 @@
+"""
+Tests for auto-detection of the actual EOT token for Gemma-like models
+where tokenizer.eos_token != the chat template turn terminator.
+
+Covers issue #3754: chat_template strategy never trains the Gemma turn
+terminator because <eos> (id=1) is used as the EOT token, but Gemma
+templates emit <end_of_turn> (id=107) / <turn|> (id=106).
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from axolotl.prompt_strategies.chat_template import ChatTemplateStrategy
+
+
+# Gemma 2 chat template - uses <end_of_turn>, NOT eos_token variable
+GEMMA2_TEMPLATE = (
+    "{{ bos_token }}"
+    "{% for message in messages %}"
+    "{% if (message['role'] == 'assistant') %}{% set role = 'model' %}"
+    "{% else %}{% set role = message['role'] %}{% endif %}"
+    "{{ '<start_of_turn>' + role + '\\n' + message['content'] | trim + '<end_of_turn>\\n' }}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}{{'<start_of_turn>model\\n'}}{% endif %}"
+)
+
+# A template that DOES use eos_token variable (e.g., ChatML, Llama3 style)
+LLAMA3_STYLE_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{ '<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n\\n' }}"
+    "{{ message['content'] | trim + eos_token }}"
+    "{% endfor %}"
+)
+
+_EOT_ID = 107  # <end_of_turn> Gemma token id
+_EOS_ID = 1    # <eos> Gemma real eos_token id
+_SENTINEL_IDS = [300, 400, 500]
+
+
+def _make_gemma_mock_tokenizer():
+    """Build a minimal mock tokenizer that mimics Gemma 2 token behavior."""
+    tok = MagicMock()
+    tok.eos_token = "<eos>"
+    tok.eos_token_id = _EOS_ID
+
+    def _encode(text, add_special_tokens=False):
+        if "SENTINEL_XYZ_DO_NOT_USE" in str(text):
+            return list(_SENTINEL_IDS)
+        if text == "<end_of_turn>":
+            return [_EOT_ID]
+        if text == "<eos>":
+            return [_EOS_ID]
+        return [999]
+
+    def _decode(token_ids, skip_special_tokens=False):
+        mapping = {_EOT_ID: "<end_of_turn>", 108: "\n", _EOS_ID: "<eos>"}
+        if len(token_ids) == 1 and token_ids[0] in mapping:
+            return mapping[token_ids[0]]
+        return ""
+
+    def _apply_chat_template(conv, tokenize=True, add_generation_prompt=False, **kwargs):
+        # Simulate:
+        # <bos>(2) <start_of_turn>(106) user(100) \n(108) x(150) <end_of_turn>(107) \n(108)
+        # <start_of_turn>(106) model(200) \n(108) SENTINEL(300,400,500) <end_of_turn>(107) \n(108)
+        return [2, 106, 100, 108, 150, _EOT_ID, 108,
+                106, 200, 108, 300, 400, 500, _EOT_ID, 108]
+
+    tok.encode = _encode
+    tok.decode = _decode
+    tok.apply_chat_template = _apply_chat_template
+    return tok
+
+
+def _make_prompter(chat_template: str):
+    prompter = MagicMock()
+    prompter.chat_template = chat_template
+    prompter.roles = {"user": "user", "assistant": "assistant"}
+    prompter.chat_template_msg_variables = {"role", "content"}
+    return prompter
+
+
+class TestGemmaEotAutoDetection:
+    """Auto-detection of EOT token when eos_token is absent from chat template."""
+
+    def test_eot_not_found_before_fix(self):
+        """
+        RED: Without the fix, _eot_token_ids is {1} (<eos>), which never
+        appears in Gemma renders, so the turn terminator is never trained.
+        After the fix, _eot_token_ids should contain 107 (<end_of_turn>).
+        This test asserts the FIXED behaviour; failing it means the fix
+        is absent.
+        """
+        tok = _make_gemma_mock_tokenizer()
+        prompter = _make_prompter(GEMMA2_TEMPLATE)
+
+        strategy = ChatTemplateStrategy(
+            prompter=prompter,
+            tokenizer=tok,
+            train_on_inputs=False,
+            sequence_len=512,
+        )
+
+        # After fix: the wrong <eos> id must NOT be cached as an EOT id
+        assert _EOS_ID not in strategy._eot_token_ids, (
+            "Bug still present: <eos> (id=1) is used as EOT but never appears "
+            "in Gemma renders, so the turn terminator is never trained."
+        )
+
+    def test_gemma_eot_auto_detected(self):
+        """
+        GREEN: After the fix, <end_of_turn> (id=107) is auto-detected and
+        stored in _eot_token_ids, so find_first_eot_token will label it.
+        """
+        tok = _make_gemma_mock_tokenizer()
+        prompter = _make_prompter(GEMMA2_TEMPLATE)
+
+        strategy = ChatTemplateStrategy(
+            prompter=prompter,
+            tokenizer=tok,
+            train_on_inputs=False,
+            sequence_len=512,
+        )
+
+        assert _EOT_ID in strategy._eot_token_ids, (
+            "<end_of_turn> (id=107) was not auto-detected as an EOT token. "
+            "The Gemma turn terminator will not be trained."
+        )
+        assert "<end_of_turn>" in strategy.eot_tokens
+
+    def test_explicit_eot_tokens_not_overridden(self):
+        """
+        When the caller explicitly passes eot_tokens, auto-detection must
+        NOT override them.
+        """
+        tok = _make_gemma_mock_tokenizer()
+        prompter = _make_prompter(GEMMA2_TEMPLATE)
+        # The template has <end_of_turn> so it will pass validation
+        prompter.chat_template = GEMMA2_TEMPLATE.replace(
+            "<end_of_turn>", "<custom_eot>"
+        )
+        tok.encode = lambda text, **kw: [555] if text == "<custom_eot>" else [999]
+
+        strategy = ChatTemplateStrategy(
+            prompter=prompter,
+            tokenizer=tok,
+            train_on_inputs=False,
+            sequence_len=512,
+            eot_tokens=["<custom_eot>"],
+        )
+
+        assert strategy.eot_tokens == ["<custom_eot>"]
+
+    def test_normal_template_with_eos_token_var_unchanged(self):
+        """
+        Templates that reference eos_token (Llama3 / ChatML style) should
+        remain unaffected; no auto-detection should fire.
+        """
+        tok = MagicMock()
+        tok.eos_token = "<|eot_id|>"
+        tok.eos_token_id = 128009
+        tok.encode = MagicMock(return_value=[128009])
+        prompter = _make_prompter(LLAMA3_STYLE_TEMPLATE)
+
+        strategy = ChatTemplateStrategy(
+            prompter=prompter,
+            tokenizer=tok,
+            train_on_inputs=False,
+            sequence_len=512,
+        )
+
+        # <|eot_id|> IS in the template via `eos_token`, so no auto-detection;
+        # the original eot_tokens = ['<|eot_id|>'] should be preserved.
+        assert strategy.eot_tokens == ["<|eot_id|>"]
+        assert 128009 in strategy._eot_token_ids
+
+    def test_find_first_eot_correctly_locates_gemma_terminator(self):
+        """
+        End-to-end: find_first_eot_token must return the correct index when
+        the rendered sequence contains <end_of_turn> (id=107).
+        """
+        tok = _make_gemma_mock_tokenizer()
+        prompter = _make_prompter(GEMMA2_TEMPLATE)
+
+        strategy = ChatTemplateStrategy(
+            prompter=prompter,
+            tokenizer=tok,
+            train_on_inputs=False,
+            sequence_len=512,
+        )
+
+        # Simulated rendered assistant turn: content at [0..2], EOT at [3]
+        fake_ids = [300, 400, 500, _EOT_ID, 108]
+        idx = strategy.find_first_eot_token(fake_ids, start_idx=0)
+
+        assert idx == 3, (
+            f"Expected EOT at index 3, got {idx}. "
+            "<end_of_turn> (id=107) is not being searched for."
+        )


### PR DESCRIPTION
## Description

Auto-detect the actual end-of-turn (EOT) token from the chat template when
`tokenizer.eos_token` is absent from it. This fixes Gemma models where the
turn terminator (`<end_of_turn>` / `<turn|>`) was silently masked and never
trained.

## Motivation and Context

Closes #3754

For every Gemma generation (1/2/3/3n/4), `tokenizer.eos_token = "<eos>"` (id 1),
but the chat template emits `<end_of_turn>` (Gemma 1/2/3/3n, id 107/106) or
`<turn|>` (Gemma 4, id 106) as the per-turn stop marker.

The old code defaulted `eot_tokens = [tokenizer.eos_token]` and cached token
id 1. `find_first_eot_token` never found a match because id 1 never appears in
rendered Gemma sequences, leaving every turn terminator with label -100. The
model was never trained to stop, but loss/eval curves look fine because the
untrained token never contributed to the loss.

A warning was already emitted, but not acted upon.

PR #3756 (open) adds an `eot_tokens` workaround to example YAML configs and
improves the warning. This PR fixes the root cause in `chat_template.py` so
Gemma works out of the box without any config change.

## Changes

### `src/axolotl/prompt_strategies/chat_template.py`

- When `_validate_eot_and_eos_tokens` detects that `eos_token` is absent from
  the template, call `_detect_eot_from_template()` instead of just warning.
- `_detect_eot_from_template()`: renders the template with a sentinel assistant
  turn, locates the sentinel token-ids in the output, then collects the
  non-whitespace non-EOS tokens that immediately follow. These are the actual
  turn terminator(s). Updates `self.eot_tokens` with them.
- If detection fails, clears `self.eot_tokens` (correct: stop searching for the
  wrong id) and logs a warning with explicit instructions.
- Explicit `eot_tokens` set by the user always win; the new logic only triggers
  when the default `[eos_token]` is in use and that token is absent from the
  template.
- Templates that reference `eos_token` as a Jinja variable (Llama-3, ChatML,
  Mistral, …) are completely unaffected.

## Verification

```
pytest tests/prompt_strategies/test_gemma_eot_autodetect.py -v
# 5 passed
```

All tests use a mock tokenizer and are fully offline (no GPU / model download).
No existing test was edited.

```
pytest tests/prompt_strategies/test_chat_template_utils.py \
       tests/prompt_strategies/test_jinja_template_analyzer.py \
       tests/prompt_strategies/test_synthetic.py \
       tests/integrations/test_kd_chat_template.py -v
# 33 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of chat turn terminators when the template uses a different end marker than the tokenizer’s EOS token.
  * Added fallback behavior that clearly warns when a terminator can’t be identified, preventing incorrect training on turn endings.
  * Preserved user-provided terminator settings so they aren’t overwritten by automatic detection.

* **Tests**
  * Added coverage for Gemma-like chat templates, EOS mismatch cases, explicit terminator overrides, and terminator position detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->