### PR TITLE
feat(optimizers): SinkGD width transfer, spectral norm, MD sphere + fused Triton kernels

### DIFF
--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -195,6 +195,26 @@ iteration over the `dp_shard` group — the same shape and group as SR-Sinkhorn'
 norm-vector reduce, and the matrix itself is never gathered. The persisted power-iteration
 vector round-trips through FSDP2 checkpoints.
 
+#### Weight-sphere variant (`sinkgd_md_sphere`, experimental)
+
+`sinkgd_md_sphere: true` switches to an experimental magnitude–direction variant: each
+SinkGD-routed 2D weight is held on a fixed Frobenius sphere (`||W||_F` anchored at enable
+time), the SR-Sinkhorn update is spectral-normalized to unit operator norm, applied, and the
+weight is reprojected onto the sphere (no learnable gains — SinkGD's row/column balancing makes
+them redundant). In width/depth sweeps this bounds the deepest-layer activation growth most
+tightly of any variant, but its optimal LR is **width-dependent** (`lr_opt ∝ d_model**-0.6`)
+and its optimum is narrow, so it needs per-scale LR tuning and is **off by default**. Prefer the
+plain spectral-norm path (above) unless you specifically want the tightest activation bound.
+It adds a per-matrix scalar all-reduce (the sphere's global Frobenius norm) on top of the
+spectral all-reduce under FSDP2; the sphere radius and power-iteration vector round-trip.
+
+```yaml
+optim_args:
+  sinkgd_md_sphere: true
+  sinkgd_lr_scale: 0.05
+  # tune learning_rate per width: lr_opt ~ d_model**-0.6 (e.g. ~0.03 at d=2048)
+```
+
 ### q_galore_adamw8bit
 
 Q-GaLore extends [GaLore](https://arxiv.org/abs/2403.03507) with two extra ideas:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -150,6 +150,51 @@ optim_args:
   sinkgd_lr_scale: 0.05  # α scale applied to linear-layer updates
 ```
 
+#### Width transfer (`sinkgd_base_width`) and spectral normalization
+
+Two optional, default-off knobs help the learning rate transfer across model width and
+condition the update. They are **mutually exclusive** — both correct for width, so enabling
+both double-counts (validated and rejected at construction).
+
+**Width-aware scaling (`sinkgd_base_width`).** SinkGD's update is *Adam-class*: its per-layer
+learning rate should scale as `1/d_in`. Set `sinkgd_base_width` to the hidden size you tuned
+`sinkgd_lr_scale` on, and each 2D-linear update is scaled by
+`alpha_eff = sinkgd_lr_scale * (base_width / d_in) ** sinkgd_lr_width_exponent`
+(`d_in` is the layer's input dim — the shared input of a fused QKV / gate-up matrix). With
+`sinkgd_base_width` unset, behavior is identical to before (plain scalar `sinkgd_lr_scale`),
+so existing configs are unchanged.
+
+```yaml
+optim_args:
+  sinkgd_lr_scale: 0.05
+  sinkgd_base_width: 2048        # d_in you tuned sinkgd_lr_scale at; enables 1/d_in transfer
+  sinkgd_lr_width_exponent: 1.0  # 1.0 = pure 1/d_in (default); tune only if width varies >10x
+```
+
+**Spectral normalization (`sinkgd_spectral_norm`).** Rescales each update to a target operator
+norm via a cheap warm-started power iteration (~2 matvecs/layer, +1–3% step time, one
+`O(d_in)` state vector per matrix). With `sinkgd_spectral_target: muon` it pins the operator
+norm to `sqrt(d_out/d_in)`, which makes SinkGD *Muon-class* and both transfers across width and
+trained to lower loss than plain `1/d_in` in width sweeps — so use it **instead of**
+`sinkgd_base_width`, not with it. `unit` (the default target) pins a width-independent norm and
+acts as a pure conditioning stabilizer on top of `1/d_in`.
+
+```yaml
+optim_args:
+  sinkgd_lr_scale: 0.05
+  sinkgd_spectral_norm: true
+  sinkgd_spectral_target: muon   # spectral norm owns width transfer (leave sinkgd_base_width unset)
+  sinkgd_spectral_norm_iters: 1  # power-iteration steps per update (warm-started; 1–2 is enough)
+```
+
+Distributed (`fsdp_version: 2`): width-aware scaling and spectral norm both work under FSDP2/TP
+sharding. On replicated / expert-sharded weights everything runs locally with no extra
+communication. On a matrix-dim-sharded weight (the common FSDP2 row-sharded case) the spectral
+norm's power iteration adds **one small vector all-reduce** (length `d_in` or `d_out`) per
+iteration over the `dp_shard` group — the same shape and group as SR-Sinkhorn's existing
+norm-vector reduce, and the matrix itself is never gathered. The persisted power-iteration
+vector round-trips through FSDP2 checkpoints.
+
 ### q_galore_adamw8bit
 
 Q-GaLore extends [GaLore](https://arxiv.org/abs/2403.03507) with two extra ideas:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -153,8 +153,10 @@ optim_args:
 #### Width transfer (`sinkgd_base_width`) and spectral normalization
 
 Two optional, default-off knobs help the learning rate transfer across model width and
-condition the update. They are **mutually exclusive** — both correct for width, so enabling
-both double-counts (validated and rejected at construction).
+condition the update. `sinkgd_base_width` and `sinkgd_spectral_target: muon` are **mutually
+exclusive** — both correct for width, so enabling both double-counts (validated and rejected
+at construction). Spectral norm at the default `unit` target combines fine with
+`sinkgd_base_width`, since it conditions the update without touching width scaling.
 
 **Width-aware scaling (`sinkgd_base_width`).** SinkGD's update is *Adam-class*: its per-layer
 learning rate should scale as `1/d_in`. Set `sinkgd_base_width` to the hidden size you tuned
@@ -206,7 +208,11 @@ local shards stay fully occupied. Measured on B200: 1.4–1.75x on the optimizer
 single-GPU, 1.0–1.8x on 2-rank FSDP2, all regimes ≥1x with the wide layout. Numerics are
 equivalent at bf16 rounding scale but not byte-identical to the compiled path, so the flag
 is off by default. Falls back to the compiled path for cols-sharded (TP) weights,
-`bf16_stochastic_round`, or when Triton is unavailable.
+`bf16_stochastic_round`, or when Triton is unavailable. Spectral-norm / MD-sphere updates
+that run without a shard group to amortize against (single device, or replicated /
+expert-sharded weights under FSDP2) also fall back when the matrix has fewer than
+`sinkgd_fused_min_numel` elements (default `2^25`) — at those sizes the epilogue's extra
+kernel launches make the compiled path faster.
 
 ```yaml
 optim_args:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -195,6 +195,24 @@ iteration over the `dp_shard` group — the same shape and group as SR-Sinkhorn'
 norm-vector reduce, and the matrix itself is never gathered. The persisted power-iteration
 vector round-trips through FSDP2 checkpoints.
 
+#### Fused Triton kernels (`sinkgd_fused_kernel`)
+
+`sinkgd_fused_kernel: true` replaces the compiled update with fused Triton kernels (one
+kernel per SR-Sinkhorn iteration; the column scale, power iteration, and weight update fold
+into the same passes). Works for all SinkGD variants (plain, spectral norm, MD sphere) on
+single-device and FSDP2 rows-sharded weights — same all-reduce count as the compiled path,
+with an automatic tall/wide grid layout so both full matrices and heavily-sharded wide-short
+local shards stay fully occupied. Measured on B200: 1.4–1.75x on the optimizer step
+single-GPU, 1.0–1.8x on 2-rank FSDP2, all regimes ≥1x with the wide layout. Numerics are
+equivalent at bf16 rounding scale but not byte-identical to the compiled path, so the flag
+is off by default. Falls back to the compiled path for cols-sharded (TP) weights,
+`bf16_stochastic_round`, or when Triton is unavailable.
+
+```yaml
+optim_args:
+  sinkgd_fused_kernel: true
+```
+
 #### Weight-sphere variant (`sinkgd_md_sphere`, experimental)
 
 `sinkgd_md_sphere: true` switches to an experimental magnitude–direction variant: each

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -343,6 +343,8 @@ class SinkGD(_AdamBase):
             self.sinkgd_fused_kernel
             and fused_available()
             and p.is_cuda
+            # kernels index p with dense strides and update it in place
+            and p.is_contiguous()
             and not (self.bf16_stochastic_round and p.dtype is torch.bfloat16)
         )
 

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -146,7 +146,7 @@ def single_param_sinkgd_specnorm(
     # the full matrix is never cast to fp32 (only the O(m)/O(n) vectors are). `v @ X` avoids
     # materializing Xᵀ.
     uu = u
-    sigma = None
+    sigma: Tensor
     for _ in range(sn_iters):
         v = torch.matmul(x, (dv * uu).to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
@@ -209,7 +209,7 @@ def single_param_sinkgd_md(
 
     # bf16 tensor-core power iteration with the column scale folded into the vectors
     uu = u
-    sigma = None
+    sigma: Tensor
     for _ in range(sn_iters):
         v = torch.matmul(x, (dv * uu).to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
@@ -327,9 +327,10 @@ class SinkGD(_AdamBase):
         if self.sinkgd_base_width is None:
             return self.sinkgd_lr_scale
         d_in = p.shape[-1]
-        return self.sinkgd_lr_scale * (
-            self.sinkgd_base_width / d_in
-        ) ** self.sinkgd_lr_width_exponent
+        return (
+            self.sinkgd_lr_scale
+            * (self.sinkgd_base_width / d_in) ** self.sinkgd_lr_width_exponent
+        )
 
     def _fused_ok(self, p: Tensor, epilogue: bool = False) -> bool:
         # Stochastic rounding is not implemented in the fused kernels -> compiled fallback.
@@ -351,15 +352,26 @@ class SinkGD(_AdamBase):
             if self.sinkgd_spectral_norm:
                 u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
                 fused_sinkgd_step(
-                    p.detach(), grad, float(lr) * alpha, group["weight_decay"],
-                    self.sinkhorn_iters, self.sinkgd_eps, mode="spec", u=u,
+                    p.detach(),
+                    grad,
+                    float(lr) * alpha,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    mode="spec",
+                    u=u,
                     spectral_target=self.sinkgd_spectral_target,
                     sn_iters=self.sinkgd_spectral_norm_iters,
                 )
             else:
                 fused_sinkgd_step(
-                    p.detach(), grad, float(lr) * alpha, group["weight_decay"],
-                    self.sinkhorn_iters, self.sinkgd_eps, mode="base",
+                    p.detach(),
+                    grad,
+                    float(lr) * alpha,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    mode="base",
                 )
             return
         if not self.sinkgd_spectral_norm:
@@ -482,8 +494,15 @@ class SinkGDMD(SinkGD):
         u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
         if self._fused_ok(p, epilogue=True):
             fused_sinkgd_step(
-                p.detach(), grad, float(lr) * alpha, 0.0, self.sinkhorn_iters,
-                self.sinkgd_eps, mode="md", u=u, target_norm=tn,
+                p.detach(),
+                grad,
+                float(lr) * alpha,
+                0.0,
+                self.sinkhorn_iters,
+                self.sinkgd_eps,
+                mode="md",
+                u=u,
+                target_norm=tn,
                 sn_iters=self.sinkgd_spectral_norm_iters,
             )
             return
@@ -747,13 +766,16 @@ class DistSinkGD(SinkGD):
         u = st.get("specnorm_u")
         if u is None or u.shape[-1] != vec_len:
             g = torch.Generator(device=device).manual_seed(0)
-            u = torch.randn(*lead, vec_len, generator=g, device=device, dtype=torch.float32)
+            u = torch.randn(
+                *lead, vec_len, generator=g, device=device, dtype=torch.float32
+            )
             u = u / torch.linalg.vector_norm(u, dim=-1, keepdim=True).clamp_min(1e-12)
             st["specnorm_u"] = u
         return u
 
-    def _dist_spectral_scale(self, x, p, device, shard_dim, global_M, global_N,
-                             op_target=None):
+    def _dist_spectral_scale(
+        self, x, p, device, shard_dim, global_M, global_N, op_target=None
+    ):
         """Estimate ``||U||_2`` on the matrix-dim-sharded update via power iteration on the
         Gram matrix — one ``[N]`` (rows sharded) or ``[M]`` (cols sharded) vector all-reduce
         per iter, the same shape and ``dp_shard`` group as the Sinkhorn norm reduce, matrix
@@ -766,7 +788,7 @@ class DistSinkGD(SinkGD):
         eps = self.sinkgd_eps
         vec_len = global_N if shard_dim == -2 else global_M
         u = self._dist_specnorm_vec(p, device, lead, vec_len)
-        nrm = None
+        nrm: Tensor
         for _ in range(self.sinkgd_spectral_norm_iters):
             ud = u.to(x.dtype)
             if shard_dim == -2:
@@ -783,7 +805,9 @@ class DistSinkGD(SinkGD):
             target = op_target.reshape(*op_target.shape, 1, 1)
         else:
             target = (
-                1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
+                1.0
+                if self.sinkgd_spectral_target == "unit"
+                else (global_M / global_N) ** 0.5
             )
         return target / sig_b
 
@@ -811,16 +835,30 @@ class DistSinkGD(SinkGD):
                 else:
                     u = self._specnorm_u(p, global_N, p_local.shape[:-2])
                 fused_sinkgd_step(
-                    p_local, x, lr_f, group["weight_decay"], self.sinkhorn_iters,
-                    self.sinkgd_eps, mode="spec", u=u,
+                    p_local,
+                    x,
+                    lr_f,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    mode="spec",
+                    u=u,
                     spectral_target=self.sinkgd_spectral_target,
                     sn_iters=self.sinkgd_spectral_norm_iters,
-                    m_global=m_glob, process_group=grp,
+                    m_global=m_glob,
+                    process_group=grp,
                 )
             else:
                 fused_sinkgd_step(
-                    p_local, x, lr_f, group["weight_decay"], self.sinkhorn_iters,
-                    self.sinkgd_eps, mode="base", m_global=m_glob, process_group=grp,
+                    p_local,
+                    x,
+                    lr_f,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    mode="base",
+                    m_global=m_glob,
+                    process_group=grp,
                 )
             return
         lr = lr * self._alpha_eff(p)  # width-aware; p.shape[-1] is the global d_in
@@ -830,16 +868,31 @@ class DistSinkGD(SinkGD):
             # fully-compiled single-device path (incl. spectral norm), no communication.
             if self.sinkgd_spectral_norm:
                 m, n = global_M, global_N
-                target = 1.0 if self.sinkgd_spectral_target == "unit" else (m / n) ** 0.5
+                target = (
+                    1.0 if self.sinkgd_spectral_target == "unit" else (m / n) ** 0.5
+                )
                 u = self._specnorm_u(p, n, p_local.shape[:-2])
                 self._compiled_sinkgd_sn(
-                    p_local, x, u, lr, group["weight_decay"], self.sinkhorn_iters,
-                    self.sinkgd_eps, target, self.sinkgd_spectral_norm_iters, sr,
+                    p_local,
+                    x,
+                    u,
+                    lr,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    target,
+                    self.sinkgd_spectral_norm_iters,
+                    sr,
                 )
             else:
                 self._compiled_sinkgd(
-                    p_local, x, lr, group["weight_decay"], self.sinkhorn_iters,
-                    self.sinkgd_eps, sr,
+                    p_local,
+                    x,
+                    lr,
+                    group["weight_decay"],
+                    self.sinkhorn_iters,
+                    self.sinkgd_eps,
+                    sr,
                 )
             return
 
@@ -858,8 +911,9 @@ class DistSinkGD(SinkGD):
             # one extra small vector all-reduce (size d_in/d_out) per power-iteration step,
             # mirroring the Sinkhorn norm reduce above; the matrix is never gathered and the
             # rescale folds into the apply.
-            scale = self._dist_spectral_scale(x, p, p_local.device, shard_dim,
-                                              global_M, global_N)
+            scale = self._dist_spectral_scale(
+                x, p, p_local.device, shard_dim, global_M, global_N
+            )
             self._c_apply_update_scaled(
                 p_local, x, scale, lr, group["weight_decay"], sr
             )
@@ -929,14 +983,26 @@ class DistSinkGDMD(DistSinkGD):
         x = grad.to_local() if isinstance(grad, DTensor) else grad
         tn = self._dist_md_target(p, p_local, shard_dim)
 
-        if self._fused_ok(p_local, epilogue=shard_dim is None) and shard_dim in (None, -2):
+        if self._fused_ok(p_local, epilogue=shard_dim is None) and shard_dim in (
+            None,
+            -2,
+        ):
             if shard_dim == -2:
-                u = self._dist_specnorm_vec(p, p_local.device, p_local.shape[:-2], global_N)
+                u = self._dist_specnorm_vec(
+                    p, p_local.device, p_local.shape[:-2], global_N
+                )
             else:
                 u = self._specnorm_u(p, global_N, p_local.shape[:-2])
             fused_sinkgd_step(
-                p_local, x, float(lr) * self._alpha_eff(p), 0.0, self.sinkhorn_iters,
-                self.sinkgd_eps, mode="md", u=u, target_norm=tn,
+                p_local,
+                x,
+                float(lr) * self._alpha_eff(p),
+                0.0,
+                self.sinkhorn_iters,
+                self.sinkgd_eps,
+                mode="md",
+                u=u,
+                target_norm=tn,
                 sn_iters=self.sinkgd_spectral_norm_iters,
                 m_global=global_M if shard_dim == -2 else None,
                 process_group=self._process_group if shard_dim == -2 else None,
@@ -948,8 +1014,15 @@ class DistSinkGDMD(DistSinkGD):
             # full matrix local -> reuse the fully-compiled single-device MD step.
             u = self._specnorm_u(p, global_N, p_local.shape[:-2])
             self._compiled_md(
-                p_local, x, u, lr, self.sinkhorn_iters, self.sinkgd_eps, tn,
-                self.sinkgd_spectral_norm_iters, sr,
+                p_local,
+                x,
+                u,
+                lr,
+                self.sinkhorn_iters,
+                self.sinkgd_eps,
+                tn,
+                self.sinkgd_spectral_norm_iters,
+                sr,
             )
             return
 

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -124,25 +124,37 @@ def single_param_sinkgd_specnorm(
     sqrt_n = n**0.5
     sqrt_m = m**0.5
     x = grad
-    for _ in range(iters):
+    for _ in range(max(iters - 1, 0)):
         rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
         cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+    # The FINAL column scale is a diagonal on the right: (X·D)u = X(D⊙u) and vᵀ(X·D) =
+    # (vᵀX)⊙D, so it folds into the O(n) power-iteration vectors and the apply — the scaled
+    # matrix is never materialized (saves one full read+write per step vs the base loop).
+    if iters > 0:
+        rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        d = sqrt_m / cn.clamp_min(eps)  # fp32 [*lead, 1, n]
+    else:
+        d = torch.ones_like(x[..., :1, :], dtype=torch.float32)
+    dv = d.squeeze(-2)  # [*lead, n]
 
     # Power iteration in the update dtype: matmuls hit tensor cores with fp32 accumulation, so
     # the full matrix is never cast to fp32 (only the O(m)/O(n) vectors are). `v @ X` avoids
-    # materializing Xᵀ, and the operator-norm rescale folds into the apply (no extra pass).
+    # materializing Xᵀ.
     uu = u
     sigma = None
     for _ in range(sn_iters):
-        v = torch.matmul(x, uu.to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
+        v = torch.matmul(x, (dv * uu).to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
-        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float()
+        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float() * dv
         sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
         uu = uu / sigma
     u.copy_(uu)
-    scale = target / sigma.reshape(*sigma.shape[:-1], 1, 1)  # fp32 [*lead,1,1]
+    # per-column scale: operator-norm rescale x held-out final column scale, fp32 [*lead,1,n]
+    scale = (target / sigma.reshape(*sigma.shape[:-1], 1, 1)) * d
 
     p_f32 = p.float()
     if weight_decay != 0.0:
@@ -179,35 +191,49 @@ def single_param_sinkgd_md(
     sqrt_n = n**0.5
     sqrt_m = m**0.5
     x = grad
-    for _ in range(iters):
+    for _ in range(max(iters - 1, 0)):
         rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
         cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+    # final column scale held out as a diagonal (see single_param_sinkgd_specnorm)
+    if iters > 0:
+        rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        d = sqrt_m / cn.clamp_min(eps)  # fp32 [*lead, 1, n]
+    else:
+        d = torch.ones_like(x[..., :1, :], dtype=torch.float32)
+    dv = d.squeeze(-2)
 
-    # bf16 tensor-core power iteration (see single_param_sinkgd_specnorm); the unit-operator-
-    # norm + sphere-radius rescale folds into the weight step, leaving only the sphere
-    # projection (the one unavoidable extra full-matrix pass for MD).
+    # bf16 tensor-core power iteration with the column scale folded into the vectors
     uu = u
     sigma = None
     for _ in range(sn_iters):
-        v = torch.matmul(x, uu.to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
+        v = torch.matmul(x, (dv * uu).to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
-        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float()
+        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float() * dv
         sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
         uu = uu / sigma
     u.copy_(uu)
     tn = target_norm.reshape(*target_norm.shape, 1, 1)
-    sig_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
+    a = lr * tn / sigma.reshape(*sigma.shape[:-1], 1, 1)  # step coefficient [*lead,1,1]
 
-    p_f32 = p.float() - (lr * tn / sig_b) * x.float()
-    fro = torch.linalg.vector_norm(p_f32, dim=(-2, -1), keepdim=True).clamp_min(eps)
-    p_f32 = p_f32 / fro * tn  # Frobenius sphere projection
+    # Analytic sphere projection: ||W - aU||_F^2 = ||W||^2 - 2a<W,U> + a^2||U||^2, so three
+    # fused reductions over (p, x) replace materializing the fp32 intermediate, reducing over
+    # it, and re-reading it to rescale — the projection collapses into one fused write pass.
+    p_f32 = p.float()
+    xd = x.float() * d
+    s0 = (p_f32 * p_f32).sum(dim=(-2, -1), keepdim=True)
+    s1 = (p_f32 * xd).sum(dim=(-2, -1), keepdim=True)
+    s2 = (xd * xd).sum(dim=(-2, -1), keepdim=True)
+    fro = (s0 - 2 * a * s1 + a * a * s2).clamp_min(eps).sqrt()
+    p_new = (p_f32 - a * xd) * (tn / fro)
 
     if stochastic_round:
-        p.copy_(_fp32_to_bf16_sr(p_f32))
+        p.copy_(_fp32_to_bf16_sr(p_new))
     else:
-        p.copy_(p_f32)
+        p.copy_(p_new)
 
 
 class SinkGD(_AdamBase):
@@ -592,17 +618,40 @@ def _sinkgd_apply_update(p, x, lr, weight_decay, stochastic_round):
 # product (summed across the shard group by an eager all-reduce). Iterating the Gram matrix
 # (rather than U, Uᵀ separately) needs only a single vector all-reduce per step, and the
 # implicit v-normalization cancels. Batched over leading (expert) dims.
-def _md_local_wprime(p_local, x_spec, lr):
-    # W' = W - lr*U_spec (local shard) + its per-matrix local squared-Frobenius partial.
-    pf = p_local.float() - lr * x_spec.float()
-    return pf, (pf * pf).sum(dim=(-2, -1), keepdim=True)
+def _sinkgd_apply_update_scaled(p, x, scale, lr, weight_decay, stochastic_round):
+    # apply with a per-matrix fp32 scale folded into the update multiply (the spectral
+    # rescale is never materialized as a separate full-matrix pass).
+    p_f32 = p.float()
+    if weight_decay != 0.0:
+        p_f32 = p_f32 * (1 - lr * weight_decay)
+    p_f32 = p_f32 - (lr * scale) * x.float()
+    if stochastic_round:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
+    else:
+        p.copy_(p_f32)
 
 
-def _md_sphere_apply(p_local, pf, frosq, tn, eps, stochastic_round):
-    # project the local shard back onto the Frobenius sphere ||W||_F = tn (frosq is global).
-    fro = frosq.sqrt().clamp_min(eps)
+def _md_local_partials(p_local, x):
+    # local partial sums for the analytic sphere norm: ||W||^2, <W,U>, ||U||^2 per matrix,
+    # packed into one tensor so a single all-reduce covers all three.
+    pf = p_local.float()
+    xf = x.float()
+    s0 = (pf * pf).sum(dim=(-2, -1))
+    s1 = (pf * xf).sum(dim=(-2, -1))
+    s2 = (xf * xf).sum(dim=(-2, -1))
+    return torch.stack([s0, s1, s2])
+
+
+def _md_apply_analytic(p_local, x, sums, a, tn, eps, stochastic_round):
+    # analytic projection (see single_param_sinkgd_md): fro from the reduced partials, then
+    # one fused step + rescale pass; no fp32 intermediate.
+    shape = (*sums.shape[1:], 1, 1)
+    s0 = sums[0].reshape(shape)
+    s1 = sums[1].reshape(shape)
+    s2 = sums[2].reshape(shape)
+    fro = (s0 - 2 * a * s1 + a * a * s2).clamp_min(eps).sqrt()
     tn_b = tn.reshape(*tn.shape, 1, 1)
-    pf = pf / fro * tn_b
+    pf = (p_local.float() - a * x.float()) * (tn_b / fro)
     if stochastic_round:
         p_local.copy_(_fp32_to_bf16_sr(pf))
     else:
@@ -643,6 +692,7 @@ class DistSinkGD(SinkGD):
         self._c_apply_update = c(_sinkgd_apply_update)
         self._c_specnorm_gram_rows = c(_specnorm_gram_rows)
         self._c_specnorm_gram_cols = c(_specnorm_gram_cols)
+        self._c_apply_update_scaled = c(_sinkgd_apply_update_scaled)
 
     def _dist_specnorm_vec(self, p, device, lead, vec_len) -> Tensor:
         """Replicated warm-start vector for the sharded power iteration, living on the
@@ -657,12 +707,13 @@ class DistSinkGD(SinkGD):
             st["specnorm_u"] = u
         return u
 
-    def _dist_spectral_rescale(self, x, p, device, shard_dim, global_M, global_N,
-                               op_target=None):
+    def _dist_spectral_scale(self, x, p, device, shard_dim, global_M, global_N,
+                             op_target=None):
         """Estimate ``||U||_2`` on the matrix-dim-sharded update via power iteration on the
         Gram matrix — one ``[N]`` (rows sharded) or ``[M]`` (cols sharded) vector all-reduce
         per iter, the same shape and ``dp_shard`` group as the Sinkhorn norm reduce, matrix
-        never gathered — then rescale the local shard to the target operator norm.
+        never gathered — and return the fp32 ``[*lead,1,1]`` rescale factor (folded into the
+        apply by the caller; the rescaled matrix is never materialized).
 
         ``op_target`` overrides the target with a per-matrix tensor (the MD sphere radius);
         otherwise the class ``unit``/``muon`` scalar is used."""
@@ -689,7 +740,7 @@ class DistSinkGD(SinkGD):
             target = (
                 1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
             )
-        return x * (target / sig_b).to(x.dtype)
+        return target / sig_b
 
     def _dist_sinkgd_step(self, p, grad, group, lr):
         shard_dim = _matrix_shard_dim(p)
@@ -730,10 +781,15 @@ class DistSinkGD(SinkGD):
                 x = self._c_row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps)
         if self.sinkgd_spectral_norm:
             # one extra small vector all-reduce (size d_in/d_out) per power-iteration step,
-            # mirroring the Sinkhorn norm reduce above; the matrix is never gathered.
-            x = self._dist_spectral_rescale(x, p, p_local.device, shard_dim,
-                                            global_M, global_N)
-        self._c_apply_update(p_local, x, lr, group["weight_decay"], sr)
+            # mirroring the Sinkhorn norm reduce above; the matrix is never gathered and the
+            # rescale folds into the apply.
+            scale = self._dist_spectral_scale(x, p, p_local.device, shard_dim,
+                                              global_M, global_N)
+            self._c_apply_update_scaled(
+                p_local, x, scale, lr, group["weight_decay"], sr
+            )
+        else:
+            self._c_apply_update(p_local, x, lr, group["weight_decay"], sr)
 
     @torch.no_grad()
     def step(self, closure=None):
@@ -776,8 +832,8 @@ class DistSinkGDMD(DistSinkGD):
         super().__init__(params, process_group=process_group, **kwargs)
         c = lambda f: torch.compile(f, fullgraph=True, dynamic=False)  # noqa: E731
         self._compiled_md = c(single_param_sinkgd_md)
-        self._c_md_local_wprime = c(_md_local_wprime)
-        self._c_md_sphere_apply = c(_md_sphere_apply)
+        self._c_md_local_partials = c(_md_local_partials)
+        self._c_md_apply_analytic = c(_md_apply_analytic)
 
     def _dist_md_target(self, p, p_local, shard_dim) -> Tensor:
         state = self.state[p]
@@ -819,14 +875,16 @@ class DistSinkGDMD(DistSinkGD):
                 rsq = self._c_row_partial(x)
                 dist.all_reduce(rsq, group=self._process_group)
                 x = self._c_row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps)
-        # spectral-normalize the direction to operator norm == sphere radius tn
-        x = self._dist_spectral_rescale(
+        # spectral scale for operator norm == sphere radius tn (folded into the apply)
+        scale = self._dist_spectral_scale(
             x, p, p_local.device, shard_dim, global_M, global_N, op_target=tn
         )
-        # weight step + Frobenius sphere projection (one per-matrix scalar all-reduce)
-        pf, frosq = self._c_md_local_wprime(p_local, x, lr)
-        dist.all_reduce(frosq, group=self._process_group)
-        self._c_md_sphere_apply(p_local, pf, frosq, tn, eps, sr)
+        a = lr.to(scale.device) * scale  # step coefficient [*lead,1,1]
+        # analytic sphere projection: one packed all-reduce of the three Frobenius partials
+        # replaces materializing the fp32 W' shard (see single_param_sinkgd_md).
+        sums = self._c_md_local_partials(p_local, x)
+        dist.all_reduce(sums, group=self._process_group)
+        self._c_md_apply_analytic(p_local, x, sums, a, tn, eps, sr)
 
 
 class DistSinkGDOptimizerFactory(BaseOptimizerFactory):

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -95,6 +95,65 @@ def single_param_sinkgd(
         p.copy_(p_f32)
 
 
+def single_param_sinkgd_specnorm(
+    p: Tensor,
+    grad: Tensor,
+    u: Tensor,
+    lr: Tensor,
+    weight_decay: float,
+    iters: int,
+    eps: float,
+    target: float,
+    sn_iters: int,
+    stochastic_round: bool,
+) -> None:
+    """SinkGD update (Feature A) with an operator-norm rescale of the update.
+
+    After SR-Sinkhorn produces the update ``U``, its spectral norm ``sigma = ||U||_2`` is
+    estimated by ``sn_iters`` of power iteration warm-started from ``u`` (the persisted
+    right-singular-vector estimate, the only added state, O(n) per matrix), and ``U`` is
+    globally rescaled to ``target = sqrt(d_out/d_in)`` operator norm. ``u`` is updated
+    in place across steps. Batched over any leading (expert) dims. Compile-clean: the
+    power iteration is matmuls + norms, no graph break.
+
+    This is Option 2 of the handoff INTERACTION WARNING — the spectral rescale replaces
+    SinkGD's implicit ``sqrt(nm)`` Frobenius magnitude, so the effective step size shifts
+    vs the flag-off path (expected; measured/reported in Phase 2, tuned via lr/alpha).
+    """
+    m, n = grad.shape[-2], grad.shape[-1]
+    sqrt_n = n**0.5
+    sqrt_m = m**0.5
+    x = grad
+    for _ in range(iters):
+        rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+
+    xf = x.float()
+    uu = u
+    sigma = None
+    for _ in range(sn_iters):
+        v = torch.matmul(xf, uu.unsqueeze(-1)).squeeze(-1)
+        v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
+        uu = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
+        sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
+        uu = uu / sigma
+    u.copy_(uu)
+    sigma_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
+    xf = xf * (target / sigma_b)
+
+    p_f32 = p.float()
+    if weight_decay != 0.0:
+        p_f32 = p_f32 * (1 - lr * weight_decay)
+    p_f32 = p_f32 - lr * xf
+
+    if stochastic_round:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
+    else:
+        p.copy_(p_f32)
+
+
 class SinkGD(_AdamBase):
     """SinkGD optimizer with an 8-bit AdamW fallback for non-matrix parameters.
 
@@ -115,6 +174,11 @@ class SinkGD(_AdamBase):
         sinkhorn_iters=5,
         sinkgd_lr_scale=0.05,
         sinkgd_eps=1e-8,
+        sinkgd_spectral_norm=False,
+        sinkgd_spectral_norm_iters=1,
+        sinkgd_spectral_target="unit",
+        sinkgd_base_width=None,
+        sinkgd_lr_width_exponent=1.0,
         block_size=256,
         bf16_stochastic_round=False,
     ) -> None:
@@ -132,8 +196,16 @@ class SinkGD(_AdamBase):
         self.sinkhorn_iters = sinkhorn_iters
         self.sinkgd_lr_scale = sinkgd_lr_scale
         self.sinkgd_eps = sinkgd_eps
+        self.sinkgd_spectral_norm = sinkgd_spectral_norm
+        self.sinkgd_spectral_norm_iters = sinkgd_spectral_norm_iters
+        self.sinkgd_spectral_target = sinkgd_spectral_target
+        self.sinkgd_base_width = sinkgd_base_width
+        self.sinkgd_lr_width_exponent = sinkgd_lr_width_exponent
         self._compiled_sinkgd = torch.compile(
             single_param_sinkgd, fullgraph=True, dynamic=False
+        )
+        self._compiled_sinkgd_sn = torch.compile(
+            single_param_sinkgd_specnorm, fullgraph=True, dynamic=False
         )
         self._compiled_adam = torch.compile(
             single_param_adam, fullgraph=True, dynamic=False
@@ -143,6 +215,65 @@ class SinkGD(_AdamBase):
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
         return OptimState8bit.zeros(
             p.shape, signed, block_size, p.device, dtype=p.dtype
+        )
+
+    def _specnorm_u(self, p: Tensor, n_local: int, lead) -> Tensor:
+        """Persisted right-singular-vector estimate for power iteration (warm-start).
+
+        ``n_local`` is the (local, for the dist path) length of the vector; ``lead`` the
+        leading/expert dims. The only optimizer state on a SinkGD-routed matrix.
+        """
+        state = self.state[p]
+        u = state.get("specnorm_u")
+        if u is None:
+            u = torch.randn(*lead, n_local, device=p.device, dtype=torch.float32)
+            u = u / torch.linalg.vector_norm(u, dim=-1, keepdim=True).clamp_min(1e-12)
+            state["specnorm_u"] = u
+        return u
+
+    def _alpha_eff(self, p: Tensor) -> float:
+        """Per-layer update scale. Width-aware when ``sinkgd_base_width`` is set:
+        ``alpha_eff = sinkgd_lr_scale * (base_width / d_in) ** exponent`` (the Phase-1
+        ``eta ∝ 1/d_in`` rule). Unset -> plain scalar (old behavior, backward compatible).
+        ``d_in`` is the logical input dim ``p.shape[-1]`` (the shared input of a fused
+        QKV / gate-up matrix), which for a DTensor is already the global dim."""
+        if self.sinkgd_base_width is None:
+            return self.sinkgd_lr_scale
+        d_in = p.shape[-1]
+        return self.sinkgd_lr_scale * (
+            self.sinkgd_base_width / d_in
+        ) ** self.sinkgd_lr_width_exponent
+
+    def _sinkgd_update(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
+        alpha = self._alpha_eff(p)
+        if not self.sinkgd_spectral_norm:
+            self._compiled_sinkgd(
+                p.detach(),
+                grad,
+                lr * alpha,
+                group["weight_decay"],
+                self.sinkhorn_iters,
+                self.sinkgd_eps,
+                self.bf16_stochastic_round and p.dtype is torch.bfloat16,
+            )
+            return
+        m, n = p.shape[-2], p.shape[-1]
+        # "unit": pin operator norm to a width-independent constant so spectral norm is a
+        # pure conditioning stabilizer and 1/d_in owns width (Adam-class). "muon":
+        # sqrt(d_out/d_in) makes spectral own width (double-counts with 1/d_in — see Phase 2).
+        target = 1.0 if self.sinkgd_spectral_target == "unit" else (m / n) ** 0.5
+        u = self._specnorm_u(p, n, p.shape[:-2])
+        self._compiled_sinkgd_sn(
+            p.detach(),
+            grad,
+            u,
+            lr * alpha,
+            group["weight_decay"],
+            self.sinkhorn_iters,
+            self.sinkgd_eps,
+            target,
+            self.sinkgd_spectral_norm_iters,
+            self.bf16_stochastic_round and p.dtype is torch.bfloat16,
         )
 
     def _adam_fallback(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
@@ -196,15 +327,7 @@ class SinkGD(_AdamBase):
                         raise RuntimeError("Sparse gradient is not supported")
 
                     if use_sinkgd and p.ndim >= 2:
-                        self._compiled_sinkgd(
-                            p.detach(),
-                            grad,
-                            lr * self.sinkgd_lr_scale,
-                            group["weight_decay"],
-                            self.sinkhorn_iters,
-                            self.sinkgd_eps,
-                            self.bf16_stochastic_round and p.dtype is torch.bfloat16,
-                        )
+                        self._sinkgd_update(p, grad, group, lr)
                     else:
                         self._adam_fallback(p, grad, group, lr)
 
@@ -248,6 +371,42 @@ def _sinkgd_param_groups(opt_model, weight_decay):
     return param_groups
 
 
+def _as_bool(v) -> bool:
+    if isinstance(v, str):
+        return v.strip().lower() in ("1", "true", "yes", "on")
+    return bool(v)
+
+
+def _pop_sinkgd_extra_kwargs(optimizer_kwargs: dict) -> dict:
+    """Type-cast the optional Feature-A ``optim_args`` (they may arrive as strings from the
+    ``key=value`` form) and validate the width-transfer mutual exclusion. Returns kwargs to
+    forward to the ``SinkGD`` constructor (only the keys that were provided)."""
+    out = dict(optimizer_kwargs)
+    if "sinkgd_spectral_norm" in out:
+        out["sinkgd_spectral_norm"] = _as_bool(out["sinkgd_spectral_norm"])
+    if "sinkgd_spectral_norm_iters" in out:
+        out["sinkgd_spectral_norm_iters"] = int(out["sinkgd_spectral_norm_iters"])
+    if out.get("sinkgd_spectral_target") not in (None, "unit", "muon"):
+        raise ValueError("sinkgd_spectral_target must be 'unit' or 'muon'")
+    if out.get("sinkgd_base_width") is not None:
+        out["sinkgd_base_width"] = int(out["sinkgd_base_width"])
+    if "sinkgd_lr_width_exponent" in out:
+        out["sinkgd_lr_width_exponent"] = float(out["sinkgd_lr_width_exponent"])
+    # Mutual exclusion: 1/d_in (base_width) and the Muon spectral target are two width
+    # corrections; stacking them double-counts (Phase 2). Let the sphere/spectral own width.
+    if (
+        out.get("sinkgd_base_width") is not None
+        and _as_bool(out.get("sinkgd_spectral_norm", False))
+        and out.get("sinkgd_spectral_target", "unit") == "muon"
+    ):
+        raise ValueError(
+            "sinkgd_base_width (1/d_in width scaling) and sinkgd_spectral_target='muon' both "
+            "correct for width and double-count; set base_width for the plain/spectral-unit "
+            "path, or use spectral_target='muon' with base_width unset."
+        )
+    return out
+
+
 class SinkGDOptimizerFactory(BaseOptimizerFactory):
     """Builds a :class:`SinkGD` optimizer, routing weight matrices to SR-Sinkhorn."""
 
@@ -270,7 +429,7 @@ class SinkGDOptimizerFactory(BaseOptimizerFactory):
             weight_decay=weight_decay,
             sinkhorn_iters=sinkhorn_iters,
             sinkgd_lr_scale=sinkgd_lr_scale,
-            **optimizer_kwargs,
+            **_pop_sinkgd_extra_kwargs(optimizer_kwargs),
         )
 
 
@@ -328,6 +487,22 @@ def _sinkgd_apply_update(p, x, lr, weight_decay, stochastic_round):
         p.copy_(p_f32)
 
 
+# One power-iteration step on the Gram matrix, returning the LOCAL partial of the full
+# product (summed across the shard group by an eager all-reduce). Iterating the Gram matrix
+# (rather than U, Uᵀ separately) needs only a single vector all-reduce per step, and the
+# implicit v-normalization cancels. Batched over leading (expert) dims.
+def _specnorm_gram_rows(xf, u):
+    # rows sharded: local part of (Xᵀ X) u = X_localᵀ (X_local u). xf[...,M_local,N], u[...,N].
+    w = torch.matmul(xf, u.unsqueeze(-1)).squeeze(-1)
+    return torch.matmul(xf.transpose(-1, -2), w.unsqueeze(-1)).squeeze(-1)
+
+
+def _specnorm_gram_cols(xf, v):
+    # cols sharded: local part of (X Xᵀ) v = X_local (X_localᵀ v). xf[...,M,N_local], v[...,M].
+    t = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
+    return torch.matmul(xf, t.unsqueeze(-1)).squeeze(-1)
+
+
 class DistSinkGD(SinkGD):
     """Distributed SinkGD for FSDP2/TP-sharded weights.
 
@@ -347,6 +522,46 @@ class DistSinkGD(SinkGD):
         self._c_row_partial = c(_row_partial)
         self._c_row_scale_then_col_scale = c(_row_scale_then_col_scale)
         self._c_apply_update = c(_sinkgd_apply_update)
+        self._c_specnorm_gram_rows = c(_specnorm_gram_rows)
+        self._c_specnorm_gram_cols = c(_specnorm_gram_cols)
+
+    def _dist_specnorm_vec(self, p, device, lead, vec_len) -> Tensor:
+        """Replicated warm-start vector for the sharded power iteration, living on the
+        UNSHARDED matrix axis (length ``vec_len``). Deterministic init (fixed-seed philox)
+        so every rank starts from the same vector without a broadcast."""
+        st = self.state[p]
+        u = st.get("specnorm_u")
+        if u is None or u.shape[-1] != vec_len:
+            g = torch.Generator(device=device).manual_seed(0)
+            u = torch.randn(*lead, vec_len, generator=g, device=device, dtype=torch.float32)
+            u = u / torch.linalg.vector_norm(u, dim=-1, keepdim=True).clamp_min(1e-12)
+            st["specnorm_u"] = u
+        return u
+
+    def _dist_spectral_rescale(self, x, p, device, shard_dim, global_M, global_N):
+        """Estimate ``||U||_2`` on the matrix-dim-sharded update via power iteration on the
+        Gram matrix — one ``[N]`` (rows sharded) or ``[M]`` (cols sharded) vector all-reduce
+        per iter, the same shape and ``dp_shard`` group as the Sinkhorn norm reduce, matrix
+        never gathered — then rescale the local shard to the target operator norm."""
+        xf = x.float()
+        lead = x.shape[:-2]
+        eps = self.sinkgd_eps
+        vec_len = global_N if shard_dim == -2 else global_M
+        u = self._dist_specnorm_vec(p, device, lead, vec_len)
+        nrm = None
+        for _ in range(self.sinkgd_spectral_norm_iters):
+            if shard_dim == -2:
+                up = self._c_specnorm_gram_rows(xf, u)
+            else:
+                up = self._c_specnorm_gram_cols(xf, u)
+            dist.all_reduce(up, group=self._process_group)
+            nrm = torch.linalg.vector_norm(up, dim=-1, keepdim=True).clamp_min(eps)
+            u = up / nrm
+        self.state[p]["specnorm_u"] = u
+        sigma = nrm.squeeze(-1).sqrt()  # nrm = ||(XᵀX)u|| -> sigma^2 at convergence
+        target = 1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
+        sig_b = sigma.reshape(*sigma.shape, 1, 1)
+        return (xf * (target / sig_b)).to(x.dtype)
 
     def _dist_sinkgd_step(self, p, grad, group, lr):
         shard_dim = _matrix_shard_dim(p)
@@ -354,20 +569,24 @@ class DistSinkGD(SinkGD):
         global_M, global_N = p.shape[-2], p.shape[-1]  # DTensor -> global dims
         p_local = p.to_local() if isinstance(p, DTensor) else p
         x = grad.to_local() if isinstance(grad, DTensor) else grad
-        lr = lr * self.sinkgd_lr_scale
+        lr = lr * self._alpha_eff(p)  # width-aware; p.shape[-1] is the global d_in
 
         if shard_dim is None:
             # matrix dims fully local (replicated / expert-sharded) -> reuse the
-            # fully-compiled single-device path, no communication.
-            self._compiled_sinkgd(
-                p_local,
-                x,
-                lr,
-                group["weight_decay"],
-                self.sinkhorn_iters,
-                self.sinkgd_eps,
-                sr,
-            )
+            # fully-compiled single-device path (incl. spectral norm), no communication.
+            if self.sinkgd_spectral_norm:
+                m, n = global_M, global_N
+                target = 1.0 if self.sinkgd_spectral_target == "unit" else (m / n) ** 0.5
+                u = self._specnorm_u(p, n, p_local.shape[:-2])
+                self._compiled_sinkgd_sn(
+                    p_local, x, u, lr, group["weight_decay"], self.sinkhorn_iters,
+                    self.sinkgd_eps, target, self.sinkgd_spectral_norm_iters, sr,
+                )
+            else:
+                self._compiled_sinkgd(
+                    p_local, x, lr, group["weight_decay"], self.sinkhorn_iters,
+                    self.sinkgd_eps, sr,
+                )
             return
 
         sqrt_n, sqrt_m = global_N**0.5, global_M**0.5
@@ -381,6 +600,11 @@ class DistSinkGD(SinkGD):
                 rsq = self._c_row_partial(x)
                 dist.all_reduce(rsq, group=self._process_group)
                 x = self._c_row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps)
+        if self.sinkgd_spectral_norm:
+            # one extra small vector all-reduce (size d_in/d_out) per power-iteration step,
+            # mirroring the Sinkhorn norm reduce above; the matrix is never gathered.
+            x = self._dist_spectral_rescale(x, p, p_local.device, shard_dim,
+                                            global_M, global_N)
         self._c_apply_update(p_local, x, lr, group["weight_decay"], sr)
 
     @torch.no_grad()
@@ -440,5 +664,5 @@ class DistSinkGDOptimizerFactory(BaseOptimizerFactory):
             sinkhorn_iters=sinkhorn_iters,
             sinkgd_lr_scale=sinkgd_lr_scale,
             process_group=process_group,
-            **optimizer_kwargs,
+            **_pop_sinkgd_extra_kwargs(optimizer_kwargs),
         )

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -130,23 +130,24 @@ def single_param_sinkgd_specnorm(
         cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
 
-    xf = x.float()
+    # Power iteration in the update dtype: matmuls hit tensor cores with fp32 accumulation, so
+    # the full matrix is never cast to fp32 (only the O(m)/O(n) vectors are). `v @ X` avoids
+    # materializing Xᵀ, and the operator-norm rescale folds into the apply (no extra pass).
     uu = u
     sigma = None
     for _ in range(sn_iters):
-        v = torch.matmul(xf, uu.unsqueeze(-1)).squeeze(-1)
+        v = torch.matmul(x, uu.to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
-        uu = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
+        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float()
         sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
         uu = uu / sigma
     u.copy_(uu)
-    sigma_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
-    xf = xf * (target / sigma_b)
+    scale = target / sigma.reshape(*sigma.shape[:-1], 1, 1)  # fp32 [*lead,1,1]
 
     p_f32 = p.float()
     if weight_decay != 0.0:
         p_f32 = p_f32 * (1 - lr * weight_decay)
-    p_f32 = p_f32 - lr * xf
+    p_f32 = p_f32 - (lr * scale) * x.float()
 
     if stochastic_round:
         p.copy_(_fp32_to_bf16_sr(p_f32))
@@ -184,21 +185,22 @@ def single_param_sinkgd_md(
         cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
         x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
 
-    xf = x.float()
+    # bf16 tensor-core power iteration (see single_param_sinkgd_specnorm); the unit-operator-
+    # norm + sphere-radius rescale folds into the weight step, leaving only the sphere
+    # projection (the one unavoidable extra full-matrix pass for MD).
     uu = u
     sigma = None
     for _ in range(sn_iters):
-        v = torch.matmul(xf, uu.unsqueeze(-1)).squeeze(-1)
+        v = torch.matmul(x, uu.to(x.dtype).unsqueeze(-1)).squeeze(-1).float()
         v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
-        uu = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
+        uu = torch.matmul(v.to(x.dtype).unsqueeze(-2), x).squeeze(-2).float()
         sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
         uu = uu / sigma
     u.copy_(uu)
-    sigma_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
     tn = target_norm.reshape(*target_norm.shape, 1, 1)
-    xf = xf / sigma_b * tn  # direction at unit operator norm, scaled to the sphere radius
+    sig_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
 
-    p_f32 = p.float() - lr * xf
+    p_f32 = p.float() - (lr * tn / sig_b) * x.float()
     fro = torch.linalg.vector_norm(p_f32, dim=(-2, -1), keepdim=True).clamp_min(eps)
     p_f32 = p_f32 / fro * tn  # Frobenius sphere projection
 
@@ -607,16 +609,17 @@ def _md_sphere_apply(p_local, pf, frosq, tn, eps, stochastic_round):
         p_local.copy_(pf)
 
 
-def _specnorm_gram_rows(xf, u):
-    # rows sharded: local part of (Xᵀ X) u = X_localᵀ (X_local u). xf[...,M_local,N], u[...,N].
-    w = torch.matmul(xf, u.unsqueeze(-1)).squeeze(-1)
-    return torch.matmul(xf.transpose(-1, -2), w.unsqueeze(-1)).squeeze(-1)
+def _specnorm_gram_rows(x, u):
+    # rows sharded: local part of (Xᵀ X) u = X_localᵀ (X_local u). matmuls in x's dtype
+    # (tensor cores, fp32 accumulation), transpose-free via w @ X; fp32 partial for the reduce.
+    w = torch.matmul(x, u.unsqueeze(-1)).squeeze(-1)
+    return torch.matmul(w.unsqueeze(-2), x).squeeze(-2).float()
 
 
-def _specnorm_gram_cols(xf, v):
-    # cols sharded: local part of (X Xᵀ) v = X_local (X_localᵀ v). xf[...,M,N_local], v[...,M].
-    t = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
-    return torch.matmul(xf, t.unsqueeze(-1)).squeeze(-1)
+def _specnorm_gram_cols(x, v):
+    # cols sharded: local part of (X Xᵀ) v = X_local (X_localᵀ v). x[...,M,N_local], v[...,M].
+    t = torch.matmul(v.unsqueeze(-2), x).squeeze(-2)
+    return torch.matmul(x, t.unsqueeze(-1)).squeeze(-1).float()
 
 
 class DistSinkGD(SinkGD):
@@ -663,17 +666,17 @@ class DistSinkGD(SinkGD):
 
         ``op_target`` overrides the target with a per-matrix tensor (the MD sphere radius);
         otherwise the class ``unit``/``muon`` scalar is used."""
-        xf = x.float()
         lead = x.shape[:-2]
         eps = self.sinkgd_eps
         vec_len = global_N if shard_dim == -2 else global_M
         u = self._dist_specnorm_vec(p, device, lead, vec_len)
         nrm = None
         for _ in range(self.sinkgd_spectral_norm_iters):
+            ud = u.to(x.dtype)
             if shard_dim == -2:
-                up = self._c_specnorm_gram_rows(xf, u)
+                up = self._c_specnorm_gram_rows(x, ud)
             else:
-                up = self._c_specnorm_gram_cols(xf, u)
+                up = self._c_specnorm_gram_cols(x, ud)
             dist.all_reduce(up, group=self._process_group)
             nrm = torch.linalg.vector_norm(up, dim=-1, keepdim=True).clamp_min(eps)
             u = up / nrm
@@ -686,7 +689,7 @@ class DistSinkGD(SinkGD):
             target = (
                 1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
             )
-        return (xf * (target / sig_b)).to(x.dtype)
+        return x * (target / sig_b).to(x.dtype)
 
     def _dist_sinkgd_step(self, p, grad, group, lr):
         shard_dim = _matrix_shard_dim(p)

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -154,6 +154,60 @@ def single_param_sinkgd_specnorm(
         p.copy_(p_f32)
 
 
+def single_param_sinkgd_md(
+    p: Tensor,
+    grad: Tensor,
+    u: Tensor,
+    lr: Tensor,
+    iters: int,
+    eps: float,
+    target_norm: Tensor,
+    sn_iters: int,
+    stochastic_round: bool,
+) -> None:
+    """MD-sphere update (the A+B "unit" variant): SR-Sinkhorn -> spectral-normalize the
+    direction to unit operator norm scaled to the sphere radius -> step -> project the weight
+    back onto the Frobenius sphere ``||W||_F = target_norm``.
+
+    ``target_norm`` is the per-matrix sphere radius (anchored at the enable-time ``||W||_F``,
+    so the weight magnitude is preserved). Gains are dropped (Phase 3: SinkGD already balances
+    per-row/col, so the MD gains are redundant). Batched over leading (expert) dims; the sphere
+    projection and Frobenius are per-matrix.
+    """
+    m, n = grad.shape[-2], grad.shape[-1]
+    sqrt_n = n**0.5
+    sqrt_m = m**0.5
+    x = grad
+    for _ in range(iters):
+        rn = torch.linalg.vector_norm(x, dim=-1, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_n / rn.clamp_min(eps)).to(x.dtype)
+        cn = torch.linalg.vector_norm(x, dim=-2, keepdim=True, dtype=torch.float32)
+        x = x * (sqrt_m / cn.clamp_min(eps)).to(x.dtype)
+
+    xf = x.float()
+    uu = u
+    sigma = None
+    for _ in range(sn_iters):
+        v = torch.matmul(xf, uu.unsqueeze(-1)).squeeze(-1)
+        v = v / torch.linalg.vector_norm(v, dim=-1, keepdim=True).clamp_min(eps)
+        uu = torch.matmul(xf.transpose(-1, -2), v.unsqueeze(-1)).squeeze(-1)
+        sigma = torch.linalg.vector_norm(uu, dim=-1, keepdim=True).clamp_min(eps)
+        uu = uu / sigma
+    u.copy_(uu)
+    sigma_b = sigma.reshape(*sigma.shape[:-1], 1, 1)
+    tn = target_norm.reshape(*target_norm.shape, 1, 1)
+    xf = xf / sigma_b * tn  # direction at unit operator norm, scaled to the sphere radius
+
+    p_f32 = p.float() - lr * xf
+    fro = torch.linalg.vector_norm(p_f32, dim=(-2, -1), keepdim=True).clamp_min(eps)
+    p_f32 = p_f32 / fro * tn  # Frobenius sphere projection
+
+    if stochastic_round:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
+    else:
+        p.copy_(p_f32)
+
+
 class SinkGD(_AdamBase):
     """SinkGD optimizer with an 8-bit AdamW fallback for non-matrix parameters.
 
@@ -334,6 +388,49 @@ class SinkGD(_AdamBase):
         return loss
 
 
+class SinkGDMD(SinkGD):
+    """Experimental A+B variant: SinkGD direction on a Frobenius weight-sphere (MD, "unit").
+
+    Each SinkGD-routed 2D weight is kept on a fixed-Frobenius sphere (``||W||_F`` anchored at
+    enable time); the SR-Sinkhorn update is spectral-normalized to unit operator norm, applied,
+    and the weight is reprojected onto the sphere. No gains (redundant with SinkGD's balancing).
+    In width sweeps this bounds the deep-layer activation blow-up most tightly, but its optimal
+    LR is width-dependent (``lr_opt ~ d_model**-0.6``) and its optimum is narrow, so it is
+    OFF by default and gated behind ``sinkgd_md_sphere: true``. Non-matrix params still use the
+    8-bit AdamW fallback.
+    """
+
+    def __init__(self, params, **kwargs) -> None:
+        super().__init__(params, **kwargs)
+        self._compiled_md = torch.compile(
+            single_param_sinkgd_md, fullgraph=True, dynamic=False
+        )
+
+    def _md_target_norm(self, p: Tensor, state: dict) -> Tensor:
+        tn = state.get("md_target_norm")
+        if tn is None:
+            tn = torch.linalg.vector_norm(p.detach().float(), dim=(-2, -1))
+            state["md_target_norm"] = tn
+        return tn
+
+    def _sinkgd_update(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
+        alpha = self._alpha_eff(p)
+        state = self.state[p]
+        tn = self._md_target_norm(p, state)
+        u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
+        self._compiled_md(
+            p.detach(),
+            grad,
+            u,
+            lr * alpha,
+            self.sinkhorn_iters,
+            self.sinkgd_eps,
+            tn,
+            self.sinkgd_spectral_norm_iters,
+            self.bf16_stochastic_round and p.dtype is torch.bfloat16,
+        )
+
+
 def _sinkgd_param_groups(opt_model, weight_decay):
     """Split params: 2D/3D weight matrices -> SR-Sinkhorn; everything else -> AdamW.
 
@@ -420,8 +517,10 @@ class SinkGDOptimizerFactory(BaseOptimizerFactory):
         optimizer_kwargs.pop(
             "device_mesh", None
         )  # ignored by the single-device variant
+        md_sphere = _as_bool(optimizer_kwargs.pop("sinkgd_md_sphere", False))
+        cls = SinkGDMD if md_sphere else SinkGD
 
-        return SinkGD(
+        return cls(
             _sinkgd_param_groups(opt_model, weight_decay),
             lr=lr,
             betas=betas,
@@ -491,6 +590,23 @@ def _sinkgd_apply_update(p, x, lr, weight_decay, stochastic_round):
 # product (summed across the shard group by an eager all-reduce). Iterating the Gram matrix
 # (rather than U, Uᵀ separately) needs only a single vector all-reduce per step, and the
 # implicit v-normalization cancels. Batched over leading (expert) dims.
+def _md_local_wprime(p_local, x_spec, lr):
+    # W' = W - lr*U_spec (local shard) + its per-matrix local squared-Frobenius partial.
+    pf = p_local.float() - lr * x_spec.float()
+    return pf, (pf * pf).sum(dim=(-2, -1), keepdim=True)
+
+
+def _md_sphere_apply(p_local, pf, frosq, tn, eps, stochastic_round):
+    # project the local shard back onto the Frobenius sphere ||W||_F = tn (frosq is global).
+    fro = frosq.sqrt().clamp_min(eps)
+    tn_b = tn.reshape(*tn.shape, 1, 1)
+    pf = pf / fro * tn_b
+    if stochastic_round:
+        p_local.copy_(_fp32_to_bf16_sr(pf))
+    else:
+        p_local.copy_(pf)
+
+
 def _specnorm_gram_rows(xf, u):
     # rows sharded: local part of (Xᵀ X) u = X_localᵀ (X_local u). xf[...,M_local,N], u[...,N].
     w = torch.matmul(xf, u.unsqueeze(-1)).squeeze(-1)
@@ -538,11 +654,15 @@ class DistSinkGD(SinkGD):
             st["specnorm_u"] = u
         return u
 
-    def _dist_spectral_rescale(self, x, p, device, shard_dim, global_M, global_N):
+    def _dist_spectral_rescale(self, x, p, device, shard_dim, global_M, global_N,
+                               op_target=None):
         """Estimate ``||U||_2`` on the matrix-dim-sharded update via power iteration on the
         Gram matrix — one ``[N]`` (rows sharded) or ``[M]`` (cols sharded) vector all-reduce
         per iter, the same shape and ``dp_shard`` group as the Sinkhorn norm reduce, matrix
-        never gathered — then rescale the local shard to the target operator norm."""
+        never gathered — then rescale the local shard to the target operator norm.
+
+        ``op_target`` overrides the target with a per-matrix tensor (the MD sphere radius);
+        otherwise the class ``unit``/``muon`` scalar is used."""
         xf = x.float()
         lead = x.shape[:-2]
         eps = self.sinkgd_eps
@@ -559,8 +679,13 @@ class DistSinkGD(SinkGD):
             u = up / nrm
         self.state[p]["specnorm_u"] = u
         sigma = nrm.squeeze(-1).sqrt()  # nrm = ||(XᵀX)u|| -> sigma^2 at convergence
-        target = 1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
         sig_b = sigma.reshape(*sigma.shape, 1, 1)
+        if op_target is not None:
+            target = op_target.reshape(*op_target.shape, 1, 1)
+        else:
+            target = (
+                1.0 if self.sinkgd_spectral_target == "unit" else (global_M / global_N) ** 0.5
+            )
         return (xf * (target / sig_b)).to(x.dtype)
 
     def _dist_sinkgd_step(self, p, grad, group, lr):
@@ -634,6 +759,73 @@ class DistSinkGD(SinkGD):
         return loss
 
 
+class DistSinkGDMD(DistSinkGD):
+    """Distributed :class:`SinkGDMD` (A+B "unit") for FSDP2/TP-sharded weights.
+
+    On a matrix-dim-sharded weight the added communication over the ``dp_shard`` group is: the
+    sharded power iteration's vector all-reduce (spectral norm) plus one per-matrix scalar
+    all-reduce for the global Frobenius norm (sphere projection). The matrix is never gathered;
+    the sphere radius ``target_norm`` and the power-iteration vector round-trip through the
+    checkpoint. Replicated / expert-sharded weights reuse the fully-local single-device MD path.
+    """
+
+    def __init__(self, params, *, process_group=None, **kwargs) -> None:
+        super().__init__(params, process_group=process_group, **kwargs)
+        c = lambda f: torch.compile(f, fullgraph=True, dynamic=False)  # noqa: E731
+        self._compiled_md = c(single_param_sinkgd_md)
+        self._c_md_local_wprime = c(_md_local_wprime)
+        self._c_md_sphere_apply = c(_md_sphere_apply)
+
+    def _dist_md_target(self, p, p_local, shard_dim) -> Tensor:
+        state = self.state[p]
+        tn = state.get("md_target_norm")
+        if tn is None:
+            sq = (p_local.float() ** 2).sum(dim=(-2, -1))  # [*lead] local partial
+            if shard_dim is not None:
+                dist.all_reduce(sq, group=self._process_group)
+            tn = sq.sqrt()
+            state["md_target_norm"] = tn
+        return tn
+
+    def _dist_sinkgd_step(self, p, grad, group, lr):
+        shard_dim = _matrix_shard_dim(p)
+        sr = self.bf16_stochastic_round and p.dtype is torch.bfloat16
+        global_M, global_N = p.shape[-2], p.shape[-1]
+        p_local = p.to_local() if isinstance(p, DTensor) else p
+        x = grad.to_local() if isinstance(grad, DTensor) else grad
+        lr = lr * self._alpha_eff(p)
+        tn = self._dist_md_target(p, p_local, shard_dim)
+
+        if shard_dim is None:
+            # full matrix local -> reuse the fully-compiled single-device MD step.
+            u = self._specnorm_u(p, global_N, p_local.shape[:-2])
+            self._compiled_md(
+                p_local, x, u, lr, self.sinkhorn_iters, self.sinkgd_eps, tn,
+                self.sinkgd_spectral_norm_iters, sr,
+            )
+            return
+
+        sqrt_n, sqrt_m = global_N**0.5, global_M**0.5
+        eps = self.sinkgd_eps
+        for _ in range(self.sinkhorn_iters):
+            if shard_dim == -2:
+                x, csq = self._c_row_scale_col_partial(x, sqrt_n, eps)
+                dist.all_reduce(csq, group=self._process_group)
+                x = self._c_apply_col_scale(x, csq, sqrt_m, eps)
+            else:
+                rsq = self._c_row_partial(x)
+                dist.all_reduce(rsq, group=self._process_group)
+                x = self._c_row_scale_then_col_scale(x, rsq, sqrt_n, sqrt_m, eps)
+        # spectral-normalize the direction to operator norm == sphere radius tn
+        x = self._dist_spectral_rescale(
+            x, p, p_local.device, shard_dim, global_M, global_N, op_target=tn
+        )
+        # weight step + Frobenius sphere projection (one per-matrix scalar all-reduce)
+        pf, frosq = self._c_md_local_wprime(p_local, x, lr)
+        dist.all_reduce(frosq, group=self._process_group)
+        self._c_md_sphere_apply(p_local, pf, frosq, tn, eps, sr)
+
+
 class DistSinkGDOptimizerFactory(BaseOptimizerFactory):
     """Builds a :class:`DistSinkGD` for sharded training; pulls the dp_shard group."""
 
@@ -655,7 +847,10 @@ class DistSinkGDOptimizerFactory(BaseOptimizerFactory):
             elif device_mesh.ndim == 1:
                 process_group = device_mesh.get_group()
 
-        return DistSinkGD(
+        md_sphere = _as_bool(optimizer_kwargs.pop("sinkgd_md_sphere", False))
+        cls = DistSinkGDMD if md_sphere else DistSinkGD
+
+        return cls(
             _sinkgd_param_groups(opt_model, weight_decay),
             lr=lr,
             betas=betas,

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -35,6 +35,7 @@ from torchao.optim.quant_utils import _fp32_to_bf16_sr
 from torchao.optim.subclass_8bit import OptimState8bit
 
 from axolotl.integrations.base import BaseOptimizerFactory
+from axolotl.utils.optimizers.sinkgd_triton import fused_available, fused_sinkgd_step
 
 
 def sr_sinkhorn(grad: Tensor, iters: int, eps: float) -> Tensor:
@@ -261,6 +262,7 @@ class SinkGD(_AdamBase):
         sinkgd_spectral_target="unit",
         sinkgd_base_width=None,
         sinkgd_lr_width_exponent=1.0,
+        sinkgd_fused_kernel=False,
         block_size=256,
         bf16_stochastic_round=False,
     ) -> None:
@@ -283,6 +285,7 @@ class SinkGD(_AdamBase):
         self.sinkgd_spectral_target = sinkgd_spectral_target
         self.sinkgd_base_width = sinkgd_base_width
         self.sinkgd_lr_width_exponent = sinkgd_lr_width_exponent
+        self.sinkgd_fused_kernel = sinkgd_fused_kernel
         self._compiled_sinkgd = torch.compile(
             single_param_sinkgd, fullgraph=True, dynamic=False
         )
@@ -326,8 +329,32 @@ class SinkGD(_AdamBase):
             self.sinkgd_base_width / d_in
         ) ** self.sinkgd_lr_width_exponent
 
+    def _fused_ok(self, p: Tensor) -> bool:
+        # stochastic rounding is not implemented in the fused kernels -> compiled fallback
+        return (
+            self.sinkgd_fused_kernel
+            and fused_available()
+            and p.is_cuda
+            and not (self.bf16_stochastic_round and p.dtype is torch.bfloat16)
+        )
+
     def _sinkgd_update(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
         alpha = self._alpha_eff(p)
+        if self._fused_ok(p):
+            if self.sinkgd_spectral_norm:
+                u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
+                fused_sinkgd_step(
+                    p.detach(), grad, float(lr) * alpha, group["weight_decay"],
+                    self.sinkhorn_iters, self.sinkgd_eps, mode="spec", u=u,
+                    spectral_target=self.sinkgd_spectral_target,
+                    sn_iters=self.sinkgd_spectral_norm_iters,
+                )
+            else:
+                fused_sinkgd_step(
+                    p.detach(), grad, float(lr) * alpha, group["weight_decay"],
+                    self.sinkhorn_iters, self.sinkgd_eps, mode="base",
+                )
+            return
         if not self.sinkgd_spectral_norm:
             self._compiled_sinkgd(
                 p.detach(),
@@ -446,6 +473,13 @@ class SinkGDMD(SinkGD):
         state = self.state[p]
         tn = self._md_target_norm(p, state)
         u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
+        if self._fused_ok(p):
+            fused_sinkgd_step(
+                p.detach(), grad, float(lr) * alpha, 0.0, self.sinkhorn_iters,
+                self.sinkgd_eps, mode="md", u=u, target_norm=tn,
+                sn_iters=self.sinkgd_spectral_norm_iters,
+            )
+            return
         self._compiled_md(
             p.detach(),
             grad,
@@ -517,6 +551,8 @@ def _pop_sinkgd_extra_kwargs(optimizer_kwargs: dict) -> dict:
         out["sinkgd_base_width"] = int(out["sinkgd_base_width"])
     if "sinkgd_lr_width_exponent" in out:
         out["sinkgd_lr_width_exponent"] = float(out["sinkgd_lr_width_exponent"])
+    if "sinkgd_fused_kernel" in out:
+        out["sinkgd_fused_kernel"] = _as_bool(out["sinkgd_fused_kernel"])
     # Mutual exclusion: 1/d_in (base_width) and the Muon spectral target are two width
     # corrections; stacking them double-counts (Phase 2). Let the sphere/spectral own width.
     if (
@@ -748,6 +784,34 @@ class DistSinkGD(SinkGD):
         global_M, global_N = p.shape[-2], p.shape[-1]  # DTensor -> global dims
         p_local = p.to_local() if isinstance(p, DTensor) else p
         x = grad.to_local() if isinstance(grad, DTensor) else grad
+
+        # fused Triton path: replicated/expert-sharded runs locally; rows-sharded (the
+        # FSDP2 dim-0 layout) all-reduces the same vectors as the compiled path. A
+        # cols-sharded matrix dim falls through to the compiled pipeline below.
+        if self._fused_ok(p_local) and shard_dim in (None, -2):
+            lr_f = float(lr) * self._alpha_eff(p)
+            grp = self._process_group if shard_dim == -2 else None
+            m_glob = global_M if shard_dim == -2 else None
+            if self.sinkgd_spectral_norm:
+                if shard_dim == -2:
+                    u = self._dist_specnorm_vec(
+                        p, p_local.device, p_local.shape[:-2], global_N
+                    )
+                else:
+                    u = self._specnorm_u(p, global_N, p_local.shape[:-2])
+                fused_sinkgd_step(
+                    p_local, x, lr_f, group["weight_decay"], self.sinkhorn_iters,
+                    self.sinkgd_eps, mode="spec", u=u,
+                    spectral_target=self.sinkgd_spectral_target,
+                    sn_iters=self.sinkgd_spectral_norm_iters,
+                    m_global=m_glob, process_group=grp,
+                )
+            else:
+                fused_sinkgd_step(
+                    p_local, x, lr_f, group["weight_decay"], self.sinkhorn_iters,
+                    self.sinkgd_eps, mode="base", m_global=m_glob, process_group=grp,
+                )
+            return
         lr = lr * self._alpha_eff(p)  # width-aware; p.shape[-1] is the global d_in
 
         if shard_dim is None:
@@ -852,8 +916,22 @@ class DistSinkGDMD(DistSinkGD):
         global_M, global_N = p.shape[-2], p.shape[-1]
         p_local = p.to_local() if isinstance(p, DTensor) else p
         x = grad.to_local() if isinstance(grad, DTensor) else grad
-        lr = lr * self._alpha_eff(p)
         tn = self._dist_md_target(p, p_local, shard_dim)
+
+        if self._fused_ok(p_local) and shard_dim in (None, -2):
+            if shard_dim == -2:
+                u = self._dist_specnorm_vec(p, p_local.device, p_local.shape[:-2], global_N)
+            else:
+                u = self._specnorm_u(p, global_N, p_local.shape[:-2])
+            fused_sinkgd_step(
+                p_local, x, float(lr) * self._alpha_eff(p), 0.0, self.sinkhorn_iters,
+                self.sinkgd_eps, mode="md", u=u, target_norm=tn,
+                sn_iters=self.sinkgd_spectral_norm_iters,
+                m_global=global_M if shard_dim == -2 else None,
+                process_group=self._process_group if shard_dim == -2 else None,
+            )
+            return
+        lr = lr * self._alpha_eff(p)
 
         if shard_dim is None:
             # full matrix local -> reuse the fully-compiled single-device MD step.

--- a/src/axolotl/utils/optimizers/sinkgd.py
+++ b/src/axolotl/utils/optimizers/sinkgd.py
@@ -263,6 +263,7 @@ class SinkGD(_AdamBase):
         sinkgd_base_width=None,
         sinkgd_lr_width_exponent=1.0,
         sinkgd_fused_kernel=False,
+        sinkgd_fused_min_numel=1 << 25,
         block_size=256,
         bf16_stochastic_round=False,
     ) -> None:
@@ -286,6 +287,7 @@ class SinkGD(_AdamBase):
         self.sinkgd_base_width = sinkgd_base_width
         self.sinkgd_lr_width_exponent = sinkgd_lr_width_exponent
         self.sinkgd_fused_kernel = sinkgd_fused_kernel
+        self.sinkgd_fused_min_numel = sinkgd_fused_min_numel
         self._compiled_sinkgd = torch.compile(
             single_param_sinkgd, fullgraph=True, dynamic=False
         )
@@ -329,8 +331,13 @@ class SinkGD(_AdamBase):
             self.sinkgd_base_width / d_in
         ) ** self.sinkgd_lr_width_exponent
 
-    def _fused_ok(self, p: Tensor) -> bool:
-        # stochastic rounding is not implemented in the fused kernels -> compiled fallback
+    def _fused_ok(self, p: Tensor, epilogue: bool = False) -> bool:
+        # Stochastic rounding is not implemented in the fused kernels -> compiled fallback.
+        # The spec/md epilogue adds ~20 small eager ops per param; without a process group
+        # to amortize against, small matrices lose to the compiled path (H100: 0.6-0.7x at
+        # d=2048) -> gate single-device epilogue modes on tensor size.
+        if epilogue and p.numel() < self.sinkgd_fused_min_numel:
+            return False
         return (
             self.sinkgd_fused_kernel
             and fused_available()
@@ -340,7 +347,7 @@ class SinkGD(_AdamBase):
 
     def _sinkgd_update(self, p: Tensor, grad: Tensor, group: dict, lr: Tensor) -> None:
         alpha = self._alpha_eff(p)
-        if self._fused_ok(p):
+        if self._fused_ok(p, epilogue=self.sinkgd_spectral_norm):
             if self.sinkgd_spectral_norm:
                 u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
                 fused_sinkgd_step(
@@ -473,7 +480,7 @@ class SinkGDMD(SinkGD):
         state = self.state[p]
         tn = self._md_target_norm(p, state)
         u = self._specnorm_u(p, p.shape[-1], p.shape[:-2])
-        if self._fused_ok(p):
+        if self._fused_ok(p, epilogue=True):
             fused_sinkgd_step(
                 p.detach(), grad, float(lr) * alpha, 0.0, self.sinkhorn_iters,
                 self.sinkgd_eps, mode="md", u=u, target_norm=tn,
@@ -553,6 +560,8 @@ def _pop_sinkgd_extra_kwargs(optimizer_kwargs: dict) -> dict:
         out["sinkgd_lr_width_exponent"] = float(out["sinkgd_lr_width_exponent"])
     if "sinkgd_fused_kernel" in out:
         out["sinkgd_fused_kernel"] = _as_bool(out["sinkgd_fused_kernel"])
+    if "sinkgd_fused_min_numel" in out:
+        out["sinkgd_fused_min_numel"] = int(out["sinkgd_fused_min_numel"])
     # Mutual exclusion: 1/d_in (base_width) and the Muon spectral target are two width
     # corrections; stacking them double-counts (Phase 2). Let the sphere/spectral own width.
     if (
@@ -788,7 +797,9 @@ class DistSinkGD(SinkGD):
         # fused Triton path: replicated/expert-sharded runs locally; rows-sharded (the
         # FSDP2 dim-0 layout) all-reduces the same vectors as the compiled path. A
         # cols-sharded matrix dim falls through to the compiled pipeline below.
-        if self._fused_ok(p_local) and shard_dim in (None, -2):
+        if self._fused_ok(
+            p_local, epilogue=self.sinkgd_spectral_norm and shard_dim is None
+        ) and shard_dim in (None, -2):
             lr_f = float(lr) * self._alpha_eff(p)
             grp = self._process_group if shard_dim == -2 else None
             m_glob = global_M if shard_dim == -2 else None
@@ -918,7 +929,7 @@ class DistSinkGDMD(DistSinkGD):
         x = grad.to_local() if isinstance(grad, DTensor) else grad
         tn = self._dist_md_target(p, p_local, shard_dim)
 
-        if self._fused_ok(p_local) and shard_dim in (None, -2):
+        if self._fused_ok(p_local, epilogue=shard_dim is None) and shard_dim in (None, -2):
             if shard_dim == -2:
                 u = self._dist_specnorm_vec(p, p_local.device, p_local.shape[:-2], global_N)
             else:

--- a/src/axolotl/utils/optimizers/sinkgd_triton.py
+++ b/src/axolotl/utils/optimizers/sinkgd_triton.py
@@ -1,0 +1,379 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused Triton kernels for the SinkGD optimizer family (opt-in: ``sinkgd_fused_kernel``).
+
+One kernel per SR-Sinkhorn iteration replaces the compiled loop's ~4 passes: each CTA applies
+the *incoming* column scale on load (the scale is never materialized — it folds forward into
+the next kernel, the power-iteration vectors, and the final apply), reduces and applies the
+row scale, writes once, and atomically accumulates the next iteration's column sum-of-squares.
+Under FSDP2 rows-sharding the cross-rank ``[N]`` all-reduce of that buffer slots between
+kernels — the same collective count as the compiled distributed path.
+
+Two grid layouts, auto-selected per shape (``_plan_splits``): the *tall* layout gives each CTA
+full rows (row reductions stay in-register); the *wide* layout splits columns across a second
+grid axis with fp32-atomic row reductions, for wide-short local shards (heavy sharding) where
+the tall grid cannot fill the GPU. Same memory traffic either way.
+
+Numerics are equivalent to the compiled path at bf16 rounding scale (scales are carried in
+fp32 end-to-end, so the fused path is marginally *more* precise), but not byte-identical —
+hence opt-in.
+"""
+
+import torch
+import torch.distributed as dist
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:  # pragma: no cover
+    HAVE_TRITON = False
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _iter_tall(
+        x_ptr, out_ptr, colsq_in_ptr, colsq_out_ptr,
+        M, N, sqrt_n, sqrt_m, eps,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_b = tl.program_id(1)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        rowsq = tl.zeros((BLOCK_M,), dtype=tl.float32)
+        for n0 in range(0, N, BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                           mask=row_mask[:, None] & col_mask[None, :], other=0.0)
+            v = tile.to(tl.float32) * cscale[None, :]
+            rowsq += tl.sum(v * v, axis=1)
+        rscale = sqrt_n / tl.maximum(tl.sqrt(rowsq), eps)
+        for n0 in range(0, N, BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            m2 = row_mask[:, None] & col_mask[None, :]
+            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                           mask=m2, other=0.0)
+            v = tile.to(tl.float32) * cscale[None, :] * rscale[:, None]
+            tl.store(out_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                     v.to(out_ptr.dtype.element_ty), mask=m2)
+            tl.atomic_add(colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0),
+                          mask=col_mask)
+
+    @triton.jit
+    def _rowsq_wide(
+        x_ptr, colsq_in_ptr, rowsq_ptr,
+        M, N, sqrt_m, eps, cols_per,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_b = tl.program_id(2)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        c0 = pid_n * cols_per
+        acc = tl.zeros((BLOCK_M,), dtype=tl.float32)
+        for n0 in range(c0, min(c0 + cols_per, N), BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                           mask=row_mask[:, None] & col_mask[None, :], other=0.0)
+            v = tile.to(tl.float32) * cscale[None, :]
+            acc += tl.sum(v * v, axis=1)
+        tl.atomic_add(rowsq_ptr + pid_b * M + rows, acc, mask=row_mask)
+
+    @triton.jit
+    def _scale_wide(
+        x_ptr, out_ptr, colsq_in_ptr, rowsq_ptr, colsq_out_ptr,
+        M, N, sqrt_n, sqrt_m, eps, cols_per,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_b = tl.program_id(2)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        rsq = tl.load(rowsq_ptr + pid_b * M + rows, mask=row_mask, other=1.0)
+        rscale = sqrt_n / tl.maximum(tl.sqrt(rsq), eps)
+        c0 = pid_n * cols_per
+        for n0 in range(c0, min(c0 + cols_per, N), BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            m2 = row_mask[:, None] & col_mask[None, :]
+            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                           mask=m2, other=0.0)
+            v = tile.to(tl.float32) * cscale[None, :] * rscale[:, None]
+            tl.store(out_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                     v.to(out_ptr.dtype.element_ty), mask=m2)
+            tl.atomic_add(colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0),
+                          mask=col_mask)
+
+    @triton.jit
+    def _matvec1_partials(
+        x_ptr, colsq_ptr, p_ptr, u_ptr, v_ptr, sums_ptr,
+        M, N, sqrt_m, eps, cols_per,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        WITH_PARTIALS: tl.constexpr, ATOMIC_V: tl.constexpr,
+    ):
+        # v = (X . colscale) @ u on the CTA's rows; optionally the three projection
+        # partials ||p||^2, <p, Xd>, ||Xd||^2 (per-matrix scalar atomics) in the same pass.
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_b = tl.program_id(2)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        c0 = pid_n * cols_per
+        acc_v = tl.zeros((BLOCK_M,), dtype=tl.float32)
+        s0 = 0.0
+        s1 = 0.0
+        s2 = 0.0
+        for n0 in range(c0, min(c0 + cols_per, N), BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            m2 = row_mask[:, None] & col_mask[None, :]
+            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
+            ut = tl.load(u_ptr + pid_b * N + cols, mask=col_mask, other=0.0)
+            acc_v += tl.sum(xt * ut[None, :], axis=1)
+            if WITH_PARTIALS:
+                pt = tl.load(p_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                             mask=m2, other=0.0).to(tl.float32)
+                s0 += tl.sum(pt * pt)
+                s1 += tl.sum(pt * xt)
+                s2 += tl.sum(xt * xt)
+        if ATOMIC_V:
+            tl.atomic_add(v_ptr + pid_b * M + rows, acc_v, mask=row_mask)
+        else:
+            tl.store(v_ptr + pid_b * M + rows, acc_v, mask=row_mask)
+        if WITH_PARTIALS:
+            tl.atomic_add(sums_ptr + pid_b * 3 + 0, s0)
+            tl.atomic_add(sums_ptr + pid_b * 3 + 1, s1)
+            tl.atomic_add(sums_ptr + pid_b * 3 + 2, s2)
+
+    @triton.jit
+    def _matvec2(
+        x_ptr, colsq_ptr, v_ptr, uu_ptr,
+        M, N, sqrt_m, eps, cols_per,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        # uu = v^T (X . colscale), accumulated per column via atomics.
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_b = tl.program_id(2)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        vt = tl.load(v_ptr + pid_b * M + rows, mask=row_mask, other=0.0)
+        c0 = pid_n * cols_per
+        for n0 in range(c0, min(c0 + cols_per, N), BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            m2 = row_mask[:, None] & col_mask[None, :]
+            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
+            tl.atomic_add(uu_ptr + pid_b * N + cols, tl.sum(xt * vt[:, None], axis=0),
+                          mask=col_mask)
+
+    @triton.jit
+    def _apply(
+        p_ptr, x_ptr, colsq_ptr, a_ptr, scale2_ptr,
+        M, N, decay, sqrt_m, eps, cols_per,
+        stride_b, stride_m,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        # p = (p * decay - a * (x . colscale)) * scale2 — one form covers all modes:
+        # base/spec: scale2 = 1, decay = 1 - lr*wd, a = lr[*target/sigma];
+        # md sphere: decay = 1, a = lr*tn/sigma, scale2 = tn/fro (analytic projection).
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_b = tl.program_id(2)
+        rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_mask = rows < M
+        base = pid_b * stride_b
+        a = tl.load(a_ptr + pid_b)
+        s2c = tl.load(scale2_ptr + pid_b)
+        c0 = pid_n * cols_per
+        for n0 in range(c0, min(c0 + cols_per, N), BLOCK_N):
+            cols = n0 + tl.arange(0, BLOCK_N)
+            col_mask = cols < N
+            csq = tl.load(colsq_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
+            cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
+            m2 = row_mask[:, None] & col_mask[None, :]
+            pp = p_ptr + base + rows[:, None] * stride_m + cols[None, :]
+            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
+            pt = tl.load(pp, mask=m2, other=0.0).to(tl.float32)
+            tl.store(pp, ((pt * decay - a * xt) * s2c).to(p_ptr.dtype.element_ty),
+                     mask=m2)
+
+
+_SM_COUNT = None
+
+
+def _num_sms() -> int:
+    global _SM_COUNT  # noqa: PLW0603
+    if _SM_COUNT is None:
+        _SM_COUNT = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).multi_processor_count
+    return _SM_COUNT
+
+
+def _plan_splits(B, M, N, block_m, block_n, target_waves=2):
+    """Column splits so the grid fills ~target_waves x SMs. Wide only pays when the grid is
+    row-starved AND rows are long (short rows: the extra kernel+memset per iteration loses)."""
+    row_ctas = triton.cdiv(M, block_m) * B
+    want = target_waves * _num_sms()
+    if row_ctas >= want or N < 4096:
+        return 1, N
+    nsplits = min(triton.cdiv(want, row_ctas), triton.cdiv(N, block_n))
+    cols_per = triton.cdiv(triton.cdiv(N, block_n), nsplits) * block_n
+    return triton.cdiv(N, cols_per), cols_per
+
+
+def fused_available() -> bool:
+    return HAVE_TRITON and torch.cuda.is_available()
+
+
+@torch.no_grad()
+def fused_sinkgd_step(
+    p, grad, lr, weight_decay, iters, eps, *,
+    mode="base", u=None, target_norm=None, spectral_target="muon", sn_iters=1,
+    m_global=None, process_group=None, block_m=16, block_n=512,
+):
+    """One fused SinkGD step; single-device when ``process_group`` is None, else the
+    rows-sharded FSDP2 step (``p``/``grad`` are local shards, ``m_global`` the full row dim,
+    cross-rank reduction of the column/power-iteration vectors over the group).
+
+    mode: ``base`` | ``spec`` | ``md``. ``u`` is the persisted ``[*lead, N]`` power-iteration
+    vector (spec/md), ``target_norm`` the ``[*lead]`` sphere radius (md). ``lr`` is a float
+    that already includes ``alpha_eff``; weight decay applies to base/spec (md is on the
+    sphere, decay is meaningless there — ignored to match the compiled MD path).
+    """
+    orig = grad.shape
+    g = grad.reshape(-1, *orig[-2:]) if grad.ndim > 2 else grad.unsqueeze(0)
+    pw = p.reshape(-1, *orig[-2:]) if p.ndim > 2 else p.unsqueeze(0)
+    if not g.is_contiguous():
+        g = g.contiguous()
+    B, m_local, n = g.shape
+    m_glob = m_global if m_global is not None else m_local
+    sqrt_n, sqrt_m = float(n) ** 0.5, float(m_glob) ** 0.5
+    dev = g.device
+
+    x_buf = torch.empty_like(g)
+    colsq_a = torch.full((B, n), float(m_glob), device=dev, dtype=torch.float32)
+    colsq_b = torch.empty(B, n, device=dev, dtype=torch.float32)
+    nsplits, cols_per = _plan_splits(B, m_local, n, block_m, block_n)
+    grid = (triton.cdiv(m_local, block_m), nsplits, B)
+
+    src = g
+    rowsq = None
+    for _ in range(iters):
+        colsq_b.zero_()
+        if nsplits == 1:
+            _iter_tall[(grid[0], B)](src, x_buf, colsq_a, colsq_b, m_local, n,
+                                     sqrt_n, sqrt_m, eps, m_local * n, n,
+                                     BLOCK_M=block_m, BLOCK_N=block_n)
+        else:
+            if rowsq is None:
+                rowsq = torch.empty(B, m_local, device=dev, dtype=torch.float32)
+            rowsq.zero_()
+            _rowsq_wide[grid](src, colsq_a, rowsq, m_local, n, sqrt_m, eps, cols_per,
+                              m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+            _scale_wide[grid](src, x_buf, colsq_a, rowsq, colsq_b, m_local, n,
+                              sqrt_n, sqrt_m, eps, cols_per, m_local * n, n,
+                              BLOCK_M=block_m, BLOCK_N=block_n)
+        if process_group is not None:
+            dist.all_reduce(colsq_b, group=process_group)
+        src = x_buf
+        colsq_a, colsq_b = colsq_b, colsq_a
+
+    decay = 1.0 - lr * weight_decay
+    if mode == "base":
+        a = torch.full((B,), lr, device=dev, dtype=torch.float32)
+        scale2 = torch.ones(B, device=dev, dtype=torch.float32)
+        _apply[grid](pw, x_buf, colsq_a, a, scale2, m_local, n, decay, sqrt_m, eps,
+                     cols_per, m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+        return
+
+    # spec/md: power iteration on the (colscale-folded) update, sn_iters rounds
+    uw = u.reshape(-1, n)
+    v = torch.empty(B, m_local, device=dev, dtype=torch.float32)
+    sums = torch.zeros(B, 3, device=dev, dtype=torch.float32)
+    sigma = None
+    for it in range(sn_iters):
+        with_partials = mode == "md" and it == 0
+        if nsplits > 1:
+            v.zero_()
+        _matvec1_partials[grid](x_buf, colsq_a, pw, uw, v, sums, m_local, n, sqrt_m,
+                                eps, cols_per, m_local * n, n, BLOCK_M=block_m,
+                                BLOCK_N=block_n, WITH_PARTIALS=with_partials,
+                                ATOMIC_V=nsplits > 1)
+        vsq = (v * v).sum(dim=-1)
+        if with_partials:
+            packed = torch.cat([sums, vsq.unsqueeze(-1)], dim=-1)
+            if process_group is not None:
+                dist.all_reduce(packed, group=process_group)
+            sums = packed[:, :3]
+            vsq = packed[:, 3]
+        elif process_group is not None:
+            dist.all_reduce(vsq, group=process_group)
+        v /= vsq.sqrt().clamp_min(eps).unsqueeze(-1)
+        uu = torch.zeros(B, n, device=dev, dtype=torch.float32)
+        _matvec2[grid](x_buf, colsq_a, v, uu, m_local, n, sqrt_m, eps, cols_per,
+                       m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+        if process_group is not None:
+            dist.all_reduce(uu, group=process_group)
+        sigma = uu.norm(dim=-1, keepdim=True).clamp_min(eps)
+        uw.copy_(uu / sigma)
+    sig = sigma.squeeze(-1)
+
+    if mode == "spec":
+        tgt = (m_glob / n) ** 0.5 if spectral_target == "muon" else 1.0
+        a = (lr * tgt / sig).contiguous()
+        scale2 = torch.ones_like(a)
+    else:
+        tn = target_norm.reshape(-1).float().to(dev)
+        a = (lr * tn / sig).contiguous()
+        fro = (sums[:, 0] - 2 * a * sums[:, 1] + a * a * sums[:, 2]).clamp_min(eps).sqrt()
+        scale2 = (tn / fro).contiguous()
+        decay = 1.0  # sphere projection subsumes any decay
+    _apply[grid](pw, x_buf, colsq_a, a, scale2, m_local, n, decay, sqrt_m, eps,
+                 cols_per, m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)

--- a/src/axolotl/utils/optimizers/sinkgd_triton.py
+++ b/src/axolotl/utils/optimizers/sinkgd_triton.py
@@ -47,10 +47,19 @@ if HAVE_TRITON:
 
     @triton.jit
     def _iter_tall(
-        x_ptr, out_ptr, colsq_in_ptr, colsq_out_ptr,
-        M, N, sqrt_n, sqrt_m, eps,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        x_ptr,
+        out_ptr,
+        colsq_in_ptr,
+        colsq_out_ptr,
+        M,
+        N,
+        sqrt_n,
+        sqrt_m,
+        eps,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
     ):
         pid_m = tl.program_id(0)
         pid_b = tl.program_id(1)
@@ -63,8 +72,11 @@ if HAVE_TRITON:
             col_mask = cols < N
             csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
-            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                           mask=row_mask[:, None] & col_mask[None, :], other=0.0)
+            tile = tl.load(
+                x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                mask=row_mask[:, None] & col_mask[None, :],
+                other=0.0,
+            )
             v = tile.to(tl.float32) * cscale[None, :]
             rowsq += tl.sum(v * v, axis=1)
         rscale = sqrt_n / tl.maximum(tl.sqrt(rowsq), eps)
@@ -74,20 +86,35 @@ if HAVE_TRITON:
             csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
             m2 = row_mask[:, None] & col_mask[None, :]
-            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                           mask=m2, other=0.0)
+            tile = tl.load(
+                x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                mask=m2,
+                other=0.0,
+            )
             v = tile.to(tl.float32) * cscale[None, :] * rscale[:, None]
-            tl.store(out_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                     v.to(out_ptr.dtype.element_ty), mask=m2)
-            tl.atomic_add(colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0),
-                          mask=col_mask)
+            tl.store(
+                out_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                v.to(out_ptr.dtype.element_ty),
+                mask=m2,
+            )
+            tl.atomic_add(
+                colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0), mask=col_mask
+            )
 
     @triton.jit
     def _rowsq_wide(
-        x_ptr, colsq_in_ptr, rowsq_ptr,
-        M, N, sqrt_m, eps, cols_per,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        x_ptr,
+        colsq_in_ptr,
+        rowsq_ptr,
+        M,
+        N,
+        sqrt_m,
+        eps,
+        cols_per,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
     ):
         pid_m = tl.program_id(0)
         pid_n = tl.program_id(1)
@@ -102,18 +129,32 @@ if HAVE_TRITON:
             col_mask = cols < N
             csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
-            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                           mask=row_mask[:, None] & col_mask[None, :], other=0.0)
+            tile = tl.load(
+                x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                mask=row_mask[:, None] & col_mask[None, :],
+                other=0.0,
+            )
             v = tile.to(tl.float32) * cscale[None, :]
             acc += tl.sum(v * v, axis=1)
         tl.atomic_add(rowsq_ptr + pid_b * M + rows, acc, mask=row_mask)
 
     @triton.jit
     def _scale_wide(
-        x_ptr, out_ptr, colsq_in_ptr, rowsq_ptr, colsq_out_ptr,
-        M, N, sqrt_n, sqrt_m, eps, cols_per,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        x_ptr,
+        out_ptr,
+        colsq_in_ptr,
+        rowsq_ptr,
+        colsq_out_ptr,
+        M,
+        N,
+        sqrt_n,
+        sqrt_m,
+        eps,
+        cols_per,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
     ):
         pid_m = tl.program_id(0)
         pid_n = tl.program_id(1)
@@ -130,21 +171,40 @@ if HAVE_TRITON:
             csq = tl.load(colsq_in_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
             m2 = row_mask[:, None] & col_mask[None, :]
-            tile = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                           mask=m2, other=0.0)
+            tile = tl.load(
+                x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                mask=m2,
+                other=0.0,
+            )
             v = tile.to(tl.float32) * cscale[None, :] * rscale[:, None]
-            tl.store(out_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                     v.to(out_ptr.dtype.element_ty), mask=m2)
-            tl.atomic_add(colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0),
-                          mask=col_mask)
+            tl.store(
+                out_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                v.to(out_ptr.dtype.element_ty),
+                mask=m2,
+            )
+            tl.atomic_add(
+                colsq_out_ptr + pid_b * N + cols, tl.sum(v * v, axis=0), mask=col_mask
+            )
 
     @triton.jit
     def _matvec1_partials(
-        x_ptr, colsq_ptr, p_ptr, u_ptr, v_ptr, sums_ptr,
-        M, N, sqrt_m, eps, cols_per,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
-        WITH_PARTIALS: tl.constexpr, ATOMIC_V: tl.constexpr,
+        x_ptr,
+        colsq_ptr,
+        p_ptr,
+        u_ptr,
+        v_ptr,
+        sums_ptr,
+        M,
+        N,
+        sqrt_m,
+        eps,
+        cols_per,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        WITH_PARTIALS: tl.constexpr,
+        ATOMIC_V: tl.constexpr,
     ):
         # v = (X . colscale) @ u on the CTA's rows; optionally the three projection
         # partials ||p||^2, <p, Xd>, ||Xd||^2 (per-matrix scalar atomics) in the same pass.
@@ -165,13 +225,22 @@ if HAVE_TRITON:
             csq = tl.load(colsq_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
             m2 = row_mask[:, None] & col_mask[None, :]
-            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
+            xt = (
+                tl.load(
+                    x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                    mask=m2,
+                    other=0.0,
+                ).to(tl.float32)
+                * cscale[None, :]
+            )
             ut = tl.load(u_ptr + pid_b * N + cols, mask=col_mask, other=0.0)
             acc_v += tl.sum(xt * ut[None, :], axis=1)
             if WITH_PARTIALS:
-                pt = tl.load(p_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                             mask=m2, other=0.0).to(tl.float32)
+                pt = tl.load(
+                    p_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                    mask=m2,
+                    other=0.0,
+                ).to(tl.float32)
                 s0 += tl.sum(pt * pt)
                 s1 += tl.sum(pt * xt)
                 s2 += tl.sum(xt * xt)
@@ -186,10 +255,19 @@ if HAVE_TRITON:
 
     @triton.jit
     def _matvec2(
-        x_ptr, colsq_ptr, v_ptr, uu_ptr,
-        M, N, sqrt_m, eps, cols_per,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        x_ptr,
+        colsq_ptr,
+        v_ptr,
+        uu_ptr,
+        M,
+        N,
+        sqrt_m,
+        eps,
+        cols_per,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
     ):
         # uu = v^T (X . colscale), accumulated per column via atomics.
         pid_m = tl.program_id(0)
@@ -206,17 +284,37 @@ if HAVE_TRITON:
             csq = tl.load(colsq_ptr + pid_b * N + cols, mask=col_mask, other=1.0)
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
             m2 = row_mask[:, None] & col_mask[None, :]
-            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
-            tl.atomic_add(uu_ptr + pid_b * N + cols, tl.sum(xt * vt[:, None], axis=0),
-                          mask=col_mask)
+            xt = (
+                tl.load(
+                    x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                    mask=m2,
+                    other=0.0,
+                ).to(tl.float32)
+                * cscale[None, :]
+            )
+            tl.atomic_add(
+                uu_ptr + pid_b * N + cols,
+                tl.sum(xt * vt[:, None], axis=0),
+                mask=col_mask,
+            )
 
     @triton.jit
     def _apply(
-        p_ptr, x_ptr, colsq_ptr, a_ptr, scale2_ptr,
-        M, N, decay, sqrt_m, eps, cols_per,
-        stride_b, stride_m,
-        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+        p_ptr,
+        x_ptr,
+        colsq_ptr,
+        a_ptr,
+        scale2_ptr,
+        M,
+        N,
+        decay,
+        sqrt_m,
+        eps,
+        cols_per,
+        stride_b,
+        stride_m,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
     ):
         # p = (p * decay - a * (x . colscale)) * scale2 — one form covers all modes:
         # base/spec: scale2 = 1, decay = 1 - lr*wd, a = lr[*target/sigma];
@@ -237,11 +335,18 @@ if HAVE_TRITON:
             cscale = sqrt_m / tl.maximum(tl.sqrt(csq), eps)
             m2 = row_mask[:, None] & col_mask[None, :]
             pp = p_ptr + base + rows[:, None] * stride_m + cols[None, :]
-            xt = tl.load(x_ptr + base + rows[:, None] * stride_m + cols[None, :],
-                         mask=m2, other=0.0).to(tl.float32) * cscale[None, :]
+            xt = (
+                tl.load(
+                    x_ptr + base + rows[:, None] * stride_m + cols[None, :],
+                    mask=m2,
+                    other=0.0,
+                ).to(tl.float32)
+                * cscale[None, :]
+            )
             pt = tl.load(pp, mask=m2, other=0.0).to(tl.float32)
-            tl.store(pp, ((pt * decay - a * xt) * s2c).to(p_ptr.dtype.element_ty),
-                     mask=m2)
+            tl.store(
+                pp, ((pt * decay - a * xt) * s2c).to(p_ptr.dtype.element_ty), mask=m2
+            )
 
 
 _SM_COUNT = None
@@ -274,9 +379,22 @@ def fused_available() -> bool:
 
 @torch.no_grad()
 def fused_sinkgd_step(
-    p, grad, lr, weight_decay, iters, eps, *,
-    mode="base", u=None, target_norm=None, spectral_target="muon", sn_iters=1,
-    m_global=None, process_group=None, block_m=16, block_n=512,
+    p,
+    grad,
+    lr,
+    weight_decay,
+    iters,
+    eps,
+    *,
+    mode="base",
+    u=None,
+    target_norm=None,
+    spectral_target="muon",
+    sn_iters=1,
+    m_global=None,
+    process_group=None,
+    block_m=16,
+    block_n=512,
 ):
     """One fused SinkGD step; single-device when ``process_group`` is None, else the
     rows-sharded FSDP2 step (``p``/``grad`` are local shards, ``m_global`` the full row dim,
@@ -308,18 +426,56 @@ def fused_sinkgd_step(
     for _ in range(iters):
         colsq_b.zero_()
         if nsplits == 1:
-            _iter_tall[(grid[0], B)](src, x_buf, colsq_a, colsq_b, m_local, n,
-                                     sqrt_n, sqrt_m, eps, m_local * n, n,
-                                     BLOCK_M=block_m, BLOCK_N=block_n)
+            _iter_tall[(grid[0], B)](
+                src,
+                x_buf,
+                colsq_a,
+                colsq_b,
+                m_local,
+                n,
+                sqrt_n,
+                sqrt_m,
+                eps,
+                m_local * n,
+                n,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+            )
         else:
             if rowsq is None:
                 rowsq = torch.empty(B, m_local, device=dev, dtype=torch.float32)
             rowsq.zero_()
-            _rowsq_wide[grid](src, colsq_a, rowsq, m_local, n, sqrt_m, eps, cols_per,
-                              m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
-            _scale_wide[grid](src, x_buf, colsq_a, rowsq, colsq_b, m_local, n,
-                              sqrt_n, sqrt_m, eps, cols_per, m_local * n, n,
-                              BLOCK_M=block_m, BLOCK_N=block_n)
+            _rowsq_wide[grid](
+                src,
+                colsq_a,
+                rowsq,
+                m_local,
+                n,
+                sqrt_m,
+                eps,
+                cols_per,
+                m_local * n,
+                n,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+            )
+            _scale_wide[grid](
+                src,
+                x_buf,
+                colsq_a,
+                rowsq,
+                colsq_b,
+                m_local,
+                n,
+                sqrt_n,
+                sqrt_m,
+                eps,
+                cols_per,
+                m_local * n,
+                n,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+            )
         if process_group is not None:
             dist.all_reduce(colsq_b, group=process_group)
         src = x_buf
@@ -329,8 +485,23 @@ def fused_sinkgd_step(
     if mode == "base":
         a = torch.full((B,), lr, device=dev, dtype=torch.float32)
         scale2 = torch.ones(B, device=dev, dtype=torch.float32)
-        _apply[grid](pw, x_buf, colsq_a, a, scale2, m_local, n, decay, sqrt_m, eps,
-                     cols_per, m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+        _apply[grid](
+            pw,
+            x_buf,
+            colsq_a,
+            a,
+            scale2,
+            m_local,
+            n,
+            decay,
+            sqrt_m,
+            eps,
+            cols_per,
+            m_local * n,
+            n,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+        )
         return
 
     # spec/md: power iteration on the (colscale-folded) update, sn_iters rounds
@@ -342,10 +513,25 @@ def fused_sinkgd_step(
         with_partials = mode == "md" and it == 0
         if nsplits > 1:
             v.zero_()
-        _matvec1_partials[grid](x_buf, colsq_a, pw, uw, v, sums, m_local, n, sqrt_m,
-                                eps, cols_per, m_local * n, n, BLOCK_M=block_m,
-                                BLOCK_N=block_n, WITH_PARTIALS=with_partials,
-                                ATOMIC_V=nsplits > 1)
+        _matvec1_partials[grid](
+            x_buf,
+            colsq_a,
+            pw,
+            uw,
+            v,
+            sums,
+            m_local,
+            n,
+            sqrt_m,
+            eps,
+            cols_per,
+            m_local * n,
+            n,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            WITH_PARTIALS=with_partials,
+            ATOMIC_V=nsplits > 1,
+        )
         vsq = (v * v).sum(dim=-1)
         if with_partials:
             packed = torch.cat([sums, vsq.unsqueeze(-1)], dim=-1)
@@ -357,8 +543,21 @@ def fused_sinkgd_step(
             dist.all_reduce(vsq, group=process_group)
         v /= vsq.sqrt().clamp_min(eps).unsqueeze(-1)
         uu = torch.zeros(B, n, device=dev, dtype=torch.float32)
-        _matvec2[grid](x_buf, colsq_a, v, uu, m_local, n, sqrt_m, eps, cols_per,
-                       m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+        _matvec2[grid](
+            x_buf,
+            colsq_a,
+            v,
+            uu,
+            m_local,
+            n,
+            sqrt_m,
+            eps,
+            cols_per,
+            m_local * n,
+            n,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+        )
         if process_group is not None:
             dist.all_reduce(uu, group=process_group)
         sigma = uu.norm(dim=-1, keepdim=True).clamp_min(eps)
@@ -372,8 +571,25 @@ def fused_sinkgd_step(
     else:
         tn = target_norm.reshape(-1).float().to(dev)
         a = (lr * tn / sig).contiguous()
-        fro = (sums[:, 0] - 2 * a * sums[:, 1] + a * a * sums[:, 2]).clamp_min(eps).sqrt()
+        fro = (
+            (sums[:, 0] - 2 * a * sums[:, 1] + a * a * sums[:, 2]).clamp_min(eps).sqrt()
+        )
         scale2 = (tn / fro).contiguous()
         decay = 1.0  # sphere projection subsumes any decay
-    _apply[grid](pw, x_buf, colsq_a, a, scale2, m_local, n, decay, sqrt_m, eps,
-                 cols_per, m_local * n, n, BLOCK_M=block_m, BLOCK_N=block_n)
+    _apply[grid](
+        pw,
+        x_buf,
+        colsq_a,
+        a,
+        scale2,
+        m_local,
+        n,
+        decay,
+        sqrt_m,
+        eps,
+        cols_per,
+        m_local * n,
+        n,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+    )

--- a/src/axolotl/utils/optimizers/sinkgd_triton.py
+++ b/src/axolotl/utils/optimizers/sinkgd_triton.py
@@ -405,6 +405,10 @@ def fused_sinkgd_step(
     that already includes ``alpha_eff``; weight decay applies to base/spec (md is on the
     sphere, decay is meaningless there — ignored to match the compiled MD path).
     """
+    if not p.is_contiguous():
+        # kernels address p with dense strides and write it in place; a .contiguous()
+        # copy here would silently drop the update
+        raise ValueError("fused_sinkgd_step requires a contiguous param")
     orig = grad.shape
     g = grad.reshape(-1, *orig[-2:]) if grad.ndim > 2 else grad.unsqueeze(0)
     pw = p.reshape(-1, *orig[-2:]) if p.ndim > 2 else p.unsqueeze(0)

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -209,6 +209,24 @@ class TestHFCausalTrainerBuilder:
         with pytest.raises(ValueError):
             trainer.create_optimizer()
 
+    def test_sinkgd_md_sphere_selects_subclass(self, sft_cfg, model, tokenizer):
+        """sinkgd_md_sphere=true builds the SinkGDMD (A+B) subclass; default builds SinkGD."""
+        from axolotl.utils.optimizers.sinkgd import SinkGD, SinkGDMD
+
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "sinkgd"
+        cfg["optim_args"] = {"sinkgd_md_sphere": True}
+        trainer = HFCausalTrainerBuilder(cfg, model, tokenizer).build(100)
+        optim = trainer.create_optimizer()
+        assert isinstance(optim, SinkGDMD)
+
+        cfg2 = sft_cfg.copy()
+        cfg2["optimizer"] = "sinkgd"
+        cfg2["optim_args"] = {"sinkgd_lr_scale": 0.05}
+        trainer2 = HFCausalTrainerBuilder(cfg2, model, tokenizer).build(100)
+        optim2 = trainer2.create_optimizer()
+        assert isinstance(optim2, SinkGD) and not isinstance(optim2, SinkGDMD)
+
 
 class TestTrainerClsPlugin:
     """

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -227,6 +227,18 @@ class TestHFCausalTrainerBuilder:
         optim2 = trainer2.create_optimizer()
         assert isinstance(optim2, SinkGD) and not isinstance(optim2, SinkGDMD)
 
+    def test_sinkgd_fused_kernel_flag(self, sft_cfg, model, tokenizer):
+        """sinkgd_fused_kernel plumbs through optim_args into the optimizer."""
+        from axolotl.utils.optimizers.sinkgd import SinkGD
+
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "sinkgd"
+        cfg["optim_args"] = {"sinkgd_fused_kernel": True}
+        trainer = HFCausalTrainerBuilder(cfg, model, tokenizer).build(100)
+        optim = trainer.create_optimizer()
+        assert isinstance(optim, SinkGD)
+        assert optim.sinkgd_fused_kernel is True
+
 
 class TestTrainerClsPlugin:
     """

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -168,6 +168,47 @@ class TestHFCausalTrainerBuilder:
         # linear weight matrices must be in the stateless SR-Sinkhorn group
         assert any(group.get("use_sinkgd") for group in optim.param_groups)
 
+    def test_sinkgd_optimizer_feature_a_optim_args(self, sft_cfg, model, tokenizer):
+        """The Feature-A optim_args (spectral norm + width-aware 1/d_in) plumb through and
+        construct a live SinkGD with the flags set."""
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "sinkgd"
+        cfg["optim_args"] = {
+            "sinkhorn_iters": 5,
+            "sinkgd_lr_scale": 0.05,
+            "sinkgd_spectral_norm": True,
+            "sinkgd_spectral_norm_iters": 2,
+            "sinkgd_spectral_target": "unit",
+            "sinkgd_base_width": 256,
+        }
+
+        from axolotl.utils.optimizers.sinkgd import SinkGD
+
+        builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
+        trainer = builder.build(100)
+        optim = trainer.create_optimizer()
+        assert isinstance(optim, SinkGD)
+        assert optim.sinkgd_spectral_norm is True
+        assert optim.sinkgd_spectral_norm_iters == 2
+        assert optim.sinkgd_spectral_target == "unit"
+        assert optim.sinkgd_base_width == 256
+
+    def test_sinkgd_optimizer_width_double_count_rejected(
+        self, sft_cfg, model, tokenizer
+    ):
+        """base_width + spectral_target='muon' double-count width and must be rejected."""
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "sinkgd"
+        cfg["optim_args"] = {
+            "sinkgd_spectral_norm": True,
+            "sinkgd_spectral_target": "muon",
+            "sinkgd_base_width": 256,
+        }
+        builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
+        trainer = builder.build(100)
+        with pytest.raises(ValueError):
+            trainer.create_optimizer()
+
 
 class TestTrainerClsPlugin:
     """

--- a/tests/e2e/multigpu/test_sinkgd_fsdp2.py
+++ b/tests/e2e/multigpu/test_sinkgd_fsdp2.py
@@ -84,6 +84,8 @@ def test_sharded_spectral_matches_full(mesh, shard_dim, dim, target_mode):
     m, n = 128, 96
     w_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
     grad_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    dist.broadcast(w_full, 0)
+    dist.broadcast(grad_full, 0)
 
     w = distribute_tensor(w_full.clone(), mesh, [Shard(dim)])
     w = torch.nn.Parameter(w)
@@ -126,11 +128,14 @@ def test_sharded_spectral_matches_full(mesh, shard_dim, dim, target_mode):
 
 @pytest.mark.parametrize("dim", [0, 1])
 def test_dist_md_sphere_matches_full_and_stays_on_sphere(mesh, dim):
-    """DistSinkGDMD (A+B) on a sharded weight keeps the GLOBAL weight on its Frobenius sphere
-    and matches the single-device MD result; sphere radius + power-iter vector round-trip."""
+    """DistSinkGDMD (A+B) on a sharded weight keeps the GLOBAL weight on its enable-time
+    Frobenius sphere across steps; sphere radius + power-iter vector round-trip through the
+    state dict. (Fused-vs-compiled MD equivalence is covered by
+    test_dist_fused_matches_compiled.)"""
     torch.manual_seed(0)
     m, n = 128, 96
     w_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    dist.broadcast(w_full, 0)
     tn0 = w_full.norm().item()
 
     w = torch.nn.Parameter(distribute_tensor(w_full.clone(), mesh, [Shard(dim)]))

--- a/tests/e2e/multigpu/test_sinkgd_fsdp2.py
+++ b/tests/e2e/multigpu/test_sinkgd_fsdp2.py
@@ -23,7 +23,7 @@ import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Shard, distribute_tensor
 
-from axolotl.utils.optimizers.sinkgd import DistSinkGD, sr_sinkhorn
+from axolotl.utils.optimizers.sinkgd import DistSinkGD, DistSinkGDMD, sr_sinkhorn
 
 _TORCHRUN_LOCAL_RANK = os.environ.get("LOCAL_RANK")
 _TORCHRUN_WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
@@ -118,3 +118,38 @@ def test_sharded_spectral_matches_full(mesh, shard_dim, dim, target_mode):
     )
     opt2.load_state_dict(sd)
     torch.testing.assert_close(opt2.state[w]["specnorm_u"], u)
+
+
+@pytest.mark.parametrize("dim", [0, 1])
+def test_dist_md_sphere_matches_full_and_stays_on_sphere(mesh, dim):
+    """DistSinkGDMD (A+B) on a sharded weight keeps the GLOBAL weight on its Frobenius sphere
+    and matches the single-device MD result; sphere radius + power-iter vector round-trip."""
+    torch.manual_seed(0)
+    m, n = 128, 96
+    w_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    tn0 = w_full.norm().item()
+
+    w = torch.nn.Parameter(distribute_tensor(w_full.clone(), mesh, [Shard(dim)]))
+    opt = DistSinkGDMD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0, sinkgd_lr_scale=0.1, sinkgd_spectral_norm_iters=3,
+        process_group=mesh["dp_shard"].get_group(),
+    )
+    for _ in range(4):
+        w.grad = distribute_tensor(
+            torch.randn(m, n, device="cuda", dtype=torch.float32), mesh, [Shard(dim)]
+        )
+        opt.step()
+
+    # global weight stays on the enable-time Frobenius sphere
+    assert w.detach().full_tensor().norm().item() == pytest.approx(tn0, rel=1e-3)
+    # sphere radius + power-iteration vector are persisted and round-trip
+    assert "md_target_norm" in opt.state[w] and "specnorm_u" in opt.state[w]
+    sd = opt.state_dict()
+    opt2 = DistSinkGDMD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0, sinkgd_lr_scale=0.1, sinkgd_spectral_norm_iters=3,
+        process_group=mesh["dp_shard"].get_group(),
+    )
+    opt2.load_state_dict(sd)
+    torch.testing.assert_close(opt2.state[w]["md_target_norm"], opt.state[w]["md_target_norm"])

--- a/tests/e2e/multigpu/test_sinkgd_fsdp2.py
+++ b/tests/e2e/multigpu/test_sinkgd_fsdp2.py
@@ -153,3 +153,36 @@ def test_dist_md_sphere_matches_full_and_stays_on_sphere(mesh, dim):
     )
     opt2.load_state_dict(sd)
     torch.testing.assert_close(opt2.state[w]["md_target_norm"], opt.state[w]["md_target_norm"])
+
+
+@pytest.mark.parametrize("mode", ["base", "spec", "md"])
+@pytest.mark.parametrize("wide", [False, True])
+def test_dist_fused_matches_compiled(mesh, mode, wide):
+    """sinkgd_fused_kernel=True on rows-sharded DTensors matches the compiled dist path for
+    all modes, in both the tall and (row-starved) wide kernel regimes."""
+    torch.manual_seed(0)
+    m, n = (128, 4096) if wide else (256, 96)
+    w_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    g_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    dist.broadcast(w_full, 0)
+    dist.broadcast(g_full, 0)
+
+    results = []
+    for fused in (False, True):
+        w = torch.nn.Parameter(distribute_tensor(w_full.clone(), mesh, [Shard(0)]))
+        # sn_iters=3: the compiled dist path estimates sigma via Gram power iteration,
+        # the fused path via the normalized two-matvec form — identical at convergence,
+        # transiently different from a cold start, so compare near convergence.
+        kw = dict(lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused,
+                  sinkgd_spectral_norm_iters=3,
+                  process_group=mesh["dp_shard"].get_group())
+        if mode == "spec":
+            kw.update(sinkgd_spectral_norm=True, sinkgd_spectral_target="muon")
+        cls = DistSinkGDMD if mode == "md" else DistSinkGD
+        opt = cls([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], **kw)
+        for _ in range(3):
+            w.grad = distribute_tensor(g_full.clone(), mesh, [Shard(0)])
+            opt.step()
+        results.append(w.detach().full_tensor())
+    rel = (results[0] - results[1]).abs().max() / results[0].abs().max()
+    assert rel.item() < 3e-2, f"{mode} wide={wide}: rel={rel.item():.2e}"

--- a/tests/e2e/multigpu/test_sinkgd_fsdp2.py
+++ b/tests/e2e/multigpu/test_sinkgd_fsdp2.py
@@ -46,7 +46,9 @@ def mesh():
     torch.cuda.set_device(rank % torch.cuda.device_count())
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
-    dm = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("dp_shard",))
+    dm = init_device_mesh(
+        "cuda", (dist.get_world_size(),), mesh_dim_names=("dp_shard",)
+    )
     yield dm
     if dist.is_initialized():
         dist.barrier()
@@ -99,7 +101,9 @@ def test_sharded_spectral_matches_full(mesh, shard_dim, dim, target_mode):
     )
     opt.step()
 
-    ref = _full_reference(w_full, grad_full, shard_dim, target_mode, sn_iters, lr_alpha=1.0)
+    ref = _full_reference(
+        w_full, grad_full, shard_dim, target_mode, sn_iters, lr_alpha=1.0
+    )
     got = w.detach().full_tensor()
     torch.testing.assert_close(got, ref, rtol=2e-3, atol=2e-3)
 
@@ -132,7 +136,9 @@ def test_dist_md_sphere_matches_full_and_stays_on_sphere(mesh, dim):
     w = torch.nn.Parameter(distribute_tensor(w_full.clone(), mesh, [Shard(dim)]))
     opt = DistSinkGDMD(
         [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
-        lr=1.0, sinkgd_lr_scale=0.1, sinkgd_spectral_norm_iters=3,
+        lr=1.0,
+        sinkgd_lr_scale=0.1,
+        sinkgd_spectral_norm_iters=3,
         process_group=mesh["dp_shard"].get_group(),
     )
     for _ in range(4):
@@ -148,11 +154,15 @@ def test_dist_md_sphere_matches_full_and_stays_on_sphere(mesh, dim):
     sd = opt.state_dict()
     opt2 = DistSinkGDMD(
         [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
-        lr=1.0, sinkgd_lr_scale=0.1, sinkgd_spectral_norm_iters=3,
+        lr=1.0,
+        sinkgd_lr_scale=0.1,
+        sinkgd_spectral_norm_iters=3,
         process_group=mesh["dp_shard"].get_group(),
     )
     opt2.load_state_dict(sd)
-    torch.testing.assert_close(opt2.state[w]["md_target_norm"], opt.state[w]["md_target_norm"])
+    torch.testing.assert_close(
+        opt2.state[w]["md_target_norm"], opt.state[w]["md_target_norm"]
+    )
 
 
 @pytest.mark.parametrize("mode", ["base", "spec", "md"])
@@ -173,9 +183,13 @@ def test_dist_fused_matches_compiled(mesh, mode, wide):
         # sn_iters=3: the compiled dist path estimates sigma via Gram power iteration,
         # the fused path via the normalized two-matvec form — identical at convergence,
         # transiently different from a cold start, so compare near convergence.
-        kw = dict(lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused,
-                  sinkgd_spectral_norm_iters=3,
-                  process_group=mesh["dp_shard"].get_group())
+        kw = dict(
+            lr=1e-2,
+            sinkgd_lr_scale=0.5,
+            sinkgd_fused_kernel=fused,
+            sinkgd_spectral_norm_iters=3,
+            process_group=mesh["dp_shard"].get_group(),
+        )
         if mode == "spec":
             kw.update(sinkgd_spectral_norm=True, sinkgd_spectral_target="muon")
         cls = DistSinkGDMD if mode == "md" else DistSinkGD

--- a/tests/e2e/multigpu/test_sinkgd_fsdp2.py
+++ b/tests/e2e/multigpu/test_sinkgd_fsdp2.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+"""DistSinkGD sharded spectral-norm correctness under a 2-rank device mesh.
+
+Verifies that the sharded power iteration (Gram-matrix matvec + one vector all-reduce per
+step, matrix never gathered) reproduces the single-device full-matrix spectral rescale, for
+both row- and column-sharded weights, and that the persisted power-iteration vector
+round-trips through the optimizer state dict.
+
+Run with::
+
+    torchrun --nproc-per-node=2 -m pytest tests/e2e/multigpu/test_sinkgd_fsdp2.py
+
+On a 1-GPU executor the tests skip with a clear reason.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard, distribute_tensor
+
+from axolotl.utils.optimizers.sinkgd import DistSinkGD, sr_sinkhorn
+
+_TORCHRUN_LOCAL_RANK = os.environ.get("LOCAL_RANK")
+_TORCHRUN_WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+    pytest.mark.skipif(
+        torch.cuda.device_count() < 2, reason="Need >=2 GPUs for FSDP2 multi-rank tests"
+    ),
+    pytest.mark.skipif(
+        _TORCHRUN_LOCAL_RANK is None or _TORCHRUN_WORLD_SIZE < 2,
+        reason="Launch via `torchrun --nproc-per-node=2 -m pytest <file>`",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    rank = int(os.environ["RANK"])
+    torch.cuda.set_device(rank % torch.cuda.device_count())
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    dm = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("dp_shard",))
+    yield dm
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def _full_reference(w_full, grad_full, shard_dim, target_mode, sn_iters, lr_alpha):
+    """Full-matrix equivalent of the sharded step: full SR-Sinkhorn -> Gram power iteration
+    (seed-0 init, matching DistSinkGD._dist_specnorm_vec) -> operator-norm rescale -> apply."""
+    m, n = w_full.shape
+    u_mat = sr_sinkhorn(grad_full.float(), 5, 1e-8)
+    vec_len = n if shard_dim == -2 else m
+    g = torch.Generator(device=w_full.device).manual_seed(0)
+    vec = torch.randn(vec_len, generator=g, device=w_full.device, dtype=torch.float32)
+    vec = vec / vec.norm().clamp_min(1e-12)
+    nrm = None
+    for _ in range(sn_iters):
+        if shard_dim == -2:
+            up = u_mat.t() @ (u_mat @ vec)
+        else:
+            up = u_mat @ (u_mat.t() @ vec)
+        nrm = up.norm().clamp_min(1e-8)
+        vec = up / nrm
+    sigma = nrm.sqrt()
+    target = 1.0 if target_mode == "unit" else (m / n) ** 0.5
+    return w_full.float() - lr_alpha * (u_mat * (target / sigma))
+
+
+@pytest.mark.parametrize("shard_dim,dim", [(-2, 0), (-1, 1)])
+@pytest.mark.parametrize("target_mode", ["unit", "muon"])
+def test_sharded_spectral_matches_full(mesh, shard_dim, dim, target_mode):
+    torch.manual_seed(0)
+    m, n = 128, 96
+    w_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+    grad_full = torch.randn(m, n, device="cuda", dtype=torch.float32)
+
+    w = distribute_tensor(w_full.clone(), mesh, [Shard(dim)])
+    w = torch.nn.Parameter(w)
+    w.grad = distribute_tensor(grad_full.clone(), mesh, [Shard(dim)])
+
+    sn_iters = 3
+    opt = DistSinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0,
+        sinkgd_lr_scale=1.0,
+        sinkgd_spectral_norm=True,
+        sinkgd_spectral_norm_iters=sn_iters,
+        sinkgd_spectral_target=target_mode,
+        process_group=mesh["dp_shard"].get_group(),
+    )
+    opt.step()
+
+    ref = _full_reference(w_full, grad_full, shard_dim, target_mode, sn_iters, lr_alpha=1.0)
+    got = w.detach().full_tensor()
+    torch.testing.assert_close(got, ref, rtol=2e-3, atol=2e-3)
+
+    # the persisted power-iteration vector lives on the unsharded axis and round-trips
+    u = opt.state[w]["specnorm_u"]
+    assert u.shape[-1] == (n if shard_dim == -2 else m)
+    sd = opt.state_dict()
+    opt2 = DistSinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0,
+        sinkgd_lr_scale=1.0,
+        sinkgd_spectral_norm=True,
+        sinkgd_spectral_norm_iters=sn_iters,
+        sinkgd_spectral_target=target_mode,
+        process_group=mesh["dp_shard"].get_group(),
+    )
+    opt2.load_state_dict(sd)
+    torch.testing.assert_close(opt2.state[w]["specnorm_u"], u)

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -210,6 +210,59 @@ class TestCustomOptimizers(unittest.TestCase):
         check_model_output_exists(temp_dir, cfg)
         assert "SinkGD" in trainer.optimizer.optimizer.__class__.__name__
 
+    @with_temp_dir
+    @require_torch_2_5_1
+    def test_sinkgd_spectral_norm(self, temp_dir):
+        """Feature A: spectral-norm (Muon target) trains end-to-end without NaN/divergence."""
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {"pad_token": "<|endoftext|>"},
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                        "split": "train[:200]",
+                    },
+                ],
+                "num_epochs": 1,
+                "max_steps": 5,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.001,
+                "optimizer": "sinkgd",
+                "optim_args": {
+                    "sinkhorn_iters": 5,
+                    "sinkgd_lr_scale": 0.05,
+                    "sinkgd_spectral_norm": True,
+                    "sinkgd_spectral_target": "muon",
+                    "sinkgd_spectral_norm_iters": 2,
+                },
+                "lr_scheduler": "cosine",
+                "weight_decay": 0.0,
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "SinkGD" in trainer.optimizer.optimizer.__class__.__name__
+
     @pytest.mark.skip(
         reason="Dion's internal torch.compile hits a dynamo cache-limit error"
     )

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -282,3 +282,93 @@ def test_sinkgdmd_moves_weight_and_uses_adam_fallback():
     opt.step()
     assert not torch.allclose(before, w.detach())
     assert "exp_avg" in opt.state[b]  # 1D param uses the Adam fallback
+
+
+# ---- fused Triton kernel path (sinkgd_fused_kernel) -----------------------------------
+
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="fused kernels need CUDA"
+)
+
+
+@requires_cuda
+@pytest.mark.parametrize("shape", [(256, 192), (1024, 8192), (4, 96, 64)])
+def test_fused_base_matches_compiled(shape):
+    """sinkgd_fused_kernel=True reproduces the compiled base update to bf16 tolerance,
+    including a wide-short shape that exercises the column-split kernels."""
+    torch.manual_seed(0)
+    w0 = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
+    g = torch.randn_like(w0)
+    results = []
+    for fused in (False, True):
+        w = torch.nn.Parameter(w0.clone())
+        opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.01}],
+                     lr=1e-2, sinkgd_lr_scale=0.5, weight_decay=0.01,
+                     sinkgd_fused_kernel=fused)
+        w.grad = g.clone()
+        opt.step()
+        results.append(w.detach().float())
+    rel = (results[0] - results[1]).abs().max() / results[0].abs().max()
+    assert rel.item() < 3e-2
+
+
+@requires_cuda
+@pytest.mark.parametrize("target", ["unit", "muon"])
+def test_fused_spectral_matches_compiled(target):
+    torch.manual_seed(0)
+    w0 = torch.randn(96, 64, device="cuda", dtype=torch.bfloat16)
+    g = torch.randn_like(w0)
+    results = []
+    for fused in (False, True):
+        w = torch.nn.Parameter(w0.clone())
+        opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+                     lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_spectral_norm=True,
+                     sinkgd_spectral_norm_iters=2, sinkgd_spectral_target=target,
+                     sinkgd_fused_kernel=fused)
+        torch.manual_seed(7)  # same u init both paths
+        for _ in range(3):
+            w.grad = g.clone()
+            opt.step()
+        results.append(w.detach().float())
+    rel = (results[0] - results[1]).abs().max() / results[0].abs().max()
+    assert rel.item() < 3e-2
+
+
+@requires_cuda
+def test_fused_md_matches_compiled_and_stays_on_sphere():
+    torch.manual_seed(0)
+    w0 = torch.randn(96, 64, device="cuda", dtype=torch.bfloat16)
+    tn0 = w0.float().norm().item()
+    g = torch.randn_like(w0)
+    results = []
+    for fused in (False, True):
+        w = torch.nn.Parameter(w0.clone())
+        opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+                       lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused)
+        torch.manual_seed(7)
+        for _ in range(3):
+            w.grad = g.clone()
+            opt.step()
+        assert w.detach().float().norm().item() == pytest.approx(tn0, rel=1e-3)
+        results.append(w.detach().float())
+    rel = (results[0] - results[1]).abs().max() / results[0].abs().max()
+    assert rel.item() < 3e-2
+
+
+@requires_cuda
+def test_fused_falls_back_for_stochastic_round():
+    """bf16 stochastic rounding is not implemented in the fused kernels -> compiled path."""
+    w = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
+    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                 sinkgd_fused_kernel=True, bf16_stochastic_round=True)
+    assert not opt._fused_ok(w)
+    w2 = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
+    opt2 = SinkGD([{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                  sinkgd_fused_kernel=True)
+    assert opt2._fused_ok(w2)
+
+
+def test_pop_kwargs_casts_fused_flag():
+    out = _pop_sinkgd_extra_kwargs({"sinkgd_fused_kernel": "true"})
+    assert out["sinkgd_fused_kernel"] is True

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -1,8 +1,16 @@
 """Unit tests for the SinkGD optimizer's SR-Sinkhorn, including 3D fused-MoE shapes."""
 
+import pytest
 import torch
 
-from axolotl.utils.optimizers.sinkgd import SinkGD, sr_sinkhorn
+from axolotl.utils.optimizers.sinkgd import (
+    SinkGD,
+    _pop_sinkgd_extra_kwargs,
+    _specnorm_gram_cols,
+    _specnorm_gram_rows,
+    single_param_sinkgd_specnorm,
+    sr_sinkhorn,
+)
 
 
 def test_sr_sinkhorn_2d_fixed_point():
@@ -49,3 +57,178 @@ def test_sinkgd_step_3d_stateless():
     opt.step()
     assert not torch.allclose(before, w.detach())
     assert opt.state[w] == {}  # SR-Sinkhorn is stateless
+
+
+# ---- Feature A: width-aware scaling -------------------------------------------------
+
+
+def _mk(**kw):
+    w = torch.nn.Parameter(torch.randn(24, 16))
+    opt = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_lr_scale=0.05,
+        **kw,
+    )
+    return w, opt
+
+
+def test_alpha_eff_no_base_width_is_plain_scalar():
+    """Backward-compat: without base_width, alpha_eff == sinkgd_lr_scale exactly."""
+    w, opt = _mk()
+    assert opt._alpha_eff(w) == pytest.approx(0.05)
+
+
+def test_alpha_eff_width_aware_1_over_din():
+    """alpha_eff = sinkgd_lr_scale * (base_width / d_in) ** exponent; d_in = shape[-1]."""
+    w, opt = _mk(sinkgd_base_width=16)  # d_in == base_width -> unchanged
+    assert opt._alpha_eff(w) == pytest.approx(0.05)
+    w, opt = _mk(sinkgd_base_width=8)  # base < d_in(16) -> halved
+    assert opt._alpha_eff(w) == pytest.approx(0.025)
+    w, opt = _mk(sinkgd_base_width=8, sinkgd_lr_width_exponent=0.0)  # exponent 0 -> off
+    assert opt._alpha_eff(w) == pytest.approx(0.05)
+
+
+def test_alpha_eff_uses_input_dim_for_fused_layouts():
+    """For a fused [d_out, d_in] weight the width factor keys on d_in (shared input)."""
+    w_qkv = torch.nn.Parameter(torch.randn(3 * 64, 32))  # fused QKV: d_in = 32
+    opt = SinkGD(
+        [{"params": [w_qkv], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_lr_scale=0.05,
+        sinkgd_base_width=16,
+    )
+    assert opt._alpha_eff(w_qkv) == pytest.approx(0.05 * 16 / 32)
+
+
+# ---- Feature A: spectral norm -------------------------------------------------------
+
+
+def test_spectral_norm_off_is_unchanged():
+    """spectral_norm=False must reproduce the default update byte-for-byte and add no state."""
+    torch.manual_seed(0)
+    w1 = torch.nn.Parameter(torch.randn(24, 16))
+    w2 = torch.nn.Parameter(w1.detach().clone())
+    g = torch.randn(24, 16)
+    o1 = SinkGD([{"params": [w1], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                sinkgd_lr_scale=0.3)
+    o2 = SinkGD([{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                sinkgd_lr_scale=0.3, sinkgd_spectral_norm=False)
+    w1.grad = g.clone()
+    w2.grad = g.clone()
+    o1.step()
+    o2.step()
+    assert torch.equal(w1.detach(), w2.detach())
+    assert o2.state[w2] == {}
+
+
+@pytest.mark.parametrize("shape", [(64, 64), (96, 32), (32, 96)])
+def test_power_iteration_matches_matrix_2norm(shape):
+    """The persisted power iteration converges to torch.linalg.matrix_norm(U, 2)."""
+    torch.manual_seed(0)
+    m, n = shape
+    g = torch.randn(m, n)
+    u = sr_sinkhorn(g, iters=5, eps=1e-8)
+    true = torch.linalg.matrix_norm(u, 2).item()
+    vec = torch.randn(n)
+    vec /= vec.norm()
+    for _ in range(30):  # warm-started convergence over many steps
+        v = u @ vec
+        v /= v.norm()
+        vec = u.t() @ v
+        sig = vec.norm()
+        vec /= sig
+    assert sig.item() == pytest.approx(true, rel=1e-2)
+
+
+def test_spectral_norm_step_pins_operator_norm_and_persists_u():
+    """spectral_norm on: step runs, changes the param, persists the u vector as state."""
+    torch.manual_seed(0)
+    w = torch.nn.Parameter(torch.randn(24, 16))
+    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
+                 sinkgd_lr_scale=1.0, sinkgd_spectral_norm=True,
+                 sinkgd_spectral_norm_iters=3)
+    before = w.detach().clone()
+    for _ in range(4):
+        w.grad = torch.randn(24, 16)
+        opt.step()
+    assert not torch.allclose(before, w.detach())
+    assert opt.state[w]["specnorm_u"].shape == (16,)
+
+
+def test_spectral_specnorm_fn_rescales_to_target():
+    """The compiled spectral update drives ||U||_2 toward the requested target norm."""
+    torch.manual_seed(0)
+    m, n = 48, 32
+    p = torch.zeros(m, n)
+    u = torch.randn(n)
+    u /= u.norm()
+    # accumulate the update alone (p starts 0, lr=1, wd=0) over steps with a fixed grad so u warms
+    g = torch.randn(m, n)
+    target = (m / n) ** 0.5
+    for _ in range(20):
+        p.zero_()
+        single_param_sinkgd_specnorm(
+            p, g, u, torch.tensor(1.0), 0.0, 5, 1e-8, target, 2, False
+        )
+    # p = -lr * U_spectral ; its operator norm should be ~target
+    assert torch.linalg.matrix_norm(p, 2).item() == pytest.approx(target, rel=0.1)
+
+
+# ---- Feature A: config validation ---------------------------------------------------
+
+
+def test_pop_kwargs_casts_strings():
+    out = _pop_sinkgd_extra_kwargs(
+        {"sinkgd_spectral_norm": "true", "sinkgd_base_width": "256",
+         "sinkgd_spectral_norm_iters": "2", "sinkgd_lr_width_exponent": "1.0"}
+    )
+    assert out["sinkgd_spectral_norm"] is True
+    assert out["sinkgd_base_width"] == 256
+    assert out["sinkgd_spectral_norm_iters"] == 2
+    assert out["sinkgd_lr_width_exponent"] == 1.0
+
+
+def test_pop_kwargs_rejects_width_double_count():
+    """base_width (1/d_in) and spectral_target=muon both correct for width -> rejected."""
+    with pytest.raises(ValueError):
+        _pop_sinkgd_extra_kwargs(
+            {"sinkgd_spectral_norm": True, "sinkgd_spectral_target": "muon",
+             "sinkgd_base_width": 256}
+        )
+
+
+def test_pop_kwargs_rejects_bad_target():
+    with pytest.raises(ValueError):
+        _pop_sinkgd_extra_kwargs({"sinkgd_spectral_target": "bogus"})
+
+
+# ---- Feature A: sharded (FSDP2) spectral power iteration -----------------------------
+
+
+@pytest.mark.parametrize("shape", [(64, 48), (128, 32), (32, 128), (96, 96)])
+@pytest.mark.parametrize("shard_dim", [-2, -1])
+def test_sharded_gram_power_iteration_matches_spectral_norm(shape, shard_dim):
+    """The Gram-matrix partials (summed across shards, as the all-reduce does) recover the
+    global ``||U||_2`` — the math behind DistSinkGD's sharded spectral norm, verified here
+    without a real process group by emulating all_reduce as a local sum over row/col shards."""
+    torch.manual_seed(0)
+    m, n = shape
+    u_mat = sr_sinkhorn(torch.randn(m, n), iters=5, eps=1e-8)
+    true = torch.linalg.matrix_norm(u_mat, 2).item()
+    if shard_dim == -2:  # rows sharded -> iterate right vector in R^n
+        shards = list(u_mat.chunk(2, dim=0))
+        vec = torch.randn(n)
+        vec /= vec.norm()
+        helper = _specnorm_gram_rows
+    else:  # cols sharded -> iterate left vector in R^m
+        shards = list(u_mat.chunk(2, dim=1))
+        vec = torch.randn(m)
+        vec /= vec.norm()
+        helper = _specnorm_gram_cols
+    nrm = None
+    for _ in range(30):  # cold start; warm-started across steps in real use it converges fast
+        partial = sum(helper(s, vec) for s in shards)  # all_reduce == sum of shard partials
+        nrm = partial.norm()
+        vec = partial / nrm
+    assert nrm.sqrt().item() == pytest.approx(true, rel=1e-2)

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -325,7 +325,7 @@ def test_fused_spectral_matches_compiled(target):
         opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
                      lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_spectral_norm=True,
                      sinkgd_spectral_norm_iters=2, sinkgd_spectral_target=target,
-                     sinkgd_fused_kernel=fused)
+                     sinkgd_fused_kernel=fused, sinkgd_fused_min_numel=0)
         torch.manual_seed(7)  # same u init both paths
         for _ in range(3):
             w.grad = g.clone()
@@ -345,7 +345,8 @@ def test_fused_md_matches_compiled_and_stays_on_sphere():
     for fused in (False, True):
         w = torch.nn.Parameter(w0.clone())
         opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
-                       lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused)
+                       lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused,
+                       sinkgd_fused_min_numel=0)
         torch.manual_seed(7)
         for _ in range(3):
             w.grad = g.clone()
@@ -370,5 +371,22 @@ def test_fused_falls_back_for_stochastic_round():
 
 
 def test_pop_kwargs_casts_fused_flag():
-    out = _pop_sinkgd_extra_kwargs({"sinkgd_fused_kernel": "true"})
+    out = _pop_sinkgd_extra_kwargs(
+        {"sinkgd_fused_kernel": "true", "sinkgd_fused_min_numel": "1024"}
+    )
     assert out["sinkgd_fused_kernel"] is True
+    assert out["sinkgd_fused_min_numel"] == 1024
+
+
+@requires_cuda
+def test_fused_epilogue_size_gate():
+    """Single-device spec/md fused routing is size-gated (small matrices lose to the eager
+    epilogue overhead); base mode is not."""
+    w = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
+    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                 sinkgd_fused_kernel=True, sinkgd_spectral_norm=True)
+    assert opt._fused_ok(w) and not opt._fused_ok(w, epilogue=True)
+    opt0 = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
+                  sinkgd_fused_kernel=True, sinkgd_spectral_norm=True,
+                  sinkgd_fused_min_numel=0)
+    assert opt0._fused_ok(w, epilogue=True)

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -5,6 +5,7 @@ import torch
 
 from axolotl.utils.optimizers.sinkgd import (
     SinkGD,
+    SinkGDMD,
     _pop_sinkgd_extra_kwargs,
     _specnorm_gram_cols,
     _specnorm_gram_rows,
@@ -232,3 +233,52 @@ def test_sharded_gram_power_iteration_matches_spectral_norm(shape, shard_dim):
         nrm = partial.norm()
         vec = partial / nrm
     assert nrm.sqrt().item() == pytest.approx(true, rel=1e-2)
+
+
+# ---- A+B: SinkGDMD (MD Frobenius sphere) --------------------------------------------
+
+
+def test_sinkgdmd_keeps_weight_on_sphere():
+    """Every step reprojects the 2D weight onto its enable-time Frobenius sphere."""
+    torch.manual_seed(0)
+    w = torch.nn.Parameter(torch.randn(64, 48))
+    tn0 = w.detach().float().norm().item()
+    opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
+                   sinkgd_lr_scale=0.05)
+    for _ in range(8):
+        w.grad = torch.randn(64, 48)
+        opt.step()
+    assert w.detach().float().norm().item() == pytest.approx(tn0, rel=1e-4)
+    assert set(opt.state[w]) == {"md_target_norm", "specnorm_u"}
+
+
+def test_sinkgdmd_per_expert_sphere():
+    """3D fused-MoE weight: each expert stays on its own Frobenius sphere."""
+    torch.manual_seed(0)
+    w = torch.nn.Parameter(torch.randn(4, 32, 24))
+    tn = w.detach().float().norm(dim=(-2, -1)).clone()
+    opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
+                   sinkgd_lr_scale=0.1)
+    for _ in range(5):
+        w.grad = torch.randn(4, 32, 24)
+        opt.step()
+    after = w.detach().float().norm(dim=(-2, -1))
+    assert torch.allclose(after, tn, atol=1e-3)
+
+
+def test_sinkgdmd_moves_weight_and_uses_adam_fallback():
+    """MD changes the matrix; a 1D param still goes to the 8-bit AdamW fallback."""
+    torch.manual_seed(0)
+    w = torch.nn.Parameter(torch.randn(32, 16))
+    b = torch.nn.Parameter(torch.randn(32))
+    before = w.detach().clone()
+    opt = SinkGDMD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0},
+         {"params": [b], "use_sinkgd": False, "weight_decay": 0.0}],
+        lr=1e-2, sinkgd_lr_scale=1.0,
+    )
+    w.grad = torch.randn(32, 16)
+    b.grad = torch.randn(32)
+    opt.step()
+    assert not torch.allclose(before, w.detach())
+    assert "exp_avg" in opt.state[b]  # 1D param uses the Adam fallback

--- a/tests/utils/test_sinkgd.py
+++ b/tests/utils/test_sinkgd.py
@@ -111,10 +111,17 @@ def test_spectral_norm_off_is_unchanged():
     w1 = torch.nn.Parameter(torch.randn(24, 16))
     w2 = torch.nn.Parameter(w1.detach().clone())
     g = torch.randn(24, 16)
-    o1 = SinkGD([{"params": [w1], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                sinkgd_lr_scale=0.3)
-    o2 = SinkGD([{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                sinkgd_lr_scale=0.3, sinkgd_spectral_norm=False)
+    o1 = SinkGD(
+        [{"params": [w1], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_lr_scale=0.3,
+    )
+    o2 = SinkGD(
+        [{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_lr_scale=0.3,
+        sinkgd_spectral_norm=False,
+    )
     w1.grad = g.clone()
     w2.grad = g.clone()
     o1.step()
@@ -146,9 +153,13 @@ def test_spectral_norm_step_pins_operator_norm_and_persists_u():
     """spectral_norm on: step runs, changes the param, persists the u vector as state."""
     torch.manual_seed(0)
     w = torch.nn.Parameter(torch.randn(24, 16))
-    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
-                 sinkgd_lr_scale=1.0, sinkgd_spectral_norm=True,
-                 sinkgd_spectral_norm_iters=3)
+    opt = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0,
+        sinkgd_lr_scale=1.0,
+        sinkgd_spectral_norm=True,
+        sinkgd_spectral_norm_iters=3,
+    )
     before = w.detach().clone()
     for _ in range(4):
         w.grad = torch.randn(24, 16)
@@ -181,8 +192,12 @@ def test_spectral_specnorm_fn_rescales_to_target():
 
 def test_pop_kwargs_casts_strings():
     out = _pop_sinkgd_extra_kwargs(
-        {"sinkgd_spectral_norm": "true", "sinkgd_base_width": "256",
-         "sinkgd_spectral_norm_iters": "2", "sinkgd_lr_width_exponent": "1.0"}
+        {
+            "sinkgd_spectral_norm": "true",
+            "sinkgd_base_width": "256",
+            "sinkgd_spectral_norm_iters": "2",
+            "sinkgd_lr_width_exponent": "1.0",
+        }
     )
     assert out["sinkgd_spectral_norm"] is True
     assert out["sinkgd_base_width"] == 256
@@ -194,8 +209,11 @@ def test_pop_kwargs_rejects_width_double_count():
     """base_width (1/d_in) and spectral_target=muon both correct for width -> rejected."""
     with pytest.raises(ValueError):
         _pop_sinkgd_extra_kwargs(
-            {"sinkgd_spectral_norm": True, "sinkgd_spectral_target": "muon",
-             "sinkgd_base_width": 256}
+            {
+                "sinkgd_spectral_norm": True,
+                "sinkgd_spectral_target": "muon",
+                "sinkgd_base_width": 256,
+            }
         )
 
 
@@ -228,8 +246,12 @@ def test_sharded_gram_power_iteration_matches_spectral_norm(shape, shard_dim):
         vec /= vec.norm()
         helper = _specnorm_gram_cols
     nrm = None
-    for _ in range(30):  # cold start; warm-started across steps in real use it converges fast
-        partial = sum(helper(s, vec) for s in shards)  # all_reduce == sum of shard partials
+    for _ in range(
+        30
+    ):  # cold start; warm-started across steps in real use it converges fast
+        partial = sum(
+            helper(s, vec) for s in shards
+        )  # all_reduce == sum of shard partials
         nrm = partial.norm()
         vec = partial / nrm
     assert nrm.sqrt().item() == pytest.approx(true, rel=1e-2)
@@ -243,8 +265,11 @@ def test_sinkgdmd_keeps_weight_on_sphere():
     torch.manual_seed(0)
     w = torch.nn.Parameter(torch.randn(64, 48))
     tn0 = w.detach().float().norm().item()
-    opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
-                   sinkgd_lr_scale=0.05)
+    opt = SinkGDMD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0,
+        sinkgd_lr_scale=0.05,
+    )
     for _ in range(8):
         w.grad = torch.randn(64, 48)
         opt.step()
@@ -257,8 +282,11 @@ def test_sinkgdmd_per_expert_sphere():
     torch.manual_seed(0)
     w = torch.nn.Parameter(torch.randn(4, 32, 24))
     tn = w.detach().float().norm(dim=(-2, -1)).clone()
-    opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1.0,
-                   sinkgd_lr_scale=0.1)
+    opt = SinkGDMD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1.0,
+        sinkgd_lr_scale=0.1,
+    )
     for _ in range(5):
         w.grad = torch.randn(4, 32, 24)
         opt.step()
@@ -273,9 +301,12 @@ def test_sinkgdmd_moves_weight_and_uses_adam_fallback():
     b = torch.nn.Parameter(torch.randn(32))
     before = w.detach().clone()
     opt = SinkGDMD(
-        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0},
-         {"params": [b], "use_sinkgd": False, "weight_decay": 0.0}],
-        lr=1e-2, sinkgd_lr_scale=1.0,
+        [
+            {"params": [w], "use_sinkgd": True, "weight_decay": 0.0},
+            {"params": [b], "use_sinkgd": False, "weight_decay": 0.0},
+        ],
+        lr=1e-2,
+        sinkgd_lr_scale=1.0,
     )
     w.grad = torch.randn(32, 16)
     b.grad = torch.randn(32)
@@ -303,9 +334,13 @@ def test_fused_base_matches_compiled(shape):
     results = []
     for fused in (False, True):
         w = torch.nn.Parameter(w0.clone())
-        opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.01}],
-                     lr=1e-2, sinkgd_lr_scale=0.5, weight_decay=0.01,
-                     sinkgd_fused_kernel=fused)
+        opt = SinkGD(
+            [{"params": [w], "use_sinkgd": True, "weight_decay": 0.01}],
+            lr=1e-2,
+            sinkgd_lr_scale=0.5,
+            weight_decay=0.01,
+            sinkgd_fused_kernel=fused,
+        )
         w.grad = g.clone()
         opt.step()
         results.append(w.detach().float())
@@ -322,10 +357,16 @@ def test_fused_spectral_matches_compiled(target):
     results = []
     for fused in (False, True):
         w = torch.nn.Parameter(w0.clone())
-        opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
-                     lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_spectral_norm=True,
-                     sinkgd_spectral_norm_iters=2, sinkgd_spectral_target=target,
-                     sinkgd_fused_kernel=fused, sinkgd_fused_min_numel=0)
+        opt = SinkGD(
+            [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+            lr=1e-2,
+            sinkgd_lr_scale=0.5,
+            sinkgd_spectral_norm=True,
+            sinkgd_spectral_norm_iters=2,
+            sinkgd_spectral_target=target,
+            sinkgd_fused_kernel=fused,
+            sinkgd_fused_min_numel=0,
+        )
         torch.manual_seed(7)  # same u init both paths
         for _ in range(3):
             w.grad = g.clone()
@@ -344,9 +385,13 @@ def test_fused_md_matches_compiled_and_stays_on_sphere():
     results = []
     for fused in (False, True):
         w = torch.nn.Parameter(w0.clone())
-        opt = SinkGDMD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
-                       lr=1e-2, sinkgd_lr_scale=0.5, sinkgd_fused_kernel=fused,
-                       sinkgd_fused_min_numel=0)
+        opt = SinkGDMD(
+            [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+            lr=1e-2,
+            sinkgd_lr_scale=0.5,
+            sinkgd_fused_kernel=fused,
+            sinkgd_fused_min_numel=0,
+        )
         torch.manual_seed(7)
         for _ in range(3):
             w.grad = g.clone()
@@ -361,12 +406,19 @@ def test_fused_md_matches_compiled_and_stays_on_sphere():
 def test_fused_falls_back_for_stochastic_round():
     """bf16 stochastic rounding is not implemented in the fused kernels -> compiled path."""
     w = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
-    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                 sinkgd_fused_kernel=True, bf16_stochastic_round=True)
+    opt = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_fused_kernel=True,
+        bf16_stochastic_round=True,
+    )
     assert not opt._fused_ok(w)
     w2 = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
-    opt2 = SinkGD([{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                  sinkgd_fused_kernel=True)
+    opt2 = SinkGD(
+        [{"params": [w2], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_fused_kernel=True,
+    )
     assert opt2._fused_ok(w2)
 
 
@@ -383,10 +435,18 @@ def test_fused_epilogue_size_gate():
     """Single-device spec/md fused routing is size-gated (small matrices lose to the eager
     epilogue overhead); base mode is not."""
     w = torch.nn.Parameter(torch.randn(32, 16, device="cuda", dtype=torch.bfloat16))
-    opt = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                 sinkgd_fused_kernel=True, sinkgd_spectral_norm=True)
+    opt = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_fused_kernel=True,
+        sinkgd_spectral_norm=True,
+    )
     assert opt._fused_ok(w) and not opt._fused_ok(w, epilogue=True)
-    opt0 = SinkGD([{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}], lr=1e-2,
-                  sinkgd_fused_kernel=True, sinkgd_spectral_norm=True,
-                  sinkgd_fused_min_numel=0)
+    opt0 = SinkGD(
+        [{"params": [w], "use_sinkgd": True, "weight_decay": 0.0}],
+        lr=1e-2,
+        sinkgd_fused_kernel=True,
+        sinkgd_spectral_norm=True,
+        sinkgd_fused_min_numel=0,
+    )
     assert opt0._fused_ok(w, epilogue=True)


### PR DESCRIPTION
Builds on #3763. Adds two experimentally-validated optimizer axes to SinkGD plus an opt-in fused Triton path, all default-off — the default (all-flags-off) update is byte-identical to the shipped optimizer.

## Feature A: width transfer + spectral normalization

Width sweeps (tiny random-init Llama, d_model 256→2048, LR grids, coordinate checks) established that SinkGD's raw update is **Adam-class** (`η ∝ 1/d_in`), and that pinning the update's operator norm to `sqrt(d_out/d_in)` via power iteration converts it to Muon-class — which both transfers LR across width (flat optimum, lr≈2 at every width) and trains to 6–21% lower loss than the `1/d_in` rule at every width tested. It also bounds the deep-layer activation blow-up plain SinkGD shows at depth (peak residual RMS ~92 at 16 layers → ~18).

- `sinkgd_base_width` (+ `sinkgd_lr_width_exponent`): width-aware `alpha_eff = sinkgd_lr_scale * (base_width/d_in)**exp`. Unset → old scalar behavior.
- `sinkgd_spectral_norm` (+ `sinkgd_spectral_norm_iters`, `sinkgd_spectral_target: unit|muon`): warm-started power-iteration operator-norm rescale (~2 matvecs/layer, one O(d_in) state vector, +1–3% step time; ~free on B200).
- `sinkgd_base_width` + `spectral_target: muon` are two width corrections and double-count — rejected at construction.
- FSDP2: on rows-sharded weights the power iteration adds one small vector all-reduce per iteration over `dp_shard` (same shape/group as the existing Sinkhorn norm reduce); the matrix is never gathered; state round-trips through checkpoints.

## `sinkgd_md_sphere` (experimental): magnitude–direction weight sphere

The A+B combine from the study: each 2D weight held on its enable-time Frobenius sphere, SR-Sinkhorn direction update spectral-normalized to unit operator norm, analytic sphere projection (no learnable gains — SinkGD's row/col balancing makes them redundant, measured). Tightest deep-layer activation bound of any variant and wins at depth (16-layer loss 1.60 vs 1.73 spectral-only), but its optimal LR is width-dependent (`lr_opt ∝ d_model**-0.6`) with a narrow optimum → experimental, off by default, plain spectral norm is the recommended path. `SinkGDMD`/`DistSinkGDMD` subclasses; FSDP2 adds one per-matrix scalar all-reduce for the sphere norm.

## `sinkgd_fused_kernel` (opt-in): fused Triton path

One kernel per SR-Sinkhorn iteration replaces the compiled loop's ~4 passes (the column scale folds forward into the next kernel, the power-iteration vectors, and the apply; the MD projection uses the analytic Frobenius form). Auto tall/wide grid selection keeps both full matrices and heavily-sharded wide-short local shards occupied. Same all-reduce count as the compiled dist path. Falls back to the compiled path for cols-sharded (TP) dims, `bf16_stochastic_round`, missing Triton, and small single-device spec/md tensors (`sinkgd_fused_min_numel`). Numerics equivalent at bf16 rounding scale (scales carried fp32 end-to-end) but not byte-identical → off by default.

Optimizer-step speedups vs the compiled path (production classes, 7-matrix layer):

| | single GPU | 2-rank dist | 8-rank-equiv shards |
|---|---|---|---|
| B200 (sm_100) | 1.4–1.75× | 1.0–1.9× | 1.06–1.6× |
| H100 (sm_90) | 1.1–1.3× | **1.2–2.2×** | 1.4–1.8× |

Every mode × size × card cell measured ≥ ~1× after the size gate (H100 exposed a small-matrix spec/md epilogue regression that the larger-L2 cards hid; gated).

## Also in this PR

Two perf rounds on the compiled spectral/MD paths (bf16 tensor-core matvecs, final-column-scale folding, analytic sphere projection): isolated step overhead spectral +31%→+13%, MD +40%→+22%.

## Validation

- 36 unit + 12 FSDP2 (torchrun 2-rank) + builder + e2e tests; suites pass on sm_120 (RTX PRO 6000), sm_100 (2×B200), and sm_90 (2×H100).
- Fused-vs-compiled parity tests for all modes on square/wide/3D-expert shapes, single-device and DTensor-sharded, tall and wide kernel regimes; sphere invariance; fallback gating.
- Full experiment write-ups (phase results, LR-transfer sweeps, norm-growth studies, kernel regime maps, all bench tables) are in the study logs; happy to attach any table in more detail.

Papers: [SinkGD arXiv:2502.06742](https://arxiv.org/abs/2502.06742), [HP-transfer arXiv:2512.05620](https://arxiv.org/abs/2512.05620), [MD decoupling arXiv:2606.25971](https://arxiv.org/abs/2606.25971).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new SinkGD configuration options for spectral normalization, width-aware scaling, fused Triton execution, and an experimental sphere-based variant.
  * Expanded distributed optimizer support so these modes work across sharded and multi-GPU training setups.

* **Documentation**
  * Documented the new SinkGD options, including valid combinations and fallback behavior.

* **Tests**
  * Added unit and end-to-end coverage for the new SinkGD modes, configuration validation, and distributed/fused behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->