### PR TITLE
fix(merge): dequantize quantized bases before folding LoRA delta

### DIFF
--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -116,12 +116,15 @@ def _do_merge_lora_efficient(*, cfg: DictDefault) -> None:
         nf4_blocksize=nf4_blocksize,
         nf4_double_quant=nf4_double_quant,
         trust_remote_code=bool(getattr(cfg, "trust_remote_code", False)),
+        dequant=bool(getattr(cfg, "merge_dequant", False)),
     )
 
     LOG.debug("Memory-efficient LoRA merge completed successfully!")
 
 
-def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs) -> None:
+def do_cli(
+    config: Union[Path, str] = Path("examples/"), dequant: bool = False, **kwargs
+) -> None:
     """
     Parses `axolotl` config, CLI args, and calls `do_merge_lora`. Note that various
     config values will be overwritten to allow the LoRA merge logic to work as expected
@@ -129,6 +132,8 @@ def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs) -> None:
 
     Args:
         config: Path to `axolotl` config YAML file.
+        dequant: If set (``--dequant``), dequantize a quantized base to bf16 in the merged
+            checkpoint. Default keeps the base's quantized dtypes (fp8/nvfp4) intact.
         kwargs: Additional keyword arguments to override config file values.
 
     Raises:
@@ -159,6 +164,7 @@ def do_cli(config: Union[Path, str] = Path("examples/"), **kwargs) -> None:
     parsed_cfg._original_load_in_4bit = original_load_in_4bit
     parsed_cfg._original_adapter = original_adapter
     parsed_cfg._original_quantize_moe_experts = original_quantize_moe_experts
+    parsed_cfg.merge_dequant = bool(dequant)
 
     if not parsed_cfg.lora_model_dir and parsed_cfg.output_dir:
         parsed_cfg.lora_model_dir = parsed_cfg.output_dir

--- a/src/axolotl/cli/utils/lora_merge.py
+++ b/src/axolotl/cli/utils/lora_merge.py
@@ -650,82 +650,180 @@ def _dequant_nvfp4(w, scale, scale2, dev: str) -> torch.Tensor:
     return nv.dequantize(torch.bfloat16)
 
 
+def _detect_quant_format(key, w, shard_tensors, e8m0):
+    """Return (fmt, {suffix: scale_tensor}) for a quantized weight ``key``, else (None, {}).
+    fmt in {block_fp8, mxfp8, nvfp4, mxfp4}."""
+    si = shard_tensors.get(key + "_scale_inv")
+    sc = shard_tensors.get(key + "_scale")
+    sc2 = shard_tensors.get(key + "_scale_2")
+    is_e8m0 = sc is not None and (
+        sc.dtype == torch.uint8 or (e8m0 is not None and sc.dtype == e8m0)
+    )
+    if w.dtype == torch.float8_e4m3fn and si is not None:
+        return "block_fp8", {"_scale_inv": si}
+    if w.dtype == torch.float8_e4m3fn and is_e8m0:
+        return "mxfp8", {"_scale": sc}
+    if w.dtype == torch.uint8 and sc is not None and sc.dtype == torch.float8_e4m3fn:
+        scales = {"_scale": sc}
+        if sc2 is not None:
+            scales["_scale_2"] = sc2
+        return "nvfp4", scales
+    if w.dtype == torch.uint8 and is_e8m0:
+        return "mxfp4", {"_scale": sc}
+    return None, {}
+
+
+def _dequant_by_format(fmt, w, scales, dev):
+    if fmt == "block_fp8":
+        return _dequant_block_fp8(w, scales["_scale_inv"], dev)
+    if fmt == "mxfp8":
+        return _dequant_mxfp8(w, scales["_scale"], dev)
+    if fmt == "nvfp4":
+        return _dequant_nvfp4(w, scales["_scale"], scales.get("_scale_2"), dev)
+    return _dequant_mxfp4(w, scales["_scale"], dev)  # mxfp4
+
+
+def _requant_by_format(fmt, w_bf16, scales, dev):
+    """Re-quantize a merged bf16 weight back to its original format (fresh block scales). Returns
+    ``{"": qweight, "_scale*": scale_tensors}`` matching the original scale dtypes/shapes so the
+    merged checkpoint loads exactly like the base did."""
+    w = w_bf16.to(dev).float()
+    if fmt == "block_fp8":
+        si = scales["_scale_inv"]
+        *lead, N, K = w.shape
+        sr, sc = si.shape[-2], si.shape[-1]
+        bn, bk = N // sr, K // sc
+        wb = w.reshape(*lead, sr, bn, sc, bk)
+        amax = wb.abs().amax(dim=(-3, -1), keepdim=True).clamp_min(1e-12)
+        scale_inv = amax / 448.0
+        q = (wb / scale_inv).clamp_(-448, 448).to(torch.float8_e4m3fn)
+        return {
+            "": q.reshape(*lead, N, K).cpu(),
+            "_scale_inv": scale_inv.reshape(*lead, sr, sc).to(si.dtype).cpu(),
+        }
+    if fmt == "mxfp8":
+        q, ebyte = _quant_mx(w, 32)
+        s = scales["_scale"]
+        return {"": q.cpu(), "_scale": ebyte.view(s.dtype).cpu()}
+    if fmt == "mxfp4":
+        packed, ebyte = _quant_mxfp4(w)
+        s = scales["_scale"]
+        return {"": packed.cpu(), "_scale": ebyte.view(s.dtype).cpu()}
+    # nvfp4 via torchao (matches the loader)
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    two_level = "_scale_2" in scales
+    p = (
+        (w.abs().max() / (6.0 * 448.0)).reshape(1).clamp_min(1e-12)
+        if two_level
+        else None
+    )
+    nv = NVFP4Tensor.to_nvfp4(w, per_tensor_scale=p, is_swizzled_scales=False)
+    out = {"": nv.qdata.cpu(), "_scale": nv.scale.to(scales["_scale"].dtype).cpu()}
+    if two_level:
+        out["_scale_2"] = nv.per_tensor_scale.reshape(scales["_scale_2"].shape).cpu()
+    return out
+
+
+def _quant_mx(w_f32, block):
+    """bf16/f32 -> (e4m3 qdata, uint8 e8m0 exponent byte), FLOOR e8m0, 32-wide blocks along last dim."""
+    *lead, N, K = w_f32.shape
+    nb = K // block
+    wb = w_f32.reshape(*lead, N, nb, block)
+    amax = wb.abs().amax(-1).clamp_min(1e-12)
+    exp = torch.floor(torch.log2(amax)) - 8.0
+    q = (wb / torch.exp2(exp)[..., None]).clamp_(-448, 448).to(torch.float8_e4m3fn)
+    ebyte = (exp + 127.0).clamp_(0, 254).to(torch.uint8)
+    return q.reshape(*lead, N, K), ebyte
+
+
+def _quant_mxfp4(w_f32):
+    """f32 -> (packed e2m1 uint8 [.., K/2], uint8 e8m0 [.., K/32]); nearest-codebook, low/high nibble."""
+    lut = torch.tensor(_FP4_E2M1_LUT, dtype=torch.float32, device=w_f32.device)
+    *lead, N, K = w_f32.shape
+    nb = K // _MX_BLOCK
+    wb = w_f32.reshape(*lead, N, nb, _MX_BLOCK)
+    amax = wb.abs().amax(-1).clamp_min(1e-6)
+    exp = torch.floor(torch.log2(amax / 6.0))
+    wn = (wb / torch.exp2(exp)[..., None]).reshape(*lead, N, K)
+    idx = (wn.unsqueeze(-1) - lut).abs().argmin(-1).to(torch.uint8)  # [.., N, K]
+    packed = idx[..., 0::2] | (idx[..., 1::2] << 4)
+    ebyte = (exp + 127.0).clamp_(0, 254).to(torch.uint8)
+    return packed, ebyte
+
+
+def _key_has_lora(key, shape, lora_state, weight_renamings):
+    a, b = find_lora_weights(lora_state, key, weight_renamings)
+    if a is not None and b is not None:
+        return True
+    if len(shape) >= 3:
+        pa, pb, _ = _find_param_wrapper_lora(lora_state, key, tuple(shape))
+        return pa is not None and pb is not None
+    return False
+
+
 def _dequantize_quantized_shard(
-    shard_tensors: Dict[str, torch.Tensor], device: str
-) -> tuple[Dict[str, torch.Tensor], bool, bool]:
-    """Dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 in place, dropping their
-    scale sibling tensors. Returns ``(new_shard, any_dequantized, any_left_quantized)`` — the last flag
-    is True if a quantized tensor was detected but NOT dequantized (unsupported format, or torchao
-    missing for nvfp4), so the caller must NOT strip the quantization_config.
+    shard_tensors: Dict[str, torch.Tensor],
+    device: str,
+    lora_state: Optional[Dict[str, torch.Tensor]] = None,
+    weight_renamings: Optional[Dict[str, str]] = None,
+    dequant_all: bool = True,
+) -> tuple[Dict[str, torch.Tensor], bool, bool, Dict]:
+    """Dequantize quantized weights to bf16 so the LoRA delta folds into the true value.
 
-    The LoRA merge folds ``scaling*(B@A)`` into the weight and must do so on the *dequantized* value,
-    then keep bf16 (re-rounding the sum back to the quant format would drop the low-magnitude delta).
-    A weight ``K`` is detected by its scale sibling(s):
+    Returns ``(new_shard, any_dequantized, any_left_quantized, requant_plan)``.
 
-      * ``K_scale_inv`` (fp32) + ``K`` e4m3          -> block-fp8 (128x128)
-      * ``K_scale`` (e8m0/uint8) + ``K`` e4m3        -> mxfp8 (32-wide)
-      * ``K_scale`` (e4m3) + ``K_scale_2`` + ``K`` uint8 -> nvfp4 (block-16 two-level)
+    ``dequant_all=True`` dequantizes EVERY quantized weight to bf16 (the ``--dequant`` merge: output is
+    bf16). Default (``dequant_all=False``) is FORMAT-PRESERVING: only LoRA-targeted quantized weights
+    are dequantized (so the delta can fold correctly); ``requant_plan[key] = (fmt, scales)`` records how
+    to re-quantize each back to its original format after the merge, and quantized weights with no LoRA
+    are left untouched (same dtype + scales). ``any_left_quantized`` = a quantized weight was detected
+    but could not be dequantized (unsupported format / torchao missing) -> keep the config.
 
-    Covers 2D linears (``q_proj.weight`` + ``q_proj.weight_scale*``) AND fused-3D experts
-    (``experts.gate_up_proj`` + ``experts.gate_up_proj_scale*``, no ``.weight`` suffix — match on
-    ``key + "_scale*"``). NOTE: native nvfp4/mxfp4 checkpoints that store experts *per-expert*
-    (``experts.0.gate_proj.weight`` ...) unfused are NOT handled here — that needs a fuse->merge->
-    unfuse writer (see the nvfp4 expert-merge writer)."""
+    Formats (detected by scale sibling): block-fp8 (``_scale_inv`` fp32, 128x128), mxfp8 (``_scale``
+    e8m0/32), nvfp4 (``_scale`` e4m3/16 [+ ``_scale_2``]), mxfp4 (``_scale`` e8m0/32). Covers 2D linears
+    and fused-3D experts; native per-expert-unfused nvfp4/mxfp4 is not handled here."""
     dev = device if (device != "cpu" and torch.cuda.is_available()) else "cpu"
     e8m0 = getattr(torch, "float8_e8m0fnu", None)
     out: Dict[str, torch.Tensor] = dict(shard_tensors)
     drop: set = set()
+    plan: Dict = {}
     did = False
     left = False
+    lora_state = lora_state or {}
     for key, w in shard_tensors.items():
         if key in drop or key.endswith(("_scale", "_scale_inv", "_scale_2")):
             continue
         if w.ndim not in (2, 3):
             continue
-        si = shard_tensors.get(key + "_scale_inv")
-        sc = shard_tensors.get(key + "_scale")
-        sc2 = shard_tensors.get(key + "_scale_2")
-        is_e8m0 = sc is not None and (
-            sc.dtype == torch.uint8 or (e8m0 is not None and sc.dtype == e8m0)
-        )
-        # a quantized weight = a low-bit dtype WITH a scale sibling (else it's a normal tensor)
-        is_quant = w.dtype in (torch.float8_e4m3fn, torch.uint8) and (
-            si is not None or sc is not None
-        )
-        deq = None
-        if w.dtype == torch.float8_e4m3fn and si is not None:
-            deq = _dequant_block_fp8(w, si, dev)  # block-fp8 (128x128)
-            drop.add(key + "_scale_inv")
-        elif w.dtype == torch.float8_e4m3fn and is_e8m0:
-            deq = _dequant_mxfp8(w, sc, dev)  # mxfp8 (e4m3 + e8m0/32)
-            drop.add(key + "_scale")
-        elif (
-            w.dtype == torch.uint8
-            and sc is not None
-            and sc.dtype == torch.float8_e4m3fn
+        fmt, scales = _detect_quant_format(key, w, shard_tensors, e8m0)
+        if fmt is None:
+            # a low-bit weight with a scale sibling but an unrecognized format -> keep the config
+            if w.dtype in (torch.float8_e4m3fn, torch.uint8) and (
+                shard_tensors.get(key + "_scale_inv") is not None
+                or shard_tensors.get(key + "_scale") is not None
+            ):
+                left = True
+            continue
+        # format-preserving: only touch quantized weights a LoRA actually targets
+        if not dequant_all and not _key_has_lora(
+            key, w.shape, lora_state, weight_renamings
         ):
-            try:  # nvfp4: e4m3 block-16 scale, two-level if scale_2 present else single-level
-                deq = _dequant_nvfp4(w, sc, sc2, dev)
-            except Exception as ex:  # torchao missing / shape mismatch -> leave as-is
-                LOG.warning("nvfp4 dequant skipped for %s: %s", key, ex)
-                left = True  # tensor stays quantized -> config must be kept
-                continue
-            drop.add(key + "_scale")
-            if sc2 is not None:
-                drop.add(key + "_scale_2")
-        elif w.dtype == torch.uint8 and is_e8m0:
-            deq = _dequant_mxfp4(w, sc, dev)  # mxfp4 (packed e2m1 + e8m0/32)
-            drop.add(key + "_scale")
-        if deq is not None:
-            out[key] = deq.to(torch.bfloat16).cpu()
-            did = True
-        elif is_quant:
-            left = (
-                True  # a quantized weight in an unsupported layout -> keep the config
-            )
+            continue
+        try:
+            deq = _dequant_by_format(fmt, w, scales, dev)
+        except Exception as ex:  # torchao missing / shape mismatch -> leave quantized
+            LOG.warning("%s dequant skipped for %s: %s", fmt, key, ex)
+            left = True
+            continue
+        out[key] = deq.to(torch.bfloat16).cpu()
+        did = True
+        drop.update(key + suf for suf in scales)
+        if not dequant_all:
+            plan[key] = (fmt, scales)  # re-quantize after the LoRA fold
     for sk in drop:
         out.pop(sk, None)
-    return out, did, left
+    return out, did, left, plan
 
 
 _FUSED_EXPERT_LORA_RE = re.compile(r"\.experts\.(?:base_layer\.)?lora_[AB]\.weight$")
@@ -1285,10 +1383,16 @@ def merge_lora_sharded_efficient(
     nf4_blocksize: Optional[int] = None,
     nf4_double_quant: bool = True,
     trust_remote_code: bool = False,
+    dequant: bool = False,
 ) -> None:
     """
     Memory-efficient LoRA merging that processes shards individually
     without loading the full model into memory.
+
+    dequant: if True, dequantize every quantized weight and write a bf16 checkpoint (strips
+        quantization_config). Default False = FORMAT-PRESERVING: LoRA-targeted quantized weights are
+        dequantized, the delta folded, then re-quantized back to the SAME format (fp8 stays fp8,
+        nvfp4 stays nvfp4), so a large quantized base does not double in size.
 
     Args:
         simulate_nf4: Apply NF4 roundtrip to ALL weight tensors (for QLoRA)
@@ -1452,11 +1556,17 @@ def merge_lora_sharded_efficient(
 
         total_tensors += len(shard_tensors)
 
-        # Step 0: dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 so the LoRA
-        # delta folds into the TRUE weight — a raw read misses the block scale and re-rounds the sum
-        # back to the quant format, dropping the delta (an otherwise silently-wrong merge).
-        shard_tensors, _shard_deq, _shard_left = _dequantize_quantized_shard(
-            shard_tensors, device
+        # Step 0: dequantize quantized weights so the LoRA delta folds into the TRUE weight (a raw read
+        # misses the block scale). Default (dequant=False) touches only LoRA-targeted weights and plans
+        # to re-quantize them back to their original format after the fold; dequant=True dequants all.
+        shard_tensors, _shard_deq, _shard_left, requant_plan = (
+            _dequantize_quantized_shard(
+                shard_tensors,
+                device,
+                lora_state=lora_state,
+                weight_renamings=weight_renamings,
+                dequant_all=dequant,
+            )
         )
         block_fp8_dequantized = block_fp8_dequantized or _shard_deq
         left_quantized = left_quantized or _shard_left
@@ -1520,6 +1630,23 @@ def merge_lora_sharded_efficient(
             if was_merged:
                 merged_count += 1
 
+        # Step 3 (format-preserving): re-quantize each merged weight back to its original format
+        # (fresh block scales) so the output dtype matches the input (fp8 -> fp8, nvfp4 -> nvfp4).
+        for key, (fmt, scales) in requant_plan.items():
+            if key not in merged_tensors:
+                continue
+            try:
+                requant = _requant_by_format(fmt, merged_tensors[key], scales, device)
+            except (
+                Exception
+            ) as ex:  # torchao missing etc. -> keep the bf16 merge for this weight
+                LOG.warning("%s re-quant skipped for %s: %s", fmt, key, ex)
+                left_quantized = True
+                continue
+            merged_tensors[key] = requant.pop("")
+            for suf, t in requant.items():
+                merged_tensors[key + suf] = t
+
         output_shard_path = output_path / shard_path.name
         merged_tensors = {k: v.detach().cpu() for k, v in merged_tensors.items()}
 
@@ -1562,7 +1689,9 @@ def merge_lora_sharded_efficient(
             _json.dump(index, f, indent=2)
         LOG.debug(f"Wrote weight-map index: {index_name}")
 
-    if block_fp8_dequantized and not left_quantized:
+    # Only the --dequant merge emits a bf16 checkpoint; the format-preserving default keeps the
+    # quantized dtypes (and their quantization_config) intact.
+    if dequant and block_fp8_dequantized and not left_quantized:
         _strip_quantization_config(output_path)
     elif block_fp8_dequantized and left_quantized:
         LOG.warning(

--- a/src/axolotl/cli/utils/lora_merge.py
+++ b/src/axolotl/cli/utils/lora_merge.py
@@ -1,6 +1,7 @@
 import gc
 import math
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Dict, Optional, Union
@@ -544,6 +545,298 @@ def _find_dora_magnitude(
     return None
 
 
+def _dequant_block_fp8(w: torch.Tensor, si: torch.Tensor, dev: str) -> torch.Tensor:
+    """FineGrainedFP8 (block-fp8): ``W`` e4m3 * ``scale_inv`` fp32 (128x128 blocks). 2D or fused-3D
+    (block axes = last two dims)."""
+    wf = w.to(dev).float()
+    s = si.to(dev).float()
+    *lead, N, K = w.shape
+    sr, sc = s.shape[-2], s.shape[-1]
+    if N % sr == 0 and K % sc == 0:
+        bn, bk = N // sr, K // sc
+        return (
+            wf.reshape(*lead, sr, bn, sc, bk) * s.reshape(*lead, sr, 1, sc, 1)
+        ).reshape(*lead, N, K)
+    return wf * s.repeat_interleave(N // sr, -2).repeat_interleave(K // sc, -1)
+
+
+# Standard OCP-MX / NVFP4 FP4 E2M1 codebook, indexed by raw 4-bit nibble (sign|2-exp|1-mantissa).
+_FP4_E2M1_LUT = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def _mx_block_scale(sb_bytes: torch.Tensor, N: int, K: int, dev: str) -> torch.Tensor:
+    """e8m0 biased-exponent bytes [.., N, nb] -> per-element multiplier [.., N, K] (32-wide MX blocks).
+    Handles ragged K (K not a whole multiple of the block via repeat_interleave)."""
+    s = torch.exp2(sb_bytes.to(dev).float() - 127.0)
+    nb = s.shape[-1]
+    if K % nb == 0:
+        return s[..., None].expand(*s.shape, K // nb).reshape(*s.shape[:-1], K)
+    return s.repeat_interleave((K + nb - 1) // nb, dim=-1)[..., :K]
+
+
+def _dequant_mxfp8(w: torch.Tensor, s: torch.Tensor, dev: str) -> torch.Tensor:
+    """OCP-MX fp8: ``W`` e4m3 * ``2^(e8m0_byte-127)`` (32-wide blocks along the last dim). ``s`` is the
+    e8m0 scale (``float8_e8m0fnu`` or raw ``uint8``). Ragged-K safe."""
+    wf = w.to(dev).float()
+    *lead, N, K = w.shape
+    scale = _mx_block_scale(s.view(torch.uint8), N, K, dev).reshape(*lead, N, K)
+    return wf * scale
+
+
+def _unpack_fp4(packed: torch.Tensor, dev: str) -> torch.Tensor:
+    """Unpack a packed-e2m1 uint8 tensor [.., K/2] -> fp32 values [.., K] via the OCP LUT. Low nibble =
+    element 2i, high nibble = element 2i+1 (torchao / OCP convention)."""
+    lut = torch.tensor(_FP4_E2M1_LUT, dtype=torch.float32, device=dev)
+    b = packed.to(dev)
+    lo = (b & 0xF).long()
+    hi = ((b >> 4) & 0xF).long()
+    nib = torch.stack([lo, hi], dim=-1).reshape(*b.shape[:-1], b.shape[-1] * 2)
+    return lut[nib]
+
+
+def _dequant_mxfp4(w: torch.Tensor, s: torch.Tensor, dev: str) -> torch.Tensor:
+    """OCP-MX fp4: packed e2m1 ``W`` [.., K/2] uint8 * ``2^(e8m0-127)`` (32-wide blocks). Ragged-K safe.
+    Matches the codebook + low/high nibble order the ScatterMoE MX forward uses, so the merged weight
+    equals what the model computes."""
+    vals = _unpack_fp4(w, dev)
+    *lead, N, K = vals.shape
+    scale = _mx_block_scale(s.view(torch.uint8), N, K, dev).reshape(*lead, N, K)
+    return vals * scale
+
+
+def _dequant_nvfp4(w, scale, scale2, dev: str) -> torch.Tensor:
+    """NVFP4: packed e2m1 ``W`` [..,K/2] uint8 + e4m3 block-16 ``scale`` [..,K/16] + optional per-tensor
+    ``scale_2`` (two-level; single-level when absent -> per_tensor_scale=1). Uses torchao's own
+    dequantize (matches the loader). Auto-detects swizzled scales by shape and passes the flag. Raises
+    if torchao is unavailable (caller degrades)."""
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    wt = w.to(dev)
+    st = scale.to(dev)
+    p = scale2.to(dev).float().reshape(()) if scale2 is not None else None
+    *lead, N, K = wt.shape
+    # plain (non-swizzled) block-16 scale has exactly N*(K*2/16) elements per leading index; a padded
+    # 32x4x4-swizzled scale is larger -> tell torchao to unswizzle it.
+    expect = 1
+    for d in (*lead, N, (K * 2) // 16):
+        expect *= d
+    swizzled = st.numel() != expect
+    nv = NVFP4Tensor(
+        wt, st, 16, torch.bfloat16, per_tensor_scale=p, is_swizzled_scales=swizzled
+    )
+    return nv.dequantize(torch.bfloat16)
+
+
+def _dequantize_quantized_shard(
+    shard_tensors: Dict[str, torch.Tensor], device: str
+) -> tuple[Dict[str, torch.Tensor], bool]:
+    """Dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 in place, dropping their
+    scale sibling tensors. Returns ``(new_shard, any_dequantized)``.
+
+    The LoRA merge folds ``scaling*(B@A)`` into the weight and must do so on the *dequantized* value,
+    then keep bf16 (re-rounding the sum back to the quant format would drop the low-magnitude delta).
+    A weight ``K`` is detected by its scale sibling(s):
+
+      * ``K_scale_inv`` (fp32) + ``K`` e4m3          -> block-fp8 (128x128)
+      * ``K_scale`` (e8m0/uint8) + ``K`` e4m3        -> mxfp8 (32-wide)
+      * ``K_scale`` (e4m3) + ``K_scale_2`` + ``K`` uint8 -> nvfp4 (block-16 two-level)
+
+    Covers 2D linears (``q_proj.weight`` + ``q_proj.weight_scale*``) AND fused-3D experts
+    (``experts.gate_up_proj`` + ``experts.gate_up_proj_scale*``, no ``.weight`` suffix — match on
+    ``key + "_scale*"``). NOTE: native nvfp4/mxfp4 checkpoints that store experts *per-expert*
+    (``experts.0.gate_proj.weight`` ...) unfused are NOT handled here — that needs a fuse->merge->
+    unfuse writer (see the nvfp4 expert-merge writer)."""
+    dev = device if (device != "cpu" and torch.cuda.is_available()) else "cpu"
+    e8m0 = getattr(torch, "float8_e8m0fnu", None)
+    out: Dict[str, torch.Tensor] = dict(shard_tensors)
+    drop: set = set()
+    did = False
+    for key, w in shard_tensors.items():
+        if key in drop or key.endswith(("_scale", "_scale_inv", "_scale_2")):
+            continue
+        if w.ndim not in (2, 3):
+            continue
+        si = shard_tensors.get(key + "_scale_inv")
+        sc = shard_tensors.get(key + "_scale")
+        sc2 = shard_tensors.get(key + "_scale_2")
+        is_e8m0 = sc is not None and (
+            sc.dtype == torch.uint8 or (e8m0 is not None and sc.dtype == e8m0)
+        )
+        deq = None
+        if w.dtype == torch.float8_e4m3fn and si is not None:
+            deq = _dequant_block_fp8(w, si, dev)  # block-fp8 (128x128)
+            drop.add(key + "_scale_inv")
+        elif w.dtype == torch.float8_e4m3fn and is_e8m0:
+            deq = _dequant_mxfp8(w, sc, dev)  # mxfp8 (e4m3 + e8m0/32)
+            drop.add(key + "_scale")
+        elif (
+            w.dtype == torch.uint8
+            and sc is not None
+            and sc.dtype == torch.float8_e4m3fn
+        ):
+            try:  # nvfp4: e4m3 block-16 scale, two-level if scale_2 present else single-level
+                deq = _dequant_nvfp4(w, sc, sc2, dev)
+            except Exception as ex:  # torchao missing / shape mismatch -> leave as-is
+                LOG.warning("nvfp4 dequant skipped for %s: %s", key, ex)
+                continue
+            drop.add(key + "_scale")
+            if sc2 is not None:
+                drop.add(key + "_scale_2")
+        elif w.dtype == torch.uint8 and is_e8m0:
+            deq = _dequant_mxfp4(w, sc, dev)  # mxfp4 (packed e2m1 + e8m0/32)
+            drop.add(key + "_scale")
+        if deq is not None:
+            out[key] = deq.to(torch.bfloat16).cpu()
+            did = True
+    for sk in drop:
+        out.pop(sk, None)
+    return out, did
+
+
+_FUSED_EXPERT_LORA_RE = re.compile(r"\.experts\.(?:base_layer\.)?lora_[AB]\.weight$")
+_PER_EXPERT_WEIGHT_RE = re.compile(
+    r"\.experts\.\d+\.(?:gate_proj|up_proj|down_proj|w1|w2|w3|gate_up_proj)\.weight$"
+)
+
+
+def _detect_per_expert_unfused_mismatch(model_shards, lora_state) -> bool:
+    """True if the adapter carries a FUSED expert LoRA (``experts.lora_A``, targeting a fused
+    ``experts.gate_up_proj`` param) but the base stores experts PER-EXPERT and unfused
+    (``experts.0.gate_proj.weight`` ...). In that case the fused adapter keys match no base tensor,
+    so the expert LoRA would be *silently dropped* by the shard-by-shard merge. Peeks shard keys
+    only (no tensor loads)."""
+    if not any(_FUSED_EXPERT_LORA_RE.search(k) for k in lora_state):
+        return False
+    for shard in model_shards:
+        try:
+            if str(shard).endswith(".safetensors"):
+                with safetensors.safe_open(shard, framework="pt") as f:
+                    keys = list(f.keys())
+            else:
+                keys = list(
+                    torch.load(shard, map_location="meta", weights_only=True).keys()  # nosec B614
+                )
+        except Exception:  # noqa: BLE001  # nosec B112 - unreadable shard: skip the peek, not fatal
+            continue
+        if any(_PER_EXPERT_WEIGHT_RE.search(k) for k in keys):
+            return True
+    return False
+
+
+def _update_config_vocab_size(output_path: Path, vocab_size: int) -> None:
+    """After carrying a resized ``embed_tokens`` into the merge, set ``vocab_size`` in the merged
+    ``config.json`` (and any nested text config) so the checkpoint loads with the enlarged vocab."""
+    import json as _json
+
+    cfg_path = output_path / "config.json"
+    if not cfg_path.exists():
+        return
+    cfg = _json.loads(cfg_path.read_text())
+    changed = cfg.get("vocab_size") != vocab_size
+    cfg["vocab_size"] = vocab_size
+    for sub in ("text_config", "llm_config"):
+        if isinstance(cfg.get(sub), dict):
+            cfg[sub]["vocab_size"] = vocab_size
+            changed = True
+    if changed:
+        cfg_path.write_text(_json.dumps(cfg, indent=2))
+        LOG.info(
+            "Set merged config.json vocab_size=%d (resized embeddings carried)",
+            vocab_size,
+        )
+
+
+def _find_full_override(
+    lora_state: Dict[str, torch.Tensor], key: str
+) -> Optional[torch.Tensor]:
+    """Return the adapter's FULL-weight override for a base ``key`` if present, else None.
+
+    PEFT saves trainable non-LoRA modules — ``modules_to_save`` and resized ``embed_tokens`` /
+    ``lm_head`` — as plain ``base_model.model.<key>`` tensors (no ``lora_A``/``lora_B``). These must
+    REPLACE the base weight at merge, not be ignored (otherwise a resized vocab / trained head is
+    silently dropped). Matches ``.weight`` overrides only; ignores any ``.lora_`` tensor."""
+    if not key.endswith(".weight") or ".lora_" in key:
+        return None
+    for cand in (
+        "base_model.model." + key,
+        "base_model.model.model." + key,
+        "base_model.model." + key.replace("modules_to_save.", ""),
+    ):
+        t = lora_state.get(cand)
+        if t is not None and ".lora_" not in cand:
+            return t
+    # PEFT modules_to_save layout: ...<module>.modules_to_save.default.weight
+    ms = (
+        "base_model.model." + key[: -len(".weight")] + ".modules_to_save.default.weight"
+    )
+    return lora_state.get(ms)
+
+
+def _strip_quantization_config(output_path: Path) -> None:
+    """After a block-fp8 -> bf16 merge, remove ``quantization_config`` from the merged ``config.json``
+    so the merged checkpoint loads as bf16 (not FineGrainedFP8) and set ``torch_dtype`` to bfloat16."""
+    import json as _json
+
+    cfg_path = output_path / "config.json"
+    if not cfg_path.exists():
+        return
+    cfg = _json.loads(cfg_path.read_text())
+    changed = cfg.pop("quantization_config", None) is not None
+    if cfg.get("torch_dtype") not in (None, "bfloat16"):
+        cfg["torch_dtype"] = "bfloat16"
+        changed = True
+    if changed:
+        cfg_path.write_text(_json.dumps(cfg, indent=2))
+        LOG.info(
+            "Stripped quantization_config from merged config.json (block-fp8 -> bf16 merge)"
+        )
+
+
+_QUANT_DTYPES = {
+    torch.float8_e4m3fn,
+    getattr(torch, "float8_e5m2", torch.float8_e4m3fn),
+    torch.uint8,
+    torch.int8,
+}
+_WARNED_UNDEQUANT: set = set()
+
+
+def _warn_if_quant_undequantized(key: str, tensor: torch.Tensor, do_nf4: bool) -> None:
+    """Loudly warn (once/key) if a LoRA delta is about to be folded into a still-quantized weight
+    that the shard dequant did NOT convert to a real dtype (an unhandled format — e.g. mxfp4, a
+    per-tensor-fp8 with a scalar scale, or a per-expert-unfused nvfp4/mxfp4 layout). Folding into raw
+    packed bytes silently corrupts the weight; NF4 is handled by the simulate_nf4 roundtrip and is
+    exempt."""
+    if do_nf4 or tensor.dtype not in _QUANT_DTYPES or key in _WARNED_UNDEQUANT:
+        return
+    _WARNED_UNDEQUANT.add(key)
+    LOG.warning(
+        "LoRA merge: '%s' is still %s (a quantized format the merge did not dequantize) yet a LoRA "
+        "delta targets it — folding into raw quantized data is WRONG. This format is unsupported by "
+        "the efficient merge (handled: bf16, nf4-sim, block-fp8, mxfp8, fused-nvfp4). For per-expert "
+        "nvfp4/mxfp4 experts use the nvfp4 expert-merge writer; otherwise use merge_method: legacy.",
+        key,
+        tensor.dtype,
+    )
+
+
 def _should_nf4_roundtrip(
     key: str,
     tensor: torch.Tensor,
@@ -601,6 +894,7 @@ def _merge_tensor_with_lora(
 
     if lora_a is not None and lora_b is not None:
         LOG.debug(f"Merging LoRA for {key}: {lora_a.shape}, {lora_b.shape}")
+        _warn_if_quant_undequantized(key, tensor, do_nf4)
 
         original_dtype = tensor.dtype
 
@@ -662,6 +956,7 @@ def _merge_tensor_with_lora(
                     f"Merging ParamWrapper LoRA for {key} "
                     f"(param={param_name}): {pw_a.shape}, {pw_b.shape}"
                 )
+                _warn_if_quant_undequantized(key, tensor, do_nf4)
                 if do_nf4:
                     tensor = _simulate_nf4_roundtrip(
                         tensor,
@@ -1104,8 +1399,20 @@ def merge_lora_sharded_efficient(
     LOG.debug(f"Found {len(model_shards)} model shards in {base_model_path}")
     copy_non_model_files(base_model_path, output_path, model_shards)
 
+    if _detect_per_expert_unfused_mismatch(model_shards, lora_state):
+        LOG.warning(
+            "MERGE INCOMPLETE: the adapter has a FUSED expert LoRA (experts.gate_up_proj/down_proj) "
+            "but this base stores experts PER-EXPERT and unfused (experts.<i>.gate_proj.weight ...). "
+            "The shard-by-shard merge cannot fold a fused delta into per-expert tensors, so the "
+            "EXPERT LoRA is being DROPPED (non-expert LoRA still merges). Use the nvfp4 expert-merge "
+            "writer (fuse->merge->unfuse), or merge_method: legacy (loads the full model so PEFT "
+            "fuses the experts itself)."
+        )
+
     merged_count = 0
     total_tensors = 0
+    block_fp8_dequantized = False
+    resized_vocab = None
     # Track weight_map for index regeneration: {tensor_key: shard_filename}
     weight_map: Dict[str, str] = {}
 
@@ -1125,6 +1432,12 @@ def merge_lora_sharded_efficient(
             )
 
         total_tensors += len(shard_tensors)
+
+        # Step 0: dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 so the LoRA
+        # delta folds into the TRUE weight — a raw read misses the block scale and re-rounds the sum
+        # back to the quant format, dropping the delta (an otherwise silently-wrong merge).
+        shard_tensors, _shard_deq = _dequantize_quantized_shard(shard_tensors, device)
+        block_fp8_dequantized = block_fp8_dequantized or _shard_deq
 
         # Step 1: Handle fused weight conversions (MoE experts) if applicable
         fused_keys: set = set()
@@ -1151,6 +1464,18 @@ def merge_lora_sharded_efficient(
         for key, tensor in shard_tensors.items():
             if key in fused_keys:
                 merged_tensors[key] = tensor.detach().cpu()
+                continue
+            # Full-weight override (modules_to_save / resized embed_tokens+lm_head): replace, don't
+            # fold LoRA. Track a vocab resize so the merged config.json stays consistent.
+            override = _find_full_override(lora_state, key)
+            if override is not None:
+                merged_tensors[key] = override.to(tensor.dtype).detach().cpu()
+                merged_count += 1
+                if (
+                    key.endswith("embed_tokens.weight")
+                    and override.shape[0] != tensor.shape[0]
+                ):
+                    resized_vocab = int(override.shape[0])
                 continue
             merged_tensor, was_merged = _merge_tensor_with_lora(
                 tensor,
@@ -1212,6 +1537,11 @@ def merge_lora_sharded_efficient(
         with open(output_path / index_name, "w") as f:
             _json.dump(index, f, indent=2)
         LOG.debug(f"Wrote weight-map index: {index_name}")
+
+    if block_fp8_dequantized:
+        _strip_quantization_config(output_path)
+    if resized_vocab is not None:
+        _update_config_vocab_size(output_path, resized_vocab)
 
     if merged_count == 0:
         LOG.warning(

--- a/src/axolotl/cli/utils/lora_merge.py
+++ b/src/axolotl/cli/utils/lora_merge.py
@@ -552,12 +552,17 @@ def _dequant_block_fp8(w: torch.Tensor, si: torch.Tensor, dev: str) -> torch.Ten
     s = si.to(dev).float()
     *lead, N, K = w.shape
     sr, sc = s.shape[-2], s.shape[-1]
-    if N % sr == 0 and K % sc == 0:
-        bn, bk = N // sr, K // sc
-        return (
-            wf.reshape(*lead, sr, bn, sc, bk) * s.reshape(*lead, sr, 1, sc, 1)
-        ).reshape(*lead, N, K)
-    return wf * s.repeat_interleave(N // sr, -2).repeat_interleave(K // sc, -1)
+    # FineGrainedFP8 dims are always block-aligned; a ragged grid would need a fixed 128-block
+    # pad/slice (not a floor-spread), so refuse rather than silently mis-scale.
+    if N % sr or K % sc:
+        raise ValueError(
+            f"block-fp8 weight {tuple(w.shape)} is not aligned to its scale grid "
+            f"({sr}x{sc}); FineGrainedFP8 requires block-aligned dims"
+        )
+    bn, bk = N // sr, K // sc
+    return (wf.reshape(*lead, sr, bn, sc, bk) * s.reshape(*lead, sr, 1, sc, 1)).reshape(
+        *lead, N, K
+    )
 
 
 # Standard OCP-MX / NVFP4 FP4 E2M1 codebook, indexed by raw 4-bit nibble (sign|2-exp|1-mantissa).
@@ -581,14 +586,16 @@ _FP4_E2M1_LUT = (
 )
 
 
+_MX_BLOCK = 32  # OCP-MX block width (one e8m0 scale per 32 elements)
+
+
 def _mx_block_scale(sb_bytes: torch.Tensor, N: int, K: int, dev: str) -> torch.Tensor:
-    """e8m0 biased-exponent bytes [.., N, nb] -> per-element multiplier [.., N, K] (32-wide MX blocks).
-    Handles ragged K (K not a whole multiple of the block via repeat_interleave)."""
+    """e8m0 biased-exponent bytes [.., N, nb] -> per-element multiplier [.., N, K]. Each scale covers
+    a fixed 32-wide MX block; a ragged final block (K not a multiple of 32) is trimmed."""
     s = torch.exp2(sb_bytes.to(dev).float() - 127.0)
-    nb = s.shape[-1]
-    if K % nb == 0:
-        return s[..., None].expand(*s.shape, K // nb).reshape(*s.shape[:-1], K)
-    return s.repeat_interleave((K + nb - 1) // nb, dim=-1)[..., :K]
+    if s.shape[-1] * _MX_BLOCK == K:  # perfectly aligned -> memory-efficient expand
+        return s[..., None].expand(*s.shape, _MX_BLOCK).reshape(*s.shape[:-1], K)
+    return s.repeat_interleave(_MX_BLOCK, dim=-1)[..., :K]
 
 
 def _dequant_mxfp8(w: torch.Tensor, s: torch.Tensor, dev: str) -> torch.Tensor:
@@ -632,8 +639,7 @@ def _dequant_nvfp4(w, scale, scale2, dev: str) -> torch.Tensor:
     st = scale.to(dev)
     p = scale2.to(dev).float().reshape(()) if scale2 is not None else None
     *lead, N, K = wt.shape
-    # plain (non-swizzled) block-16 scale has exactly N*(K*2/16) elements per leading index; a padded
-    # 32x4x4-swizzled scale is larger -> tell torchao to unswizzle it.
+    # a padded swizzled scale has more elements than the plain block-16 grid; torchao must unswizzle it
     expect = 1
     for d in (*lead, N, (K * 2) // 16):
         expect *= d
@@ -646,9 +652,11 @@ def _dequant_nvfp4(w, scale, scale2, dev: str) -> torch.Tensor:
 
 def _dequantize_quantized_shard(
     shard_tensors: Dict[str, torch.Tensor], device: str
-) -> tuple[Dict[str, torch.Tensor], bool]:
+) -> tuple[Dict[str, torch.Tensor], bool, bool]:
     """Dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 in place, dropping their
-    scale sibling tensors. Returns ``(new_shard, any_dequantized)``.
+    scale sibling tensors. Returns ``(new_shard, any_dequantized, any_left_quantized)`` — the last flag
+    is True if a quantized tensor was detected but NOT dequantized (unsupported format, or torchao
+    missing for nvfp4), so the caller must NOT strip the quantization_config.
 
     The LoRA merge folds ``scaling*(B@A)`` into the weight and must do so on the *dequantized* value,
     then keep bf16 (re-rounding the sum back to the quant format would drop the low-magnitude delta).
@@ -668,6 +676,7 @@ def _dequantize_quantized_shard(
     out: Dict[str, torch.Tensor] = dict(shard_tensors)
     drop: set = set()
     did = False
+    left = False
     for key, w in shard_tensors.items():
         if key in drop or key.endswith(("_scale", "_scale_inv", "_scale_2")):
             continue
@@ -678,6 +687,10 @@ def _dequantize_quantized_shard(
         sc2 = shard_tensors.get(key + "_scale_2")
         is_e8m0 = sc is not None and (
             sc.dtype == torch.uint8 or (e8m0 is not None and sc.dtype == e8m0)
+        )
+        # a quantized weight = a low-bit dtype WITH a scale sibling (else it's a normal tensor)
+        is_quant = w.dtype in (torch.float8_e4m3fn, torch.uint8) and (
+            si is not None or sc is not None
         )
         deq = None
         if w.dtype == torch.float8_e4m3fn and si is not None:
@@ -695,6 +708,7 @@ def _dequantize_quantized_shard(
                 deq = _dequant_nvfp4(w, sc, sc2, dev)
             except Exception as ex:  # torchao missing / shape mismatch -> leave as-is
                 LOG.warning("nvfp4 dequant skipped for %s: %s", key, ex)
+                left = True  # tensor stays quantized -> config must be kept
                 continue
             drop.add(key + "_scale")
             if sc2 is not None:
@@ -705,9 +719,13 @@ def _dequantize_quantized_shard(
         if deq is not None:
             out[key] = deq.to(torch.bfloat16).cpu()
             did = True
+        elif is_quant:
+            left = (
+                True  # a quantized weight in an unsupported layout -> keep the config
+            )
     for sk in drop:
         out.pop(sk, None)
-    return out, did
+    return out, did, left
 
 
 _FUSED_EXPERT_LORA_RE = re.compile(r"\.experts\.(?:base_layer\.)?lora_[AB]\.weight$")
@@ -1412,6 +1430,7 @@ def merge_lora_sharded_efficient(
     merged_count = 0
     total_tensors = 0
     block_fp8_dequantized = False
+    left_quantized = False
     resized_vocab = None
     # Track weight_map for index regeneration: {tensor_key: shard_filename}
     weight_map: Dict[str, str] = {}
@@ -1436,8 +1455,11 @@ def merge_lora_sharded_efficient(
         # Step 0: dequantize FUSED quantized weights (block-fp8 / mxfp8 / nvfp4) to bf16 so the LoRA
         # delta folds into the TRUE weight — a raw read misses the block scale and re-rounds the sum
         # back to the quant format, dropping the delta (an otherwise silently-wrong merge).
-        shard_tensors, _shard_deq = _dequantize_quantized_shard(shard_tensors, device)
+        shard_tensors, _shard_deq, _shard_left = _dequantize_quantized_shard(
+            shard_tensors, device
+        )
         block_fp8_dequantized = block_fp8_dequantized or _shard_deq
+        left_quantized = left_quantized or _shard_left
 
         # Step 1: Handle fused weight conversions (MoE experts) if applicable
         fused_keys: set = set()
@@ -1471,8 +1493,10 @@ def merge_lora_sharded_efficient(
             if override is not None:
                 merged_tensors[key] = override.to(tensor.dtype).detach().cpu()
                 merged_count += 1
+                # a resized vocab shows up as a row-count change on embed_tokens AND/OR lm_head
+                # (they may be untied); catch either so the merged config.json stays consistent.
                 if (
-                    key.endswith("embed_tokens.weight")
+                    key.endswith(("embed_tokens.weight", "lm_head.weight"))
                     and override.shape[0] != tensor.shape[0]
                 ):
                     resized_vocab = int(override.shape[0])
@@ -1538,8 +1562,13 @@ def merge_lora_sharded_efficient(
             _json.dump(index, f, indent=2)
         LOG.debug(f"Wrote weight-map index: {index_name}")
 
-    if block_fp8_dequantized:
+    if block_fp8_dequantized and not left_quantized:
         _strip_quantization_config(output_path)
+    elif block_fp8_dequantized and left_quantized:
+        LOG.warning(
+            "Merged some quantized weights to bf16 but others were left quantized (unsupported "
+            "format); keeping quantization_config so the checkpoint still loads its quantized tensors."
+        )
     if resized_vocab is not None:
         _update_config_vocab_size(output_path, resized_vocab)
 

--- a/tests/utils/lora/test_merge_lora.py
+++ b/tests/utils/lora/test_merge_lora.py
@@ -802,3 +802,707 @@ class TestEfficientMerge:
                 "cpu",
                 use_dora=True,
             )
+
+
+class TestQuantizedBaseMerge:
+    """Per-(dtype x module-type) merge correctness for quantized base weights.
+
+    The efficient merge folds ``scaling*(B@A)`` into the base weight; for a quantized base it must do
+    so on the DEQUANTIZED value and keep bf16 (re-rounding the sum to the quant format drops the low-
+    magnitude LoRA delta). These are hermetic (synthetic tensors, CPU) regression guards.
+    """
+
+    E4M3_MAX = 448.0
+
+    @staticmethod
+    def _make_block_fp8(w: torch.Tensor, block: int):
+        """bf16 weight -> (float8_e4m3fn weight, fp32 block scale_inv). Block axes = last two dims."""
+        *lead, N, K = w.shape
+        sr, sc = N // block, K // block
+        wb = w.float().reshape(*lead, sr, block, sc, block)
+        amax = (
+            wb.abs().amax(dim=(-3, -1), keepdim=True).clamp_min(1e-12)
+        )  # per (sr,sc) block
+        scale = amax / TestQuantizedBaseMerge.E4M3_MAX
+        q = torch.clamp(
+            wb / scale,
+            -TestQuantizedBaseMerge.E4M3_MAX,
+            TestQuantizedBaseMerge.E4M3_MAX,
+        )
+        q = q.reshape(*lead, N, K).to(torch.float8_e4m3fn)
+        scale_inv = scale.reshape(*lead, sr, sc).to(torch.float32)
+        return q, scale_inv
+
+    @staticmethod
+    def _dequant(q: torch.Tensor, scale_inv: torch.Tensor) -> torch.Tensor:
+        *lead, N, K = q.shape
+        sr, sc = scale_inv.shape[-2], scale_inv.shape[-1]
+        bn, bk = N // sr, K // sc
+        wf = q.float().reshape(*lead, sr, bn, sc, bk)
+        s = scale_inv.float().reshape(*lead, sr, 1, sc, 1)
+        return (wf * s).reshape(*lead, N, K)
+
+    @pytest.mark.parametrize("shape,block", [((16, 16), 8), ((2, 16, 16), 8)])
+    def test_dequantize_block_fp8_shard(self, shape, block):
+        """_dequantize_block_fp8_shard reproduces the block dequant + drops scale_inv (2D + 3D)."""
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        torch.manual_seed(0)
+        w = torch.randn(*shape, dtype=torch.bfloat16) * 0.2
+        key = "m.experts.gate_up_proj" if len(shape) == 3 else "m.q_proj.weight"
+        q, si = self._make_block_fp8(w, block)
+        shard = {key: q, key + "_scale_inv": si, "m.norm.weight": torch.ones(4)}
+
+        out, _ = _dequantize_quantized_shard(shard, "cpu")
+
+        assert key + "_scale_inv" not in out  # scale dropped
+        assert out[key].dtype == torch.bfloat16
+        assert "m.norm.weight" in out  # unrelated tensor untouched
+        ref = self._dequant(q, si)
+        assert torch.allclose(out[key].float(), ref, atol=2e-2)
+
+    def test_block_fp8_untouched_without_scale_inv(self):
+        """A float8 weight with no *_scale_inv sibling is left as-is (can't dequant)."""
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        q = torch.randn(8, 8).to(torch.float8_e4m3fn)
+        out, _ = _dequantize_quantized_shard({"x.weight": q}, "cpu")
+        assert out["x.weight"].dtype == torch.float8_e4m3fn
+
+    def test_merge_block_fp8_linear_folds_into_dequantized(self):
+        """End-to-end 2D: dequant shard then merge == dequant(base) + scaling*(B@A), output bf16."""
+        from axolotl.cli.utils.lora_merge import (
+            _dequantize_quantized_shard,
+            _merge_tensor_with_lora,
+        )
+
+        torch.manual_seed(1)
+        hidden, r, alpha, block = 32, 8, 16, 16
+        scale = alpha / r
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, si = self._make_block_fp8(w, block)
+        key = "model.layers.0.self_attn.q_proj.weight"
+        lora_a = torch.randn(r, hidden) * 0.1
+        lora_b = torch.randn(hidden, r) * 0.1
+        lora_state = {
+            f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": lora_a,
+            f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
+        }
+
+        deq_shard, _ = _dequantize_quantized_shard(
+            {key: q, key + "_scale_inv": si}, "cpu"
+        )
+        merged, was_merged = _merge_tensor_with_lora(
+            deq_shard[key], key, lora_state, scale, {"r": r, "lora_alpha": alpha}, "cpu"
+        )
+
+        assert was_merged
+        assert merged.dtype == torch.bfloat16  # NOT re-rounded to fp8
+        expected = self._dequant(q, si) + scale * (lora_b @ lora_a)
+        rel = (merged.float() - expected).norm() / expected.norm()
+        assert rel < 5e-3, f"block-fp8 merge rel {rel:.2e}"
+
+    def test_raw_fp8_merge_is_wrong_regression(self):
+        """Guard the fix: folding the delta into the RAW fp8 (skipping dequant) is materially wrong,
+        so the dequant step must stay. Same synthetic case, merged without _dequantize_block_fp8_shard."""
+        from axolotl.cli.utils.lora_merge import _merge_tensor_with_lora
+
+        torch.manual_seed(1)
+        hidden, r, alpha, block = 32, 8, 16, 16
+        scale = alpha / r
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, si = self._make_block_fp8(w, block)
+        key = "model.layers.0.self_attn.q_proj.weight"
+        lora_a, lora_b = torch.randn(r, hidden) * 0.1, torch.randn(hidden, r) * 0.1
+        lora_state = {
+            f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": lora_a,
+            f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
+        }
+        # merge on the raw fp8 tensor (the old, broken behaviour)
+        merged, _ = _merge_tensor_with_lora(
+            q, key, lora_state, scale, {"r": r, "lora_alpha": alpha}, "cpu"
+        )
+        expected = self._dequant(q, si) + scale * (lora_b @ lora_a)
+        rel = (merged.float() - expected).norm() / expected.norm()
+        assert rel > 0.1, (
+            "raw-fp8 merge unexpectedly close — the dequant guard may be untested"
+        )
+
+    def test_strip_quantization_config(self, tmp_path):
+        from axolotl.cli.utils.lora_merge import _strip_quantization_config
+
+        cfg = {
+            "model_type": "mistral_large4",
+            "torch_dtype": "float8_e4m3fn",
+            "quantization_config": {"quant_method": "fp8"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        _strip_quantization_config(tmp_path)
+        out = json.loads((tmp_path / "config.json").read_text())
+        assert "quantization_config" not in out
+        assert out["torch_dtype"] == "bfloat16"
+
+    def test_block_fp8_merge_forward_equivalence_end_to_end(self, tmp_path):
+        """FORWARD-level, full disk round-trip: build a block-fp8 base + perturbed LoRA, run the real
+        merge_lora_sharded_efficient, reload, and compare OUTPUTS of unmerged (dequant-base + LoRA
+        path) vs merged (plain bf16 matmul). Catches config-strip / scale-drop / dtype / re-quant-on-
+        load issues the weight-level oracle can't."""
+        torch.manual_seed(3)
+        hidden, r, alpha, block = 32, 8, 16, 16
+        scale = alpha / r
+
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, si = self._make_block_fp8(w, block)
+        deq_base = self._dequant(q, si)  # what the model actually computes with
+
+        model_dir = tmp_path / "base"
+        model_dir.mkdir()
+        key = "model.layers.0.self_attn.q_proj.weight"
+        safetensors.torch.save_file(
+            {key: q, key + "_scale_inv": si}, model_dir / "model.safetensors"
+        )
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "torch_dtype": "float8_e4m3fn",
+                    "quantization_config": {"quant_method": "fp8"},
+                }
+            )
+        )
+
+        adapter_dir = tmp_path / "adapter"
+        adapter_dir.mkdir()
+        lora_a = torch.randn(r, hidden) * 0.1
+        lora_b = (
+            torch.randn(hidden, r) * 0.1
+        )  # perturbed (NOT zero-init) -> real effect
+        safetensors.torch.save_file(
+            {
+                f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": lora_a,
+                f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
+            },
+            adapter_dir / "adapter_model.safetensors",
+        )
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"r": r, "lora_alpha": alpha, "peft_type": "LORA"})
+        )
+
+        out_dir = tmp_path / "merged"
+        merge_lora_sharded_efficient(
+            base_model_path=model_dir,
+            lora_adapter_path=adapter_dir,
+            output_path=out_dir,
+            device="cpu",
+        )
+
+        # merged config is de-quantized
+        merged_cfg = json.loads((out_dir / "config.json").read_text())
+        assert "quantization_config" not in merged_cfg
+
+        merged = {}
+        with safetensors.torch.safe_open(
+            out_dir / "model.safetensors", framework="pt"
+        ) as f:
+            for k in f.keys():
+                merged[k] = f.get_tensor(k)
+        assert key + "_scale_inv" not in merged
+        assert merged[key].dtype == torch.bfloat16
+
+        x = torch.randn(4, hidden)
+        # unmerged forward: dequant-base linear + LoRA branch (the module's actual computation)
+        y_unmerged = x @ deq_base.float().T + scale * (x @ lora_a.T) @ lora_b.T
+        y_merged = x @ merged[key].float().T
+        rel = (y_unmerged - y_merged).norm() / y_unmerged.norm()
+        assert rel < 5e-3, f"forward mismatch after block-fp8 merge: rel {rel:.2e}"
+
+    @staticmethod
+    def _make_mxfp8(w: torch.Tensor, block: int = 32):
+        """bf16 -> (e4m3 weight, uint8 e8m0 scale) with FLOOR e8m0 (block along last dim)."""
+        *lead, N, K = w.shape
+        nb = K // block
+        wb = w.float().reshape(*lead, N, nb, block)
+        amax = wb.abs().amax(dim=-1).clamp_min(1e-12)
+        exp = torch.floor(torch.log2(amax)) - 8.0
+        q = torch.clamp(wb / torch.exp2(exp)[..., None], -448.0, 448.0).reshape(
+            *lead, N, K
+        )
+        return q.to(torch.float8_e4m3fn), (exp + 127.0).clamp(0, 254).to(torch.uint8)
+
+    def test_dequantize_mxfp8_shard_and_merge(self):
+        """mxfp8 (e4m3 + e8m0/32) fused dequant + 2D merge folds into the dequantized weight."""
+        from axolotl.cli.utils.lora_merge import (
+            _dequantize_quantized_shard,
+            _merge_tensor_with_lora,
+        )
+
+        torch.manual_seed(2)
+        hidden, r, alpha = 64, 8, 16
+        scale = alpha / r
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, s = self._make_mxfp8(w, 32)
+        key = "model.layers.0.self_attn.q_proj.weight"
+        deq_shard, did = _dequantize_quantized_shard({key: q, key + "_scale": s}, "cpu")
+        assert did
+        assert (
+            key + "_scale" not in deq_shard and deq_shard[key].dtype == torch.bfloat16
+        )
+
+        # dequant reference (block-32 e8m0)
+        ref_deq = (
+            q.float().reshape(hidden, hidden // 32, 32)
+            * torch.exp2(s.float() - 127.0)[..., None]
+        ).reshape(hidden, hidden)
+        assert torch.allclose(deq_shard[key].float(), ref_deq, atol=2e-2)
+
+        lora_a, lora_b = torch.randn(r, hidden) * 0.1, torch.randn(hidden, r) * 0.1
+        lora_state = {
+            f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": lora_a,
+            f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
+        }
+        merged, was = _merge_tensor_with_lora(
+            deq_shard[key], key, lora_state, scale, {"r": r, "lora_alpha": alpha}, "cpu"
+        )
+        assert was and merged.dtype == torch.bfloat16
+        expected = ref_deq + scale * (lora_b @ lora_a)
+        assert (merged.float() - expected).norm() / expected.norm() < 5e-3
+
+    def test_dequantize_nvfp4_shard(self):
+        """nvfp4 (packed uint8 + e4m3 block-16 scale + per-tensor scale_2) fused dequant: components
+        built by torchao ``to_nvfp4`` (the same schema the loader reads) recover the original weight
+        within nvfp4 tolerance, and the scale tensors are dropped. ``_dequant_nvfp4`` reconstructs the
+        NVFP4Tensor identically to nvfp4_moe_loading's loader path."""
+        pytest.importorskip("torchao")
+        try:
+            from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+        except Exception:  # pragma: no cover
+            pytest.skip("NVFP4Tensor unavailable")
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        torch.manual_seed(4)
+        N, K = 32, 64
+        w = torch.randn(N, K, dtype=torch.bfloat16) * 0.2
+        p = (w.abs().max() / (6.0 * 448.0)).reshape(1).float().clamp(min=1e-12)
+        try:
+            nv = NVFP4Tensor.to_nvfp4(w, per_tensor_scale=p, is_swizzled_scales=False)
+        except Exception as ex:  # pragma: no cover - torchao API / device gaps
+            pytest.skip(f"to_nvfp4 unavailable on this host: {ex}")
+
+        key = "model.layers.0.self_attn.q_proj.weight"
+        shard = {
+            key: nv.qdata,
+            key + "_scale": nv.scale,
+            key + "_scale_2": nv.per_tensor_scale.reshape(()),
+        }
+        out, did = _dequantize_quantized_shard(shard, "cpu")
+        assert did
+        assert key + "_scale" not in out and key + "_scale_2" not in out
+        assert out[key].dtype == torch.bfloat16
+        # nvfp4 round-trip recovers the weight within fp4 (3-mantissa-bit) tolerance; a wrong
+        # packing/scale interpretation would give garbage, not ~w.
+        rel = (out[key].float() - w.float()).norm() / w.float().norm()
+        assert rel < 0.2, f"nvfp4 dequant round-trip rel {rel:.2e}"
+
+    def test_undequantized_quant_base_warns(self):
+        """A LoRA folding into a still-quantized weight (an unhandled format the shard dequant left
+        as uint8/fp8) must WARN loudly rather than silently corrupt — the safety net for mxfp4 /
+        per-tensor-fp8 / per-expert-unfused layouts."""
+        from unittest.mock import patch
+
+        import axolotl.cli.utils.lora_merge as lm
+
+        lm._WARNED_UNDEQUANT.clear()
+        hidden, r, alpha = 16, 4, 8
+        # a packed-4bit-like uint8 weight that the dequant step did NOT handle
+        tensor = torch.randint(0, 255, (hidden, hidden), dtype=torch.uint8)
+        key = "model.layers.0.self_attn.q_proj.weight"
+        lora_state = {
+            f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": torch.randn(
+                r, hidden
+            ),
+            f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": torch.randn(
+                hidden, r
+            ),
+        }
+        with patch.object(lm.LOG, "warning") as mock_warn:
+            # the warning fires BEFORE the fold; folding into raw uint8 then errors (as it should) —
+            # tolerate that, we're asserting the guard warned.
+            try:
+                lm._merge_tensor_with_lora(
+                    tensor,
+                    key,
+                    lora_state,
+                    alpha / r,
+                    {"r": r, "lora_alpha": alpha},
+                    "cpu",
+                )
+            except RuntimeError:
+                pass
+        msgs = " ".join(str(c.args[0]) for c in mock_warn.call_args_list)
+        assert "still %s" in msgs or "quantized format" in msgs, (
+            "expected undequant warning"
+        )
+
+    def test_dequantize_mxfp4_shard(self):
+        """mxfp4 (packed e2m1 + e8m0/32) fused dequant recovers the fp4-quantized weight. Built with
+        the codebook + low/high nibble order the ScatterMoE MX forward uses, so the merged weight
+        equals what the model computes."""
+        from axolotl.cli.utils.lora_merge import (
+            _FP4_E2M1_LUT,
+            _dequantize_quantized_shard,
+        )
+
+        torch.manual_seed(5)
+        N, K, block = 8, 64, 32
+        lut = torch.tensor(_FP4_E2M1_LUT)
+        w = torch.randn(N, K) * 0.5
+        # per-32-block e8m0 scale, then quantize each element to the nearest codebook value
+        nb = K // block
+        amax = w.reshape(N, nb, block).abs().amax(-1).clamp_min(1e-6)
+        exp = torch.floor(torch.log2(amax / 6.0))  # 6 = fp4 max
+        scale = torch.exp2(exp)  # [N, nb]
+        wn = (w.reshape(N, nb, block) / scale[..., None]).reshape(N, K)
+        idx = (wn.unsqueeze(-1) - lut).abs().argmin(-1)  # nearest codebook index [N,K]
+        qvals = lut[idx]
+        packed = (idx[:, 0::2] | (idx[:, 1::2] << 4)).to(
+            torch.uint8
+        )  # low=even, high=odd
+        ebyte = (exp + 127.0).to(torch.uint8)
+        key = "model.layers.0.mlp.experts.gate_up_proj"  # 2D here for simplicity
+        out, did = _dequantize_quantized_shard(
+            {key: packed, key + "_scale": ebyte}, "cpu"
+        )
+        assert did and out[key].dtype == torch.bfloat16 and key + "_scale" not in out
+        expected = (qvals.reshape(N, nb, block) * scale[..., None]).reshape(N, K)
+        assert torch.allclose(out[key].float(), expected, atol=1e-2)
+
+    def test_dequantize_nvfp4_single_level(self):
+        """Single-level nvfp4 (e4m3 block-16 scale, NO scale_2) dequants with per_tensor_scale=1."""
+        pytest.importorskip("torchao")
+        try:
+            from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+        except Exception:  # pragma: no cover
+            pytest.skip("NVFP4Tensor unavailable")
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        torch.manual_seed(6)
+        w = torch.randn(16, 64, dtype=torch.bfloat16) * 0.2
+        try:
+            nv = NVFP4Tensor.to_nvfp4(
+                w, is_swizzled_scales=False
+            )  # no per_tensor_scale
+        except Exception as ex:  # pragma: no cover
+            pytest.skip(f"to_nvfp4 unavailable: {ex}")
+        key = "model.layers.0.self_attn.q_proj.weight"
+        out, did = _dequantize_quantized_shard(
+            {key: nv.qdata, key + "_scale": nv.scale}, "cpu"
+        )
+        assert did and out[key].dtype == torch.bfloat16
+        assert (out[key].float() - w.float()).norm() / w.float().norm() < 0.2
+
+    def test_mxfp8_ragged_blocks(self):
+        """mxfp8 dequant handles K not an exact multiple of the block count (ragged tail)."""
+        from axolotl.cli.utils.lora_merge import _dequant_mxfp8
+
+        torch.manual_seed(7)
+        N, K = 4, 40  # 40 not divisible by nb=3
+        w = (torch.randn(N, K) * 0.1).to(torch.float8_e4m3fn)
+        s = torch.randint(
+            120, 130, (N, 3), dtype=torch.uint8
+        )  # 3 ragged blocks over K=40
+        out = _dequant_mxfp8(w, s, "cpu")
+        assert out.shape == (N, K) and torch.isfinite(out).all()
+
+    def test_dora_on_block_fp8_base(self):
+        """DoRA merge on a block-fp8 base: dequant -> DoRA magnitude-normalized fold -> bf16 (the
+        quant base goes through the same DoRA path, no crash, finite result)."""
+        from axolotl.cli.utils.lora_merge import (
+            _dequantize_quantized_shard,
+            _merge_tensor_with_lora,
+        )
+
+        torch.manual_seed(8)
+        hidden, r, alpha = 32, 8, 16
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, si = self._make_block_fp8(w, 16)
+        key = "model.layers.0.self_attn.q_proj.weight"
+        deq, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        lora_state = {
+            f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": torch.randn(
+                r, hidden
+            )
+            * 0.1,
+            f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": torch.randn(
+                hidden, r
+            )
+            * 0.1,
+            f"base_model.model.{key[: -len('.weight')]}.lora_magnitude_vector": torch.randn(
+                hidden
+            ).abs()
+            + 0.1,
+        }
+        merged, was = _merge_tensor_with_lora(
+            deq[key],
+            key,
+            lora_state,
+            alpha / r,
+            {"r": r, "lora_alpha": alpha, "use_dora": True},
+            "cpu",
+            use_dora=True,
+        )
+        assert (
+            was
+            and merged.dtype == torch.bfloat16
+            and torch.isfinite(merged.float()).all()
+        )
+
+    def test_resized_embeddings_override_carried(self, tmp_path):
+        """A resized embed_tokens/lm_head saved as full weights in the adapter REPLACES the base and
+        bumps config.json vocab_size (otherwise the trained/enlarged vocab is silently dropped)."""
+        from axolotl.cli.utils.lora_merge import merge_lora_sharded_efficient
+
+        hidden, base_vocab, new_vocab = 8, 10, 12
+        model_dir = tmp_path / "base"
+        model_dir.mkdir()
+        safetensors.torch.save_file(
+            {
+                "model.embed_tokens.weight": torch.randn(base_vocab, hidden),
+                "lm_head.weight": torch.randn(base_vocab, hidden),
+                "model.layers.0.self_attn.q_proj.weight": torch.randn(hidden, hidden),
+            },
+            model_dir / "model.safetensors",
+        )
+        (model_dir / "config.json").write_text(json.dumps({"vocab_size": base_vocab}))
+
+        adapter_dir = tmp_path / "adapter"
+        adapter_dir.mkdir()
+        new_embed = torch.randn(new_vocab, hidden)
+        new_head = torch.randn(new_vocab, hidden)
+        safetensors.torch.save_file(
+            {
+                "base_model.model.model.embed_tokens.weight": new_embed,
+                "base_model.model.lm_head.weight": new_head,
+            },
+            adapter_dir / "adapter_model.safetensors",
+        )
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"r": 8, "lora_alpha": 16, "peft_type": "LORA"})
+        )
+
+        out_dir = tmp_path / "merged"
+        merge_lora_sharded_efficient(
+            base_model_path=model_dir,
+            lora_adapter_path=adapter_dir,
+            output_path=out_dir,
+            device="cpu",
+        )
+        merged = {}
+        with safetensors.torch.safe_open(
+            out_dir / "model.safetensors", framework="pt"
+        ) as f:
+            for k in f.keys():
+                merged[k] = f.get_tensor(k)
+        assert merged["model.embed_tokens.weight"].shape[0] == new_vocab
+        assert merged["lm_head.weight"].shape[0] == new_vocab
+        assert torch.allclose(merged["model.embed_tokens.weight"].float(), new_embed)
+        assert (
+            json.loads((out_dir / "config.json").read_text())["vocab_size"] == new_vocab
+        )
+
+    def test_per_expert_unfused_mismatch_warns(self, tmp_path):
+        """A fused expert LoRA adapter over a PER-EXPERT-unfused base must warn (the expert LoRA would
+        otherwise be silently dropped by the shard merge)."""
+        from unittest.mock import patch
+
+        import axolotl.cli.utils.lora_merge as lm
+
+        model_dir = tmp_path / "base"
+        model_dir.mkdir()
+        # per-expert unfused base experts
+        safetensors.torch.save_file(
+            {
+                "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(8, 8),
+                "model.layers.0.mlp.experts.1.gate_proj.weight": torch.randn(8, 8),
+            },
+            model_dir / "model.safetensors",
+        )
+        (model_dir / "config.json").write_text("{}")
+        adapter_dir = tmp_path / "adapter"
+        adapter_dir.mkdir()
+        # fused expert LoRA (targets experts.gate_up_proj)
+        safetensors.torch.save_file(
+            {
+                "base_model.model.model.layers.0.mlp.experts.lora_A.weight": torch.randn(
+                    16, 8
+                ),
+                "base_model.model.model.layers.0.mlp.experts.lora_B.weight": torch.randn(
+                    16, 16
+                ),
+            },
+            adapter_dir / "adapter_model.safetensors",
+        )
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"r": 8, "lora_alpha": 16, "peft_type": "LORA"})
+        )
+
+        with patch.object(lm.LOG, "warning") as mock_warn:
+            lm.merge_lora_sharded_efficient(
+                base_model_path=model_dir,
+                lora_adapter_path=adapter_dir,
+                output_path=tmp_path / "merged",
+                device="cpu",
+            )
+        assert any("PER-EXPERT" in str(c.args[0]) for c in mock_warn.call_args_list), (
+            "expected a per-expert-unfused mismatch warning"
+        )
+
+    def test_fused_expert_base_no_false_positive(self, tmp_path):
+        """A FUSED expert base (Mistral-Large-4 style) + fused adapter must NOT trigger the per-expert
+        warning."""
+        from axolotl.cli.utils.lora_merge import _detect_per_expert_unfused_mismatch
+
+        model_dir = tmp_path / "base"
+        model_dir.mkdir()
+        safetensors.torch.save_file(
+            {"model.layers.0.mlp.experts.gate_up_proj": torch.randn(2, 16, 8)},
+            model_dir / "model.safetensors",
+        )
+        lora_state = {
+            "base_model.model.model.layers.0.mlp.experts.lora_A.weight": torch.randn(
+                16, 8
+            )
+        }
+        assert not _detect_per_expert_unfused_mismatch(
+            [model_dir / "model.safetensors"], lora_state
+        )
+
+    def test_expert_lora_delta_matches_scattermoe_kernel(self):
+        """The merge's PEFT ParamWrapper expert delta EXACTLY equals what the ScatterMoE training
+        kernel applies (expert-major B via peft_lora_B_to_scattermoe). Guards against a rank-major vs
+        expert-major layout regression — the naive slice differs materially."""
+        pytest.importorskip("triton")
+        from axolotl.cli.utils.lora_merge import _build_peft_layer_and_get_delta
+        from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (
+            peft_lora_B_to_scattermoe,
+        )
+
+        torch.manual_seed(0)
+        E, r, IN, OUT, alpha = 4, 8, 16, 24, 16
+        scaling = alpha / r
+        A = torch.randn(r * E, IN) * 0.1
+        B = torch.randn(OUT, r * E) * 0.1
+        base = torch.randn(E, OUT, IN)
+
+        mine = _build_peft_layer_and_get_delta(
+            A, B, {"r": r, "lora_alpha": alpha}, base, is_param_wrapper=True
+        )
+        smB = peft_lora_B_to_scattermoe(B, E, r)
+        kern = torch.stack(
+            [
+                scaling * (smB[:, e * r : (e + 1) * r] @ A[e * r : (e + 1) * r, :])
+                for e in range(E)
+            ]
+        )
+        naive = torch.stack(
+            [
+                scaling * (B[:, e * r : (e + 1) * r] @ A[e * r : (e + 1) * r, :])
+                for e in range(E)
+            ]
+        )
+        assert torch.allclose(mine.float(), kern.float(), atol=1e-5)
+        # sanity: the layouts genuinely differ, so the test isn't vacuous
+        assert (mine.float() - naive.float()).norm() / naive.float().norm() > 0.5
+
+    def test_expert_3d_block_fp8_merge_folds(self):
+        """Full 3D fused-expert merge on a block-fp8 base: dequant -> PEFT expert delta -> matches the
+        kernel-layout reconstruction on the dequantized base."""
+        pytest.importorskip("triton")
+        from axolotl.cli.utils.lora_merge import (
+            _build_peft_layer_and_get_delta,
+            _dequantize_quantized_shard,
+        )
+        from axolotl.integrations.kernels.libs.scattermoe_lora.layers import (
+            peft_lora_B_to_scattermoe,
+        )
+
+        torch.manual_seed(1)
+        E, r, IN, OUT, alpha = 4, 8, 128, 256, 16
+        scaling = alpha / r
+        w = torch.randn(E, OUT, IN, dtype=torch.bfloat16) * 0.1
+        q, si = self._make_block_fp8(w, 64)
+        key = "model.layers.0.mlp.experts.gate_up_proj"
+        deq, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        base_deq = self._dequant(q, si)
+
+        A = torch.randn(r * E, IN) * 0.05
+        B = torch.randn(OUT, r * E) * 0.05
+        delta = _build_peft_layer_and_get_delta(
+            A, B, {"r": r, "lora_alpha": alpha}, deq[key], is_param_wrapper=True
+        )
+        merged = deq[key].float() + delta.float()
+        smB = peft_lora_B_to_scattermoe(B, E, r)
+        kern_delta = torch.stack(
+            [
+                scaling * (smB[:, e * r : (e + 1) * r] @ A[e * r : (e + 1) * r, :])
+                for e in range(E)
+            ]
+        )
+        expected = base_deq.float() + kern_delta.float()
+        assert (merged - expected).norm() / expected.norm() < 5e-3
+
+    def test_swizzled_nvfp4_detected(self):
+        """Swizzled-scale nvfp4 with a PADDED (unaligned) shape is auto-detected via the scale-numel
+        mismatch and dequants correctly. (On-disk nvfp4 checkpoints ship NON-swizzled scales — the
+        heuristic can only catch the padded case, not a same-numel reorder at block-aligned shapes;
+        the default non-swizzled path is correct for real checkpoints.)"""
+        pytest.importorskip("torchao")
+        try:
+            from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+        except Exception:  # pragma: no cover
+            pytest.skip("NVFP4Tensor unavailable")
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        torch.manual_seed(9)
+        N, K = (
+            32,
+            64,
+        )  # N<128 -> swizzle pads the scale grid, so numel differs from N*K/16
+        w = torch.randn(N, K, dtype=torch.bfloat16) * 0.2
+        p = (w.abs().max() / (6.0 * 448.0)).reshape(1).float().clamp(min=1e-12)
+        try:
+            nv = NVFP4Tensor.to_nvfp4(w, per_tensor_scale=p, is_swizzled_scales=True)
+        except Exception as ex:  # pragma: no cover
+            pytest.skip(f"swizzled to_nvfp4 unavailable: {ex}")
+        if nv.scale.numel() == N * (K // 16):
+            pytest.skip(
+                "this torchao build did not pad the swizzled scale; detection N/A"
+            )
+        key = "model.layers.0.self_attn.q_proj.weight"
+        out, did = _dequantize_quantized_shard(
+            {key: nv.qdata, key + "_scale": nv.scale, key + "_scale_2": p.reshape(())},
+            "cpu",
+        )
+        assert did and out[key].dtype == torch.bfloat16
+        assert (out[key].float() - w.float()).norm() / w.float().norm() < 0.2
+
+    def test_modules_to_save_override_path(self):
+        """_find_full_override resolves the PEFT modules_to_save layout
+        (...<module>.modules_to_save.default.weight)."""
+        from axolotl.cli.utils.lora_merge import _find_full_override
+
+        w = torch.randn(6, 8)
+        lora_state = {
+            "base_model.model.score.modules_to_save.default.weight": w,
+        }
+        got = _find_full_override(lora_state, "score.weight")
+        assert got is not None and torch.equal(got, w)
+
+    def test_dequantize_mxfp4_ragged(self):
+        """mxfp4 dequant with K not an exact multiple of the block count (ragged tail)."""
+        from axolotl.cli.utils.lora_merge import _dequant_mxfp4
+
+        torch.manual_seed(10)
+        N, Khalf = 4, 20  # K=40 nibbles, 3 ragged e8m0 blocks
+        packed = torch.randint(0, 255, (N, Khalf), dtype=torch.uint8)
+        s = torch.randint(120, 130, (N, 3), dtype=torch.uint8)
+        out = _dequant_mxfp4(packed, s, "cpu")
+        assert out.shape == (N, 40) and torch.isfinite(out).all()

--- a/tests/utils/lora/test_merge_lora.py
+++ b/tests/utils/lora/test_merge_lora.py
@@ -853,7 +853,7 @@ class TestQuantizedBaseMerge:
         q, si = self._make_block_fp8(w, block)
         shard = {key: q, key + "_scale_inv": si, "m.norm.weight": torch.ones(4)}
 
-        out, _ = _dequantize_quantized_shard(shard, "cpu")
+        out, _, _ = _dequantize_quantized_shard(shard, "cpu")
 
         assert key + "_scale_inv" not in out  # scale dropped
         assert out[key].dtype == torch.bfloat16
@@ -866,7 +866,7 @@ class TestQuantizedBaseMerge:
         from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
 
         q = torch.randn(8, 8).to(torch.float8_e4m3fn)
-        out, _ = _dequantize_quantized_shard({"x.weight": q}, "cpu")
+        out, _, _ = _dequantize_quantized_shard({"x.weight": q}, "cpu")
         assert out["x.weight"].dtype == torch.float8_e4m3fn
 
     def test_merge_block_fp8_linear_folds_into_dequantized(self):
@@ -889,7 +889,7 @@ class TestQuantizedBaseMerge:
             f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
         }
 
-        deq_shard, _ = _dequantize_quantized_shard(
+        deq_shard, _, _ = _dequantize_quantized_shard(
             {key: q, key + "_scale_inv": si}, "cpu"
         )
         merged, was_merged = _merge_tensor_with_lora(
@@ -1041,7 +1041,9 @@ class TestQuantizedBaseMerge:
         w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
         q, s = self._make_mxfp8(w, 32)
         key = "model.layers.0.self_attn.q_proj.weight"
-        deq_shard, did = _dequantize_quantized_shard({key: q, key + "_scale": s}, "cpu")
+        deq_shard, did, _ = _dequantize_quantized_shard(
+            {key: q, key + "_scale": s}, "cpu"
+        )
         assert did
         assert (
             key + "_scale" not in deq_shard and deq_shard[key].dtype == torch.bfloat16
@@ -1093,7 +1095,7 @@ class TestQuantizedBaseMerge:
             key + "_scale": nv.scale,
             key + "_scale_2": nv.per_tensor_scale.reshape(()),
         }
-        out, did = _dequantize_quantized_shard(shard, "cpu")
+        out, did, _ = _dequantize_quantized_shard(shard, "cpu")
         assert did
         assert key + "_scale" not in out and key + "_scale_2" not in out
         assert out[key].dtype == torch.bfloat16
@@ -1168,7 +1170,7 @@ class TestQuantizedBaseMerge:
         )  # low=even, high=odd
         ebyte = (exp + 127.0).to(torch.uint8)
         key = "model.layers.0.mlp.experts.gate_up_proj"  # 2D here for simplicity
-        out, did = _dequantize_quantized_shard(
+        out, did, _ = _dequantize_quantized_shard(
             {key: packed, key + "_scale": ebyte}, "cpu"
         )
         assert did and out[key].dtype == torch.bfloat16 and key + "_scale" not in out
@@ -1193,24 +1195,31 @@ class TestQuantizedBaseMerge:
         except Exception as ex:  # pragma: no cover
             pytest.skip(f"to_nvfp4 unavailable: {ex}")
         key = "model.layers.0.self_attn.q_proj.weight"
-        out, did = _dequantize_quantized_shard(
+        out, did, _ = _dequantize_quantized_shard(
             {key: nv.qdata, key + "_scale": nv.scale}, "cpu"
         )
         assert did and out[key].dtype == torch.bfloat16
         assert (out[key].float() - w.float()).norm() / w.float().norm() < 0.2
 
     def test_mxfp8_ragged_blocks(self):
-        """mxfp8 dequant handles K not an exact multiple of the block count (ragged tail)."""
+        """mxfp8 dequant: each e8m0 scale covers a fixed 32-wide MX block; the final ragged block
+        (K=40 -> blocks of 32 + 8) is trimmed, NOT floor-spread evenly across K."""
         from axolotl.cli.utils.lora_merge import _dequant_mxfp8
 
         torch.manual_seed(7)
-        N, K = 4, 40  # 40 not divisible by nb=3
+        N, K = (
+            4,
+            40,
+        )  # nb = ceil(40/32) = 2: first 32 elems use scale[0], last 8 use scale[1]
         w = (torch.randn(N, K) * 0.1).to(torch.float8_e4m3fn)
-        s = torch.randint(
-            120, 130, (N, 3), dtype=torch.uint8
-        )  # 3 ragged blocks over K=40
+        s = torch.randint(120, 130, (N, 2), dtype=torch.uint8)
         out = _dequant_mxfp8(w, s, "cpu")
-        assert out.shape == (N, K) and torch.isfinite(out).all()
+        assert out.shape == (N, K)
+        scale = torch.exp2(s.float() - 127.0)  # [N, 2]
+        exp = w.float().clone()
+        exp[:, :32] *= scale[:, :1]
+        exp[:, 32:] *= scale[:, 1:2]
+        assert torch.allclose(out.float(), exp, atol=1e-2)
 
     def test_dora_on_block_fp8_base(self):
         """DoRA merge on a block-fp8 base: dequant -> DoRA magnitude-normalized fold -> bf16 (the
@@ -1225,7 +1234,7 @@ class TestQuantizedBaseMerge:
         w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
         q, si = self._make_block_fp8(w, 16)
         key = "model.layers.0.self_attn.q_proj.weight"
-        deq, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        deq, _, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
         lora_state = {
             f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": torch.randn(
                 r, hidden
@@ -1304,6 +1313,7 @@ class TestQuantizedBaseMerge:
         assert merged["model.embed_tokens.weight"].shape[0] == new_vocab
         assert merged["lm_head.weight"].shape[0] == new_vocab
         assert torch.allclose(merged["model.embed_tokens.weight"].float(), new_embed)
+        assert torch.allclose(merged["lm_head.weight"].float(), new_head)
         assert (
             json.loads((out_dir / "config.json").read_text())["vocab_size"] == new_vocab
         )
@@ -1430,7 +1440,7 @@ class TestQuantizedBaseMerge:
         w = torch.randn(E, OUT, IN, dtype=torch.bfloat16) * 0.1
         q, si = self._make_block_fp8(w, 64)
         key = "model.layers.0.mlp.experts.gate_up_proj"
-        deq, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        deq, _, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
         base_deq = self._dequant(q, si)
 
         A = torch.randn(r * E, IN) * 0.05
@@ -1477,7 +1487,7 @@ class TestQuantizedBaseMerge:
                 "this torchao build did not pad the swizzled scale; detection N/A"
             )
         key = "model.layers.0.self_attn.q_proj.weight"
-        out, did = _dequantize_quantized_shard(
+        out, did, _ = _dequantize_quantized_shard(
             {key: nv.qdata, key + "_scale": nv.scale, key + "_scale_2": p.reshape(())},
             "cpu",
         )
@@ -1497,12 +1507,40 @@ class TestQuantizedBaseMerge:
         assert got is not None and torch.equal(got, w)
 
     def test_dequantize_mxfp4_ragged(self):
-        """mxfp4 dequant with K not an exact multiple of the block count (ragged tail)."""
-        from axolotl.cli.utils.lora_merge import _dequant_mxfp4
+        """mxfp4 dequant: fixed 32-wide MX blocks with a trimmed ragged tail (K=40 -> 32 + 8), not a
+        floor-spread."""
+        from axolotl.cli.utils.lora_merge import _dequant_mxfp4, _unpack_fp4
 
         torch.manual_seed(10)
-        N, Khalf = 4, 20  # K=40 nibbles, 3 ragged e8m0 blocks
+        N, Khalf = 4, 20  # K = 40 nibbles, nb = ceil(40/32) = 2
         packed = torch.randint(0, 255, (N, Khalf), dtype=torch.uint8)
-        s = torch.randint(120, 130, (N, 3), dtype=torch.uint8)
+        s = torch.randint(120, 130, (N, 2), dtype=torch.uint8)
         out = _dequant_mxfp4(packed, s, "cpu")
-        assert out.shape == (N, 40) and torch.isfinite(out).all()
+        assert out.shape == (N, 40)
+        vals = _unpack_fp4(packed, "cpu")  # [N, 40]
+        scale = torch.exp2(s.float() - 127.0)
+        exp = vals.clone()
+        exp[:, :32] *= scale[:, :1]
+        exp[:, 32:] *= scale[:, 1:2]
+        assert torch.allclose(out.float(), exp, atol=1e-3)
+
+    def test_partial_dequant_reports_left_quantized(self):
+        """A shard with a dequantizable tensor AND an unsupported quantized tensor (per-tensor fp8,
+        scalar scale) must report left_quantized=True so the caller keeps quantization_config."""
+        from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
+
+        blk = torch.randn(16, 16).to(torch.float8_e4m3fn)  # block-fp8 (handled)
+        pt = torch.randn(8, 8).to(
+            torch.float8_e4m3fn
+        )  # per-tensor fp8 (unsupported here)
+        shard = {
+            "a.weight": blk,
+            "a.weight_scale_inv": torch.ones(1, 1),
+            "b.weight": pt,
+            "b.weight_scale": torch.tensor(2.0),  # scalar fp32 -> not e8m0, not block
+        }
+        out, did, left = _dequantize_quantized_shard(shard, "cpu")
+        assert did and left
+        assert out["a.weight"].dtype == torch.bfloat16  # dequantized
+        assert out["b.weight"].dtype == torch.float8_e4m3fn  # left as-is
+        assert "b.weight_scale" in out  # its scale not dropped

--- a/tests/utils/lora/test_merge_lora.py
+++ b/tests/utils/lora/test_merge_lora.py
@@ -853,7 +853,7 @@ class TestQuantizedBaseMerge:
         q, si = self._make_block_fp8(w, block)
         shard = {key: q, key + "_scale_inv": si, "m.norm.weight": torch.ones(4)}
 
-        out, _, _ = _dequantize_quantized_shard(shard, "cpu")
+        out, _, _, _ = _dequantize_quantized_shard(shard, "cpu")
 
         assert key + "_scale_inv" not in out  # scale dropped
         assert out[key].dtype == torch.bfloat16
@@ -866,7 +866,7 @@ class TestQuantizedBaseMerge:
         from axolotl.cli.utils.lora_merge import _dequantize_quantized_shard
 
         q = torch.randn(8, 8).to(torch.float8_e4m3fn)
-        out, _, _ = _dequantize_quantized_shard({"x.weight": q}, "cpu")
+        out, _, _, _ = _dequantize_quantized_shard({"x.weight": q}, "cpu")
         assert out["x.weight"].dtype == torch.float8_e4m3fn
 
     def test_merge_block_fp8_linear_folds_into_dequantized(self):
@@ -889,7 +889,7 @@ class TestQuantizedBaseMerge:
             f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
         }
 
-        deq_shard, _, _ = _dequantize_quantized_shard(
+        deq_shard, _, _, _ = _dequantize_quantized_shard(
             {key: q, key + "_scale_inv": si}, "cpu"
         )
         merged, was_merged = _merge_tensor_with_lora(
@@ -993,9 +993,10 @@ class TestQuantizedBaseMerge:
             lora_adapter_path=adapter_dir,
             output_path=out_dir,
             device="cpu",
+            dequant=True,  # explicit --dequant: bf16 output
         )
 
-        # merged config is de-quantized
+        # --dequant: merged config is de-quantized
         merged_cfg = json.loads((out_dir / "config.json").read_text())
         assert "quantization_config" not in merged_cfg
 
@@ -1014,6 +1015,96 @@ class TestQuantizedBaseMerge:
         y_merged = x @ merged[key].float().T
         rel = (y_unmerged - y_merged).norm() / y_unmerged.norm()
         assert rel < 5e-3, f"forward mismatch after block-fp8 merge: rel {rel:.2e}"
+
+    def test_block_fp8_merge_preserves_format_default(self, tmp_path):
+        """DEFAULT merge is FORMAT-PRESERVING: a block-fp8 base stays block-fp8 (fp8 weight +
+        weight_scale_inv), quantization_config is kept, and the forward still matches within fp8 tol.
+        Non-LoRA quantized weights pass through byte-identical."""
+        torch.manual_seed(4)
+        hidden, r, alpha, block = 32, 8, 16, 16
+        scale = alpha / r
+        w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
+        q, si = self._make_block_fp8(w, block)
+        deq_base = self._dequant(q, si)
+        # a second block-fp8 weight WITHOUT LoRA -> must pass through untouched
+        q2, si2 = self._make_block_fp8(
+            torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2, block
+        )
+
+        model_dir = tmp_path / "base"
+        model_dir.mkdir()
+        key = "model.layers.0.self_attn.q_proj.weight"
+        okey = "model.layers.0.self_attn.o_proj.weight"
+        safetensors.torch.save_file(
+            {
+                key: q,
+                key + "_scale_inv": si,
+                okey: q2,
+                okey + "_scale_inv": si2,
+            },
+            model_dir / "model.safetensors",
+        )
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "torch_dtype": "float8_e4m3fn",
+                    "quantization_config": {"quant_method": "fp8"},
+                }
+            )
+        )
+        adapter_dir = tmp_path / "adapter"
+        adapter_dir.mkdir()
+        lora_a = torch.randn(r, hidden) * 0.1
+        lora_b = torch.randn(hidden, r) * 0.1
+        safetensors.torch.save_file(
+            {
+                f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": lora_a,
+                f"base_model.model.{key[: -len('.weight')]}.lora_B.weight": lora_b,
+            },
+            adapter_dir / "adapter_model.safetensors",
+        )
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"r": r, "lora_alpha": alpha, "peft_type": "LORA"})
+        )
+
+        out_dir = tmp_path / "merged"
+        merge_lora_sharded_efficient(  # default: NO dequant flag -> format-preserving
+            base_model_path=model_dir,
+            lora_adapter_path=adapter_dir,
+            output_path=out_dir,
+            device="cpu",
+        )
+        merged = {}
+        with safetensors.torch.safe_open(
+            out_dir / "model.safetensors", framework="pt"
+        ) as f:
+            for k in f.keys():
+                merged[k] = f.get_tensor(k)
+
+        # format preserved: fp8 weight + fp32 scale kept, config NOT stripped
+        assert merged[key].dtype == torch.float8_e4m3fn
+        assert merged[key + "_scale_inv"].dtype == torch.float32
+        assert "quantization_config" in json.loads(
+            (out_dir / "config.json").read_text()
+        )
+        # no-LoRA weight passes through byte-identical
+        assert torch.equal(merged[okey], q2) and torch.equal(
+            merged[okey + "_scale_inv"], si2
+        )
+
+        # forward matches within fp8 tolerance (the delta survives re-quantization with fresh scales)
+        def deq(qq, s):
+            O, K = qq.shape
+            sr, sc = s.shape
+            return (
+                qq.float().reshape(sr, O // sr, sc, K // sc) * s.reshape(sr, 1, sc, 1)
+            ).reshape(O, K)
+
+        x = torch.randn(4, hidden)
+        y_unmerged = x @ deq_base.float().T + scale * (x @ lora_a.T) @ lora_b.T
+        y_merged = x @ deq(merged[key], merged[key + "_scale_inv"]).T
+        rel = (y_unmerged - y_merged).norm() / y_unmerged.norm()
+        assert rel < 6e-2, f"format-preserving merge forward rel {rel:.2e}"
 
     @staticmethod
     def _make_mxfp8(w: torch.Tensor, block: int = 32):
@@ -1041,7 +1132,7 @@ class TestQuantizedBaseMerge:
         w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
         q, s = self._make_mxfp8(w, 32)
         key = "model.layers.0.self_attn.q_proj.weight"
-        deq_shard, did, _ = _dequantize_quantized_shard(
+        deq_shard, did, _, _ = _dequantize_quantized_shard(
             {key: q, key + "_scale": s}, "cpu"
         )
         assert did
@@ -1095,7 +1186,7 @@ class TestQuantizedBaseMerge:
             key + "_scale": nv.scale,
             key + "_scale_2": nv.per_tensor_scale.reshape(()),
         }
-        out, did, _ = _dequantize_quantized_shard(shard, "cpu")
+        out, did, _, _ = _dequantize_quantized_shard(shard, "cpu")
         assert did
         assert key + "_scale" not in out and key + "_scale_2" not in out
         assert out[key].dtype == torch.bfloat16
@@ -1170,7 +1261,7 @@ class TestQuantizedBaseMerge:
         )  # low=even, high=odd
         ebyte = (exp + 127.0).to(torch.uint8)
         key = "model.layers.0.mlp.experts.gate_up_proj"  # 2D here for simplicity
-        out, did, _ = _dequantize_quantized_shard(
+        out, did, _, _ = _dequantize_quantized_shard(
             {key: packed, key + "_scale": ebyte}, "cpu"
         )
         assert did and out[key].dtype == torch.bfloat16 and key + "_scale" not in out
@@ -1195,7 +1286,7 @@ class TestQuantizedBaseMerge:
         except Exception as ex:  # pragma: no cover
             pytest.skip(f"to_nvfp4 unavailable: {ex}")
         key = "model.layers.0.self_attn.q_proj.weight"
-        out, did, _ = _dequantize_quantized_shard(
+        out, did, _, _ = _dequantize_quantized_shard(
             {key: nv.qdata, key + "_scale": nv.scale}, "cpu"
         )
         assert did and out[key].dtype == torch.bfloat16
@@ -1234,7 +1325,9 @@ class TestQuantizedBaseMerge:
         w = torch.randn(hidden, hidden, dtype=torch.bfloat16) * 0.2
         q, si = self._make_block_fp8(w, 16)
         key = "model.layers.0.self_attn.q_proj.weight"
-        deq, _, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        deq, _, _, _ = _dequantize_quantized_shard(
+            {key: q, key + "_scale_inv": si}, "cpu"
+        )
         lora_state = {
             f"base_model.model.{key[: -len('.weight')]}.lora_A.weight": torch.randn(
                 r, hidden
@@ -1440,7 +1533,9 @@ class TestQuantizedBaseMerge:
         w = torch.randn(E, OUT, IN, dtype=torch.bfloat16) * 0.1
         q, si = self._make_block_fp8(w, 64)
         key = "model.layers.0.mlp.experts.gate_up_proj"
-        deq, _, _ = _dequantize_quantized_shard({key: q, key + "_scale_inv": si}, "cpu")
+        deq, _, _, _ = _dequantize_quantized_shard(
+            {key: q, key + "_scale_inv": si}, "cpu"
+        )
         base_deq = self._dequant(q, si)
 
         A = torch.randn(r * E, IN) * 0.05
@@ -1487,7 +1582,7 @@ class TestQuantizedBaseMerge:
                 "this torchao build did not pad the swizzled scale; detection N/A"
             )
         key = "model.layers.0.self_attn.q_proj.weight"
-        out, did, _ = _dequantize_quantized_shard(
+        out, did, _, _ = _dequantize_quantized_shard(
             {key: nv.qdata, key + "_scale": nv.scale, key + "_scale_2": p.reshape(())},
             "cpu",
         )
@@ -1539,7 +1634,7 @@ class TestQuantizedBaseMerge:
             "b.weight": pt,
             "b.weight_scale": torch.tensor(2.0),  # scalar fp32 -> not e8m0, not block
         }
-        out, did, left = _dequantize_quantized_shard(shard, "cpu")
+        out, did, left, _ = _dequantize_quantized_shard(shard, "cpu")
         assert did and left
         assert out["a.weight"].dtype == torch.bfloat16  # dequantized
         assert out["b.weight"].dtype == torch.float8_e4m3fn  # left as-is


### PR DESCRIPTION
The memory-efficient (shard-by-shard) LoRA merge folded scaling*(B@A) into the raw base tensor. For a block-fp8 (FineGrainedFP8) checkpoint this read the e4m3 values without applying weight_scale_inv and re-rounded the sum to fp8, dropping the delta — a silently-wrong merge (weight rel up to 1.0).

Dequantize fused quantized weights to bf16 per shard before folding, then keep bf16 and strip quantization_config so the merged checkpoint loads correctly. Detection is by weight dtype + scale sibling:

  - block-fp8 : e4m3 + <k>_scale_inv (128x128)
  - mxfp8     : e4m3 + <k>_scale (e8m0/32)
  - nvfp4     : uint8 + <k>_scale (e4m3/16) [+ <k>_scale_2]  (single- or two-level)
  - mxfp4     : uint8 + <k>_scale (e8m0/32)

Covers 2D linears and fused-3D experts (target_parameters). The expert delta uses PEFT's ParamWrapper get_delta_weight, verified to match the ScatterMoE kernel's expert-major B layout exactly.

Also:
  - carry full-weight adapter overrides (resized embed_tokens/lm_head, modules_to_save) into the merge and bump config vocab_size
  - warn when a fused expert LoRA meets a per-expert-unfused base (the expert LoRA would otherwise be silently dropped)
  - warn when a LoRA folds into a still-quantized weight the merge did not dequantize (mxfp4/per-tensor-fp8/per-expert layouts)
  - ragged-block and swizzled-scale handling

Adds TestQuantizedBaseMerge (22 hermetic cases): analytic weight-level + forward-level end-to-end + regression guards.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model merging for quantized checkpoints, reducing the risk of corrupted or incorrect merged weights.
  * Added safeguards and warnings when a merge would be unsafe for unsupported or incompatible weight formats.
  * Fixed handling for resized embeddings and output heads so merged models preserve the correct vocabulary size.
  * Improved support for expert-based model layouts to avoid silent loss of merged changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->