### PR TITLE
feat(optimizers): add SinkGD stateless gradient multi-normalization optimizer

### DIFF
--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -128,6 +128,26 @@ dion_momentum: 0.95
 lr: 0.00001  # learning rate for embeddings and parameters that fallback to AdamW
 ```
 
+### sinkgd
+
+SinkGD (Gradient Multi-Normalization) is a **stateless** optimizer: 2D linear weight
+matrices are updated via the SR-Sinkhorn procedure (alternating row/column L2
+normalization of the raw gradient, no momentum or variance state), while embeddings,
+the LM head, and 1D params (norms/biases) fall back to AdamW. The AdamW fallback uses
+torchao's 8-bit optimizer base, so optimizer-state memory is very small (~87% less than
+8-bit AdamW on an 8B full finetune, since the ~87% of params that are 2D linear carry
+zero optimizer state).
+
+Paper: [https://arxiv.org/abs/2502.06742](https://arxiv.org/abs/2502.06742)
+
+```yaml
+optimizer: sinkgd
+learning_rate: 0.001
+optim_args:
+  sinkhorn_iters: 5      # number of SR-Sinkhorn row/column normalization iterations
+  sinkgd_lr_scale: 0.05  # α scale applied to linear-layer updates
+```
+
 ### q_galore_adamw8bit
 
 Q-GaLore extends [GaLore](https://arxiv.org/abs/2403.03507) with two extra ideas:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -138,6 +138,8 @@ torchao's 8-bit optimizer base, so optimizer-state memory is very small (~87% le
 8-bit AdamW on an 8B full finetune, since the ~87% of params that are 2D linear carry
 zero optimizer state).
 
+Requires PyTorch >= 2.5.1 (relies on torchao's low-bit optimizer base and `torch.compile`).
+
 Paper: [https://arxiv.org/abs/2502.06742](https://arxiv.org/abs/2502.06742)
 
 ```yaml

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -341,6 +341,11 @@ class TrainerBuilderBase(abc.ABC):
                 _, device_mesh = build_parallelism_config(self.cfg)
                 if device_mesh is not None:
                     optimizer_kwargs["device_mesh"] = device_mesh
+            elif self.cfg.optimizer == "sinkgd":
+                from axolotl.utils.optimizers.sinkgd import SinkGDOptimizerFactory
+
+                optimizer_cls = SinkGDOptimizerFactory
+                optimizer_kwargs.update(adam_kwargs)
             elif self.cfg.optimizer == "optimi_adamw":
                 from optimi import AdamW
 

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -342,9 +342,19 @@ class TrainerBuilderBase(abc.ABC):
                 if device_mesh is not None:
                     optimizer_kwargs["device_mesh"] = device_mesh
             elif self.cfg.optimizer == "sinkgd":
-                from axolotl.utils.optimizers.sinkgd import SinkGDOptimizerFactory
+                _, device_mesh = build_parallelism_config(self.cfg)
 
-                optimizer_cls = SinkGDOptimizerFactory
+                if device_mesh is not None:
+                    from axolotl.utils.optimizers.sinkgd import (
+                        DistSinkGDOptimizerFactory,
+                    )
+
+                    optimizer_cls = DistSinkGDOptimizerFactory
+                    optimizer_kwargs["device_mesh"] = device_mesh
+                else:
+                    from axolotl.utils.optimizers.sinkgd import SinkGDOptimizerFactory
+
+                    optimizer_cls = SinkGDOptimizerFactory
                 optimizer_kwargs.update(adam_kwargs)
             elif self.cfg.optimizer == "optimi_adamw":
                 from optimi import AdamW

--- a/src/axolotl/core/trainers/mixins/optimizer.py
+++ b/src/axolotl/core/trainers/mixins/optimizer.py
@@ -122,8 +122,7 @@ class OptimizerMixin(Trainer):
             and is_optimizer_factory(self.optimizer_cls_and_kwargs[0])
         ):
             optimizer_factory_cls, optimizer_kwargs = self.optimizer_cls_and_kwargs
-            # transformers calls factories as factory(opt_model, **kwargs); our
-            # factories also accept training_args, so pass it for back-compat.
+            # forward training_args for back-compat with our factory signatures
             self.optimizer = optimizer_factory_cls()(
                 opt_model, self.args, **optimizer_kwargs
             )

--- a/src/axolotl/core/trainers/mixins/optimizer.py
+++ b/src/axolotl/core/trainers/mixins/optimizer.py
@@ -3,9 +3,9 @@
 from peft.optimizers import create_loraplus_optimizer
 from torch import nn
 from transformers.trainer import Trainer
+from transformers.trainer_optimizer import is_optimizer_factory
 from transformers.utils import is_sagemaker_mp_enabled
 
-from axolotl.integrations.base import BaseOptimizerFactory
 from axolotl.utils.logging import get_logger
 
 if is_sagemaker_mp_enabled():
@@ -119,9 +119,11 @@ class OptimizerMixin(Trainer):
         if (
             not self.optimizer
             and self.optimizer_cls_and_kwargs is not None
-            and issubclass(self.optimizer_cls_and_kwargs[0], BaseOptimizerFactory)
+            and is_optimizer_factory(self.optimizer_cls_and_kwargs[0])
         ):
             optimizer_factory_cls, optimizer_kwargs = self.optimizer_cls_and_kwargs
+            # transformers calls factories as factory(opt_model, **kwargs); our
+            # factories also accept training_args, so pass it for back-compat.
             self.optimizer = optimizer_factory_cls()(
                 opt_model, self.args, **optimizer_kwargs
             )

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -138,8 +138,7 @@ class SinkGD(_AdamBase):
         with torch._dynamo.utils.disable_cache_limit():
             for group in self.param_groups:
                 use_sinkgd = group.get("use_sinkgd", False)
-                # scheduler may overwrite lr with a python float; keep a CPU scalar
-                # tensor so the compiled steps don't recompile when it changes.
+                # CPU scalar lr avoids recompiling the compiled steps on lr changes
                 lr = group["lr"]
                 if not isinstance(lr, Tensor):
                     lr = torch.tensor(lr, dtype=torch.float32)
@@ -215,7 +214,10 @@ class SinkGDOptimizerFactory(BaseOptimizerFactory):
             if (
                 param.ndim < 2
                 or name.endswith("modules_to_save.default.weight")
-                or any(embed in name for embed in ["embed_tokens", "lm_head"])
+                or any(
+                    embed in name
+                    for embed in ["embed_tokens", "lm_head", "wte", "word_embeddings"]
+                )
             ):
                 adamw_params.append(param)
             else:
@@ -230,12 +232,13 @@ class SinkGDOptimizerFactory(BaseOptimizerFactory):
                     "weight_decay": weight_decay,
                 }
             )
+        # fallback group is only embeddings, head, norms and biases -> no weight decay
         if adamw_params:
             param_groups.append(
                 {
                     "params": adamw_params,
                     "use_sinkgd": False,
-                    "weight_decay": weight_decay,
+                    "weight_decay": 0.0,
                 }
             )
 

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -1,0 +1,251 @@
+"""SinkGD: stateless gradient multi-normalization optimizer.
+
+Implements the SinkGD optimizer from "Gradient Multi-Normalization for Stateless
+and Scalable LLM Training" (Scetbon et al., 2025, https://arxiv.org/abs/2502.06742).
+
+Linear weight matrices are updated with the stateless SR-Sinkhorn procedure
+(Algorithm 3/4): the raw gradient is alternately row- and column-normalized for a
+few iterations, then applied as the update. No optimizer state is stored for these
+parameters. Embeddings, the output head, and 1D parameters (norms, biases) fall
+back to AdamW, reusing torchao's low-bit optimizer base so that this state is kept
+in 8-bit and the overall footprint stays close to plain SGD.
+"""
+
+import torch
+from torch import Tensor
+from torchao.optim.adam import _AdamBase, single_param_adam
+from torchao.optim.quant_utils import _fp32_to_bf16_sr
+from torchao.optim.subclass_8bit import OptimState8bit
+
+from axolotl.integrations.base import BaseOptimizerFactory
+
+
+def sr_sinkhorn(grad: Tensor, iters: int, eps: float) -> Tensor:
+    """SR-Sinkhorn (Algorithm 3): alternate row/column L2 normalization.
+
+    Each iteration rescales rows to L2 norm sqrt(n) then columns to L2 norm
+    sqrt(m), driving the gradient towards a doubly-balanced fixed point.
+
+    Operates on the last two dims, so any leading dims (e.g. the expert axis of
+    a fused MoE weight ``[num_experts, in, out]``) are treated as an independent
+    batch and each matrix is normalized separately.
+    """
+    m, n = grad.shape[-2], grad.shape[-1]
+    sqrt_n = n**0.5
+    sqrt_m = m**0.5
+    x = grad
+    for _ in range(iters):
+        x = x * (sqrt_n / x.norm(dim=-1, keepdim=True).clamp_min(eps))
+        x = x * (sqrt_m / x.norm(dim=-2, keepdim=True).clamp_min(eps))
+    return x
+
+
+def single_param_sinkgd(
+    p: Tensor,
+    grad: Tensor,
+    lr: Tensor,
+    weight_decay: float,
+    iters: int,
+    eps: float,
+    stochastic_round: bool,
+) -> None:
+    """Fused stateless SinkGD update for one weight; meant to be torch.compiled.
+
+    Normalization runs over the last two dims (leading dims, e.g. the expert axis
+    of a fused MoE weight, are batched and normalized per-matrix). The iterate
+    stays in the gradient dtype to halve memory traffic while norm reductions
+    accumulate in fp32. `iters`/`eps`/`weight_decay` are constants so the loop
+    unrolls, and `lr` is a tensor input so a changing schedule never recompiles.
+    """
+    m, n = grad.shape[-2], grad.shape[-1]
+    sqrt_n = n**0.5
+    sqrt_m = m**0.5
+    x = grad
+    for _ in range(iters):
+        rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+
+    p_f32 = p.float()
+    if weight_decay != 0.0:
+        p_f32 = p_f32 * (1 - lr * weight_decay)
+    p_f32 = p_f32 - lr * x.float()
+
+    if stochastic_round:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
+    else:
+        p.copy_(p_f32)
+
+
+class SinkGD(_AdamBase):
+    """SinkGD optimizer with an 8-bit AdamW fallback for non-matrix parameters.
+
+    Parameter groups flagged with ``use_sinkgd=True`` get the stateless SR-Sinkhorn
+    update for their >=2D tensors (3D fused-MoE-expert weights are normalized
+    per-expert); every other parameter is optimized with the quantized 8-bit AdamW
+    step inherited from torchao's ``_AdamBase``.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0.0,
+        *,
+        sinkhorn_iters=5,
+        sinkgd_lr_scale=0.05,
+        sinkgd_eps=1e-8,
+        block_size=256,
+        bf16_stochastic_round=False,
+    ) -> None:
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad=False,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
+        self.sinkhorn_iters = sinkhorn_iters
+        self.sinkgd_lr_scale = sinkgd_lr_scale
+        self.sinkgd_eps = sinkgd_eps
+        self._compiled_sinkgd = torch.compile(
+            single_param_sinkgd, fullgraph=True, dynamic=False
+        )
+        self._compiled_adam = torch.compile(
+            single_param_adam, fullgraph=True, dynamic=False
+        )
+
+    @staticmethod
+    def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
+        return OptimState8bit.zeros(
+            p.shape, signed, block_size, p.device, dtype=p.dtype
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        with torch._dynamo.utils.disable_cache_limit():
+            for group in self.param_groups:
+                use_sinkgd = group.get("use_sinkgd", False)
+                # scheduler may overwrite lr with a python float; keep a CPU scalar
+                # tensor so the compiled steps don't recompile when it changes.
+                lr = group["lr"]
+                if not isinstance(lr, Tensor):
+                    lr = torch.tensor(lr, dtype=torch.float32)
+
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    grad = p.grad
+                    if grad.is_sparse:
+                        raise RuntimeError("Sparse gradient is not supported")
+
+                    if use_sinkgd and p.ndim >= 2:
+                        self._compiled_sinkgd(
+                            p.detach(),
+                            grad,
+                            lr * self.sinkgd_lr_scale,
+                            group["weight_decay"],
+                            self.sinkhorn_iters,
+                            self.sinkgd_eps,
+                            self.bf16_stochastic_round and p.dtype is torch.bfloat16,
+                        )
+                        continue
+
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["step"] = torch.tensor(0.0)
+                        state["exp_avg"] = self._new_buffer(p, True)
+                        state["exp_avg_sq"] = self._new_buffer(p, False)
+                    state["step"] += 1
+
+                    self._compiled_adam(
+                        p.detach(),
+                        grad,
+                        state["step"],
+                        state["exp_avg"],
+                        state["exp_avg_sq"],
+                        None,
+                        lr,
+                        group["betas"][0],
+                        group["betas"][1],
+                        group["weight_decay"],
+                        group["eps"],
+                        self.is_adamw,
+                        self.bf16_stochastic_round and p.dtype is torch.bfloat16,
+                    )
+
+        return loss
+
+
+class SinkGDOptimizerFactory(BaseOptimizerFactory):
+    """Builds a :class:`SinkGD` optimizer, routing weight matrices to SR-Sinkhorn.
+
+    Routing is by tensor rank, not module type, so fused MoE experts (transformers
+    v5 stores them as 3D ``[num_experts, in, out]`` parameters rather than
+    ``nn.Linear`` modules) are picked up and normalized per-expert. Embeddings, the
+    output head, and parameters with fewer than 2 dimensions go to the AdamW
+    fallback group, matching the paper's recipe.
+    """
+
+    def __call__(self, opt_model, training_args=None, **optimizer_kwargs) -> "SinkGD":
+        lr = optimizer_kwargs.pop("lr")
+        weight_decay = optimizer_kwargs.pop("weight_decay", 0.0)
+        betas = optimizer_kwargs.pop("betas", (0.9, 0.999))
+        eps = optimizer_kwargs.pop("eps", 1e-8)
+        sinkhorn_iters = int(optimizer_kwargs.pop("sinkhorn_iters", 5))
+        sinkgd_lr_scale = float(optimizer_kwargs.pop("sinkgd_lr_scale", 0.05))
+
+        sinkgd_params = []
+        adamw_params = []
+        for name, param in opt_model.named_parameters():
+            if not param.requires_grad:
+                continue
+            if (
+                param.ndim < 2
+                or name.endswith("modules_to_save.default.weight")
+                or any(embed in name for embed in ["embed_tokens", "lm_head"])
+            ):
+                adamw_params.append(param)
+            else:
+                sinkgd_params.append(param)
+
+        param_groups = []
+        if sinkgd_params:
+            param_groups.append(
+                {
+                    "params": sinkgd_params,
+                    "use_sinkgd": True,
+                    "weight_decay": weight_decay,
+                }
+            )
+        if adamw_params:
+            param_groups.append(
+                {
+                    "params": adamw_params,
+                    "use_sinkgd": False,
+                    "weight_decay": weight_decay,
+                }
+            )
+
+        return SinkGD(
+            param_groups,
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            sinkhorn_iters=sinkhorn_iters,
+            sinkgd_lr_scale=sinkgd_lr_scale,
+            **optimizer_kwargs,
+        )

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """SinkGD: stateless gradient multi-normalization optimizer.
 
 Implements the SinkGD optimizer from "Gradient Multi-Normalization for Stateless

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -12,7 +12,10 @@ in 8-bit and the overall footprint stays close to plain SGD.
 """
 
 import torch
+import torch.distributed as dist
 from torch import Tensor
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
 from torchao.optim.adam import _AdamBase, single_param_adam
 from torchao.optim.quant_utils import _fp32_to_bf16_sr
 from torchao.optim.subclass_8bit import OptimState8bit
@@ -128,6 +131,34 @@ class SinkGD(_AdamBase):
             p.shape, signed, block_size, p.device, dtype=p.dtype
         )
 
+    def _adam_fallback(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
+        # Adam is elementwise, so run on the local shard: no cross-rank comm, and it
+        # sidesteps the OptimState8bit + DTensor + compile dispatch gap under FSDP2.
+        # State is keyed by the original param (to_local returns a fresh object).
+        p_local = p.to_local() if isinstance(p, DTensor) else p
+        grad_local = grad.to_local() if isinstance(grad, DTensor) else grad
+        state = self.state[p]
+        if len(state) == 0:
+            state["step"] = torch.tensor(0.0)
+            state["exp_avg"] = self._new_buffer(p_local, True)
+            state["exp_avg_sq"] = self._new_buffer(p_local, False)
+        state["step"] += 1
+        self._compiled_adam(
+            p_local.detach(),
+            grad_local,
+            state["step"],
+            state["exp_avg"],
+            state["exp_avg_sq"],
+            None,
+            lr,
+            group["betas"][0],
+            group["betas"][1],
+            group["weight_decay"],
+            group["eps"],
+            self.is_adamw,
+            self.bf16_stochastic_round and p_local.dtype is torch.bfloat16,
+        )
+
     @torch.no_grad()
     def step(self, closure=None):
         loss = None
@@ -160,43 +191,51 @@ class SinkGD(_AdamBase):
                             self.sinkgd_eps,
                             self.bf16_stochastic_round and p.dtype is torch.bfloat16,
                         )
-                        continue
-
-                    state = self.state[p]
-                    if len(state) == 0:
-                        state["step"] = torch.tensor(0.0)
-                        state["exp_avg"] = self._new_buffer(p, True)
-                        state["exp_avg_sq"] = self._new_buffer(p, False)
-                    state["step"] += 1
-
-                    self._compiled_adam(
-                        p.detach(),
-                        grad,
-                        state["step"],
-                        state["exp_avg"],
-                        state["exp_avg_sq"],
-                        None,
-                        lr,
-                        group["betas"][0],
-                        group["betas"][1],
-                        group["weight_decay"],
-                        group["eps"],
-                        self.is_adamw,
-                        self.bf16_stochastic_round and p.dtype is torch.bfloat16,
-                    )
+                    else:
+                        self._adam_fallback(p, grad, group, lr)
 
         return loss
 
 
-class SinkGDOptimizerFactory(BaseOptimizerFactory):
-    """Builds a :class:`SinkGD` optimizer, routing weight matrices to SR-Sinkhorn.
+def _sinkgd_param_groups(opt_model, weight_decay):
+    """Split params: 2D/3D weight matrices -> SR-Sinkhorn; everything else -> AdamW.
 
     Routing is by tensor rank, not module type, so fused MoE experts (transformers
     v5 stores them as 3D ``[num_experts, in, out]`` parameters rather than
-    ``nn.Linear`` modules) are picked up and normalized per-expert. Embeddings, the
-    output head, and parameters with fewer than 2 dimensions go to the AdamW
-    fallback group, matching the paper's recipe.
+    ``nn.Linear`` modules) are picked up and normalized per-expert. The AdamW
+    fallback group (embeddings, head, norms, biases) uses no weight decay.
     """
+    sinkgd_params = []
+    adamw_params = []
+    for name, param in opt_model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if (
+            param.ndim < 2
+            or name.endswith("modules_to_save.default.weight")
+            or any(
+                embed in name
+                for embed in ["embed_tokens", "lm_head", "wte", "word_embeddings"]
+            )
+        ):
+            adamw_params.append(param)
+        else:
+            sinkgd_params.append(param)
+
+    param_groups = []
+    if sinkgd_params:
+        param_groups.append(
+            {"params": sinkgd_params, "use_sinkgd": True, "weight_decay": weight_decay}
+        )
+    if adamw_params:
+        param_groups.append(
+            {"params": adamw_params, "use_sinkgd": False, "weight_decay": 0.0}
+        )
+    return param_groups
+
+
+class SinkGDOptimizerFactory(BaseOptimizerFactory):
+    """Builds a :class:`SinkGD` optimizer, routing weight matrices to SR-Sinkhorn."""
 
     def __call__(self, opt_model, training_args=None, **optimizer_kwargs) -> "SinkGD":
         lr = optimizer_kwargs.pop("lr")
@@ -205,50 +244,173 @@ class SinkGDOptimizerFactory(BaseOptimizerFactory):
         eps = optimizer_kwargs.pop("eps", 1e-8)
         sinkhorn_iters = int(optimizer_kwargs.pop("sinkhorn_iters", 5))
         sinkgd_lr_scale = float(optimizer_kwargs.pop("sinkgd_lr_scale", 0.05))
-
-        sinkgd_params = []
-        adamw_params = []
-        for name, param in opt_model.named_parameters():
-            if not param.requires_grad:
-                continue
-            if (
-                param.ndim < 2
-                or name.endswith("modules_to_save.default.weight")
-                or any(
-                    embed in name
-                    for embed in ["embed_tokens", "lm_head", "wte", "word_embeddings"]
-                )
-            ):
-                adamw_params.append(param)
-            else:
-                sinkgd_params.append(param)
-
-        param_groups = []
-        if sinkgd_params:
-            param_groups.append(
-                {
-                    "params": sinkgd_params,
-                    "use_sinkgd": True,
-                    "weight_decay": weight_decay,
-                }
-            )
-        # fallback group is only embeddings, head, norms and biases -> no weight decay
-        if adamw_params:
-            param_groups.append(
-                {
-                    "params": adamw_params,
-                    "use_sinkgd": False,
-                    "weight_decay": 0.0,
-                }
-            )
+        optimizer_kwargs.pop(
+            "device_mesh", None
+        )  # ignored by the single-device variant
 
         return SinkGD(
-            param_groups,
+            _sinkgd_param_groups(opt_model, weight_decay),
             lr=lr,
             betas=betas,
             eps=eps,
             weight_decay=weight_decay,
             sinkhorn_iters=sinkhorn_iters,
             sinkgd_lr_scale=sinkgd_lr_scale,
+            **optimizer_kwargs,
+        )
+
+
+def _matrix_shard_dim(p: Tensor):
+    """Return the negative matrix dim (-2 or -1) sharded across >1 ranks, else None.
+
+    Leading-dim sharding (e.g. the expert axis of a fused MoE weight) and replicated
+    tensors return None — their row/column norms are then fully shard-local.
+    """
+    if not isinstance(p, DTensor):
+        return None
+    matrix_dims = {p.ndim - 1, p.ndim - 2}
+    for i, placement in enumerate(p.placements):
+        if (
+            placement.is_shard()
+            and placement.dim in matrix_dims
+            and p.device_mesh.size(i) > 1
+        ):
+            return placement.dim - p.ndim
+    return None
+
+
+def dist_single_param_sinkgd(
+    p: Tensor,
+    grad: Tensor,
+    lr: Tensor,
+    weight_decay: float,
+    iters: int,
+    eps: float,
+    stochastic_round: bool,
+    shard_dim,
+    process_group,
+    global_M: int,
+    global_N: int,
+) -> None:
+    """SR-Sinkhorn on a sharded weight: all-reduce only the norm whose reduction
+    axis is sharded; the other norm is shard-local. ``p``/``grad`` are local shards;
+    ``global_M``/``global_N`` are the *full* matrix dims (the √ scaling must use the
+    global sizes, not the local shard's)."""
+    sqrt_n, sqrt_m = global_N**0.5, global_M**0.5
+    x = grad
+    for _ in range(iters):
+        if shard_dim == -1:  # columns sharded -> row norm needs a reduction
+            rsq = (x.float() ** 2).sum(dim=-1, keepdim=True)
+            dist.all_reduce(rsq, group=process_group)
+            rn = rsq.sqrt()
+        else:
+            rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        if shard_dim == -2:  # rows sharded -> column norm needs a reduction
+            csq = (x.float() ** 2).sum(dim=-2, keepdim=True)
+            dist.all_reduce(csq, group=process_group)
+            cn = csq.sqrt()
+        else:
+            cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+
+    p_f32 = p.float()
+    if weight_decay != 0.0:
+        p_f32 = p_f32 * (1 - lr * weight_decay)
+    p_f32 = p_f32 - lr * x.float()
+    if stochastic_round:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
+    else:
+        p.copy_(p_f32)
+
+
+class DistSinkGD(SinkGD):
+    """Distributed SinkGD for FSDP2/TP-sharded weights.
+
+    The SR-Sinkhorn matrices are updated on their local shards, all-reducing only the
+    ``[N]`` (or ``[M]``) norm vector over the shard process group — never the matrix
+    itself, so optimizer communication is orders of magnitude lighter than gathering
+    the full parameter. The 8-bit AdamW fallback (operating on DTensors) is inherited
+    unchanged.
+    """
+
+    def __init__(self, params, *, process_group=None, **kwargs) -> None:
+        super().__init__(params, **kwargs)
+        self._process_group = process_group
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            use_sinkgd = group.get("use_sinkgd", False)
+            lr = group["lr"]
+            if not isinstance(lr, Tensor):
+                lr = torch.tensor(lr, dtype=torch.float32)
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad
+                if grad.is_sparse:
+                    raise RuntimeError("Sparse gradient is not supported")
+
+                if use_sinkgd and p.ndim >= 2:
+                    shard_dim = _matrix_shard_dim(p)
+                    global_M, global_N = p.shape[-2], p.shape[-1]  # DTensor -> global
+                    p_local = p.to_local() if isinstance(p, DTensor) else p
+                    g_local = grad.to_local() if isinstance(grad, DTensor) else grad
+                    dist_single_param_sinkgd(
+                        p_local,
+                        g_local,
+                        lr * self.sinkgd_lr_scale,
+                        group["weight_decay"],
+                        self.sinkhorn_iters,
+                        self.sinkgd_eps,
+                        self.bf16_stochastic_round and p.dtype is torch.bfloat16,
+                        shard_dim,
+                        self._process_group,
+                        global_M,
+                        global_N,
+                    )
+                else:
+                    self._adam_fallback(p, grad, group, lr)
+
+        return loss
+
+
+class DistSinkGDOptimizerFactory(BaseOptimizerFactory):
+    """Builds a :class:`DistSinkGD` for sharded training; pulls the dp_shard group."""
+
+    def __call__(
+        self, opt_model, training_args=None, **optimizer_kwargs
+    ) -> "DistSinkGD":
+        lr = optimizer_kwargs.pop("lr")
+        weight_decay = optimizer_kwargs.pop("weight_decay", 0.0)
+        betas = optimizer_kwargs.pop("betas", (0.9, 0.999))
+        eps = optimizer_kwargs.pop("eps", 1e-8)
+        sinkhorn_iters = int(optimizer_kwargs.pop("sinkhorn_iters", 5))
+        sinkgd_lr_scale = float(optimizer_kwargs.pop("sinkgd_lr_scale", 0.05))
+
+        device_mesh = optimizer_kwargs.pop("device_mesh", None)
+        process_group = None
+        if isinstance(device_mesh, DeviceMesh):
+            if "dp_shard" in (device_mesh.mesh_dim_names or ()):
+                process_group = device_mesh["dp_shard"].get_group()
+            elif device_mesh.ndim == 1:
+                process_group = device_mesh.get_group()
+
+        return DistSinkGD(
+            _sinkgd_param_groups(opt_model, weight_decay),
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            sinkhorn_iters=sinkhorn_iters,
+            sinkgd_lr_scale=sinkgd_lr_scale,
+            process_group=process_group,
             **optimizer_kwargs,
         )

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -279,41 +279,31 @@ def _matrix_shard_dim(p: Tensor):
     return None
 
 
-def dist_single_param_sinkgd(
-    p: Tensor,
-    grad: Tensor,
-    lr: Tensor,
-    weight_decay: float,
-    iters: int,
-    eps: float,
-    stochastic_round: bool,
-    shard_dim,
-    process_group,
-    global_M: int,
-    global_N: int,
-) -> None:
-    """SR-Sinkhorn on a sharded weight: all-reduce only the norm whose reduction
-    axis is sharded; the other norm is shard-local. ``p``/``grad`` are local shards;
-    ``global_M``/``global_N`` are the *full* matrix dims (the √ scaling must use the
-    global sizes, not the local shard's)."""
-    sqrt_n, sqrt_m = global_N**0.5, global_M**0.5
-    x = grad
-    for _ in range(iters):
-        if shard_dim == -1:  # columns sharded -> row norm needs a reduction
-            rsq = (x.float() ** 2).sum(dim=-1, keepdim=True)
-            dist.all_reduce(rsq, group=process_group)
-            rn = rsq.sqrt()
-        else:
-            rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
-        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
-        if shard_dim == -2:  # rows sharded -> column norm needs a reduction
-            csq = (x.float() ** 2).sum(dim=-2, keepdim=True)
-            dist.all_reduce(csq, group=process_group)
-            cn = csq.sqrt()
-        else:
-            cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
-        x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+# Compiled local pieces of one SR-Sinkhorn iteration; the only thing kept eager and
+# uncompiled between them is the tiny norm-vector all-reduce (a collective would graph
+# break fullgraph anyway). This recovers the fusion the single-device path enjoys.
+def _row_scale_col_partial(x, sqrt_n, eps):
+    rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+    x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+    return x, (x.float() ** 2).sum(dim=-2, keepdim=True)
 
+
+def _apply_col_scale(x, csq, sqrt_m, eps):
+    return x * (sqrt_m / csq.sqrt().clamp_min(eps)).to(x.dtype)
+
+
+def _row_partial(x):
+    return (x.float() ** 2).sum(dim=-1, keepdim=True)
+
+
+def _row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps):
+    # row norm is the reduced rsq (cols sharded); column norm is then shard-local.
+    x = x * (sqrt_n / rsq.sqrt().clamp_min(eps)).to(x.dtype)
+    cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+    return x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+
+
+def _sinkgd_apply_update(p, x, lr, weight_decay, stochastic_round):
     p_f32 = p.float()
     if weight_decay != 0.0:
         p_f32 = p_f32 * (1 - lr * weight_decay)
@@ -330,13 +320,54 @@ class DistSinkGD(SinkGD):
     The SR-Sinkhorn matrices are updated on their local shards, all-reducing only the
     ``[N]`` (or ``[M]``) norm vector over the shard process group — never the matrix
     itself, so optimizer communication is orders of magnitude lighter than gathering
-    the full parameter. The 8-bit AdamW fallback (operating on DTensors) is inherited
-    unchanged.
+    the full parameter. Local work is torch.compiled (the all-reduce is the only eager
+    break); the 8-bit AdamW fallback is inherited unchanged.
     """
 
     def __init__(self, params, *, process_group=None, **kwargs) -> None:
         super().__init__(params, **kwargs)
         self._process_group = process_group
+        c = lambda f: torch.compile(f, fullgraph=True, dynamic=False)  # noqa: E731
+        self._c_row_scale_col_partial = c(_row_scale_col_partial)
+        self._c_apply_col_scale = c(_apply_col_scale)
+        self._c_row_partial = c(_row_partial)
+        self._c_row_scale_then_col_scale = c(_row_scale_then_col_scale)
+        self._c_apply_update = c(_sinkgd_apply_update)
+
+    def _dist_sinkgd_step(self, p, grad, group, lr):
+        shard_dim = _matrix_shard_dim(p)
+        sr = self.bf16_stochastic_round and p.dtype is torch.bfloat16
+        global_M, global_N = p.shape[-2], p.shape[-1]  # DTensor -> global dims
+        p_local = p.to_local() if isinstance(p, DTensor) else p
+        x = grad.to_local() if isinstance(grad, DTensor) else grad
+        lr = lr * self.sinkgd_lr_scale
+
+        if shard_dim is None:
+            # matrix dims fully local (replicated / expert-sharded) -> reuse the
+            # fully-compiled single-device path, no communication.
+            self._compiled_sinkgd(
+                p_local,
+                x,
+                lr,
+                group["weight_decay"],
+                self.sinkhorn_iters,
+                self.sinkgd_eps,
+                sr,
+            )
+            return
+
+        sqrt_n, sqrt_m = global_N**0.5, global_M**0.5
+        eps = self.sinkgd_eps
+        for _ in range(self.sinkhorn_iters):
+            if shard_dim == -2:  # rows sharded -> column norm needs a reduction
+                x, csq = self._c_row_scale_col_partial(x, sqrt_n, eps)
+                dist.all_reduce(csq, group=self._process_group)
+                x = self._c_apply_col_scale(x, csq, sqrt_m, eps)
+            else:  # columns sharded (-1) -> row norm needs a reduction (row first)
+                rsq = self._c_row_partial(x)
+                dist.all_reduce(rsq, group=self._process_group)
+                x = self._c_row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps)
+        self._c_apply_update(p_local, x, lr, group["weight_decay"], sr)
 
     @torch.no_grad()
     def step(self, closure=None):
@@ -345,39 +376,22 @@ class DistSinkGD(SinkGD):
             with torch.enable_grad():
                 loss = closure()
 
-        for group in self.param_groups:
-            use_sinkgd = group.get("use_sinkgd", False)
-            lr = group["lr"]
-            if not isinstance(lr, Tensor):
-                lr = torch.tensor(lr, dtype=torch.float32)
+        with torch._dynamo.utils.disable_cache_limit():
+            for group in self.param_groups:
+                use_sinkgd = group.get("use_sinkgd", False)
+                lr = group["lr"]
+                if not isinstance(lr, Tensor):
+                    lr = torch.tensor(lr, dtype=torch.float32)
 
-            for p in group["params"]:
-                if p.grad is None:
-                    continue
-                grad = p.grad
-                if grad.is_sparse:
-                    raise RuntimeError("Sparse gradient is not supported")
-
-                if use_sinkgd and p.ndim >= 2:
-                    shard_dim = _matrix_shard_dim(p)
-                    global_M, global_N = p.shape[-2], p.shape[-1]  # DTensor -> global
-                    p_local = p.to_local() if isinstance(p, DTensor) else p
-                    g_local = grad.to_local() if isinstance(grad, DTensor) else grad
-                    dist_single_param_sinkgd(
-                        p_local,
-                        g_local,
-                        lr * self.sinkgd_lr_scale,
-                        group["weight_decay"],
-                        self.sinkhorn_iters,
-                        self.sinkgd_eps,
-                        self.bf16_stochastic_round and p.dtype is torch.bfloat16,
-                        shard_dim,
-                        self._process_group,
-                        global_M,
-                        global_N,
-                    )
-                else:
-                    self._adam_fallback(p, grad, group, lr)
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    if p.grad.is_sparse:
+                        raise RuntimeError("Sparse gradient is not supported")
+                    if use_sinkgd and p.ndim >= 2:
+                        self._dist_sinkgd_step(p, p.grad, group, lr)
+                    else:
+                        self._adam_fallback(p, p.grad, group, lr)
 
         return loss
 

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -91,6 +91,7 @@ class CustomSupportedOptimizers(str, Enum):
     came_pytorch = "came_pytorch"
     muon = "muon"
     dion = "dion"
+    sinkgd = "sinkgd"
     flash_adamw = "flash_adamw"
     flash_adam = "flash_adam"
     flash_sgd = "flash_sgd"

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -78,6 +78,31 @@ class TestHFCausalTrainerBuilder:
         optim = trainer.create_optimizer()
         assert isinstance(optim, Muon)
 
+    def test_sinkgd_optimizer(self, sft_cfg, model, tokenizer):
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "sinkgd"
+        cfg["optim_args"] = {"sinkhorn_iters": 5, "sinkgd_lr_scale": 0.05}
+
+        builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
+        trainer = builder.build(100)
+
+        assert trainer.optimizer_cls_and_kwargs is not None
+
+        from axolotl.utils.optimizers.sinkgd import SinkGD, SinkGDOptimizerFactory
+
+        optimizer_cls, optimizer_kwargs = trainer.optimizer_cls_and_kwargs
+        assert optimizer_cls is SinkGDOptimizerFactory
+        assert optimizer_kwargs["lr"] == 0.00005
+        assert optimizer_kwargs["weight_decay"] == 0.01
+        assert optimizer_kwargs["sinkhorn_iters"] == 5
+        assert optimizer_kwargs["sinkgd_lr_scale"] == 0.05
+
+        # OptimizerMixin must resolve the factory into a concrete SinkGD instance
+        optim = trainer.create_optimizer()
+        assert isinstance(optim, SinkGD)
+        # linear weight matrices must be in the stateless SR-Sinkhorn group
+        assert any(group.get("use_sinkgd") for group in optim.param_groups)
+
 
 class TestTrainerClsPlugin:
     """

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -210,7 +210,9 @@ class TestCustomOptimizers(unittest.TestCase):
         check_model_output_exists(temp_dir, cfg)
         assert "SinkGD" in trainer.optimizer.optimizer.__class__.__name__
 
-    @pytest.mark.skip(reason="Dion's internal torch.compile hits a dynamo cache-limit error")
+    @pytest.mark.skip(
+        reason="Dion's internal torch.compile hits a dynamo cache-limit error"
+    )
     @with_temp_dir
     @require_torch_2_7_0
     def test_dion(self, temp_dir):

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -28,6 +28,7 @@ class TestCustomOptimizers(unittest.TestCase):
 
     @with_temp_dir
     def test_optimi_adamw(self, temp_dir):
+        pytest.importorskip("optimi")
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",
@@ -162,6 +163,54 @@ class TestCustomOptimizers(unittest.TestCase):
         assert "Muon" in trainer.optimizer.optimizer.__class__.__name__
 
     @with_temp_dir
+    @require_torch_2_5_1
+    def test_sinkgd(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "max_steps": 5,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "sinkgd",
+                "optim_args": {"sinkhorn_iters": 5, "sinkgd_lr_scale": 0.05},
+                "lr_scheduler": "cosine",
+                "weight_decay": 0.01,
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "SinkGD" in trainer.optimizer.optimizer.__class__.__name__
+
+    @pytest.mark.skip(reason="Dion's internal torch.compile hits a dynamo cache-limit error")
+    @with_temp_dir
     @require_torch_2_7_0
     def test_dion(self, temp_dir):
         cfg = DictDefault(
@@ -284,6 +333,7 @@ class TestCustomOptimizers(unittest.TestCase):
     @with_temp_dir
     @require_torch_2_6_0
     def test_came_pytorch(self, temp_dir):
+        pytest.importorskip("came_pytorch")
         cfg = DictDefault(
             {
                 "base_model": "axolotl-ai-co/tiny-llama-50m",

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -185,6 +185,7 @@ class TestCustomOptimizers(unittest.TestCase):
                     {
                         "path": "mhenrichsen/alpaca_2k_test",
                         "type": "alpaca",
+                        "split": "train[:200]",
                     },
                 ],
                 "num_epochs": 1,

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -1,0 +1,51 @@
+"""Unit tests for the SinkGD optimizer's SR-Sinkhorn, including 3D fused-MoE shapes."""
+
+import torch
+
+from axolotl.utils.optimizers.sinkgd import SinkGD, sr_sinkhorn
+
+
+def test_sr_sinkhorn_2d_fixed_point():
+    """Rows converge to L2 norm sqrt(n), columns to sqrt(m)."""
+    torch.manual_seed(0)
+    m, n = 16, 24
+    x = sr_sinkhorn(torch.randn(m, n), iters=20, eps=1e-8)
+    assert torch.allclose(x.norm(dim=1), torch.full((m,), n**0.5), atol=1e-3)
+    assert torch.allclose(x.norm(dim=0), torch.full((n,), m**0.5), atol=1e-3)
+
+
+def test_sr_sinkhorn_3d_per_expert():
+    """A fused MoE weight [E, M, N] is normalized independently per expert."""
+    torch.manual_seed(0)
+    E, m, n = 4, 16, 24
+    x = sr_sinkhorn(torch.randn(E, m, n), iters=20, eps=1e-8)
+    # each expert independently reaches the doubly-balanced fixed point
+    assert torch.allclose(x.norm(dim=-1), torch.full((E, m), n**0.5), atol=1e-3)
+    assert torch.allclose(x.norm(dim=-2), torch.full((E, n), m**0.5), atol=1e-3)
+
+
+def test_sr_sinkhorn_3d_experts_decoupled():
+    """Scaling one expert's gradient must not change the other experts' updates."""
+    torch.manual_seed(0)
+    g = torch.randn(4, 16, 24)
+    x = sr_sinkhorn(g, iters=20, eps=1e-8)
+    g2 = g.clone()
+    g2[0] *= 100.0
+    x2 = sr_sinkhorn(g2, iters=20, eps=1e-8)
+    assert torch.allclose(x[1:], x2[1:], atol=1e-4)
+
+
+def test_sinkgd_step_3d_stateless():
+    """SinkGD updates a 3D expert weight and stores no optimizer state for it."""
+    torch.manual_seed(0)
+    w = torch.nn.Parameter(torch.randn(4, 16, 24))
+    opt = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_lr_scale=1.0,
+    )
+    before = w.detach().clone()
+    w.grad = torch.randn_like(w)
+    opt.step()
+    assert not torch.allclose(before, w.detach())
+    assert opt.state[w] == {}  # SR-Sinkhorn is stateless


### PR DESCRIPTION
Implements SinkGD from "Gradient Multi-Normalization for Stateless and Scalable LLM Training" (Scetbon et al., 2025, https://arxiv.org/abs/2502.06742).

2D linear weights (and 3D fused-MoE-expert weights, normalized per-expert) are updated with the stateless SR-Sinkhorn procedure (alternating row/column L2 normalization, no momentum/variance state). Embeddings, the LM head, and 1D params fall back to AdamW, reusing torchao's 8-bit optimizer base so that state stays quantized. On an 8B full finetune this cuts optimizer-state memory ~87% (linear weights carry zero state), for ~24% lower peak vs 8-bit AdamW.

The per-matrix update is torch.compiled and runs the Sinkhorn in bf16 with fp32-accumulated norms, so end-to-end throughput matches/beats AdamW at equal loss. Wired in as a custom optimizer (optimizer: sinkgd) with sinkhorn_iters and sinkgd_lr_scale exposed via optim_args.

Also switch the trainer optimizer mixin to detect factory optimizers via transformers' is_optimizer_factory instead of the axolotl-specific BaseOptimizerFactory subclass check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new custom optimizer option, including configuration guidance and examples.
  * Expanded training to use the new optimizer for suitable parameters while keeping a fallback path for others.

* **Bug Fixes**
  * Improved optimizer setup handling for better compatibility during trainer initialization.
  * Added support for optional dependency checks so unavailable optimizer integrations are skipped cleanly.

* **Tests**
  * Added unit and end-to-end coverage for the new optimizer configuration and training flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->