### PR TITLE
fix: pin version for httpx and not use pre-release

### DIFF
--- a/docker/Dockerfile-uv
+++ b/docker/Dockerfile-uv
@@ -23,7 +23,7 @@ COPY . .
 # If AXOLOTL_EXTRAS is set, append it in brackets; don't install deepspeed with arm64
 RUN uv pip uninstall causal_conv1d
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install httpx && \
+    uv pip install "httpx==0.28.1" && \
     if [ "$TARGETARCH" = "arm64" ]; then \
         BASE_EXTRAS="optimizers,ray"; \
     else \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

UV was pulling a pre-release which had issue. This fixes that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency to a specific version for more consistent builds and fewer unexpected environment differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->