### PR TITLE
feat: selective activation checkpointing (save attention instead of recomputing)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,7 @@ jobs:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
       - uses: pre-commit/action@v3.0.1
+        env:
+          # check-cli-config-options needs an installed axolotl; the dedicated
+          # tests.yml step covers it in CI
+          SKIP: check-cli-config-options

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -34,7 +34,9 @@ jobs:
           cache: "pip" # caching pip dependencies
       - uses: pre-commit/action@v3.0.1
         env:
-          SKIP: no-commit-to-branch
+          # check-cli-config-options needs an installed axolotl; the dedicated
+          # tests.yml step covers it in CI
+          SKIP: no-commit-to-branch,check-cli-config-options
 
   prime-cdn-s3-cache:
     name: Prefetch S3 once to prime the CDN cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,9 @@ jobs:
           cache: "pip" # caching pip dependencies
       - uses: pre-commit/action@v3.0.1
         env:
-          SKIP: no-commit-to-branch
+          # check-cli-config-options needs an installed axolotl; the dedicated
+          # tests.yml step covers it in CI
+          SKIP: no-commit-to-branch,check-cli-config-options
 
   prime-cdn-s3-cache:
     name: Prefetch S3 once to prime the CDN cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,11 @@ repos:
             '--ini',
             '.bandit',
         ]
+-   repo: local
+    hooks:
+    -   id: check-cli-config-options
+        name: check generated CLI config options are up to date
+        entry: axolotl generate-cli-config-options --check
+        language: system
+        files: ^src/axolotl/(utils/schemas/.*\.py|cli/config_options\.py)$
+        pass_filenames: false

--- a/docs/gradient_checkpointing.qmd
+++ b/docs/gradient_checkpointing.qmd
@@ -78,15 +78,32 @@ selective_checkpointing:
 ```
 
 For hybrid models mixing full attention and sliding-window attention (SWA), only full-attention
-calls are saved by default — SWA is cheap to recompute and not worth the memory. This is
-discriminated via the flash-attention window arguments; under SDPA the window lives inside the
-attention mask, so hybrid layers cannot be told apart there. Set
-`selective_checkpointing.save_sliding_window: true` to save SWA calls too.
+calls are saved by default — SWA is cheap to recompute and not worth the memory. Hybrid layers are
+detected two ways: the flash-attention window arguments, and the model's `layer_types` (published
+per-layer via hooks, which also covers SDPA where the window lives inside the attention mask).
+Set `selective_checkpointing.save_sliding_window: true` to save SWA calls too, or override which
+layer types recompute with `selective_checkpointing.recompute_layer_types` (default
+`[sliding_attention, chunked_attention]`; linear-attention layers never dispatch a matchable
+attention op, so they need no entry).
+
+To offload the saved tensors to pinned CPU memory instead of keeping them on GPU — asynchronous
+side-stream copies during forward, prefetched back one region ahead during backward — set:
+
+```yaml
+selective_checkpointing:
+  save: [attention]
+  offload: true
+```
+
+This makes the saved attention outputs cost ~zero GPU memory at the price of CPU RAM and PCIe
+traffic, and stacks with `activation_offloading: hidden_states`.
 
 Requires non-reentrant checkpointing (the default). Composes with
-`activation_offloading: hidden_states`: layer inputs go to CPU while attention outputs stay on GPU.
-It is incompatible with the TRL-offloader modes (`true`/`legacy`/`disk`), which replace gradient
-checkpointing instead of running inside it.
+`activation_offloading: hidden_states`: layer inputs go to CPU while attention outputs are saved
+(on GPU, or on CPU with `offload: true`). It is incompatible with the TRL-offloader modes
+(`true`/`legacy`/`disk`), which replace gradient checkpointing instead of running inside it.
+Saving matmul ops (e.g. `aten::mm`) is rejected for LoRA/QLoRA runs: PEFT mutates the base linear
+output in-place, which invalidates cached tensors.
 
 ### Enabling Layer Offloading
 

--- a/docs/gradient_checkpointing.qmd
+++ b/docs/gradient_checkpointing.qmd
@@ -51,6 +51,43 @@ parallelism.
 `activation_offloading: true` can still be faster because adapter activations are smaller and pure offload
 avoids the recompute cost.
 
+### Selective Activation Checkpointing (SAC)
+
+```yaml
+gradient_checkpointing: true
+selective_checkpointing: true
+```
+
+Plain gradient checkpointing recomputes every op in a decoder layer during backward. Selective
+checkpointing keeps the recompute for cheap ops but *saves* the outputs of expensive ones — by
+default the attention op — so backward skips re-running them. At long context, attention dominates
+the recompute cost, so this recovers most of the checkpointing slowdown for one extra
+hidden-state-sized tensor per layer.
+
+This runs eagerly (no `torch.compile`) via torch's selective-checkpoint policy API. Ops are matched
+at the dispatcher level: SDPA and flash-attention are matched out of the box, and custom kernels
+that are not registered as torch ops are simply recomputed as usual — nothing breaks.
+
+The explicit form lets you save additional ops, matched as substrings of the qualified op name:
+
+```yaml
+selective_checkpointing:
+  save:
+    - attention
+    - aten::mm        # example: also save all matmuls
+```
+
+For hybrid models mixing full attention and sliding-window attention (SWA), only full-attention
+calls are saved by default — SWA is cheap to recompute and not worth the memory. This is
+discriminated via the flash-attention window arguments; under SDPA the window lives inside the
+attention mask, so hybrid layers cannot be told apart there. Set
+`selective_checkpointing.save_sliding_window: true` to save SWA calls too.
+
+Requires non-reentrant checkpointing (the default). Composes with
+`activation_offloading: hidden_states`: layer inputs go to CPU while attention outputs stay on GPU.
+It is incompatible with the TRL-offloader modes (`true`/`legacy`/`disk`), which replace gradient
+checkpointing instead of running inside it.
+
 ### Enabling Layer Offloading
 
 ```yaml

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2030,7 +2030,19 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ),
         "selective_checkpointing__save_sliding_window",
         None,
-        "In hybrid full/sliding-window attention models, also save sliding-window attention calls. Default false: SWA is cheap to recompute, so only full-attention calls are saved. Only discriminable with flash-attention (SDPA hides the window in the mask).",
+        "In hybrid full/sliding-window attention models, also save sliding-window attention calls. Default false: SWA is cheap to recompute, so only full-attention calls are saved.",
+    ),
+    (
+        ("--selective-checkpointing.recompute-layer-types",),
+        "selective_checkpointing__recompute_layer_types",
+        None,
+        "Layer types (config.layer_types values) whose attention is recomputed instead of saved. Defaults to ['sliding_attention', 'chunked_attention']. Ignored when save_sliding_window is true. Linear-attention layers never dispatch a matchable attention op, so they need no entry.",
+    ),
+    (
+        ("--selective-checkpointing.offload/--no-selective-checkpointing.offload",),
+        "selective_checkpointing__offload",
+        None,
+        "Offload saved tensors to pinned CPU memory (side-stream copies with backward prefetch) instead of keeping them on GPU.",
     ),
     (
         ("--activation-offloading",),

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2019,6 +2019,20 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         "Additional kwargs to pass to the trainer for gradient checkpointing",
     ),
     (
+        ("--selective-checkpointing.save",),
+        "selective_checkpointing__save",
+        None,
+        "Ops to save during forward instead of recomputing in backward. 'attention' matches SDPA and flash-attention forward ops; other entries are substring-matched against qualified torch op names (e.g. 'aten::mm').",
+    ),
+    (
+        (
+            "--selective-checkpointing.save-sliding-window/--no-selective-checkpointing.save-sliding-window",
+        ),
+        "selective_checkpointing__save_sliding_window",
+        None,
+        "In hybrid full/sliding-window attention models, also save sliding-window attention calls. Default false: SWA is cheap to recompute, so only full-attention calls are saved. Only discriminable with flash-attention (SDPA hides the window in the mask).",
+    ),
+    (
         ("--activation-offloading",),
         None,
         None,

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -251,6 +251,7 @@ class ModelLoader:
             self.model = self.model.merge_and_unload()
 
         self._configure_experts_implementation()
+        self._apply_selective_checkpointing()
         self._apply_activation_checkpointing()
         self._resize_token_embeddings()
         self._reinitialize_classification_head()
@@ -318,6 +319,23 @@ class ModelLoader:
                 )
 
         self.model.set_experts_implementation(impl)
+
+    def _apply_selective_checkpointing(self):
+        sac = self.cfg.selective_checkpointing
+        if not sac:
+            return
+
+        from axolotl.monkeypatch.selective_checkpointing import (
+            apply_selective_checkpointing,
+        )
+
+        save = sac.get("save") if isinstance(sac, dict) else None
+        save_sliding_window = (
+            bool(sac.get("save_sliding_window")) if isinstance(sac, dict) else False
+        )
+        apply_selective_checkpointing(
+            self.model, save=save, save_sliding_window=save_sliding_window
+        )
 
     def _apply_activation_checkpointing(self):
         ao = self.cfg.activation_offloading

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -329,12 +329,13 @@ class ModelLoader:
             apply_selective_checkpointing,
         )
 
-        save = sac.get("save") if isinstance(sac, dict) else None
-        save_sliding_window = (
-            bool(sac.get("save_sliding_window")) if isinstance(sac, dict) else False
-        )
+        sac_kwargs = sac if isinstance(sac, dict) else {}
         apply_selective_checkpointing(
-            self.model, save=save, save_sliding_window=save_sliding_window
+            self.model,
+            save=sac_kwargs.get("save"),
+            save_sliding_window=bool(sac_kwargs.get("save_sliding_window")),
+            recompute_layer_types=sac_kwargs.get("recompute_layer_types"),
+            offload=bool(sac_kwargs.get("offload")),
         )
 
     def _apply_activation_checkpointing(self):

--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -95,6 +95,9 @@ def _is_sliding_window_call(op: Any, args: tuple, kwargs: dict) -> bool:
     return False
 
 
+_RECOMPUTE_LAYER_TYPES = {"sliding_attention", "chunked_attention"}
+
+
 class SacPolicyState:
     """Bookkeeping shared across checkpoint regions for logging/diagnostics."""
 
@@ -103,6 +106,62 @@ class SacPolicyState:
         self.sliding_op_names: set[str] = set()
         self.regions_seen: int = 0
         self.warned_no_match: bool = False
+        # published by decoder-layer hooks; read by the policy. Hooks fire again
+        # during checkpoint recompute (on the autograd thread), so forward and
+        # replay see the same value.
+        self.current_layer_type: str | None = None
+
+
+def _layer_attention_type(module) -> str | None:
+    for obj in (
+        module,
+        getattr(module, "self_attn", None),
+        getattr(module, "attention", None),
+    ):
+        if obj is None:
+            continue
+        layer_type = getattr(obj, "layer_type", None)
+        if isinstance(layer_type, str):
+            return layer_type
+        if getattr(obj, "is_sliding", None) is True:
+            return "sliding_attention"
+    return None
+
+
+def install_layer_type_hooks(model, state: SacPolicyState) -> int:
+    """Publish each checkpointed decoder layer's attention type while it runs.
+
+    Lets the policy skip saving sliding/chunked-window attention in hybrid
+    models even under SDPA, where the window lives in the mask and cannot be
+    read off the op's arguments.
+    """
+    from transformers import GradientCheckpointingLayer
+
+    hooked = 0
+    if not hasattr(model, "modules"):
+        return hooked
+    for module in model.modules():
+        if not isinstance(module, GradientCheckpointingLayer):
+            continue
+        layer_type = _layer_attention_type(module)
+        if layer_type is None:
+            continue
+
+        def _set(mod, args, kwargs=None, _lt=layer_type):
+            state.current_layer_type = _lt
+
+        def _clear(mod, args, output):
+            state.current_layer_type = None
+
+        module.register_forward_pre_hook(_set)
+        module.register_forward_hook(_clear, always_call=True)
+        hooked += 1
+    if hooked:
+        LOG.info(
+            f"selective_checkpointing: layer-type hooks on {hooked} decoder layers "
+            "(sliding/chunked-window attention will be recomputed)"
+        )
+    return hooked
 
 
 def build_sac_policy(
@@ -142,6 +201,17 @@ def build_sac_policy(
     def policy_fn(ctx, op, *args, **kwargs):  # pylint: disable=unused-argument
         if _matches(op):
             name = _op_name(op)
+            if (
+                not save_sliding_window
+                and state.current_layer_type in _RECOMPUTE_LAYER_TYPES
+            ):
+                if name not in state.sliding_op_names:
+                    state.sliding_op_names.add(name)
+                    LOG.info(
+                        f"selective_checkpointing: recomputing `{name}` in "
+                        f"{state.current_layer_type} layers"
+                    )
+                return CheckpointPolicy.PREFER_RECOMPUTE
             if not save_sliding_window and _is_sliding_window_call(op, args, kwargs):
                 if name not in state.sliding_op_names:
                     state.sliding_op_names.add(name)
@@ -163,10 +233,12 @@ def build_sac_policy(
 
 
 def build_sac_context_fn(
-    save: list[str] | None = None, save_sliding_window: bool = False
+    save: list[str] | None = None,
+    save_sliding_window: bool = False,
+    state: SacPolicyState | None = None,
 ) -> Callable:
     """Return a ``context_fn`` for ``torch.utils.checkpoint.checkpoint``."""
-    state = SacPolicyState()
+    state = state or SacPolicyState()
     policy_fn = build_sac_policy(save, state, save_sliding_window)
 
     def context_fn():
@@ -201,7 +273,10 @@ def apply_selective_checkpointing(
     if getattr(model.gradient_checkpointing_enable, "_axolotl_sac", False):
         return
 
-    context_fn = build_sac_context_fn(save, save_sliding_window)
+    state = SacPolicyState()
+    if not save_sliding_window:
+        install_layer_type_hooks(model, state)
+    context_fn = build_sac_context_fn(save, save_sliding_window, state)
     orig_enable = model.gradient_checkpointing_enable
 
     def enable_with_sac(gradient_checkpointing_kwargs=None, **kwargs):

--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -1,0 +1,218 @@
+"""Eager selective activation checkpointing (SAC): save chosen ops instead of recomputing.
+
+Uses ``torch.utils.checkpoint.create_selective_checkpoint_contexts`` (no torch.compile).
+Ops are matched at the dispatcher level, so custom kernels that are not registered as
+torch ops are simply recomputed as usual — only ops we want to *save* need to be
+dispatcher-visible.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import torch
+from torch.utils.checkpoint import (
+    CheckpointPolicy,
+    create_selective_checkpoint_contexts,
+)
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+ATTENTION_GROUP = "attention"
+
+_ATEN_ATTENTION_PACKETS = (
+    "_scaled_dot_product_flash_attention",
+    "_scaled_dot_product_efficient_attention",
+    "_scaled_dot_product_cudnn_attention",
+    "_scaled_dot_product_flash_attention_for_cpu",
+)
+
+# regions to observe before warning that no op ever matched the save policy
+_NO_MATCH_WARN_REGIONS = 64
+
+
+def _aten_attention_ops() -> set:
+    ops = set()
+    for packet_name in _ATEN_ATTENTION_PACKETS:
+        packet = getattr(torch.ops.aten, packet_name, None)
+        if packet is not None:
+            ops.add(packet.default)
+    return ops
+
+
+def _op_name(op: Any) -> str:
+    try:
+        return op.name()
+    except (AttributeError, TypeError):
+        return getattr(op, "__name__", str(op))
+
+
+def _is_flash_attention_forward(name: str) -> bool:
+    lowered = name.lower()
+    if "flash_attn" not in lowered and "flash_attention" not in lowered:
+        return False
+    if "backward" in lowered or "bwd" in lowered:
+        return False
+    return True
+
+
+# a bounded LEFT context is what defines SWA; a bounded right side alone can
+# just encode causality, so only window_size_left is inspected
+_WINDOW_ARG_NAME = "window_size_left"
+_window_arg_cache: dict[Any, int | None] = {}
+
+
+def _window_arg_index(op: Any) -> int | None:
+    """Schema position of the sliding-window arg, or None if the op has none."""
+    if op in _window_arg_cache:
+        return _window_arg_cache[op]
+    index: int | None = None
+    schema = getattr(op, "_schema", None)
+    if schema is not None:
+        for i, arg in enumerate(schema.arguments):
+            if arg.name == _WINDOW_ARG_NAME:
+                index = i
+                break
+    _window_arg_cache[op] = index
+    return index
+
+
+def _is_sliding_window_call(op: Any, args: tuple, kwargs: dict) -> bool:
+    """True when a flash-attention call is bounded by a sliding window.
+
+    flash-attn uses -1 for an unbounded side, so a non-negative window arg
+    means SWA. SDPA carries the window only inside the attention mask, so
+    hybrid models running through SDPA cannot be discriminated here.
+    """
+    val = kwargs.get(_WINDOW_ARG_NAME)
+    if isinstance(val, int):
+        return val >= 0
+    index = _window_arg_index(op)
+    if index is not None and index < len(args) and isinstance(args[index], int):
+        return args[index] >= 0
+    return False
+
+
+class SacPolicyState:
+    """Bookkeeping shared across checkpoint regions for logging/diagnostics."""
+
+    def __init__(self) -> None:
+        self.saved_op_names: set[str] = set()
+        self.sliding_op_names: set[str] = set()
+        self.regions_seen: int = 0
+        self.warned_no_match: bool = False
+
+
+def build_sac_policy(
+    save: list[str] | None = None,
+    state: SacPolicyState | None = None,
+    save_sliding_window: bool = False,
+) -> Callable:
+    """Build an eager SAC policy_fn: MUST_SAVE for matching ops, PREFER_RECOMPUTE otherwise.
+
+    ``save`` entries are either the ``"attention"`` group or substrings matched
+    against the qualified op name (e.g. ``"aten::mm"``). Unless
+    ``save_sliding_window`` is set, hybrid-model attention calls bounded by a
+    sliding window keep being recomputed — SWA is cheap and not worth the saved
+    memory; only full-attention calls are saved.
+    """
+    save = save or [ATTENTION_GROUP]
+    state = state or SacPolicyState()
+
+    exact_ops: set = set()
+    substrings: list[str] = []
+    match_flash_attention = False
+    for spec in save:
+        if spec == ATTENTION_GROUP:
+            exact_ops |= _aten_attention_ops()
+            match_flash_attention = True
+        else:
+            substrings.append(spec)
+
+    def _matches(op: Any) -> bool:
+        if op in exact_ops:
+            return True
+        name = _op_name(op)
+        if match_flash_attention and _is_flash_attention_forward(name):
+            return True
+        return any(sub in name for sub in substrings)
+
+    def policy_fn(ctx, op, *args, **kwargs):  # pylint: disable=unused-argument
+        if _matches(op):
+            name = _op_name(op)
+            if not save_sliding_window and _is_sliding_window_call(op, args, kwargs):
+                if name not in state.sliding_op_names:
+                    state.sliding_op_names.add(name)
+                    LOG.info(
+                        f"selective_checkpointing: recomputing sliding-window "
+                        f"calls of `{name}` (save_sliding_window: false)"
+                    )
+                return CheckpointPolicy.PREFER_RECOMPUTE
+            if name not in state.saved_op_names:
+                state.saved_op_names.add(name)
+                LOG.info(
+                    f"selective_checkpointing: saving `{name}` "
+                    "(backward will not recompute it)"
+                )
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return policy_fn
+
+
+def build_sac_context_fn(
+    save: list[str] | None = None, save_sliding_window: bool = False
+) -> Callable:
+    """Return a ``context_fn`` for ``torch.utils.checkpoint.checkpoint``."""
+    state = SacPolicyState()
+    policy_fn = build_sac_policy(save, state, save_sliding_window)
+
+    def context_fn():
+        state.regions_seen += 1
+        if (
+            not state.saved_op_names
+            and not state.warned_no_match
+            and state.regions_seen >= _NO_MATCH_WARN_REGIONS
+        ):
+            state.warned_no_match = True
+            LOG.warning(
+                f"selective_checkpointing: no op matched the save policy after "
+                f"{state.regions_seen} checkpoint regions. Your attention "
+                "implementation may not be dispatcher-visible (e.g. a custom "
+                "kernel not registered via torch.library); everything is being "
+                "recomputed as with plain gradient checkpointing."
+            )
+        return create_selective_checkpoint_contexts(policy_fn)
+
+    return context_fn
+
+
+def apply_selective_checkpointing(
+    model, save: list[str] | None = None, save_sliding_window: bool = False
+) -> None:
+    """Wrap ``model.gradient_checkpointing_enable`` to inject the SAC ``context_fn``.
+
+    Wrapping the instance method covers every enable call site (axolotl's model
+    loader, HF Trainer at train() time, PEFT's kbit prep) without placing a
+    non-serializable callable into ``TrainingArguments``.
+    """
+    if getattr(model.gradient_checkpointing_enable, "_axolotl_sac", False):
+        return
+
+    context_fn = build_sac_context_fn(save, save_sliding_window)
+    orig_enable = model.gradient_checkpointing_enable
+
+    def enable_with_sac(gradient_checkpointing_kwargs=None, **kwargs):
+        gc_kwargs = dict(gradient_checkpointing_kwargs or {})
+        gc_kwargs["use_reentrant"] = False
+        gc_kwargs["context_fn"] = context_fn
+        return orig_enable(gradient_checkpointing_kwargs=gc_kwargs, **kwargs)
+
+    enable_with_sac._axolotl_sac = True
+    model.gradient_checkpointing_enable = enable_with_sac
+    LOG.info(
+        "selective_checkpointing enabled: "
+        f"save={save or [ATTENTION_GROUP]} (eager SAC, non-reentrant)"
+    )

--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -95,7 +95,7 @@ def _is_sliding_window_call(op: Any, args: tuple, kwargs: dict) -> bool:
     return False
 
 
-_RECOMPUTE_LAYER_TYPES = {"sliding_attention", "chunked_attention"}
+DEFAULT_RECOMPUTE_LAYER_TYPES = ("sliding_attention", "chunked_attention")
 
 
 class SacPolicyState:
@@ -168,6 +168,7 @@ def build_sac_policy(
     save: list[str] | None = None,
     state: SacPolicyState | None = None,
     save_sliding_window: bool = False,
+    recompute_layer_types: list[str] | None = None,
 ) -> Callable:
     """Build an eager SAC policy_fn: MUST_SAVE for matching ops, PREFER_RECOMPUTE otherwise.
 
@@ -179,6 +180,15 @@ def build_sac_policy(
     """
     save = save or [ATTENTION_GROUP]
     state = state or SacPolicyState()
+    skip_layer_types = (
+        set()
+        if save_sliding_window
+        else set(
+            DEFAULT_RECOMPUTE_LAYER_TYPES
+            if recompute_layer_types is None
+            else recompute_layer_types
+        )
+    )
 
     exact_ops: set = set()
     substrings: list[str] = []
@@ -201,10 +211,7 @@ def build_sac_policy(
     def policy_fn(ctx, op, *args, **kwargs):  # pylint: disable=unused-argument
         if _matches(op):
             name = _op_name(op)
-            if (
-                not save_sliding_window
-                and state.current_layer_type in _RECOMPUTE_LAYER_TYPES
-            ):
+            if state.current_layer_type in skip_layer_types:
                 if name not in state.sliding_op_names:
                     state.sliding_op_names.add(name)
                     LOG.info(
@@ -236,10 +243,13 @@ def build_sac_context_fn(
     save: list[str] | None = None,
     save_sliding_window: bool = False,
     state: SacPolicyState | None = None,
+    recompute_layer_types: list[str] | None = None,
 ) -> Callable:
     """Return a ``context_fn`` for ``torch.utils.checkpoint.checkpoint``."""
     state = state or SacPolicyState()
-    policy_fn = build_sac_policy(save, state, save_sliding_window)
+    policy_fn = build_sac_policy(
+        save, state, save_sliding_window, recompute_layer_types
+    )
 
     def context_fn():
         state.regions_seen += 1
@@ -262,7 +272,11 @@ def build_sac_context_fn(
 
 
 def apply_selective_checkpointing(
-    model, save: list[str] | None = None, save_sliding_window: bool = False
+    model,
+    save: list[str] | None = None,
+    save_sliding_window: bool = False,
+    recompute_layer_types: list[str] | None = None,
+    offload: bool = False,
 ) -> None:
     """Wrap ``model.gradient_checkpointing_enable`` to inject the SAC ``context_fn``.
 
@@ -274,9 +288,32 @@ def apply_selective_checkpointing(
         return
 
     state = SacPolicyState()
-    if not save_sliding_window:
+    skip_layer_types = (
+        set()
+        if save_sliding_window
+        else set(
+            DEFAULT_RECOMPUTE_LAYER_TYPES
+            if recompute_layer_types is None
+            else recompute_layer_types
+        )
+    )
+    if skip_layer_types:
         install_layer_type_hooks(model, state)
-    context_fn = build_sac_context_fn(save, save_sliding_window, state)
+    if offload:
+        from axolotl.monkeypatch.selective_checkpointing_offload import (
+            build_sac_offload_context_fn,
+        )
+
+        context_fn = build_sac_offload_context_fn(
+            save,
+            save_sliding_window,
+            state,
+            recompute_layer_types=recompute_layer_types,
+        )
+    else:
+        context_fn = build_sac_context_fn(
+            save, save_sliding_window, state, recompute_layer_types
+        )
     orig_enable = model.gradient_checkpointing_enable
 
     def enable_with_sac(gradient_checkpointing_kwargs=None, **kwargs):

--- a/src/axolotl/monkeypatch/selective_checkpointing_offload.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing_offload.py
@@ -1,0 +1,347 @@
+"""Phase-2 selective checkpointing: CPU-offload the SAC-saved tensors.
+
+Replaces torch's SAC caching/cached dispatch modes with variants that move
+MUST_SAVE outputs to pinned CPU memory on a side stream during forward and
+stream them back during backward with one-region-lookahead prefetch. Saved
+attention outputs then cost ~zero GPU memory.
+
+Mutation caveat: an offloaded tensor is a snapshot at pack time; in-place
+mutation of the original after the save cannot be detected (torch's version
+guard only covers non-offloaded leaves). The known mutating case — PEFT's
+in-place adapter add on matmul outputs — is rejected at config validation.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_map
+from torch.utils.checkpoint import (
+    SAC_IGNORED_OPS,
+    CheckpointPolicy,
+    SelectiveCheckpointContext,
+    _maybe_detach,
+    _policy_from_bool,
+    _VersionWrapper,
+)
+
+from axolotl.monkeypatch.selective_checkpointing import (
+    SacPolicyState,
+    build_sac_policy,
+)
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+_SAVE_POLICIES = (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE)
+
+_BufferKey = tuple[tuple[int, ...], tuple[int, ...], torch.dtype, torch.layout]
+
+
+@dataclass
+class _OffloadRef:
+    region_id: int
+    device: torch.device
+    size: torch.Size
+    stride: tuple[int, ...]
+    storage_offset: int
+    buffer_key: _BufferKey
+    cpu_tensor: torch.Tensor | None = None
+    gpu_tensor: torch.Tensor | None = None
+    restore_event: torch.cuda.Event | None = None
+
+
+@dataclass
+class SacOffloadStats:
+    offloaded_tensors: int = 0
+    offloaded_bytes: int = 0
+    restored_tensors: int = 0
+    logged: bool = field(default=False, repr=False)
+
+
+class SacOffloadEngine:
+    """Pinned-pool, side-stream D2H/H2D engine for SAC-saved tensors."""
+
+    def __init__(
+        self,
+        min_offload_bytes: int = 1 << 20,
+        max_fwd_stash_size: int = 2,
+        max_cpu_buffer_pool_size: int = 128,
+    ) -> None:
+        self.min_offload_bytes = min_offload_bytes
+        self.max_fwd_stash_size = max_fwd_stash_size
+        self.max_cpu_buffer_pool_size = max_cpu_buffer_pool_size
+        self.stats = SacOffloadStats()
+
+        self.s0 = torch.cuda.current_stream() if torch.cuda.is_available() else None
+        self.s1 = torch.cuda.Stream() if torch.cuda.is_available() else None
+
+        self._pack_seq = 0
+        self._fwd_stash: dict[int, tuple[torch.Tensor, torch.cuda.Event]] = {}
+        self._regions: dict[int, list[_OffloadRef]] = defaultdict(list)
+        self._cpu_pool: dict[_BufferKey, list[torch.Tensor]] = {}
+        self._cpu_pool_size = 0
+        self._pending_cpu_buffers: list[
+            tuple[_BufferKey, torch.Tensor, torch.cuda.Event]
+        ] = []
+
+    @property
+    def compute_stream(self):
+        return torch.cuda.current_stream()
+
+    def should_offload(self, tensor: torch.Tensor) -> bool:
+        return (
+            tensor.device.type == "cuda"
+            and tensor.element_size() * tensor.nelement() >= self.min_offload_bytes
+            and not isinstance(tensor, torch.nn.Parameter)
+        )
+
+    def _buffer_key(self, tensor: torch.Tensor) -> _BufferKey:
+        return (
+            tuple(tensor.size()),
+            tuple(tensor.stride()),
+            tensor.dtype,
+            tensor.layout,
+        )
+
+    def _pool_cpu_buffer(self, key: _BufferKey, tensor: torch.Tensor) -> None:
+        if self._cpu_pool_size >= self.max_cpu_buffer_pool_size:
+            return
+        self._cpu_pool.setdefault(key, []).append(tensor)
+        self._cpu_pool_size += 1
+
+    def _reap_pending_cpu_buffers(self) -> None:
+        pending = self._pending_cpu_buffers
+        self._pending_cpu_buffers = []
+        for key, tensor, event in pending:
+            if event.query():
+                self._pool_cpu_buffer(key, tensor)
+            else:
+                self._pending_cpu_buffers.append((key, tensor, event))
+
+    def _empty_pinned_like(
+        self, tensor: torch.Tensor
+    ) -> tuple[torch.Tensor, _BufferKey]:
+        self._reap_pending_cpu_buffers()
+        key = self._buffer_key(tensor)
+        pool = self._cpu_pool.get(key)
+        if pool:
+            self._cpu_pool_size -= 1
+            return pool.pop(), key
+        return (
+            torch.empty_strided(
+                tuple(tensor.size()),
+                tuple(tensor.stride()),
+                dtype=tensor.dtype,
+                layout=tensor.layout,
+                device="cpu",
+                pin_memory=True,
+            ),
+            key,
+        )
+
+    def _reap_fwd_stash(self, new_seq: int) -> None:
+        compute = self.compute_stream
+        for seq in list(self._fwd_stash):
+            if seq > new_seq - self.max_fwd_stash_size:
+                continue
+            _, event = self._fwd_stash.pop(seq)
+            compute.wait_event(event)
+
+    def pack(self, tensor: torch.Tensor, region_id: int) -> _OffloadRef:
+        self._pack_seq += 1
+        self._reap_fwd_stash(self._pack_seq)
+
+        compute = self.compute_stream
+        self.s1.wait_stream(compute)
+        with torch.cuda.stream(self.s1):
+            cpu_tensor, key = self._empty_pinned_like(tensor)
+            cpu_tensor.copy_(tensor, non_blocking=True)
+        event = self.s1.record_event()
+        self._fwd_stash[self._pack_seq] = (tensor, event)
+
+        ref = _OffloadRef(
+            region_id=region_id,
+            device=tensor.device,
+            size=tensor.size(),
+            stride=tuple(tensor.stride()),
+            storage_offset=tensor.storage_offset(),
+            buffer_key=key,
+            cpu_tensor=cpu_tensor,
+        )
+        self._regions[region_id].append(ref)
+        self.stats.offloaded_tensors += 1
+        self.stats.offloaded_bytes += tensor.element_size() * tensor.nelement()
+        return ref
+
+    def _start_restore(self, ref: _OffloadRef) -> None:
+        if ref.gpu_tensor is not None or ref.cpu_tensor is None:
+            return
+        with torch.cuda.stream(self.s1):
+            gpu_tensor = ref.cpu_tensor.to(ref.device, non_blocking=True)
+            if (
+                gpu_tensor.storage_offset() != ref.storage_offset
+                or gpu_tensor.stride() != ref.stride
+            ):
+                gpu_tensor = torch.as_strided(
+                    gpu_tensor, ref.size, ref.stride, ref.storage_offset
+                )
+        ref.gpu_tensor = gpu_tensor
+        ref.restore_event = self.s1.record_event()
+
+    def prefetch_region(self, region_id: int) -> None:
+        for ref in self._regions.get(region_id, []):
+            self._start_restore(ref)
+
+    def restore(self, ref: _OffloadRef) -> torch.Tensor:
+        if ref.gpu_tensor is None:
+            self._start_restore(ref)
+        compute = self.compute_stream
+        compute.wait_event(ref.restore_event)
+        gpu_tensor = ref.gpu_tensor
+        gpu_tensor.record_stream(compute)
+
+        self._pending_cpu_buffers.append(
+            (ref.buffer_key, ref.cpu_tensor, ref.restore_event)
+        )
+        ref.cpu_tensor = None
+        ref.gpu_tensor = None
+
+        region = self._regions.get(ref.region_id)
+        if region is not None:
+            try:
+                region.remove(ref)
+            except ValueError:
+                pass
+            if not region:
+                self._regions.pop(ref.region_id, None)
+
+        self.stats.restored_tensors += 1
+        return gpu_tensor
+
+    def log_once(self) -> None:
+        if self.stats.logged or not self.stats.offloaded_tensors:
+            return
+        self.stats.logged = True
+        LOG.info(
+            "selective_checkpointing offload: "
+            f"{self.stats.offloaded_tensors} tensors "
+            f"({self.stats.offloaded_bytes / 2**30:.2f} GiB) offloaded to CPU "
+            "in the first forward"
+        )
+
+
+class _OffloadCachingMode(TorchDispatchMode):
+    def __init__(self, policy_fn, storage, engine, region_id):
+        self.policy_fn = policy_fn
+        self.storage = storage
+        self.engine = engine
+        self.region_id = region_id
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = {} if kwargs is None else kwargs
+        if func in SAC_IGNORED_OPS:
+            return func(*args, **kwargs)
+
+        out = func(*args, **kwargs)
+
+        if isinstance(func, torch._ops.HigherOrderOperator):
+            any_ret_has_alias_info = False
+        else:
+            any_ret_has_alias_info = any(
+                ret.alias_info is not None for ret in func._schema.returns
+            )
+
+        policy = self.policy_fn(
+            SelectiveCheckpointContext(is_recompute=False), func, *args, **kwargs
+        )
+        if isinstance(policy, bool):
+            policy = _policy_from_bool(policy)
+
+        if policy in _SAVE_POLICIES:
+
+            def pack_leaf(leaf):
+                detached = _maybe_detach(leaf, any_ret_has_alias_info)
+                if torch.is_tensor(detached) and self.engine.should_offload(detached):
+                    return self.engine.pack(detached, self.region_id)
+                return _VersionWrapper(detached)
+
+            self.storage[func].append(tree_map(pack_leaf, out))
+        return out
+
+
+class _OffloadCachedMode(TorchDispatchMode):
+    def __init__(self, policy_fn, storage, engine, region_id):
+        self.policy_fn = policy_fn
+        self.storage = storage
+        self.engine = engine
+        self.region_id = region_id
+
+    def __enter__(self):
+        # recompute of this region is starting: bring its tensors back and
+        # prefetch the next region backward will need
+        self.engine.prefetch_region(self.region_id)
+        if self.region_id > 0:
+            self.engine.prefetch_region(self.region_id - 1)
+        self.engine.log_once()
+        return super().__enter__()
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = {} if kwargs is None else kwargs
+        if func in SAC_IGNORED_OPS:
+            return func(*args, **kwargs)
+
+        policy = self.policy_fn(
+            SelectiveCheckpointContext(is_recompute=True), func, *args, **kwargs
+        )
+        if isinstance(policy, bool):
+            policy = _policy_from_bool(policy)
+
+        if policy in _SAVE_POLICIES:
+            entries = self.storage.get(func)
+            if not entries:
+                raise RuntimeError(
+                    f"selective_checkpointing offload: {func} encountered during "
+                    "recompute but nothing was saved for it (or an extra backward "
+                    "was attempted)"
+                )
+
+            def unpack_leaf(leaf):
+                if isinstance(leaf, _OffloadRef):
+                    return self.engine.restore(leaf)
+                if isinstance(leaf, _VersionWrapper):
+                    return leaf.get_val(False)
+                return leaf
+
+            return tree_map(unpack_leaf, entries.pop(0))
+        return func(*args, **kwargs)
+
+
+def build_sac_offload_context_fn(
+    save: list[str] | None = None,
+    save_sliding_window: bool = False,
+    state: SacPolicyState | None = None,
+    engine: SacOffloadEngine | None = None,
+    recompute_layer_types: list[str] | None = None,
+) -> Callable:
+    """Return a ``context_fn`` whose MUST_SAVE tensors are offloaded to CPU."""
+    state = state or SacPolicyState()
+    engine = engine or SacOffloadEngine()
+    policy_fn = build_sac_policy(
+        save, state, save_sliding_window, recompute_layer_types
+    )
+
+    def context_fn():
+        region_id = state.regions_seen
+        state.regions_seen += 1
+        storage: dict[Any, list[Any]] = defaultdict(list)
+        return (
+            _OffloadCachingMode(policy_fn, storage, engine, region_id),
+            _OffloadCachedMode(policy_fn, storage, engine, region_id),
+        )
+
+    return context_fn

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -60,7 +60,11 @@ from axolotl.utils.schemas.model import (
 from axolotl.utils.schemas.multimodal import MultiModalConfig
 from axolotl.utils.schemas.peft import LoraConfig, ReLoRAConfig
 from axolotl.utils.schemas.quantization import PTQConfig, QATConfig
-from axolotl.utils.schemas.training import HyperparametersConfig, JaggedLRConfig
+from axolotl.utils.schemas.training import (
+    HyperparametersConfig,
+    JaggedLRConfig,
+    SelectiveCheckpointingConfig,
+)
 from axolotl.utils.schemas.trl import TRLConfig
 from axolotl.utils.schemas.validation import ValidationMixin
 from axolotl.utils.schemas.vllm import VllmConfig
@@ -602,6 +606,17 @@ class AxolotlInputConfig(
         default=None,
         json_schema_extra={
             "description": "Additional kwargs to pass to the trainer for gradient checkpointing"
+        },
+    )
+    selective_checkpointing: SelectiveCheckpointingConfig | bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Selective activation checkpointing: within each gradient-checkpointed "
+                "layer, save the listed ops during forward instead of recomputing them "
+                "in backward. `true` saves attention (SDPA/flash-attention). Requires "
+                "gradient_checkpointing with non-reentrant checkpointing."
+            )
         },
     )
     activation_offloading: Literal["legacy", "disk", "hidden_states"] | bool | None = (

--- a/src/axolotl/utils/schemas/training.py
+++ b/src/axolotl/utils/schemas/training.py
@@ -38,9 +38,28 @@ class SelectiveCheckpointingConfig(BaseModel):
             "description": (
                 "In hybrid full/sliding-window attention models, also save "
                 "sliding-window attention calls. Default false: SWA is cheap to "
-                "recompute, so only full-attention calls are saved. Only "
-                "discriminable with flash-attention (SDPA hides the window in the "
-                "mask)."
+                "recompute, so only full-attention calls are saved."
+            )
+        },
+    )
+    recompute_layer_types: list[str] | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": (
+                "Layer types (config.layer_types values) whose attention is "
+                "recomputed instead of saved. Defaults to ['sliding_attention', "
+                "'chunked_attention']. Ignored when save_sliding_window is true. "
+                "Linear-attention layers never dispatch a matchable attention op, "
+                "so they need no entry."
+            )
+        },
+    )
+    offload: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": (
+                "Offload saved tensors to pinned CPU memory (side-stream copies "
+                "with backward prefetch) instead of keeping them on GPU."
             )
         },
     )

--- a/src/axolotl/utils/schemas/training.py
+++ b/src/axolotl/utils/schemas/training.py
@@ -18,6 +18,34 @@ class LrGroup(BaseModel):
     lr: float
 
 
+class SelectiveCheckpointingConfig(BaseModel):
+    """Selective activation checkpointing (SAC) configuration"""
+
+    save: list[str] = Field(
+        default_factory=lambda: ["attention"],
+        json_schema_extra={
+            "description": (
+                "Ops to save during forward instead of recomputing in backward. "
+                "'attention' matches SDPA and flash-attention forward ops; other "
+                "entries are substring-matched against qualified torch op names "
+                "(e.g. 'aten::mm')."
+            )
+        },
+    )
+    save_sliding_window: bool = Field(
+        default=False,
+        json_schema_extra={
+            "description": (
+                "In hybrid full/sliding-window attention models, also save "
+                "sliding-window attention calls. Default false: SWA is cheap to "
+                "recompute, so only full-attention calls are saved. Only "
+                "discriminable with flash-attention (SDPA hides the window in the "
+                "mask)."
+            )
+        },
+    )
+
+
 class HyperparametersConfig(BaseModel):
     """Training hyperparams configuration subset"""
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1468,6 +1468,23 @@ class ModelCompatibilityValidationMixin:
                 "activation_offloading: hidden_states (or false); the TRL offloader "
                 "paths bypass HF gradient checkpointing"
             )
+        if self.adapter:
+            # PEFT adds the adapter delta into the base linear output in-place,
+            # mutating cached mm outputs; SAC's cache-mutation guard errors at runtime
+            matmul_ops = ("aten::mm", "aten::addmm", "aten::matmul", "aten::bmm")
+            bad = [
+                spec
+                for spec in self.selective_checkpointing.save
+                if spec != "attention" and any(spec in op for op in matmul_ops)
+            ]
+            if bad:
+                raise ValueError(
+                    f"selective_checkpointing.save entries {bad} match matmul ops, "
+                    "which cannot be saved when training with a LoRA/QLoRA adapter: "
+                    "PEFT mutates the base linear output in-place to add the adapter "
+                    "delta, which invalidates the cached tensor. Use save: [attention] "
+                    "or train without an adapter."
+                )
         if self.torch_compile:
             LOG.warning(
                 "selective_checkpointing with torch_compile is untested in axolotl; "

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1447,6 +1447,35 @@ class ModelCompatibilityValidationMixin:
         return self
 
     @model_validator(mode="after")
+    def check_selective_checkpointing(self):
+        if not self.selective_checkpointing:
+            self.selective_checkpointing = None
+            return self
+        if self.selective_checkpointing is True:
+            from axolotl.utils.schemas.training import SelectiveCheckpointingConfig
+
+            self.selective_checkpointing = SelectiveCheckpointingConfig()
+        if not self.gradient_checkpointing:
+            raise ValueError("selective_checkpointing requires gradient_checkpointing")
+        if (self.gradient_checkpointing_kwargs or {}).get("use_reentrant"):
+            raise ValueError(
+                "selective_checkpointing requires non-reentrant checkpointing "
+                "(gradient_checkpointing_kwargs.use_reentrant: false)"
+            )
+        if self.activation_offloading and self.activation_offloading != "hidden_states":
+            raise ValueError(
+                "selective_checkpointing is only compatible with "
+                "activation_offloading: hidden_states (or false); the TRL offloader "
+                "paths bypass HF gradient checkpointing"
+            )
+        if self.torch_compile:
+            LOG.warning(
+                "selective_checkpointing with torch_compile is untested in axolotl; "
+                "the SAC context_fn targets the eager checkpointing path"
+            )
+        return self
+
+    @model_validator(mode="after")
     def check_hidden_states_offloading(self):
         if self.activation_offloading != "hidden_states":
             return self

--- a/tests/monkeypatch/test_selective_checkpointing.py
+++ b/tests/monkeypatch/test_selective_checkpointing.py
@@ -223,3 +223,65 @@ class TestSacFunctional:
         c1 = context_fn()
         c2 = context_fn()
         assert c1 is not c2
+
+
+class TestLayerTypeDiscrimination:
+    SDPA_OP = torch.ops.aten._scaled_dot_product_flash_attention.default
+
+    def test_sliding_layer_type_recomputed(self):
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state)
+        state.current_layer_type = "sliding_attention"
+        assert policy(None, self.SDPA_OP) == CheckpointPolicy.PREFER_RECOMPUTE
+        state.current_layer_type = "chunked_attention"
+        assert policy(None, self.SDPA_OP) == CheckpointPolicy.PREFER_RECOMPUTE
+
+    def test_full_or_unknown_layer_type_saved(self):
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state)
+        state.current_layer_type = "full_attention"
+        assert policy(None, self.SDPA_OP) == CheckpointPolicy.MUST_SAVE
+        state.current_layer_type = None
+        assert policy(None, self.SDPA_OP) == CheckpointPolicy.MUST_SAVE
+
+    def test_save_sliding_window_overrides_layer_type(self):
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state, save_sliding_window=True)
+        state.current_layer_type = "sliding_attention"
+        assert policy(None, self.SDPA_OP) == CheckpointPolicy.MUST_SAVE
+
+    def test_hooks_publish_layer_type(self):
+        from transformers import GradientCheckpointingLayer
+
+        from axolotl.monkeypatch.selective_checkpointing import (
+            install_layer_type_hooks,
+        )
+
+        state = SacPolicyState()
+        seen = []
+
+        class _Layer(GradientCheckpointingLayer):
+            def __init__(self, layer_type):
+                super().__init__()
+                self.layer_type = layer_type
+
+            def forward(self):
+                seen.append(state.current_layer_type)
+
+        class _Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList(
+                    [_Layer("full_attention"), _Layer("sliding_attention")]
+                )
+
+            def forward(self):
+                for layer in self.layers:
+                    layer()
+
+        model = _Model()
+        hooked = install_layer_type_hooks(model, state)
+        assert hooked == 2
+        model()
+        assert seen == ["full_attention", "sliding_attention"]
+        assert state.current_layer_type is None

--- a/tests/monkeypatch/test_selective_checkpointing.py
+++ b/tests/monkeypatch/test_selective_checkpointing.py
@@ -1,0 +1,225 @@
+"""Tests for eager selective activation checkpointing (SAC)."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.utils.checkpoint import CheckpointPolicy, checkpoint
+
+from axolotl.monkeypatch.selective_checkpointing import (
+    SacPolicyState,
+    apply_selective_checkpointing,
+    build_sac_context_fn,
+    build_sac_policy,
+)
+
+
+class _FakeOp:
+    def __init__(self, name: str):
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+class _FakeSchemaArg:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeSchema:
+    def __init__(self, arg_names: list[str]):
+        self.arguments = [_FakeSchemaArg(n) for n in arg_names]
+
+
+class _FakeFlashOp(_FakeOp):
+    """Mimics flash-attn's registered custom op with flattened window args."""
+
+    ARG_NAMES = [
+        "q",
+        "k",
+        "v",
+        "dropout_p",
+        "softmax_scale",
+        "is_causal",
+        "window_size_left",
+        "window_size_right",
+    ]
+
+    def __init__(self, name: str = "flash_attn::_flash_attn_forward"):
+        super().__init__(name)
+        self._schema = _FakeSchema(self.ARG_NAMES)
+
+    @classmethod
+    def args_with_window(cls, left: int, right: int) -> tuple:
+        return (None, None, None, 0.0, 1.0, True, left, right)
+
+
+class TestSacPolicy:
+    def test_sdpa_ops_saved(self):
+        policy = build_sac_policy(["attention"])
+        for packet in (
+            torch.ops.aten._scaled_dot_product_flash_attention,
+            torch.ops.aten._scaled_dot_product_efficient_attention,
+            torch.ops.aten._scaled_dot_product_cudnn_attention,
+        ):
+            assert policy(None, packet.default) == CheckpointPolicy.MUST_SAVE
+
+    def test_other_ops_recomputed(self):
+        policy = build_sac_policy(["attention"])
+        assert (
+            policy(None, torch.ops.aten.mm.default) == CheckpointPolicy.PREFER_RECOMPUTE
+        )
+        assert (
+            policy(None, torch.ops.aten._softmax.default)
+            == CheckpointPolicy.PREFER_RECOMPUTE
+        )
+
+    def test_flash_attn_custom_op_name_matched(self):
+        policy = build_sac_policy(["attention"])
+        assert (
+            policy(None, _FakeOp("flash_attn::_flash_attn_forward"))
+            == CheckpointPolicy.MUST_SAVE
+        )
+        assert (
+            policy(None, _FakeOp("flash_attn::_flash_attn_varlen_forward"))
+            == CheckpointPolicy.MUST_SAVE
+        )
+        assert (
+            policy(None, _FakeOp("flash_attn::_flash_attn_backward"))
+            == CheckpointPolicy.PREFER_RECOMPUTE
+        )
+
+    def test_substring_spec(self):
+        policy = build_sac_policy(["aten::mm"])
+        assert policy(None, torch.ops.aten.mm.default) == CheckpointPolicy.MUST_SAVE
+        assert (
+            policy(None, torch.ops.aten._scaled_dot_product_flash_attention.default)
+            == CheckpointPolicy.PREFER_RECOMPUTE
+        )
+
+    def test_state_records_saved_ops(self):
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state)
+        policy(None, torch.ops.aten._scaled_dot_product_flash_attention.default)
+        assert state.saved_op_names == {"aten::_scaled_dot_product_flash_attention"}
+
+
+class TestSlidingWindowDiscrimination:
+    def test_full_attention_saved(self):
+        policy = build_sac_policy(["attention"])
+        op = _FakeFlashOp()
+        args = _FakeFlashOp.args_with_window(-1, -1)
+        assert policy(None, op, *args) == CheckpointPolicy.MUST_SAVE
+
+    def test_sliding_window_recomputed(self):
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state)
+        op = _FakeFlashOp()
+        args = _FakeFlashOp.args_with_window(4095, 0)
+        assert policy(None, op, *args) == CheckpointPolicy.PREFER_RECOMPUTE
+        assert state.sliding_op_names == {"flash_attn::_flash_attn_forward"}
+
+    def test_causal_right_bound_is_not_sliding(self):
+        policy = build_sac_policy(["attention"])
+        op = _FakeFlashOp()
+        args = _FakeFlashOp.args_with_window(-1, 0)
+        assert policy(None, op, *args) == CheckpointPolicy.MUST_SAVE
+
+    def test_sliding_window_kwarg(self):
+        policy = build_sac_policy(["attention"])
+        op = _FakeFlashOp()
+        assert (
+            policy(None, op, window_size_left=1024) == CheckpointPolicy.PREFER_RECOMPUTE
+        )
+
+    def test_save_sliding_window_overrides(self):
+        policy = build_sac_policy(["attention"], save_sliding_window=True)
+        op = _FakeFlashOp()
+        args = _FakeFlashOp.args_with_window(4095, 0)
+        assert policy(None, op, *args) == CheckpointPolicy.MUST_SAVE
+
+    def test_sdpa_without_window_schema_saved(self):
+        policy = build_sac_policy(["attention"])
+        op = torch.ops.aten._scaled_dot_product_flash_attention.default
+        assert policy(None, op) == CheckpointPolicy.MUST_SAVE
+
+
+class TestEnableWrap:
+    class _FakeModel:
+        def __init__(self):
+            self.seen_kwargs = None
+
+        def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
+            self.seen_kwargs = gradient_checkpointing_kwargs
+
+    def test_injects_context_fn_and_non_reentrant(self):
+        model = self._FakeModel()
+        apply_selective_checkpointing(model)
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": True}
+        )
+        assert model.seen_kwargs["use_reentrant"] is False
+        assert callable(model.seen_kwargs["context_fn"])
+
+    def test_injects_with_none_kwargs(self):
+        model = self._FakeModel()
+        apply_selective_checkpointing(model)
+        model.gradient_checkpointing_enable()
+        assert model.seen_kwargs["use_reentrant"] is False
+        assert callable(model.seen_kwargs["context_fn"])
+
+    def test_idempotent(self):
+        model = self._FakeModel()
+        apply_selective_checkpointing(model)
+        wrapped = model.gradient_checkpointing_enable
+        apply_selective_checkpointing(model)
+        assert model.gradient_checkpointing_enable is wrapped
+
+
+class TestSacFunctional:
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA sdpa")
+    def test_checkpointed_attention_grads_match_baseline(self):
+        torch.manual_seed(0)
+        device = "cuda"
+        batch, heads, seq, dim = 2, 4, 128, 64
+
+        def make_inputs():
+            gen = torch.Generator(device="cpu").manual_seed(42)
+            qkv = torch.randn(
+                3, batch, heads, seq, dim, dtype=torch.float32, generator=gen
+            )
+            return [t.to(device).detach().clone().requires_grad_(True) for t in qkv]
+
+        def attn_block(q, k, v):
+            out = F.scaled_dot_product_attention(q, k, v)
+            return out.relu() @ v.transpose(-2, -1)
+
+        # baseline: no checkpointing
+        q0, k0, v0 = make_inputs()
+        attn_block(q0, k0, v0).sum().backward()
+
+        # SAC: checkpointed with save-attention policy
+        state = SacPolicyState()
+        policy = build_sac_policy(["attention"], state)
+
+        def context_fn():
+            from torch.utils.checkpoint import create_selective_checkpoint_contexts
+
+            return create_selective_checkpoint_contexts(policy)
+
+        q1, k1, v1 = make_inputs()
+        out = checkpoint(
+            attn_block, q1, k1, v1, use_reentrant=False, context_fn=context_fn
+        )
+        out.sum().backward()
+
+        assert state.saved_op_names, "no attention op was matched/saved"
+        torch.testing.assert_close(q0.grad, q1.grad)
+        torch.testing.assert_close(k0.grad, k1.grad)
+        torch.testing.assert_close(v0.grad, v1.grad)
+
+    def test_context_fn_returns_fresh_contexts(self):
+        context_fn = build_sac_context_fn(["attention"])
+        c1 = context_fn()
+        c2 = context_fn()
+        assert c1 is not c2

--- a/tests/monkeypatch/test_selective_checkpointing_offload.py
+++ b/tests/monkeypatch/test_selective_checkpointing_offload.py
@@ -1,0 +1,99 @@
+"""Tests for phase-2 SAC CPU offload."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint
+
+from axolotl.monkeypatch.selective_checkpointing_offload import (
+    SacOffloadEngine,
+    build_sac_offload_context_fn,
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+class TestSacOffloadFunctional:
+    @requires_cuda
+    def test_grads_match_baseline_with_offload(self):
+        device = "cuda"
+        batch, heads, seq, dim = 2, 4, 512, 64
+
+        def make_inputs():
+            gen = torch.Generator(device="cpu").manual_seed(7)
+            qkv = torch.randn(
+                3, batch, heads, seq, dim, dtype=torch.float32, generator=gen
+            )
+            return [t.to(device).detach().clone().requires_grad_(True) for t in qkv]
+
+        def attn_block(q, k, v):
+            out = F.scaled_dot_product_attention(q, k, v)
+            return out.relu() @ v.transpose(-2, -1)
+
+        q0, k0, v0 = make_inputs()
+        attn_block(q0, k0, v0).sum().backward()
+
+        engine = SacOffloadEngine(min_offload_bytes=1024)
+        context_fn = build_sac_offload_context_fn(["attention"], engine=engine)
+
+        q1, k1, v1 = make_inputs()
+        out = checkpoint(
+            attn_block, q1, k1, v1, use_reentrant=False, context_fn=context_fn
+        )
+        out.sum().backward()
+        torch.cuda.synchronize()
+
+        assert engine.stats.offloaded_tensors > 0, "nothing was offloaded"
+        assert engine.stats.restored_tensors == engine.stats.offloaded_tensors
+        torch.testing.assert_close(q0.grad, q1.grad)
+        torch.testing.assert_close(k0.grad, k1.grad)
+        torch.testing.assert_close(v0.grad, v1.grad)
+
+    @requires_cuda
+    def test_multi_region_prefetch_and_reuse(self):
+        device = "cuda"
+        n_layers, seq, hidden = 4, 256, 128
+
+        gen = torch.Generator(device="cpu").manual_seed(11)
+        weights = [
+            torch.randn(hidden, hidden, generator=gen).to(device).requires_grad_(True)
+            for _ in range(n_layers)
+        ]
+
+        def layer(x, w):
+            q = (x @ w).view(1, 2, seq, hidden // 2)
+            out = F.scaled_dot_product_attention(q, q, q)
+            return out.reshape(1, seq, hidden).relu()
+
+        def run(context_fn=None):
+            gen2 = torch.Generator(device="cpu").manual_seed(12)
+            x = torch.randn(1, seq, hidden, generator=gen2).to(device)
+            for w in weights:
+                if w.grad is not None:
+                    w.grad = None
+            h = x
+            for w in weights:
+                if context_fn is not None:
+                    h = checkpoint(
+                        layer, h, w, use_reentrant=False, context_fn=context_fn
+                    )
+                else:
+                    h = layer(h, w)
+            h.sum().backward()
+            torch.cuda.synchronize()
+            return [w.grad.clone() for w in weights]
+
+        baseline = run()
+
+        engine = SacOffloadEngine(min_offload_bytes=1024)
+        context_fn = build_sac_offload_context_fn(["attention"], engine=engine)
+        # two steps: second step exercises the pinned-buffer pool reuse
+        run(context_fn)
+        grads = run(context_fn)
+
+        assert engine.stats.offloaded_tensors >= 2 * n_layers
+        assert engine.stats.restored_tensors == engine.stats.offloaded_tensors
+        for g0, g1 in zip(baseline, grads):
+            torch.testing.assert_close(g0, g1)

--- a/tests/monkeypatch/test_selective_checkpointing_offload.py
+++ b/tests/monkeypatch/test_selective_checkpointing_offload.py
@@ -95,5 +95,5 @@ class TestSacOffloadFunctional:
 
         assert engine.stats.offloaded_tensors >= 2 * n_layers
         assert engine.stats.restored_tensors == engine.stats.offloaded_tensors
-        for g0, g1 in zip(baseline, grads):
+        for g0, g1 in zip(baseline, grads, strict=True):
             torch.testing.assert_close(g0, g1)

--- a/tests/utils/schemas/validation/test_selective_checkpointing_validation.py
+++ b/tests/utils/schemas/validation/test_selective_checkpointing_validation.py
@@ -1,0 +1,100 @@
+"""Test for config validation for selective activation checkpointing."""
+
+import pytest
+
+from axolotl.utils.config import validate_config
+from axolotl.utils.dict import DictDefault
+
+
+class TestSelectiveCheckpointing:
+    """
+    Test cases for selective_checkpointing schema validation
+    """
+
+    def test_bool_shorthand_normalizes_to_attention(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                selective_checkpointing=True,
+            )
+            | min_base_cfg
+        )
+
+        cfg = validate_config(cfg)
+        assert cfg.selective_checkpointing["save"] == ["attention"]
+        assert cfg.selective_checkpointing["save_sliding_window"] is False
+
+    def test_false_normalizes_to_none(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                selective_checkpointing=False,
+            )
+            | min_base_cfg
+        )
+
+        cfg = validate_config(cfg)
+        assert cfg.selective_checkpointing is None
+
+    def test_custom_save_list_preserved(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                selective_checkpointing={"save": ["attention", "aten::mm"]},
+            )
+            | min_base_cfg
+        )
+
+        cfg = validate_config(cfg)
+        assert cfg.selective_checkpointing["save"] == ["attention", "aten::mm"]
+
+    def test_requires_gradient_checkpointing(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                selective_checkpointing=True,
+            )
+            | min_base_cfg
+        )
+
+        with pytest.raises(ValueError, match="requires gradient_checkpointing"):
+            validate_config(cfg)
+
+    def test_rejects_reentrant(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                gradient_checkpointing_kwargs={"use_reentrant": True},
+                selective_checkpointing=True,
+            )
+            | min_base_cfg
+        )
+
+        with pytest.raises(ValueError, match="non-reentrant"):
+            validate_config(cfg)
+
+    def test_rejects_trl_activation_offloading(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                activation_offloading=True,
+                selective_checkpointing=True,
+            )
+            | min_base_cfg
+        )
+
+        with pytest.raises(ValueError, match="hidden_states"):
+            validate_config(cfg)
+
+    def test_composes_with_hidden_states_offload(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                activation_offloading="hidden_states",
+                selective_checkpointing=True,
+            )
+            | min_base_cfg
+        )
+
+        cfg = validate_config(cfg)
+        assert cfg.selective_checkpointing["save"] == ["attention"]
+        assert cfg.activation_offloading == "hidden_states"

--- a/tests/utils/schemas/validation/test_selective_checkpointing_validation.py
+++ b/tests/utils/schemas/validation/test_selective_checkpointing_validation.py
@@ -98,3 +98,31 @@ class TestSelectiveCheckpointing:
         cfg = validate_config(cfg)
         assert cfg.selective_checkpointing["save"] == ["attention"]
         assert cfg.activation_offloading == "hidden_states"
+
+    def test_rejects_matmul_save_with_adapter(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                adapter="lora",
+                lora_r=16,
+                lora_alpha=32,
+                lora_target_linear=True,
+                selective_checkpointing={"save": ["attention", "aten::mm"]},
+            )
+            | min_base_cfg
+        )
+
+        with pytest.raises(ValueError, match="in-place"):
+            validate_config(cfg)
+
+    def test_allows_matmul_save_without_adapter(self, min_base_cfg):
+        cfg = (
+            DictDefault(
+                gradient_checkpointing=True,
+                selective_checkpointing={"save": ["attention", "aten::mm"]},
+            )
+            | min_base_cfg
+        )
+
+        cfg = validate_config(cfg)
+        assert cfg.selective_checkpointing["save"] == ["attention", "aten::mm"]


### PR DESCRIPTION
## Summary

Adds `selective_checkpointing`: eager selective activation checkpointing (SAC) that saves the attention op's output during forward instead of recomputing it in backward. Attention backward is irreducible, but the recompute is not — at long context this recovers most of the checkpointing slowdown for one extra hidden-state-sized tensor per layer.

Unlike the earlier attempt in #2711 (memory-budget API), this uses torch's policy-based SAC (`create_selective_checkpoint_contexts`), which runs fully eager — **no torch.compile required**. Ops are matched at the dispatcher level, so our custom kernels that aren't registered as torch ops are simply recomputed as usual: no graph breaks, no per-kernel custom-op maintenance. Only ops we want to *save* need to be dispatcher-visible, and SDPA + flash-attn already are.

## Usage

```yaml
gradient_checkpointing: true
selective_checkpointing: true   # save attention (SDPA / flash-attn)
```

or explicitly:

```yaml
selective_checkpointing:
  save: [attention, "aten::mm"]   # substrings of qualified op names
  save_sliding_window: false      # hybrid models: recompute SWA, save only full attention (default)
```

## Implementation

- `monkeypatch/selective_checkpointing.py`: policy (MUST_SAVE for matched ops, PREFER_RECOMPUTE otherwise) + a wrapper on the **model instance's** `gradient_checkpointing_enable` that merges `context_fn` into the kwargs. Instance wrapping covers every enable call site (model loader, HF Trainer's re-enable at `train()`, PEFT kbit prep) without putting a non-serializable callable into `TrainingArguments`.
- Attention matching: exact aten SDPA forward overloads + name-based matching for flash-attn custom ops — necessary because kernels-hub builds register under hashed namespaces (e.g. `_flash_attn2_cuda_f12afc9::varlen_fwd`).
- Hybrid full/SWA models (flash-attn interface): the policy introspects the op schema for `window_size_left` and recomputes sliding-window calls by default — SWA is cheap to recompute and not worth the memory. Under SDPA the window lives in the mask, so hybrid layers can't be discriminated there (documented).
- Diagnostics: logs each saved op once; warns if no op ever matches (e.g. attention backend not dispatcher-visible).
- Validation: requires `gradient_checkpointing`, rejects reentrant checkpointing, rejects TRL-offloader `activation_offloading` modes; composes with `activation_offloading: hidden_states` (layer inputs → CPU, attention outputs stay on GPU).

## Benchmarks

Qwen3-8B LoRA, bf16, 1×RTX PRO 6000 (96GB), synthetic full-context sequences (every sample is one full-length document), median of 9 post-warmup steps. `sac` = `selective_checkpointing: true`.

| seq | attn | base step (s) | +SAC (s) | speedup | SAC mem cost |
|--:|:--|--:|--:|--:|--:|
| 4k  | sdpa | 1.120 | 1.105 | +1.4% | +1.1 GiB |
| 8k  | sdpa | 2.612 | 2.555 | +2.2% | +2.3 GiB |
| 16k | sdpa | 6.402 | 6.134 | +4.4% | +4.6 GiB |
| 16k | fa2 (kernels) | 6.131 | 5.668 | +8.2% | +4.6 GiB |
| 32k | sdpa | 16.054 | 14.709 | +9.1% | +9.1 GiB |
| 32k | fa2 (kernels) | 16.070 | 13.980 | +15.0% | +9.1 GiB |

Combined with `activation_offloading: hidden_states` (best mode at every length — offloaded layer inputs offset the saved attention outputs):

| seq | base (s) | sac_offload (s) | speedup | GPU vs base | CPU RSS |
|--:|--:|--:|--:|--:|--:|
| 8k  | 2.612 | 2.481 | +5.2% | +0.2 GiB | 4.8 GiB |
| 16k | 6.402 | 5.767 | +11.0% | +0.5 GiB | 7.1 GiB |
| 32k | 16.054 | 14.064 | +14.1% | +0.9 GiB | 11.8 GiB |

- Speedup grows with context (attention share grows); the structural ceiling is ~20–25% (SAC deletes 1 of ~4.5 attention cost-units: fwd + recompute + ~2.5× bwd).
- Combining with `activation_offloading: hidden_states` was the best mode at every length in the sweep — the offloaded layer inputs roughly pay for the saved attention outputs, netting ~base GPU memory at the highest speed.
- Loss parity verified: identical first-step loss vs baseline, thousandths-level drift afterward (nondeterministic attention backward).

## Phase 2: CPU offload of the saved tensors

`selective_checkpointing.offload: true` moves MUST_SAVE tensors to pinned CPU memory (async side-stream D2H during forward, one-region-lookahead prefetch during backward) via custom SAC dispatch modes — upstream's eager `CheckpointPolicy.MUST_CPU_OFFLOAD` is enum-only/unwired. Verified at 32k (stacked with `activation_offloading: hidden_states`):

| 32k mode | step (s) | vs base_offload | GPU alloc (GiB) | CPU RSS (GiB) |
|:--|--:|--:|--:|--:|
| hidden_states offload only | 15.389 | | 74.1 | 11.8 |
| + SAC, saves on GPU (phase 1) | 14.064 | +9.4% | 83.3 | 11.8 |
| + SAC, saves on CPU (phase 2) | 13.938 | +10.4% | 74.4 | 20.9 |

SAC speed at base-offload VRAM: the ~9 GiB of attention saves move to CPU with no wall-clock loss at 32k (~1% copy overhead at 16k). Grad-parity covered by GPU tests with real D2H/H2D round trips.

## Hybrid models

Sliding/chunked-window attention is recomputed by default (cheap, not worth the memory) and discriminated two ways: flash-attn window args, and `layer_types` published per-layer via hooks — the latter covers SDPA, where the window lives in the mask. `save_sliding_window: true` saves everything; `recompute_layer_types` overrides the skip list. Linear-attention layers never dispatch a matchable op and need no config.

## Validated

- FSDP2, 2 GPUs: SAC active per rank, loss trajectory identical to baseline, +2.9% at 8k, no hangs.
- `save: ["aten::mm"]`-style matmul saves are rejected at config time for LoRA/QLoRA (PEFT mutates the base linear output in-place, invalidating the cache; runtime guard also errors loudly).

## Known gaps / follow-ups

- DeepSpeed not yet validated (FSDP2 is).
- Config-surface unification of gradient_checkpointing / activation_offloading / selective_checkpointing is drafted as a follow-up proposal (separate PR).
