### PR TITLE
fix(expert_parallel): post-fix for glm dsa branch

### DIFF
--- a/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
+++ b/examples/glm_moe_dsa/glm-5.2-nvfp4-lora.yaml
@@ -56,7 +56,7 @@ expert_parallel_num_nvl_bytes: 4294967296    # 4 GiB DeepEP intranode (NVLink) d
 # to -1. Guards the DeepEP intranode combine, which HANGS once one expert's token count exceeds the
 # NVLink buffer (the GLM router concentrates with depth). This is a FIXED token threshold tied to
 # expert_parallel_num_nvl_bytes — NOT proportional to sequence length, so don't scale it with seq_len.
-# The 1,000,000 default is an effectively-off ceiling: per rank there are only seq_len*top_k assignments
+# The schema default is None (no cap); the 1,000,000 set here is an effectively-off ceiling: per rank there are only seq_len*top_k assignments
 # spread over 256 experts (e.g. 64k seq = 512k total < 1M, so it never fires), so it won't over-drop at
 # normal lengths. But it also barely protects — at very long context (64k/128k) a hot expert can cross
 # the combine-hang threshold while still under 1M. If you train at long context, lower this toward the

--- a/src/axolotl/integrations/expert_parallel/args.py
+++ b/src/axolotl/integrations/expert_parallel/args.py
@@ -44,6 +44,15 @@ class ExpertParallelArgs(BaseModel):
                 f"Use 1 to disable EP."
             )
 
+        if (
+            self.expert_parallel_token_capacity is not None
+            and self.expert_parallel_token_capacity < 1
+        ):
+            raise ValueError(
+                f"expert_parallel_token_capacity must be >= 1 when set "
+                f"(got {self.expert_parallel_token_capacity!r}). Use None to disable the cap."
+            )
+
         if self.expert_parallel_size > 1 and self.expert_parallel_num_rdma_bytes != 0:
             LOG.warning(
                 "expert_parallel_num_rdma_bytes != 0 — RDMA path requires "

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -38,9 +38,12 @@ def set_token_capacity(cap: int | None) -> None:
 
 def _apply_expert_capacity(topk_idx, topk_w, cap):
     """Cap tokens-per-expert to ``cap`` by sentinelling (-1) the lowest-weight excess (token,expert)
-    assignments. DeepEP's intranode combine hangs once one expert receives too many tokens (the
-    GLM router concentrates more with depth, crossing the hang threshold ~layer 31); standard MoE
-    capacity-dropping keeps every expert under the limit. Already-(-1) slots are left untouched."""
+    assignments, then rescale each token's surviving weights back to its pre-drop gate sum. DeepEP's
+    intranode combine hangs once one expert receives too many tokens (the GLM router concentrates more
+    with depth, crossing the hang threshold ~layer 31); standard MoE capacity-dropping keeps every
+    expert under the limit. The GLM router normalizes the top-k weights to sum to 1, so dropping an
+    expert without rescaling would silently attenuate that token's combined expert output. Already-(-1)
+    slots are left untouched. Returns ``(capped_idx, rescaled_w)``."""
     import torch
 
     ntok, K = topk_idx.shape
@@ -59,7 +62,14 @@ def _apply_expert_capacity(topk_idx, topk_w, cap):
     drop_sorted = (within >= cap) & (se >= 0)
     drop = torch.zeros_like(flat_e, dtype=torch.bool)
     drop[order] = drop_sorted
-    return topk_idx.reshape(-1).masked_fill(drop, -1).reshape(ntok, K)
+    capped_idx = flat_e.masked_fill(drop, -1).reshape(ntok, K)
+
+    orig_sum = (topk_w * (topk_idx >= 0)).sum(dim=-1, keepdim=True)
+    kept = (capped_idx >= 0).to(topk_w.dtype)
+    kept_sum = (topk_w * kept).sum(dim=-1, keepdim=True)
+    rescale = torch.where(kept_sum > 0, orig_sum / kept_sum, torch.ones_like(kept_sum))
+    rescaled_w = topk_w * kept * rescale
+    return capped_idx, rescaled_w
 
 
 def set_valid_token_mask(mask: torch.Tensor | None) -> None:
@@ -270,7 +280,9 @@ def _deep_ep_forward(self, hidden_states, top_k_index, top_k_weights, *, kernel_
     # Cap tokens-per-expert before building the dispatch layout — an overloaded expert deadlocks
     # DeepEP's intranode combine (the GLM router concentrates with depth).
     if _TOKEN_CAPACITY is not None:
-        topk_idx_i64 = _apply_expert_capacity(topk_idx_i64, topk_w_f32, _TOKEN_CAPACITY)
+        topk_idx_i64, topk_w_f32 = _apply_expert_capacity(
+            topk_idx_i64, topk_w_f32, _TOKEN_CAPACITY
+        )
 
     # Drop padding tokens from the dispatch. Under non-packed training with
     # `pad_to_sequence_len`, padding rows carry identical embeddings, so the router

--- a/src/axolotl/integrations/expert_parallel/experts_fn.py
+++ b/src/axolotl/integrations/expert_parallel/experts_fn.py
@@ -67,7 +67,11 @@ def _apply_expert_capacity(topk_idx, topk_w, cap):
     orig_sum = (topk_w * (topk_idx >= 0)).sum(dim=-1, keepdim=True)
     kept = (capped_idx >= 0).to(topk_w.dtype)
     kept_sum = (topk_w * kept).sum(dim=-1, keepdim=True)
-    rescale = torch.where(kept_sum > 0, orig_sum / kept_sum, torch.ones_like(kept_sum))
+    # double-where: guard the divisor so a fully-dropped token (kept_sum==0) can't backprop 0*inf=NaN
+    safe_kept_sum = torch.where(kept_sum > 0, kept_sum, torch.ones_like(kept_sum))
+    rescale = torch.where(
+        kept_sum > 0, orig_sum / safe_kept_sum, torch.ones_like(kept_sum)
+    )
     rescaled_w = topk_w * kept * rescale
     return capped_idx, rescaled_w
 

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
@@ -1,5 +1,9 @@
 """Sparse top-k MLA attention for GLM-5.2 DSA (forward + backward, training-correct).
 
+Not on the live training path: the runtime dispatcher (``dispatch.py``/``patch.py``) uses the
+weight-absorption kernel in ``attention_mla_absorb`` instead. This head-per-program baseline is
+retained only as an autotune/benchmarking reference (see ``autotune_collector``).
+
 The DSA training path (eager/sdpa) scatters the per-query top-k indices into a dense ``[B,S,T]``
 additive mask and runs full attention over all T keys — O(S^2) memory + compute even though only
 ``index_topk`` (2048) keys per query matter. This kernel **gathers** each query's selected keys and

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -812,9 +812,8 @@ def patch_tied_keys_for_meta_device():
 
     from transformers import PreTrainedModel
 
-    # transformers >= 5.11 dropped data_ptr-based tie detection (_adjust_tied_keys_with_tied_pointers)
-    # for the config-driven get_expanded_tied_weights_keys, so on the pinned version there is nothing
-    # to patch; bail rather than bind a phantom method that transformers never calls.
+    # recent transformers replaced data_ptr tie detection (_adjust_tied_keys_with_tied_pointers) with
+    # config-driven get_expanded_tied_weights_keys; absent on the pinned version, so bail (nothing to patch).
     if not hasattr(PreTrainedModel, "_adjust_tied_keys_with_tied_pointers"):
         return
 

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -812,6 +812,12 @@ def patch_tied_keys_for_meta_device():
 
     from transformers import PreTrainedModel
 
+    # transformers >= 5.11 dropped data_ptr-based tie detection (_adjust_tied_keys_with_tied_pointers)
+    # for the config-driven get_expanded_tied_weights_keys, so on the pinned version there is nothing
+    # to patch; bail rather than bind a phantom method that transformers never calls.
+    if not hasattr(PreTrainedModel, "_adjust_tied_keys_with_tied_pointers"):
+        return
+
     def _patched_adjust_tied_keys_with_tied_pointers(self, missing_keys):
         param_pointers = defaultdict(list)
         for param_name, param_value in self.state_dict().items():

--- a/src/axolotl/monkeypatch/accelerate/parallelism_config.py
+++ b/src/axolotl/monkeypatch/accelerate/parallelism_config.py
@@ -102,11 +102,15 @@ def _validate_accelerator(self, accelerator):
     if self.total_size == 1:
         self._set_size("dp_replicate", accelerator.num_processes)
 
-    if self.total_size != accelerator.num_processes:
+    # DeepSpeed manages SP process groups globally, so total_size (the local parallelism config)
+    # need not equal num_processes; keep this branch in sync with accelerate's upstream validator.
+    if self.sp_backend == "deepspeed" and self.sp_size > 1:
+        pass
+    elif self.total_size != accelerator.num_processes:
         raise ValueError(
             f"ParallelismConfig total_size ({self.total_size}) does not match "
             f"num_processes ({accelerator.num_processes}). Please adjust dp_replicate_size/ "
-            f"dp_shard_size/tp_size/cp_size/ep_size."
+            f"dp_shard_size/tp_size/cp_size/sp_size/ep_size."
         )
 
     # allow parallelism config when not using fsdp if using pure context parallelism
@@ -132,10 +136,14 @@ def _validate_accelerator(self, accelerator):
     if (
         self.total_size > 1
         and not allow_parallelism_config
-        and not (accelerator.is_fsdp2 or accelerator.multi_device)
+        and not (
+            accelerator.is_fsdp2
+            or accelerator.multi_device
+            or accelerator.distributed_type == DistributedType.DEEPSPEED
+        )
     ):
         raise ValueError(
-            f"ParallelismConfig is only compatible DistributedType.FSDP (version 2) or DistributedType.Multi{{Device}}, but got {accelerator.distributed_type}."
+            f"ParallelismConfig is only compatible with DistributedType.FSDP (version 2), DistributedType.Multi{{Device}}, or DistributedType.DEEPSPEED, but got {accelerator.distributed_type}."
         )
 
     for parallelism, size in self._sizes.items():

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -71,6 +71,20 @@ def test_expert_capacity_preserves_existing_sentinels():
     assert int((out == 0).sum()) <= 2
 
 
+def test_expert_capacity_no_nan_grad_when_token_fully_dropped():
+    # 3 tokens all route both top-2 slots to expert 0; cap=1 keeps only the single highest-weight
+    # assignment, so tokens 1 and 2 lose every slot (kept_sum==0). The gate-sum rescale must not
+    # backprop 0*inf=NaN into the router weights (double-where guard on the divisor).
+    topk_idx = torch.tensor([[0, 0], [0, 0], [0, 0]], dtype=torch.int64)
+    topk_w = torch.tensor([[0.9, 0.8], [0.7, 0.6], [0.5, 0.4]], requires_grad=True)
+    out, w = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=1)
+
+    assert (~(out >= 0).any(dim=-1)).any()  # at least one token lost every slot
+    assert not torch.isnan(w).any()  # forward weights stay finite
+    w.sum().backward()
+    assert not (torch.isnan(topk_w.grad).any() or torch.isinf(topk_w.grad).any())
+
+
 def _absorb():
     import axolotl.integrations.kernels.libs.glm_dsa.attention_mla_absorb as M
 

--- a/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
+++ b/tests/integrations/kernels/glm_dsa/test_glm_dsa_cpu.py
@@ -31,11 +31,16 @@ def test_expert_capacity_caps_tokens_per_expert():
         [[0.9, 0.5], [0.8, 0.4], [0.7, 0.6], [0.3, 0.2], [0.95, 0.1], [0.55, 0.45]]
     )
     cap = 2
-    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap)
+    out, w = _apply_expert_capacity(topk_idx.clone(), topk_w, cap)
 
     # every expert now has <= cap surviving assignments
     for e in range(3):
         assert int((out == e).sum()) <= cap, f"expert {e} exceeds cap"
+    # surviving weights are rescaled back to each token's original gate sum (no silent attenuation)
+    survived = (out >= 0).any(dim=-1)
+    assert torch.allclose(
+        w.sum(dim=-1)[survived], topk_w.sum(dim=-1)[survived], atol=1e-6
+    )
     # dropped slots are sentinelled to -1, and the number dropped is exactly the overflow
     n_orig = int((topk_idx >= 0).sum())
     n_kept = int((out >= 0).sum())
@@ -53,14 +58,15 @@ def test_expert_capacity_caps_tokens_per_expert():
 def test_expert_capacity_noop_when_under_cap():
     topk_idx = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
     topk_w = torch.tensor([[0.9, 0.1], [0.5, 0.5]])
-    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=8)
+    out, w = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=8)
     assert torch.equal(out, topk_idx)  # nothing dropped when every expert is under cap
+    assert torch.allclose(w, topk_w)  # weights unchanged when nothing is dropped
 
 
 def test_expert_capacity_preserves_existing_sentinels():
     topk_idx = torch.tensor([[0, -1], [0, 0]], dtype=torch.int64)
     topk_w = torch.tensor([[0.9, 0.0], [0.8, 0.7]])
-    out = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=2)
+    out, _ = _apply_expert_capacity(topk_idx.clone(), topk_w, cap=2)
     assert out[0, 1] == -1  # pre-existing -1 untouched
     assert int((out == 0).sum()) <= 2
 

--- a/tests/integrations/test_expert_parallel.py
+++ b/tests/integrations/test_expert_parallel.py
@@ -63,6 +63,19 @@ class TestExpertParallelArgs:
         with pytest.raises(ValueError):
             ExpertParallelArgs(expert_parallel_size=0)
 
+    def test_invalid_token_capacity(self):
+        with pytest.raises(ValueError):
+            ExpertParallelArgs(expert_parallel_token_capacity=0)
+
+    def test_token_capacity_none_and_positive(self):
+        assert ExpertParallelArgs().expert_parallel_token_capacity is None
+        assert (
+            ExpertParallelArgs(
+                expert_parallel_token_capacity=1024
+            ).expert_parallel_token_capacity
+            == 1024
+        )
+
 
 class TestKernelInference:
     """Plugin auto-composes with user's chosen local kernel."""


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

There were some fixes claude recommended that I didn't get into the branch on time. Related #3759 

This PR fixes:
- experts_fn: gate not renormalized
- _validate_accelerator fork dropped accelerate 1.13.0's DeepSpeed branches
- Added a hasattr guard so it no-ops on transformers that dropped _adjust_tied_keys_with_tied_pointers
- doc correction on attention_topk.py
- doc correction on expert_parallel_token_capacity

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expert-capacity handling so routed token weights stay properly balanced when assignments are capped.
  * Added validation to prevent invalid token-capacity settings and make “no cap” behavior clearer.
  * Made distributed training checks more compatible with additional parallelism setups, reducing false validation errors.
  * Improved stability when running with newer model libraries by skipping an unavailable compatibility hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->