### PR TITLE
docs(expert_parallel): pin DeepEP to v1.2.1 for the DISABLE_NVSHMEM patches

### DIFF
--- a/src/axolotl/integrations/expert_parallel/README.md
+++ b/src/axolotl/integrations/expert_parallel/README.md
@@ -68,13 +68,14 @@ Notes:
 - Hopper kernels (FP8, TMA, etc.) are preserved; only intranode dispatch/combine is built — appropriate for single-node H100×{4,8}.
 - Patch 1 lets `DISABLE_NVSHMEM=1` skip the NVSHMEM build path, which would otherwise need Mellanox OFED dev headers (`infiniband/mlx5dv.h`).
 - Patch 2 drops `-rdc=true` when NVSHMEM is off; otherwise the device-link step has nothing to link against and import fails with `__cudaRegisterLinkedBinary_*` undefined symbol.
-- The `v1.2.1` pin sidesteps DeepEP HEAD's `csrc/elastic/` (Engram/EPv2, commit `b306af0`), which needs `ncclGinRequest_t` from NCCL 2.29+. On NCCL ≥ 2.29 (torch 2.11+) you can drop `git checkout v1.2.1` and build from HEAD with the same two patches.
+- The `v1.2.1` pin is required: it is the last release whose `setup.py` still carries the `disable_nvshmem` path the two patches edit. DeepEP `main` restructured `setup.py` and removed that path ([DeepEP #664](https://github.com/deepseek-ai/DeepEP/pull/664)), so against HEAD the patches fail with `patch failed: setup.py:19`. The pin also sidesteps DeepEP HEAD's `csrc/elastic/` (Engram/EPv2, commit `b306af0`), which needs `ncclGinRequest_t` from NCCL 2.29+.
 
 **Ampere (sm_80, A100, intranode-only)** — needs two small source patches gated on `DISABLE_NVSHMEM=1`:
 
 ```bash
-git clone --depth 1 https://github.com/deepseek-ai/DeepEP.git
+git clone https://github.com/deepseek-ai/DeepEP.git
 cd DeepEP
+git checkout v1.2.1
 
 # Patch 1: setup.py — honor DISABLE_NVSHMEM=1
 git apply <<'EOF'


### PR DESCRIPTION
The DeepEP install instructions for the patched (`DISABLE_NVSHMEM=1`) builds only work against DeepEP `v1.2.1` — DeepEP `main` restructured `setup.py` and removed the `disable_nvshmem` code path (deepseek-ai/DeepEP#664), so both README patches now fail with `patch failed: setup.py:19`. This pins the version explicitly:

- **Notes section:** the sentence saying you can drop `git checkout v1.2.1` and build from HEAD with the same two patches now states the `v1.2.1` pin is required (last release whose `setup.py` still carries the `disable_nvshmem` path the patches edit).
- **Ampere section:** `git clone --depth 1 ...` → full clone + `git checkout v1.2.1` right after `cd DeepEP` (a shallow clone can't check out the tag).

Before (Ampere):
```bash
git clone --depth 1 https://github.com/deepseek-ai/DeepEP.git
cd DeepEP
```

After:
```bash
git clone https://github.com/deepseek-ai/DeepEP.git
cd DeepEP
git checkout v1.2.1
```

Docs-only change; the unpatched Hopper multi-node instructions are untouched.

Fixes #3766.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ampere intranode build instructions to require a specific DeepEP release.
  * Clarified that the latest upstream version is incompatible with the existing patch steps and may require newer NCCL support.
  * Adjusted the example command sequence to include the recommended checkout step before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->