### PR TITLE
fix(fsdp2): use EP LoRA saver for quantized checkpoints

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -842,6 +842,19 @@ class AxolotlTrainer(
                 save_fsdp2_lora_adapter,
             )
 
+            cfg = getattr(self, "axolotl_cfg", None)
+            if cfg and (getattr(cfg, "expert_parallel_size", 1) or 1) > 1:
+                from axolotl.integrations.expert_parallel.plugin import (
+                    ExpertParallelPlugin,
+                )
+                from axolotl.integrations.expert_parallel.shard import (
+                    save_ep_lora_adapter,
+                )
+
+                ep_group = ExpertParallelPlugin._resolve_ep_group(cfg)
+                if save_ep_lora_adapter(unwrapped, output_dir, ep_group):
+                    return True
+
             return bool(save_fsdp2_lora_adapter(unwrapped, output_dir))
         except Exception as exc:  # pylint: disable=broad-except
             LOG.warning(

--- a/tests/core/test_quantized_lora_checkpoint_resume.py
+++ b/tests/core/test_quantized_lora_checkpoint_resume.py
@@ -9,6 +9,8 @@ and assert the resume artifacts are written after the adapter save.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import peft
+
 from axolotl.core.trainers.base import AxolotlTrainer
 
 
@@ -85,3 +87,46 @@ def test_fsdp2_quantized_param_detector_checks_parameter_data():
     MXTensor = type("MXTensor", (), {})
     param = SimpleNamespace(data=MXTensor())
     assert AxolotlTrainer._is_fsdp2_quantized_param(param)
+
+
+def test_quantized_lora_checkpoint_uses_ep_adapter_save(monkeypatch, tmp_path):
+    class NVFP4Tensor:
+        pass
+
+    class FakePeftModel:
+        def parameters(self):
+            return [SimpleNamespace(_local_tensor=NVFP4Tensor())]
+
+    model = FakePeftModel()
+    stub = SimpleNamespace(
+        is_fsdp_enabled=True,
+        axolotl_cfg=SimpleNamespace(expert_parallel_size=2),
+        accelerator=SimpleNamespace(unwrap_model=lambda wrapped: wrapped),
+        _is_fsdp2_quantized_param=AxolotlTrainer._is_fsdp2_quantized_param,
+    )
+    # _save_fsdp2_quantized_lora_adapter gates on these helpers; bind the real
+    # implementations so the test exercises actual enablement + quant detection.
+    stub._is_fsdp2_checkpoint_save_enabled = lambda: (
+        AxolotlTrainer._is_fsdp2_checkpoint_save_enabled(stub)
+    )
+
+    monkeypatch.setattr(peft, "PeftModel", FakePeftModel)
+
+    from axolotl.integrations.expert_parallel import shard
+    from axolotl.integrations.expert_parallel.plugin import ExpertParallelPlugin
+
+    resolve_ep_group = MagicMock(return_value=object())
+    save_ep_lora_adapter = MagicMock(return_value=True)
+    save_fsdp2_lora_adapter = MagicMock(return_value=True)
+    monkeypatch.setattr(ExpertParallelPlugin, "_resolve_ep_group", resolve_ep_group)
+    monkeypatch.setattr(shard, "save_ep_lora_adapter", save_ep_lora_adapter)
+    monkeypatch.setattr(shard, "save_fsdp2_lora_adapter", save_fsdp2_lora_adapter)
+
+    handled = AxolotlTrainer._save_fsdp2_quantized_lora_adapter(
+        stub, model, str(tmp_path)
+    )
+
+    assert handled is True
+    resolve_ep_group.assert_called_once_with(stub.axolotl_cfg)
+    save_ep_lora_adapter.assert_called_once()
+    save_fsdp2_lora_adapter.assert_not_called()


### PR DESCRIPTION
fixes #3772 (assuming the reporter used the examples and enabled EP=8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saving of quantized LoRA checkpoints when expert parallelism is enabled.
  * Adapter saving now correctly uses the expert-parallel path in supported setups, helping avoid incorrect checkpoint handling and improving resume reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->