### PR TITLE
feat: register custom torch ops for in-repo kernels

### DIFF
--- a/src/axolotl/core/trainers/ebft/kernels.py
+++ b/src/axolotl/core/trainers/ebft/kernels.py
@@ -14,6 +14,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 # ---------------------------------------------------------------------------
 # 1. Fused log_softmax + gather (selective log softmax)
 # ---------------------------------------------------------------------------
@@ -61,6 +63,7 @@ def _fused_log_softmax_gather_kernel(
     tl.store(output_ptr + row, result)
 
 
+@register_kernel_op("ebft_fused_log_softmax_gather")
 def fused_log_softmax_gather(
     logits: torch.Tensor, labels: torch.Tensor
 ) -> torch.Tensor:
@@ -93,6 +96,11 @@ def fused_log_softmax_gather(
     )
 
     return output.view(orig_shape)
+
+
+@fused_log_softmax_gather.register_fake
+def _(logits, labels):
+    return torch.empty(logits.shape[:-1], device=logits.device, dtype=torch.float32)
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +137,7 @@ def _fused_reinforce_loss_kernel(
     tl.store(partial_cnt_ptr + block_id, block_cnt)
 
 
+@register_kernel_op("ebft_fused_reinforce_loss")
 def fused_reinforce_loss(
     per_token_logps: torch.Tensor,
     advantages: torch.Tensor,
@@ -162,6 +171,11 @@ def fused_reinforce_loss(
     total_sum = partial_sum.sum()
     total_cnt = partial_cnt.sum().clamp(min=1)
     return total_sum / total_cnt
+
+
+@fused_reinforce_loss.register_fake
+def _(per_token_logps, advantages, action_mask):
+    return torch.empty((), device=per_token_logps.device, dtype=torch.float32)
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +218,7 @@ def _fused_cosine_sim_kernel(
     tl.store(out_ptr + row, result)
 
 
+@register_kernel_op("ebft_fused_cosine_similarity")
 def fused_cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     """Compute cosine similarity along the last dimension.
 
@@ -232,6 +247,11 @@ def fused_cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     )
 
     return output.view(orig_shape)
+
+
+@fused_cosine_similarity.register_fake
+def _(a, b):
+    return torch.empty(a.shape[:-1], device=a.device, dtype=torch.float32)
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +300,7 @@ def _fused_diversity_kernel(
     tl.store(out_ptr + b * N + i, result)
 
 
+@register_kernel_op("ebft_fused_diversity_penalty")
 def fused_diversity_penalty(embeddings: torch.Tensor) -> torch.Tensor:
     """Compute mean pairwise dot product (excluding self) per sample.
 
@@ -306,3 +327,10 @@ def fused_diversity_penalty(embeddings: torch.Tensor) -> torch.Tensor:
     )
 
     return output
+
+
+@fused_diversity_penalty.register_fake
+def _(embeddings):
+    return torch.empty(
+        embeddings.shape[:-1], device=embeddings.device, dtype=torch.float32
+    )

--- a/src/axolotl/integrations/kernels/libs/dsv4/attention.py
+++ b/src/axolotl/integrations/kernels/libs/dsv4/attention.py
@@ -27,6 +27,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 # Autotuner prunes configs that overflow SMEM per dtype/head_dim. ``EL`` (element size) is
 # in the autotune key so fp32 and bf16 are tuned/cached separately.
 _CONFIGS = [
@@ -202,12 +204,21 @@ def _fwd_kernel(
     tl.store(L + pid_bh * S + offs_m, m_i + tl.log(l_i), mask=offs_m < S)
 
 
-def _fwd(q, k, v, sinks, scale, window, acc_dtype):
+@register_kernel_op("dsv4_sliding_attn_fwd")
+def _sliding_attn_fwd_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sinks: torch.Tensor,
+    scale: float,
+    window: int,
+    acc_fp32: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
     B, H, S, D = q.shape
     KV = k.shape[1]
     out = torch.empty(B, H, S, D, device=q.device, dtype=q.dtype)
     L = torch.empty(B * H, S, device=q.device, dtype=torch.float32)
-    ACC = tl.float32 if acc_dtype == torch.float32 else tl.bfloat16
+    ACC = tl.float32 if acc_fp32 else tl.bfloat16
     grid = lambda meta: (triton.cdiv(S, meta["BLOCK_M"]), B * H)
     _fwd_kernel[grid](
         q,
@@ -241,6 +252,14 @@ def _fwd(q, k, v, sinks, scale, window, acc_dtype):
         PREC=("ieee" if q.element_size() == 4 else "tf32"),
     )
     return out, L
+
+
+@_sliding_attn_fwd_op.register_fake
+def _(q, k, v, sinks, scale, window, acc_fp32):
+    B, H, S, _ = q.shape
+    return torch.empty(q.shape, dtype=q.dtype, device=q.device), torch.empty(
+        B * H, S, device=q.device, dtype=torch.float32
+    )
 
 
 # Two-kernel backward (dq pass, dk/dv pass): splitting halves the resident D-wide dot
@@ -464,7 +483,19 @@ def _bwd_dkdv_kernel(
     tl.atomic_add(dv_ptr, dv, mask=nmask[:, None])
 
 
-def _bwd(q, k, v, sinks, out, do, L, scale, window, acc_dtype):
+@register_kernel_op("dsv4_sliding_attn_bwd")
+def _sliding_attn_bwd_op(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sinks: torch.Tensor,
+    out: torch.Tensor,
+    L: torch.Tensor,
+    scale: float,
+    window: int,
+    acc_fp32: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, H, S, D = q.shape
     KV = k.shape[1]
     do = do.contiguous()
@@ -473,7 +504,7 @@ def _bwd(q, k, v, sinks, out, do, L, scale, window, acc_dtype):
     dk = torch.zeros_like(k, dtype=torch.float32)
     dv = torch.zeros_like(v, dtype=torch.float32)
     dsink = torch.zeros_like(sinks, dtype=torch.float32)
-    ACC = tl.float32 if acc_dtype == torch.float32 else tl.bfloat16
+    ACC = tl.float32 if acc_fp32 else tl.bfloat16
     PREC = "ieee" if q.element_size() == 4 else "tf32"
     EL = q.element_size()
     args = (
@@ -499,10 +530,22 @@ def _bwd(q, k, v, sinks, out, do, L, scale, window, acc_dtype):
     return dq, dk.to(k.dtype), dv.to(v.dtype), dsink.to(sinks.dtype)
 
 
+@_sliding_attn_bwd_op.register_fake
+def _(do, q, k, v, sinks, out, L, scale, window, acc_fp32):
+    return (
+        torch.empty_like(q),
+        torch.empty_like(k),
+        torch.empty_like(v),
+        torch.empty_like(sinks),
+    )
+
+
 class _SlidingAttn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, sinks, scale, window, acc_dtype):
-        out, L = _fwd(q, k, v, sinks, scale, window, acc_dtype)
+        out, L = _sliding_attn_fwd_op(
+            q, k, v, sinks, scale, window, acc_dtype == torch.float32
+        )
         ctx.save_for_backward(q, k, v, sinks, out, L)
         ctx.scale, ctx.window, ctx.acc_dtype = scale, window, acc_dtype
         return out
@@ -510,8 +553,17 @@ class _SlidingAttn(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         q, k, v, sinks, out, L = ctx.saved_tensors
-        dq, dk, dv, dsink = _bwd(
-            q, k, v, sinks, out, do, L, ctx.scale, ctx.window, ctx.acc_dtype
+        dq, dk, dv, dsink = _sliding_attn_bwd_op(
+            do,
+            q,
+            k,
+            v,
+            sinks,
+            out,
+            L,
+            ctx.scale,
+            ctx.window,
+            ctx.acc_dtype == torch.float32,
         )
         return dq, dk, dv, dsink, None, None, None
 

--- a/src/axolotl/integrations/kernels/libs/dsv4/attention_csa.py
+++ b/src/axolotl/integrations/kernels/libs/dsv4/attention_csa.py
@@ -21,6 +21,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 from .attention import _CONFIGS, _prune_smem
 
 
@@ -150,7 +152,16 @@ def _csa_fwd_kernel(
     tl.store(L + pid_bh * S + offs_m, m_i + tl.log(l_i), mask=offs_m < S)
 
 
-def _csa_fwd(q, ks, kc, bb, sinks, scale, window):
+@register_kernel_op("dsv4_csa_attn_fwd")
+def _csa_attn_fwd_op(
+    q: torch.Tensor,
+    ks: torch.Tensor,
+    kc: torch.Tensor,
+    bb: torch.Tensor,
+    sinks: torch.Tensor,
+    scale: float,
+    window: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
     B, H, S, D = q.shape
     T = kc.shape[1]
     out = torch.empty(B, H, S, D, device=q.device, dtype=q.dtype)
@@ -194,6 +205,14 @@ def _csa_fwd(q, ks, kc, bb, sinks, scale, window):
         PREC=PREC,
     )
     return out, L
+
+
+@_csa_attn_fwd_op.register_fake
+def _(q, ks, kc, bb, sinks, scale, window):
+    B, H, S, _ = q.shape
+    return torch.empty(q.shape, dtype=q.dtype, device=q.device), torch.empty(
+        B * H, S, device=q.device, dtype=torch.float32
+    )
 
 
 @triton.autotune(
@@ -450,7 +469,19 @@ def _csa_bwd_dkv_kernel(
         tl.atomic_add(ptr, (dk + dv), mask=nmask[:, None])
 
 
-def _csa_bwd(q, ks, kc, bb, sinks, out, do, L, scale, window):
+@register_kernel_op("dsv4_csa_attn_bwd")
+def _csa_attn_bwd_op(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    ks: torch.Tensor,
+    kc: torch.Tensor,
+    bb: torch.Tensor,
+    sinks: torch.Tensor,
+    out: torch.Tensor,
+    L: torch.Tensor,
+    scale: float,
+    window: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     B, H, S, D = q.shape
     T = kc.shape[1]
     do = do.contiguous()
@@ -520,10 +551,20 @@ def _csa_bwd(q, ks, kc, bb, sinks, out, do, L, scale, window):
     return dq, dks.to(ks.dtype), dkc.to(kc.dtype), dsink.to(sinks.dtype)
 
 
+@_csa_attn_bwd_op.register_fake
+def _(do, q, ks, kc, bb, sinks, out, L, scale, window):
+    return (
+        torch.empty_like(q),
+        torch.empty_like(ks),
+        torch.empty_like(kc),
+        torch.empty_like(sinks),
+    )
+
+
 class _CSAAttn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, ks, kc, bb, sinks, scale, window):
-        out, L = _csa_fwd(q, ks, kc, bb, sinks, scale, window)
+        out, L = _csa_attn_fwd_op(q, ks, kc, bb, sinks, scale, window)
         ctx.save_for_backward(q, ks, kc, bb, sinks, out, L)
         ctx.scale, ctx.window = scale, window
         return out
@@ -531,8 +572,8 @@ class _CSAAttn(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         q, ks, kc, bb, sinks, out, L = ctx.saved_tensors
-        dq, dks, dkc, dsink = _csa_bwd(
-            q, ks, kc, bb, sinks, out, do, L, ctx.scale, ctx.window
+        dq, dks, dkc, dsink = _csa_attn_bwd_op(
+            do, q, ks, kc, bb, sinks, out, L, ctx.scale, ctx.window
         )
         return dq, dks, dkc, None, dsink, None, None
 

--- a/src/axolotl/integrations/kernels/libs/dsv4/attention_gather.py
+++ b/src/axolotl/integrations/kernels/libs/dsv4/attention_gather.py
@@ -20,6 +20,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 from .attention import _max_m, _smem_limit
 
 # BH (head tile, MMA M-axis) must be >= 16 (tensor-core min M). bwd also holds do +
@@ -295,50 +297,148 @@ def _gather_bwd_kernel(
     )
 
 
+@register_kernel_op("dsv4_csa_topk_attn_fwd")
+def _csa_topk_attn_fwd_op(
+    q: torch.Tensor,
+    ks: torch.Tensor,
+    kc: torch.Tensor,
+    idx: torch.Tensor,
+    sinks: torch.Tensor,
+    scale: float,
+    window: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, H, S, D = q.shape
+    K = idx.shape[2]
+    out = torch.empty(B, H, S, D, device=q.device, dtype=q.dtype)
+    L = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+    ACC = tl.bfloat16 if q.dtype == torch.bfloat16 else tl.float32
+    PREC = "ieee" if q.element_size() == 4 else "tf32"
+    args = (
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        ks.stride(0),
+        ks.stride(1),
+        ks.stride(2),
+        kc.stride(0),
+        kc.stride(1),
+        kc.stride(2),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+    )
+    grid = lambda m: (S, B * triton.cdiv(H, m["BH"]))
+    _gather_fwd_kernel[grid](
+        q,
+        ks,
+        kc,
+        idx,
+        sinks,
+        out,
+        L,
+        scale,
+        *args,
+        H,
+        S,
+        K,
+        window,
+        q.element_size(),
+        D=D,
+        ACC=ACC,
+        PREC=PREC,
+    )
+    return out, L
+
+
+@_csa_topk_attn_fwd_op.register_fake
+def _(q, ks, kc, idx, sinks, scale, window):
+    B, H, S, _ = q.shape
+    return torch.empty(q.shape, dtype=q.dtype, device=q.device), torch.empty(
+        B, H, S, device=q.device, dtype=torch.float32
+    )
+
+
+@register_kernel_op("dsv4_csa_topk_attn_bwd")
+def _csa_topk_attn_bwd_op(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    ks: torch.Tensor,
+    kc: torch.Tensor,
+    idx: torch.Tensor,
+    sinks: torch.Tensor,
+    out: torch.Tensor,
+    L: torch.Tensor,
+    scale: float,
+    window: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, H, S, D = q.shape
+    K = idx.shape[2]
+    do = do.contiguous()
+    delta = (do.to(torch.float32) * out.to(torch.float32)).sum(-1)  # [B,H,S]
+    dq = torch.empty_like(q)
+    dks = torch.zeros_like(ks, dtype=torch.float32)
+    dkc = torch.zeros_like(kc, dtype=torch.float32)
+    dsink = torch.zeros_like(sinks, dtype=torch.float32)
+    ACC = tl.bfloat16 if q.dtype == torch.bfloat16 else tl.float32
+    PREC = "ieee" if q.element_size() == 4 else "tf32"
+    args = (
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        ks.stride(0),
+        ks.stride(1),
+        ks.stride(2),
+        kc.stride(0),
+        kc.stride(1),
+        kc.stride(2),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+    )
+    grid = lambda m: (S, B * triton.cdiv(H, m["BH"]))
+    _gather_bwd_kernel[grid](
+        q,
+        ks,
+        kc,
+        idx,
+        sinks,
+        do,
+        L,
+        delta,
+        dq,
+        dks,
+        dkc,
+        dsink,
+        scale,
+        *args,
+        H,
+        S,
+        K,
+        window,
+        q.element_size(),
+        D=D,
+        ACC=ACC,
+        PREC=PREC,
+    )
+    return dq, dks.to(ks.dtype), dkc.to(kc.dtype), dsink.to(sinks.dtype)
+
+
+@_csa_topk_attn_bwd_op.register_fake
+def _(do, q, ks, kc, idx, sinks, out, L, scale, window):
+    return (
+        torch.empty_like(q),
+        torch.empty_like(ks),
+        torch.empty_like(kc),
+        torch.empty_like(sinks),
+    )
+
+
 class _CSATopK(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, ks, kc, idx, sinks, scale, window):
-        B, H, S, D = q.shape
-        K = idx.shape[2]
-        out = torch.empty(B, H, S, D, device=q.device, dtype=q.dtype)
-        L = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
-        ACC = tl.bfloat16 if q.dtype == torch.bfloat16 else tl.float32
-        PREC = "ieee" if q.element_size() == 4 else "tf32"
-        args = (
-            q.stride(0),
-            q.stride(1),
-            q.stride(2),
-            q.stride(3),
-            ks.stride(0),
-            ks.stride(1),
-            ks.stride(2),
-            kc.stride(0),
-            kc.stride(1),
-            kc.stride(2),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
-        )
-        grid = lambda m: (S, B * triton.cdiv(H, m["BH"]))
-        _gather_fwd_kernel[grid](
-            q,
-            ks,
-            kc,
-            idx,
-            sinks,
-            out,
-            L,
-            scale,
-            *args,
-            H,
-            S,
-            K,
-            window,
-            q.element_size(),
-            D=D,
-            ACC=ACC,
-            PREC=PREC,
-        )
+        out, L = _csa_topk_attn_fwd_op(q, ks, kc, idx, sinks, scale, window)
         ctx.save_for_backward(q, ks, kc, idx, sinks, out, L)
         ctx.scale, ctx.window = scale, window
         return out
@@ -346,65 +446,10 @@ class _CSATopK(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         q, ks, kc, idx, sinks, out, L = ctx.saved_tensors
-        B, H, S, D = q.shape
-        K = idx.shape[2]
-        do = do.contiguous()
-        delta = (do.to(torch.float32) * out.to(torch.float32)).sum(-1)  # [B,H,S]
-        dq = torch.empty_like(q)
-        dks = torch.zeros_like(ks, dtype=torch.float32)
-        dkc = torch.zeros_like(kc, dtype=torch.float32)
-        dsink = torch.zeros_like(sinks, dtype=torch.float32)
-        ACC = tl.bfloat16 if q.dtype == torch.bfloat16 else tl.float32
-        PREC = "ieee" if q.element_size() == 4 else "tf32"
-        args = (
-            q.stride(0),
-            q.stride(1),
-            q.stride(2),
-            q.stride(3),
-            ks.stride(0),
-            ks.stride(1),
-            ks.stride(2),
-            kc.stride(0),
-            kc.stride(1),
-            kc.stride(2),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
+        dq, dks, dkc, dsink = _csa_topk_attn_bwd_op(
+            do, q, ks, kc, idx, sinks, out, L, ctx.scale, ctx.window
         )
-        grid = lambda m: (S, B * triton.cdiv(H, m["BH"]))
-        _gather_bwd_kernel[grid](
-            q,
-            ks,
-            kc,
-            idx,
-            sinks,
-            do,
-            L,
-            delta,
-            dq,
-            dks,
-            dkc,
-            dsink,
-            ctx.scale,
-            *args,
-            H,
-            S,
-            K,
-            ctx.window,
-            q.element_size(),
-            D=D,
-            ACC=ACC,
-            PREC=PREC,
-        )
-        return (
-            dq,
-            dks.to(ks.dtype),
-            dkc.to(kc.dtype),
-            None,
-            dsink.to(sinks.dtype),
-            None,
-            None,
-        )
+        return dq, dks, dkc, None, dsink, None, None
 
 
 def csa_attn_topk(

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
@@ -361,8 +361,7 @@ def _grid_fn(B, S, H):
     return grid
 
 
-# seq_q/seq_k are dummies (idx, zero strides) when has_doc is False, mirroring the
-# flash_attn_d512 pos/doc_end pattern: the op signature stays tensor-only.
+# zero strides signal dummy seq_q/seq_k when has_doc is False (keeps op signature tensor-only)
 def _doc_strides(seq_q, seq_k, has_doc):
     if has_doc:
         return (seq_q.stride(0), seq_q.stride(1), seq_k.stride(0), seq_k.stride(1))

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_mla_absorb.py
@@ -27,6 +27,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 from ._autotune import smem_prune
 from .config import KV_LORA_RANK, QK_NOPE_HEAD_DIM, QK_ROPE_HEAD_DIM, V_HEAD_DIM
 
@@ -359,68 +361,169 @@ def _grid_fn(B, S, H):
     return grid
 
 
+# seq_q/seq_k are dummies (idx, zero strides) when has_doc is False, mirroring the
+# flash_attn_d512 pos/doc_end pattern: the op signature stays tensor-only.
+def _doc_strides(seq_q, seq_k, has_doc):
+    if has_doc:
+        return (seq_q.stride(0), seq_q.stride(1), seq_k.stride(0), seq_k.stride(1))
+    return (0, 0, 0, 0)
+
+
+@register_kernel_op("glm_dsa_mla_absorb_attn_fwd")
+def _mla_absorb_fwd_op(
+    q_abs: torch.Tensor,
+    k_shared: torch.Tensor,
+    idx: torch.Tensor,
+    seq_q: torch.Tensor,
+    seq_k: torch.Tensor,
+    scale: float,
+    q_offset: int,
+    has_doc: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, H, S, _ = (
+        q_abs.shape
+    )  # S = local queries; k_shared may be longer (global, under CP)
+    DV = KV_LORA_RANK
+    TOPK = idx.shape[-1]
+    out = torch.empty(B, H, S, DV, device=q_abs.device, dtype=q_abs.dtype)
+    lse = torch.empty(B, H, S, device=q_abs.device, dtype=torch.float32)
+    _absorb_fwd_kernel[_grid_fn(B, S, H)](
+        q_abs,
+        k_shared,
+        idx,
+        out,
+        lse,
+        scale,
+        S,
+        TOPK,
+        H,
+        q_offset,
+        q_abs.stride(0),
+        q_abs.stride(1),
+        q_abs.stride(2),
+        q_abs.stride(3),
+        k_shared.stride(0),
+        k_shared.stride(1),
+        k_shared.stride(2),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        lse.stride(0),
+        lse.stride(1),
+        lse.stride(2),
+        seq_q,
+        seq_k,
+        *_doc_strides(seq_q, seq_k, has_doc),
+        DL=KV_LORA_RANK,
+        DR=QK_ROPE_HEAD_DIM,
+        HAS_DOC=has_doc,
+    )
+    return out, lse
+
+
+@_mla_absorb_fwd_op.register_fake
+def _(q_abs, k_shared, idx, seq_q, seq_k, scale, q_offset, has_doc):
+    B, H, S, _ = q_abs.shape
+    return (
+        torch.empty(B, H, S, KV_LORA_RANK, device=q_abs.device, dtype=q_abs.dtype),
+        torch.empty(B, H, S, device=q_abs.device, dtype=torch.float32),
+    )
+
+
+@register_kernel_op("glm_dsa_mla_absorb_attn_bwd")
+def _mla_absorb_bwd_op(
+    dout: torch.Tensor,
+    q_abs: torch.Tensor,
+    k_shared: torch.Tensor,
+    idx: torch.Tensor,
+    out: torch.Tensor,
+    lse: torch.Tensor,
+    seq_q: torch.Tensor,
+    seq_k: torch.Tensor,
+    scale: float,
+    q_offset: int,
+    has_doc: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, H, S, DQk = q_abs.shape
+    Skv = k_shared.shape[1]  # global key count (>= S under CP)
+    TOPK = idx.shape[-1]
+    dout = dout.contiguous()
+    dq_abs = torch.zeros(B, H, S, DQk, device=q_abs.device, dtype=q_abs.dtype)
+    # dk_shared scatters at GLOBAL key positions -> size it like k_shared, not the local queries.
+    dk_shared = torch.zeros(B, Skv, DQk, device=q_abs.device, dtype=torch.float32)
+    _absorb_bwd_kernel[_grid_fn(B, S, H)](
+        q_abs,
+        k_shared,
+        idx,
+        out,
+        dout,
+        lse,
+        dq_abs,
+        dk_shared,
+        scale,
+        S,
+        TOPK,
+        H,
+        q_offset,
+        q_abs.stride(0),
+        q_abs.stride(1),
+        q_abs.stride(2),
+        q_abs.stride(3),
+        dk_shared.stride(0),
+        dk_shared.stride(1),
+        dk_shared.stride(2),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        lse.stride(0),
+        lse.stride(1),
+        lse.stride(2),
+        seq_q,
+        seq_k,
+        *_doc_strides(seq_q, seq_k, has_doc),
+        DL=KV_LORA_RANK,
+        DR=QK_ROPE_HEAD_DIM,
+        HAS_DOC=has_doc,
+    )
+    return dq_abs, dk_shared
+
+
+@_mla_absorb_bwd_op.register_fake
+def _(dout, q_abs, k_shared, idx, out, lse, seq_q, seq_k, scale, q_offset, has_doc):
+    B, H, S, DQk = q_abs.shape
+    return (
+        torch.empty(B, H, S, DQk, device=q_abs.device, dtype=q_abs.dtype),
+        torch.empty(
+            B, k_shared.shape[1], DQk, device=q_abs.device, dtype=torch.float32
+        ),
+    )
+
+
 class _MlaAbsorbAttn(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx, q_abs, k_shared, topk_idx, scale, q_offset, seq_q=None, seq_k=None
     ):
-        B, H, S, _ = (
-            q_abs.shape
-        )  # S = local queries; k_shared may be longer (global, under CP)
-        DV = KV_LORA_RANK
-        TOPK = topk_idx.shape[-1]
         q_abs, k_shared = q_abs.contiguous(), k_shared.contiguous()
         idx = topk_idx.contiguous()
         has_doc = seq_q is not None and seq_k is not None
         if has_doc:
             seq_q = seq_q.contiguous()
             seq_k = seq_k.contiguous()
-            doc_args = (
-                seq_q,
-                seq_k,
-                seq_q.stride(0),
-                seq_q.stride(1),
-                seq_k.stride(0),
-                seq_k.stride(1),
-            )
         else:
-            doc_args = (idx, idx, 0, 0, 0, 0)
-        out = torch.empty(B, H, S, DV, device=q_abs.device, dtype=q_abs.dtype)
-        lse = torch.empty(B, H, S, device=q_abs.device, dtype=torch.float32)
-        _absorb_fwd_kernel[_grid_fn(B, S, H)](
-            q_abs,
-            k_shared,
-            idx,
-            out,
-            lse,
-            float(scale),
-            S,
-            TOPK,
-            H,
-            int(q_offset),
-            q_abs.stride(0),
-            q_abs.stride(1),
-            q_abs.stride(2),
-            q_abs.stride(3),
-            k_shared.stride(0),
-            k_shared.stride(1),
-            k_shared.stride(2),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
-            out.stride(0),
-            out.stride(1),
-            out.stride(2),
-            out.stride(3),
-            lse.stride(0),
-            lse.stride(1),
-            lse.stride(2),
-            *doc_args,
-            DL=KV_LORA_RANK,
-            DR=QK_ROPE_HEAD_DIM,
-            HAS_DOC=has_doc,
+            seq_q, seq_k = idx, idx
+        out, lse = _mla_absorb_fwd_op(
+            q_abs, k_shared, idx, seq_q, seq_k, float(scale), int(q_offset), has_doc
         )
-        ctx.save_for_backward(q_abs, k_shared, idx, out, lse, doc_args[0], doc_args[1])
+        ctx.save_for_backward(q_abs, k_shared, idx, out, lse, seq_q, seq_k)
         ctx.scale = float(scale)
         ctx.q_offset = int(q_offset)
         ctx.has_doc = has_doc
@@ -429,60 +532,18 @@ class _MlaAbsorbAttn(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout):
         q_abs, k_shared, idx, out, lse, seq_q, seq_k = ctx.saved_tensors
-        has_doc = ctx.has_doc
-        if has_doc:
-            doc_args = (
-                seq_q,
-                seq_k,
-                seq_q.stride(0),
-                seq_q.stride(1),
-                seq_k.stride(0),
-                seq_k.stride(1),
-            )
-        else:
-            doc_args = (idx, idx, 0, 0, 0, 0)
-        B, H, S, DQk = q_abs.shape
-        Skv = k_shared.shape[1]  # global key count (>= S under CP)
-        TOPK = idx.shape[-1]
-        dout = dout.contiguous()
-        dq_abs = torch.zeros(B, H, S, DQk, device=q_abs.device, dtype=q_abs.dtype)
-        # dk_shared scatters at GLOBAL key positions -> size it like k_shared, not the local queries.
-        dk_shared = torch.zeros(B, Skv, DQk, device=q_abs.device, dtype=torch.float32)
-        _absorb_bwd_kernel[_grid_fn(B, S, H)](
+        dq_abs, dk_shared = _mla_absorb_bwd_op(
+            dout,
             q_abs,
             k_shared,
             idx,
             out,
-            dout,
             lse,
-            dq_abs,
-            dk_shared,
+            seq_q,
+            seq_k,
             ctx.scale,
-            S,
-            TOPK,
-            H,
             ctx.q_offset,
-            q_abs.stride(0),
-            q_abs.stride(1),
-            q_abs.stride(2),
-            q_abs.stride(3),
-            dk_shared.stride(0),
-            dk_shared.stride(1),
-            dk_shared.stride(2),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
-            out.stride(0),
-            out.stride(1),
-            out.stride(2),
-            out.stride(3),
-            lse.stride(0),
-            lse.stride(1),
-            lse.stride(2),
-            *doc_args,
-            DL=KV_LORA_RANK,
-            DR=QK_ROPE_HEAD_DIM,
-            HAS_DOC=has_doc,
+            ctx.has_doc,
         )
         return dq_abs, dk_shared.to(k_shared.dtype), None, None, None, None, None
 

--- a/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
+++ b/src/axolotl/integrations/kernels/libs/glm_dsa/attention_topk.py
@@ -25,6 +25,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 
 @triton.autotune(
     configs=[
@@ -219,53 +221,149 @@ def _bwd_kernel(
     tl.store(DQO + b * sq_b + h * sq_h + s * sq_s + offs_d * sq_d, dq)
 
 
+@register_kernel_op("glm_dsa_sparse_topk_attn_fwd")
+def _sparse_topk_fwd_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    idx: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, H, S, D = q.shape
+    DV = v.shape[-1]
+    TOPK = idx.shape[-1]
+    out = torch.empty(B, H, S, DV, device=q.device, dtype=q.dtype)
+    lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+    grid = (B * H, S)
+    _fwd_kernel[grid](
+        q,
+        k,
+        v,
+        idx,
+        out,
+        lse,
+        scale,
+        S,
+        TOPK,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        lse.stride(0),
+        lse.stride(1),
+        lse.stride(2),
+        H,
+        D=D,
+        DV=DV,
+    )
+    return out, lse
+
+
+@_sparse_topk_fwd_op.register_fake
+def _(q, k, v, idx, scale):
+    B, H, S, _ = q.shape
+    return (
+        torch.empty(B, H, S, v.shape[-1], device=q.device, dtype=q.dtype),
+        torch.empty(B, H, S, device=q.device, dtype=torch.float32),
+    )
+
+
+@register_kernel_op("glm_dsa_sparse_topk_attn_bwd")
+def _sparse_topk_bwd_op(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    idx: torch.Tensor,
+    out: torch.Tensor,
+    lse: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, H, S, D = q.shape
+    DV = v.shape[-1]
+    TOPK = idx.shape[-1]
+    dout = dout.contiguous()
+    dq = torch.zeros_like(q, dtype=torch.float32)
+    # dK/dV accumulate across query positions selecting the same key -> fp32 atomics.
+    dk = torch.zeros(B, H, S, D, device=q.device, dtype=torch.float32)
+    dv = torch.zeros(B, H, S, DV, device=q.device, dtype=torch.float32)
+    grid = (B * H, S)
+    _bwd_kernel[grid](
+        q,
+        k,
+        v,
+        idx,
+        out,
+        dout,
+        lse,
+        dq,
+        dk,
+        dv,
+        scale,
+        S,
+        TOPK,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        dk.stride(0),
+        dk.stride(1),
+        dk.stride(2),
+        dk.stride(3),
+        dv.stride(0),
+        dv.stride(1),
+        dv.stride(2),
+        dv.stride(3),
+        idx.stride(0),
+        idx.stride(1),
+        idx.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        lse.stride(0),
+        lse.stride(1),
+        lse.stride(2),
+        H,
+        D=D,
+        DV=DV,
+    )
+    return dq, dk, dv
+
+
+@_sparse_topk_bwd_op.register_fake
+def _(dout, q, k, v, idx, out, lse, scale):
+    B, H, S, D = q.shape
+    DV = v.shape[-1]
+    return (
+        torch.empty_like(q, dtype=torch.float32),
+        torch.empty(B, H, S, D, device=q.device, dtype=torch.float32),
+        torch.empty(B, H, S, DV, device=q.device, dtype=torch.float32),
+    )
+
+
 class _SparseAttnTopK(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, topk_idx, scale):
-        B, H, S, D = q.shape
-        DV = v.shape[-1]
-        TOPK = topk_idx.shape[-1]
+        H = q.shape[1]
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
         idx = topk_idx.contiguous()
-        out = torch.empty(B, H, S, DV, device=q.device, dtype=q.dtype)
-        lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
-        grid = (B * H, S)
-        _fwd_kernel[grid](
-            q,
-            k,
-            v,
-            idx,
-            out,
-            lse,
-            float(scale),
-            S,
-            TOPK,
-            q.stride(0),
-            q.stride(1),
-            q.stride(2),
-            q.stride(3),
-            k.stride(0),
-            k.stride(1),
-            k.stride(2),
-            k.stride(3),
-            v.stride(0),
-            v.stride(1),
-            v.stride(2),
-            v.stride(3),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
-            out.stride(0),
-            out.stride(1),
-            out.stride(2),
-            out.stride(3),
-            lse.stride(0),
-            lse.stride(1),
-            lse.stride(2),
-            H,
-            D=D,
-            DV=DV,
-        )
+        out, lse = _sparse_topk_fwd_op(q, k, v, idx, float(scale))
         ctx.save_for_backward(q, k, v, idx, out, lse)
         ctx.scale = float(scale)
         ctx.H = H
@@ -274,55 +372,7 @@ class _SparseAttnTopK(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout):
         q, k, v, idx, out, lse = ctx.saved_tensors
-        B, H, S, D = q.shape
-        DV = v.shape[-1]
-        TOPK = idx.shape[-1]
-        dout = dout.contiguous()
-        dq = torch.zeros_like(q, dtype=torch.float32)
-        # dK/dV accumulate across query positions selecting the same key -> fp32 atomics.
-        dk = torch.zeros(B, H, S, D, device=q.device, dtype=torch.float32)
-        dv = torch.zeros(B, H, S, DV, device=q.device, dtype=torch.float32)
-        grid = (B * H, S)
-        _bwd_kernel[grid](
-            q,
-            k,
-            v,
-            idx,
-            out,
-            dout,
-            lse,
-            dq,
-            dk,
-            dv,
-            ctx.scale,
-            S,
-            TOPK,
-            q.stride(0),
-            q.stride(1),
-            q.stride(2),
-            q.stride(3),
-            dk.stride(0),
-            dk.stride(1),
-            dk.stride(2),
-            dk.stride(3),
-            dv.stride(0),
-            dv.stride(1),
-            dv.stride(2),
-            dv.stride(3),
-            idx.stride(0),
-            idx.stride(1),
-            idx.stride(2),
-            out.stride(0),
-            out.stride(1),
-            out.stride(2),
-            out.stride(3),
-            lse.stride(0),
-            lse.stride(1),
-            lse.stride(2),
-            H,
-            D=D,
-            DV=DV,
-        )
+        dq, dk, dv = _sparse_topk_bwd_op(dout, q, k, v, idx, out, lse, ctx.scale)
         return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), None, None
 
 

--- a/src/axolotl/kernels/geglu.py
+++ b/src/axolotl/kernels/geglu.py
@@ -9,6 +9,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 
 @triton.jit
 def _geglu_fwd_kernel(
@@ -42,6 +44,7 @@ def _geglu_fwd_kernel(
     tl.store(out_ptr + offsets, result, mask=mask)
 
 
+@register_kernel_op("geglu_fwd")
 def geglu_forward(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     """GEGLU forward pass.
 
@@ -122,6 +125,32 @@ def _geglu_bwd_kernel(
     tl.store(up_ptr + offsets, grad_up, mask=mask)
 
 
+@geglu_forward.register_fake
+def _(gate, up):
+    return torch.empty_like(gate)
+
+
+@register_kernel_op("geglu_bwd", mutates_args=("grad_output", "gate", "up"))
+def _geglu_bwd_op(
+    grad_output: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
+) -> None:
+    n_elements = grad_output.numel()
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+    _geglu_bwd_kernel[grid](
+        grad_out_ptr=grad_output,
+        gate_ptr=gate,
+        up_ptr=up,
+        n_elements=n_elements,
+        BLOCK_SIZE=1024,
+    )
+
+
+@_geglu_bwd_op.register_fake
+def _(grad_output, gate, up):
+    return None
+
+
 def geglu_backward(
     grad_output: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -141,15 +170,8 @@ def geglu_backward(
     Note:
         This function modifies its input tensors in-place to store results.
     """
-    n_elements = grad_output.numel()
-
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
-    _geglu_bwd_kernel[grid](
-        grad_out_ptr=grad_output,
-        gate_ptr=gate,
-        up_ptr=up,
-        n_elements=n_elements,
-        BLOCK_SIZE=1024,
-    )
-
+    # the op mutates in place: grad_output <- h, gate <- grad_gate, up <- grad_up.
+    # Returning the mutated inputs must happen here — a custom op's outputs may
+    # not alias its inputs.
+    _geglu_bwd_op(grad_output, gate, up)
     return grad_output, gate, up

--- a/src/axolotl/kernels/geglu.py
+++ b/src/axolotl/kernels/geglu.py
@@ -170,8 +170,6 @@ def geglu_backward(
     Note:
         This function modifies its input tensors in-place to store results.
     """
-    # the op mutates in place: grad_output <- h, gate <- grad_gate, up <- grad_up.
-    # Returning the mutated inputs must happen here — a custom op's outputs may
-    # not alias its inputs.
+    # op mutates in place; return the aliases here — op outputs must not alias inputs
     _geglu_bwd_op(grad_output, gate, up)
     return grad_output, gate, up

--- a/src/axolotl/kernels/op_registry.py
+++ b/src/axolotl/kernels/op_registry.py
@@ -1,0 +1,57 @@
+"""Registration helper for axolotl's custom torch ops.
+
+Kernel entry points registered through here become dispatcher-visible:
+``torch.compile`` treats them as opaque ops instead of graph-breaking, and
+policy-based selective checkpointing can match them by name. Registration
+failure (exotic torch builds) falls back to the raw python callable so the
+kernel keeps working — it just stays invisible to the dispatcher.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import torch
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+NAMESPACE = "axolotl"
+
+
+class _UnregisteredOp:
+    """Callable shim with the CustomOpDef surface we use, for fallback."""
+
+    def __init__(self, fn: Callable):
+        self._fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+    def register_fake(self, fn: Callable) -> Callable:
+        return fn
+
+
+def register_kernel_op(name: str, mutates_args: Sequence[str] = ()) -> Callable:
+    """Decorator: register the function as ``torch.ops.axolotl.<name>``.
+
+    Returns the registered op (callable), or a passthrough shim wrapping the
+    raw function if registration is unavailable.
+    """
+
+    def decorator(fn: Callable):
+        try:
+            return torch.library.custom_op(
+                f"{NAMESPACE}::{name}", mutates_args=tuple(mutates_args)
+            )(fn)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOG.warning(
+                f"custom op registration failed for {NAMESPACE}::{name} "
+                f"({type(exc).__name__}: {exc}); kernel will run unregistered "
+                "(functional, but invisible to torch.compile and selective "
+                "checkpointing)"
+            )
+            return _UnregisteredOp(fn)
+
+    return decorator

--- a/src/axolotl/kernels/op_registry.py
+++ b/src/axolotl/kernels/op_registry.py
@@ -19,6 +19,8 @@ LOG = get_logger(__name__)
 
 NAMESPACE = "axolotl"
 
+_warned_registration_failure = False
+
 
 class _UnregisteredOp:
     """Callable shim with the CustomOpDef surface we use, for fallback."""
@@ -46,12 +48,18 @@ def register_kernel_op(name: str, mutates_args: Sequence[str] = ()) -> Callable:
                 f"{NAMESPACE}::{name}", mutates_args=tuple(mutates_args)
             )(fn)
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            LOG.warning(
+            global _warned_registration_failure
+            message = (
                 f"custom op registration failed for {NAMESPACE}::{name} "
                 f"({type(exc).__name__}: {exc}); kernel will run unregistered "
                 "(functional, but invisible to torch.compile and selective "
                 "checkpointing)"
             )
+            if _warned_registration_failure:
+                LOG.debug(message)
+            else:
+                _warned_registration_failure = True
+                LOG.warning(message)
             return _UnregisteredOp(fn)
 
     return decorator

--- a/src/axolotl/kernels/rms_norm_gated.py
+++ b/src/axolotl/kernels/rms_norm_gated.py
@@ -22,6 +22,8 @@ from liger_kernel.ops.utils import (
 )
 from liger_kernel.utils import is_npu_available
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
     try:
         from triton.language.extra.libdevice import rsqrt
@@ -188,23 +190,20 @@ def _rms_norm_gated_backward_kernel(
     )
 
 
-def rms_norm_gated_forward(X, G, W, eps, offset):
-    shape = X.shape
-    dim = shape[-1]
-    X = X.view(-1, dim)
-    G = G.view(-1, dim)
+@register_kernel_op("rms_norm_gated_fwd")
+def _rms_norm_gated_fwd_op(
+    X: torch.Tensor,
+    G: torch.Tensor,
+    W: torch.Tensor,
+    eps: float,
+    offset: float,
+    BLOCK_SIZE: int,
+    num_warps: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
     n_rows, n_cols = X.shape
-    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
 
     Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
     RSTD = torch.empty(n_rows, dtype=torch.float32, device=X.device)
-
-    assert X.shape[1] == W.shape[0], (
-        f"Incompatible hidden size: X.shape[1]={X.shape[1]} vs W.shape[0]={W.shape[0]}"
-    )
-    assert X.shape == G.shape, (
-        f"X and G must have same shape, got {X.shape} and {G.shape}"
-    )
 
     _rms_norm_gated_forward_kernel[(n_rows,)](
         Y,
@@ -223,13 +222,27 @@ def rms_norm_gated_forward(X, G, W, eps, offset):
         BLOCK_SIZE=BLOCK_SIZE,
         num_warps=num_warps,
     )
-    return Y.view(*shape), X, G, RSTD, BLOCK_SIZE, num_warps
+    return Y, RSTD
 
 
-def rms_norm_gated_backward(dY, X, G, W, RSTD, offset, BLOCK_SIZE, num_warps):
-    shape = dY.shape
-    dim = shape[-1]
-    dY = dY.view(-1, dim)
+@_rms_norm_gated_fwd_op.register_fake
+def _(X, G, W, eps, offset, BLOCK_SIZE, num_warps):
+    return torch.empty_like(X), torch.empty(
+        X.shape[0], dtype=torch.float32, device=X.device
+    )
+
+
+@register_kernel_op("rms_norm_gated_bwd")
+def _rms_norm_gated_bwd_op(
+    dY: torch.Tensor,
+    X: torch.Tensor,
+    G: torch.Tensor,
+    W: torch.Tensor,
+    RSTD: torch.Tensor,
+    offset: float,
+    BLOCK_SIZE: int,
+    num_warps: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     n_rows, n_cols = dY.shape
 
     sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
@@ -267,9 +280,45 @@ def rms_norm_gated_backward(dY, X, G, W, RSTD, offset, BLOCK_SIZE, num_warps):
         num_warps=num_warps,
     )
 
+    dW = _dW.sum(dim=0).to(W.dtype)
+    return dX, dG, dW
+
+
+@_rms_norm_gated_bwd_op.register_fake
+def _(dY, X, G, W, RSTD, offset, BLOCK_SIZE, num_warps):
+    return torch.empty_like(dY), torch.empty_like(dY), torch.empty_like(W)
+
+
+def rms_norm_gated_forward(X, G, W, eps, offset):
+    shape = X.shape
+    dim = shape[-1]
+    X = X.view(-1, dim)
+    G = G.view(-1, dim)
+    n_rows, n_cols = X.shape
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+
+    assert X.shape[1] == W.shape[0], (
+        f"Incompatible hidden size: X.shape[1]={X.shape[1]} vs W.shape[0]={W.shape[0]}"
+    )
+    assert X.shape == G.shape, (
+        f"X and G must have same shape, got {X.shape} and {G.shape}"
+    )
+
+    Y, RSTD = _rms_norm_gated_fwd_op(X, G, W, eps, offset, BLOCK_SIZE, num_warps)
+    return Y.view(*shape), X, G, RSTD, BLOCK_SIZE, num_warps
+
+
+def rms_norm_gated_backward(dY, X, G, W, RSTD, offset, BLOCK_SIZE, num_warps):
+    shape = dY.shape
+    dim = shape[-1]
+    dY = dY.view(-1, dim)
+
+    dX, dG, dW = _rms_norm_gated_bwd_op(
+        dY, X, G, W, RSTD, offset, BLOCK_SIZE, num_warps
+    )
+
     dX = dX.view(*shape)
     dG = dG.view(*shape)
-    dW = _dW.sum(dim=0).to(W.dtype)
     return dX, dG, dW
 
 

--- a/src/axolotl/kernels/rms_norm_gated.py
+++ b/src/axolotl/kernels/rms_norm_gated.py
@@ -294,8 +294,7 @@ def rms_norm_gated_forward(X, G, W, eps, offset):
     dim = shape[-1]
     X = X.view(-1, dim)
     G = G.view(-1, dim)
-    n_rows, n_cols = X.shape
-    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+    BLOCK_SIZE, num_warps = calculate_settings(X.shape[-1])
 
     assert X.shape[1] == W.shape[0], (
         f"Incompatible hidden size: X.shape[1]={X.shape[1]} vs W.shape[0]={W.shape[0]}"

--- a/src/axolotl/kernels/swiglu.py
+++ b/src/axolotl/kernels/swiglu.py
@@ -173,8 +173,6 @@ def swiglu_backward(
             - Gradient with respect to gate (`df`)
             - Gradient with respect to up-projection (`de`)
     """
-    # the op mutates in place: grad_output <- h, gate <- grad_gate, up <- grad_up.
-    # Returning the mutated inputs must happen here — a custom op's outputs may
-    # not alias its inputs.
+    # op mutates in place; return the aliases here — op outputs must not alias inputs
     _swiglu_bwd_op(grad_output, gate, up)
     return grad_output, gate, up

--- a/src/axolotl/kernels/swiglu.py
+++ b/src/axolotl/kernels/swiglu.py
@@ -10,6 +10,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 
 @triton.jit
 def _swiglu_fwd_kernel(
@@ -99,6 +101,7 @@ def _swiglu_bwd_kernel(
     tl.store(up_ptr + offsets, grad_up, mask=mask)  # grad wrt up
 
 
+@register_kernel_op("swiglu_fwd")
 def swiglu_forward(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     """
     SwiGLU forward pass. Computes SwiGLU activation: `x * sigmoid(x) * up`, where
@@ -127,6 +130,32 @@ def swiglu_forward(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@swiglu_forward.register_fake
+def _(gate, up):
+    return torch.empty_like(gate)
+
+
+@register_kernel_op("swiglu_bwd", mutates_args=("grad_output", "gate", "up"))
+def _swiglu_bwd_op(
+    grad_output: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
+) -> None:
+    n_elements = grad_output.numel()
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["block_size"]),)  # noqa: E731
+    _swiglu_bwd_kernel[grid](
+        grad_out_ptr=grad_output,
+        gate_ptr=gate,
+        up_ptr=up,
+        n_elements=n_elements,
+        block_size=1024,
+    )
+
+
+@_swiglu_bwd_op.register_fake
+def _(grad_output, gate, up):
+    return None
+
+
 def swiglu_backward(
     grad_output: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -144,19 +173,8 @@ def swiglu_backward(
             - Gradient with respect to gate (`df`)
             - Gradient with respect to up-projection (`de`)
     """
-    n_elements = grad_output.numel()
-
-    grid = lambda meta: (triton.cdiv(n_elements, meta["block_size"]),)  # noqa: E731
-    _swiglu_bwd_kernel[grid](
-        grad_out_ptr=grad_output,
-        gate_ptr=gate,
-        up_ptr=up,
-        n_elements=n_elements,
-        block_size=1024,
-    )
-
-    # After kernel execution, tensors contain:
-    # grad_output: h (forward output)
-    # gate: grad_gate (grad wrt gate)
-    # up: grad_up (grad wrt up)
+    # the op mutates in place: grad_output <- h, gate <- grad_gate, up <- grad_up.
+    # Returning the mutated inputs must happen here — a custom op's outputs may
+    # not alias its inputs.
+    _swiglu_bwd_op(grad_output, gate, up)
     return grad_output, gate, up

--- a/src/axolotl/monkeypatch/attention/flash_attn_d512.py
+++ b/src/axolotl/monkeypatch/attention/flash_attn_d512.py
@@ -14,6 +14,8 @@ import torch
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 DEV = "cuda"
 
 
@@ -358,6 +360,133 @@ def _bwd_dq(
     )
 
 
+@register_kernel_op("flash_attn_d512_fwd")
+def _flash_d512_fwd_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    pos: torch.Tensor,
+    causal: bool,
+    varlen: bool,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, H, N, D = q.shape
+    spb, spn = pos.stride()
+    o = torch.empty_like(q)
+    L = torch.empty((B * H, N), device=q.device, dtype=torch.float32)
+    # BLOCK_M/BLOCK_N, num_warps, num_stages come from the autotuner (SMEM-pruned per device).
+    _fwd[lambda meta: (triton.cdiv(N, meta["BLOCK_M"]), B * H)](
+        q,
+        k,
+        v,
+        scale,
+        o,
+        L,
+        *q.stride(),
+        *k.stride(),
+        *v.stride(),
+        *o.stride(),
+        pos,
+        spb,
+        spn,
+        H,
+        N,
+        HEAD_DIM=D,
+        CAUSAL=causal,
+        VARLEN=varlen,
+    )
+    return o, L
+
+
+@_flash_d512_fwd_op.register_fake
+def _(q, k, v, pos, causal, varlen, scale):
+    B, H, N, _ = q.shape
+    return torch.empty_like(q), torch.empty(
+        (B * H, N), device=q.device, dtype=torch.float32
+    )
+
+
+@register_kernel_op("flash_attn_d512_bwd")
+def _flash_d512_bwd_op(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    L: torch.Tensor,
+    pos: torch.Tensor,
+    doc_end: torch.Tensor,
+    causal: bool,
+    varlen: bool,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, H, N, D = q.shape
+    spb, spn = pos.stride()
+    do = do.contiguous()
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(v)
+    delta = torch.empty((B * H, N), device=q.device, dtype=torch.float32)
+    BM, BN = 16, 32
+    _bwd_pre[(triton.cdiv(N, BM), B * H)](
+        o, do, delta, *o.stride(), H, N, HEAD_DIM=D, BLOCK_M=BM, num_warps=4
+    )
+    _bwd_dkdv[(triton.cdiv(N, BN), B * H)](
+        q,
+        k,
+        v,
+        scale,
+        do,
+        dk,
+        dv,
+        L,
+        delta,
+        pos,
+        doc_end,
+        spb,
+        spn,
+        *q.stride(),
+        H,
+        N,
+        HEAD_DIM=D,
+        BLOCK_M=BM,
+        BLOCK_N=BN,
+        CAUSAL=causal,
+        VARLEN=varlen,
+        num_warps=4,
+        num_stages=1,
+    )
+    _bwd_dq[(triton.cdiv(N, BM), B * H)](
+        q,
+        k,
+        v,
+        scale,
+        do,
+        dq,
+        L,
+        delta,
+        pos,
+        spb,
+        spn,
+        *q.stride(),
+        H,
+        N,
+        HEAD_DIM=D,
+        BLOCK_M=BM,
+        BLOCK_N=BN,
+        CAUSAL=causal,
+        VARLEN=varlen,
+        num_warps=4,
+        num_stages=1,
+    )
+    return dq, dk, dv
+
+
+@_flash_d512_bwd_op.register_fake
+def _(do, q, k, v, o, L, pos, doc_end, causal, varlen, scale):
+    return torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
+
+
 class _FlashD512(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, causal, position_ids, scale=None):
@@ -366,7 +495,8 @@ class _FlashD512(torch.autograd.Function):
         # repeat_interleave); the mismatched strides make the backward read wrong memory and explode
         # the gradient (forward is unaffected -- it passes each tensor's own strides). Force one layout.
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
-        B, H, N, D = q.shape
+        B, N = q.shape[0], q.shape[2]
+        D = q.shape[3]
         VARLEN = position_ids is not None
         if position_ids is None:
             pos = torch.zeros((B, N), device=q.device, dtype=torch.int32)
@@ -376,7 +506,6 @@ class _FlashD512(torch.autograd.Function):
                 .to(torch.int32)
                 .contiguous()
             )
-        spb, spn = pos.stride()
         if VARLEN:
             doc_end = torch.empty_like(pos)
             for b in range(B):
@@ -389,30 +518,8 @@ class _FlashD512(torch.autograd.Function):
                 )
         else:
             doc_end = pos
-        o = torch.empty_like(q)
-        L = torch.empty((B * H, N), device=q.device, dtype=torch.float32)
         scale = D**-0.5 if scale is None else float(scale)
-        # BLOCK_M/BLOCK_N, num_warps, num_stages come from the autotuner (SMEM-pruned per device).
-        _fwd[lambda meta: (triton.cdiv(N, meta["BLOCK_M"]), B * H)](
-            q,
-            k,
-            v,
-            scale,
-            o,
-            L,
-            *q.stride(),
-            *k.stride(),
-            *v.stride(),
-            *o.stride(),
-            pos,
-            spb,
-            spn,
-            H,
-            N,
-            HEAD_DIM=D,
-            CAUSAL=causal,
-            VARLEN=VARLEN,
-        )
+        o, L = _flash_d512_fwd_op(q, k, v, pos, causal, VARLEN, scale)
         ctx.save_for_backward(q, k, v, o, L, pos, doc_end)
         ctx.causal = causal
         ctx.scale = scale
@@ -422,67 +529,8 @@ class _FlashD512(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         q, k, v, o, L, pos, doc_end = ctx.saved_tensors
-        B, H, N, D = q.shape
-        causal = ctx.causal
-        scale = ctx.scale
-        VARLEN = ctx.varlen
-        spb, spn = pos.stride()
-        do = do.contiguous()
-        dq = torch.empty_like(q)
-        dk = torch.empty_like(k)
-        dv = torch.empty_like(v)
-        delta = torch.empty((B * H, N), device=q.device, dtype=torch.float32)
-        BM, BN = 16, 32
-        _bwd_pre[(triton.cdiv(N, BM), B * H)](
-            o, do, delta, *o.stride(), H, N, HEAD_DIM=D, BLOCK_M=BM, num_warps=4
-        )
-        _bwd_dkdv[(triton.cdiv(N, BN), B * H)](
-            q,
-            k,
-            v,
-            scale,
-            do,
-            dk,
-            dv,
-            L,
-            delta,
-            pos,
-            doc_end,
-            spb,
-            spn,
-            *q.stride(),
-            H,
-            N,
-            HEAD_DIM=D,
-            BLOCK_M=BM,
-            BLOCK_N=BN,
-            CAUSAL=causal,
-            VARLEN=VARLEN,
-            num_warps=4,
-            num_stages=1,
-        )
-        _bwd_dq[(triton.cdiv(N, BM), B * H)](
-            q,
-            k,
-            v,
-            scale,
-            do,
-            dq,
-            L,
-            delta,
-            pos,
-            spb,
-            spn,
-            *q.stride(),
-            H,
-            N,
-            HEAD_DIM=D,
-            BLOCK_M=BM,
-            BLOCK_N=BN,
-            CAUSAL=causal,
-            VARLEN=VARLEN,
-            num_warps=4,
-            num_stages=1,
+        dq, dk, dv = _flash_d512_bwd_op(
+            do, q, k, v, o, L, pos, doc_end, ctx.causal, ctx.varlen, ctx.scale
         )
         return dq, dk, dv, None, None, None
 

--- a/src/axolotl/monkeypatch/trainer/utils.py
+++ b/src/axolotl/monkeypatch/trainer/utils.py
@@ -17,6 +17,8 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from axolotl.kernels.op_registry import register_kernel_op
+
 
 @triton.jit
 def _entropy_online_kernel(
@@ -105,19 +107,13 @@ def _entropy_online_kernel_strided(
     tl.store(output_ptr + local_row, entropy)
 
 
-def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
-    """Triton-fused entropy (online single-pass). Handles non-contiguous tensors without copying."""
-    original_shape = logits.shape[:-1]
+@register_kernel_op("entropy_from_logits")
+def _entropy_from_logits_op(logits: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    """CUDA entropy launches; returns flat float32 `(N,)` output."""
     V = logits.shape[-1]
     N = 1
-    for s in original_shape:
+    for s in logits.shape[:-1]:
         N *= s
-
-    if not logits.is_cuda:
-        # CPU fallback: stable entropy via log_softmax
-        logp = F.log_softmax(logits.float(), dim=-1)
-        ent = -(logp.exp() * logp).sum(dim=-1)
-        return ent.to(logits.dtype).reshape(original_shape)
 
     output = torch.empty(N, device=logits.device, dtype=torch.float32)
 
@@ -163,6 +159,28 @@ def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 128) -> torch.Te
                 flat_logits[start], output[start], stride, V=V, BLOCK_V=BLOCK_V
             )
 
+    return output
+
+
+@_entropy_from_logits_op.register_fake
+def _(logits, chunk_size):
+    N = 1
+    for s in logits.shape[:-1]:
+        N *= s
+    return torch.empty(N, device=logits.device, dtype=torch.float32)
+
+
+def entropy_from_logits(logits: torch.Tensor, chunk_size: int = 128) -> torch.Tensor:
+    """Triton-fused entropy (online single-pass). Handles non-contiguous tensors without copying."""
+    original_shape = logits.shape[:-1]
+
+    if not logits.is_cuda:
+        # CPU fallback: stable entropy via log_softmax
+        logp = F.log_softmax(logits.float(), dim=-1)
+        ent = -(logp.exp() * logp).sum(dim=-1)
+        return ent.to(logits.dtype).reshape(original_shape)
+
+    output = _entropy_from_logits_op(logits, chunk_size)
     return output.to(logits.dtype).reshape(original_shape)
 
 
@@ -317,28 +335,101 @@ def _selective_logsoftmax_bwd_kernel(
         tl.store(grad_logits_row_ptr + offs, grad_j, mask=mask)
 
 
+@register_kernel_op("selective_log_softmax_fwd")
+def _selective_log_softmax_fwd_op(
+    flat_logits: torch.Tensor,
+    flat_index: torch.Tensor,
+    K: int,
+    K_BLOCK: int,
+    V: int,
+    BLOCK_V: int,
+    MAX_GRID: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    N = flat_logits.shape[0]
+    output = torch.empty(N, K_BLOCK, device=flat_logits.device, dtype=torch.float32)
+    logsumexp = torch.empty(N, device=flat_logits.device, dtype=torch.float32)
+
+    for start in range(0, N, MAX_GRID):
+        n_rows = min(MAX_GRID, N - start)
+        _selective_logsoftmax_fwd_kernel[(n_rows,)](
+            flat_logits[start],
+            flat_index[start],
+            output[start],
+            logsumexp[start],
+            flat_logits.stride(0),
+            flat_index.stride(0),
+            output.stride(0),
+            K,
+            K_BLOCK=K_BLOCK,
+            V=V,
+            BLOCK_V=BLOCK_V,
+        )
+
+    return output, logsumexp
+
+
+@_selective_log_softmax_fwd_op.register_fake
+def _(flat_logits, flat_index, K, K_BLOCK, V, BLOCK_V, MAX_GRID):
+    N = flat_logits.shape[0]
+    return (
+        torch.empty(N, K_BLOCK, device=flat_logits.device, dtype=torch.float32),
+        torch.empty(N, device=flat_logits.device, dtype=torch.float32),
+    )
+
+
+@register_kernel_op("selective_log_softmax_bwd")
+def _selective_log_softmax_bwd_op(
+    grad_output: torch.Tensor,
+    flat_logits: torch.Tensor,
+    flat_index: torch.Tensor,
+    logsumexp: torch.Tensor,
+    K: int,
+    K_BLOCK: int,
+    V: int,
+    BLOCK_V: int,
+    MAX_GRID: int,
+) -> torch.Tensor:
+    N = flat_logits.shape[0]
+
+    grad_logits = torch.empty_like(flat_logits)
+
+    # grad_output may have K_BLOCK cols; backward kernel reads actual_K
+    grad_output_contig = grad_output.contiguous()
+
+    for start in range(0, N, MAX_GRID):
+        n_rows = min(MAX_GRID, N - start)
+        _selective_logsoftmax_bwd_kernel[(n_rows,)](
+            grad_output_contig[start],
+            flat_logits[start],
+            flat_index[start],
+            logsumexp[start],
+            grad_logits[start],
+            grad_output_contig.stride(0),
+            flat_logits.stride(0),
+            flat_index.stride(0),
+            grad_logits.stride(0),
+            K,
+            K_BLOCK=K_BLOCK,
+            V=V,
+            BLOCK_V=BLOCK_V,
+        )
+
+    return grad_logits
+
+
+@_selective_log_softmax_bwd_op.register_fake
+def _(
+    grad_output, flat_logits, flat_index, logsumexp, K, K_BLOCK, V, BLOCK_V, MAX_GRID
+):
+    return torch.empty_like(flat_logits)
+
+
 class _SelectiveLogSoftmaxTriton(torch.autograd.Function):
     @staticmethod
     def forward(ctx, flat_logits, flat_index, K, K_BLOCK, V, BLOCK_V, MAX_GRID):
-        N = flat_logits.shape[0]
-        output = torch.empty(N, K_BLOCK, device=flat_logits.device, dtype=torch.float32)
-        logsumexp = torch.empty(N, device=flat_logits.device, dtype=torch.float32)
-
-        for start in range(0, N, MAX_GRID):
-            n_rows = min(MAX_GRID, N - start)
-            _selective_logsoftmax_fwd_kernel[(n_rows,)](
-                flat_logits[start],
-                flat_index[start],
-                output[start],
-                logsumexp[start],
-                flat_logits.stride(0),
-                flat_index.stride(0),
-                output.stride(0),
-                K,
-                K_BLOCK=K_BLOCK,
-                V=V,
-                BLOCK_V=BLOCK_V,
-            )
+        output, logsumexp = _selective_log_softmax_fwd_op(
+            flat_logits, flat_index, K, K_BLOCK, V, BLOCK_V, MAX_GRID
+        )
 
         ctx.save_for_backward(flat_logits, flat_index, logsumexp)
         ctx.K = K
@@ -358,30 +449,17 @@ class _SelectiveLogSoftmaxTriton(torch.autograd.Function):
             ctx.BLOCK_V,
             ctx.MAX_GRID,
         )
-        N = flat_logits.shape[0]
-
-        grad_logits = torch.empty_like(flat_logits)
-
-        # grad_output may have K_BLOCK cols; backward kernel reads actual_K
-        grad_output_contig = grad_output.contiguous()
-
-        for start in range(0, N, MAX_GRID):
-            n_rows = min(MAX_GRID, N - start)
-            _selective_logsoftmax_bwd_kernel[(n_rows,)](
-                grad_output_contig[start],
-                flat_logits[start],
-                flat_index[start],
-                logsumexp[start],
-                grad_logits[start],
-                grad_output_contig.stride(0),
-                flat_logits.stride(0),
-                flat_index.stride(0),
-                grad_logits.stride(0),
-                K,
-                K_BLOCK=K_BLOCK,
-                V=V,
-                BLOCK_V=BLOCK_V,
-            )
+        grad_logits = _selective_log_softmax_bwd_op(
+            grad_output,
+            flat_logits,
+            flat_index,
+            logsumexp,
+            K,
+            K_BLOCK,
+            V,
+            BLOCK_V,
+            MAX_GRID,
+        )
 
         # Return grads for: flat_logits, flat_index, K, K_BLOCK, V, BLOCK_V, MAX_GRID
         return grad_logits, None, None, None, None, None, None

--- a/tests/integrations/kernels/dsv4/test_dsv4_attention_ops.py
+++ b/tests/integrations/kernels/dsv4/test_dsv4_attention_ops.py
@@ -1,0 +1,161 @@
+"""Parity tests for the DSV4 attention custom ops (sliding, CSA dense, CSA top-k gather).
+
+Each kernel's fwd/bwd launch is registered as a ``torch.ops.axolotl.*`` custom op; these
+tests check the ops exist and that the autograd entry points still match a dense fp32
+eager reference (fwd outputs + input grads, including the per-head sink grad).
+"""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+DEV = "cuda"
+B, H, S, D = 2, 8, 128, 128
+T, K, W = 64, 32, 32
+
+
+def _rel(a, b):
+    return (a.float() - b.float()).norm().item() / max(b.float().norm().item(), 1e-12)
+
+
+def _sink_softmax(logits, sinks):
+    """Append the per-head sink as a logit-only column, softmax, drop it."""
+    Bb, Hh, Ss, _ = logits.shape
+    sink = sinks.float().view(1, Hh, 1, 1).expand(Bb, Hh, Ss, 1)
+    return torch.cat([logits, sink], -1).softmax(-1)[..., :-1]
+
+
+def _window_mask(s_q, s_k, window, device):
+    i = torch.arange(s_q, device=device)[:, None]
+    j = torch.arange(s_k, device=device)[None, :]
+    return (j <= i) & (i - j < window)
+
+
+def test_ops_registered():
+    from axolotl.integrations.kernels.libs import dsv4  # noqa: F401
+
+    for name in (
+        "dsv4_sliding_attn_fwd",
+        "dsv4_sliding_attn_bwd",
+        "dsv4_csa_attn_fwd",
+        "dsv4_csa_attn_bwd",
+        "dsv4_csa_topk_attn_fwd",
+        "dsv4_csa_topk_attn_bwd",
+    ):
+        assert hasattr(torch.ops.axolotl, name), name
+
+
+def test_sliding_attn_matches_eager():
+    from axolotl.integrations.kernels.libs.dsv4 import sliding_attn
+
+    torch.manual_seed(0)
+    q = torch.randn(B, H, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(B, 1, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(B, 1, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    sinks = torch.randn(H, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    qr, kr, vr, sr = (t.detach().clone().requires_grad_() for t in (q, k, v, sinks))
+
+    out = sliding_attn(q, k, v, sinks, None, W)
+    out.float().pow(2).mean().backward()
+
+    scale = D**-0.5
+    scores = qr.float() @ kr[:, 0].float()[:, None].transpose(-1, -2) * scale
+    scores = scores.masked_fill(~_window_mask(S, S, W, DEV), float("-inf"))
+    p = _sink_softmax(scores, sr)
+    ref = p @ vr[:, 0].float()[:, None]
+    ref.pow(2).mean().backward()
+
+    assert _rel(out, ref) < 0.02
+    assert _rel(q.grad, qr.grad) < 0.05
+    assert _rel(k.grad, kr.grad) < 0.05
+    assert _rel(v.grad, vr.grad) < 0.05
+    assert _rel(sinks.grad, sr.grad) < 0.05
+
+
+def test_csa_attn_matches_eager():
+    from axolotl.integrations.kernels.libs.dsv4 import csa_attn
+
+    torch.manual_seed(1)
+    q = torch.randn(B, H, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    kvs = torch.randn(B, 1, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    kvc = torch.randn(B, 1, T, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    sinks = torch.randn(H, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    # additive block bias: finite bias on causally-valid compressed slots, -inf elsewhere
+    comp_valid = (
+        torch.arange(T, device=DEV)[None, :] * 2 <= torch.arange(S, device=DEV)[:, None]
+    )
+    bb = torch.where(
+        comp_valid, torch.randn(B, S, T, device=DEV), float("-inf")
+    ).unsqueeze(1)
+    qr, ksr, kcr, sr = (
+        t.detach().clone().requires_grad_() for t in (q, kvs, kvc, sinks)
+    )
+
+    out = csa_attn(q, kvs, kvc, bb, sinks, None, W)
+    out.float().pow(2).mean().backward()
+
+    scale = D**-0.5
+    ss = qr.float() @ ksr[:, 0].float()[:, None].transpose(-1, -2) * scale
+    ss = ss.masked_fill(~_window_mask(S, S, W, DEV), float("-inf"))
+    sc = qr.float() @ kcr[:, 0].float()[:, None].transpose(-1, -2) * scale + bb.float()
+    p = _sink_softmax(torch.cat([ss, sc], -1), sr)
+    ref = (
+        p[..., :S] @ ksr[:, 0].float()[:, None]
+        + p[..., S:] @ kcr[:, 0].float()[:, None]
+    )
+    ref.pow(2).mean().backward()
+
+    assert _rel(out, ref) < 0.02
+    assert _rel(q.grad, qr.grad) < 0.05
+    assert _rel(kvs.grad, ksr.grad) < 0.05
+    assert _rel(kvc.grad, kcr.grad) < 0.05
+    assert _rel(sinks.grad, sr.grad) < 0.05
+
+
+def test_csa_attn_topk_matches_eager():
+    from axolotl.integrations.kernels.libs.dsv4 import csa_attn_topk
+
+    torch.manual_seed(2)
+    q = torch.randn(B, H, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    kvs = torch.randn(B, 1, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    kvc = torch.randn(B, 1, T, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    sinks = torch.randn(H, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    # unique top-k per position (duplicates would double-count in any implementation);
+    # early positions get -1 (invalid) tails like the real indexer emits
+    idx = torch.stack(
+        [
+            torch.stack([torch.randperm(T, device=DEV)[:K] for _ in range(S)])
+            for _ in range(B)
+        ]
+    ).to(torch.int32)
+    idx[:, : S // 8, K // 2 :] = -1
+    qr, ksr, kcr, sr = (
+        t.detach().clone().requires_grad_() for t in (q, kvs, kvc, sinks)
+    )
+
+    out = csa_attn_topk(q, kvs, kvc, idx, sinks, None, W)
+    out.float().pow(2).mean().backward()
+
+    sel = torch.zeros(B, S, T, dtype=torch.bool, device=DEV)
+    for b in range(B):
+        for s in range(S):
+            row = idx[b, s]
+            sel[b, s, row[row >= 0].long()] = True
+    scale = D**-0.5
+    ss = qr.float() @ ksr[:, 0].float()[:, None].transpose(-1, -2) * scale
+    ss = ss.masked_fill(~_window_mask(S, S, W, DEV), float("-inf"))
+    sc = qr.float() @ kcr[:, 0].float()[:, None].transpose(-1, -2) * scale
+    sc = sc.masked_fill(~sel[:, None], float("-inf"))
+    p = _sink_softmax(torch.cat([ss, sc], -1), sr)
+    ref = (
+        p[..., :S] @ ksr[:, 0].float()[:, None]
+        + p[..., S:] @ kcr[:, 0].float()[:, None]
+    )
+    ref.pow(2).mean().backward()
+
+    assert _rel(out, ref) < 0.02
+    assert _rel(q.grad, qr.grad) < 0.05
+    assert _rel(kvs.grad, ksr.grad) < 0.05
+    assert _rel(kvc.grad, kcr.grad) < 0.05
+    assert _rel(sinks.grad, sr.grad) < 0.05

--- a/tests/integrations/kernels/glm_dsa/test_sparse_topk_attn.py
+++ b/tests/integrations/kernels/glm_dsa/test_sparse_topk_attn.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Parity tests for the GLM-DSA sparse top-k attention kernel and its registered custom ops.
+
+``sparse_attn`` gathers each query's selected keys and runs flash online-softmax over just those;
+the reference gathers the same keys in fp32 torch and takes a masked softmax. Forward outputs and
+input gradients (dq/dk/dv) must agree. Also asserts the kernels are dispatcher-visible as
+``torch.ops.axolotl.*`` (torch.compile opacity + selective-checkpointing matching)."""
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+import axolotl.integrations.kernels.libs.glm_dsa.attention_mla_absorb  # noqa: F401,E402
+from axolotl.integrations.kernels.libs.glm_dsa.attention_topk import (  # noqa: E402
+    sparse_attn,
+)
+
+DEV = "cuda"
+
+
+def test_glm_dsa_ops_registered():
+    for name in (
+        "glm_dsa_sparse_topk_attn_fwd",
+        "glm_dsa_sparse_topk_attn_bwd",
+        "glm_dsa_mla_absorb_attn_fwd",
+        "glm_dsa_mla_absorb_attn_bwd",
+    ):
+        assert hasattr(torch.ops.axolotl, name), f"torch.ops.axolotl.{name} missing"
+
+
+def _causal_window_topk(B, S, T, device):
+    """Per query ``s``: the last-T causal positions, padded with DISTINCT future (masked) ones so
+    slot-summed gather == de-duplicated dense softmax."""
+    idx = torch.empty(B, S, T, dtype=torch.int32, device=device)
+    for s in range(S):
+        causal = torch.arange(max(0, s - T + 1), s + 1, device=device)
+        pad = torch.arange(s + 1, s + 1 + T - causal.numel(), device=device)
+        idx[:, s, :] = torch.cat([causal, pad]).to(torch.int32)
+    return idx
+
+
+def _ref_sparse_attn(q, k, v, idx, scale):
+    B, H, S, D = q.shape
+    DV = v.shape[-1]
+    T = idx.shape[-1]
+    i = idx.long()[:, None].expand(B, H, S, T)
+    kg = torch.gather(k, 2, i.reshape(B, H, S * T, 1).expand(-1, -1, -1, D)).view(
+        B, H, S, T, D
+    )
+    vg = torch.gather(v, 2, i.reshape(B, H, S * T, 1).expand(-1, -1, -1, DV)).view(
+        B, H, S, T, DV
+    )
+    scores = (q.unsqueeze(-2) * kg).sum(-1) * scale
+    valid = idx.long()[:, None] <= torch.arange(S, device=q.device)[None, None, :, None]
+    p = scores.masked_fill(~valid, float("-inf")).softmax(dim=-1)
+    return (p.unsqueeze(-1) * vg).sum(-2)
+
+
+def test_sparse_topk_matches_reference_fwd_and_grads():
+    torch.manual_seed(0)
+    B, H, S, D, DV, T = 1, 2, 32, 64, 64, 8
+    q = torch.randn(B, H, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(B, H, S, D, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(B, H, S, DV, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    idx = _causal_window_topk(B, S, T, DEV)
+    scale = D**-0.5
+    # bf16-exact cotangent so both paths backprop the identical dout (unit scale -> the grad
+    # tolerance is meaningful, unlike a mean-loss whose grads are ~1e-4)
+    g = torch.randn(B, H, S, DV, device=DEV, dtype=torch.bfloat16).float()
+
+    out = sparse_attn(q, k, v, idx, scale)
+    (out.float() * g).sum().backward()
+
+    qr = q.detach().float().requires_grad_(True)
+    kr = k.detach().float().requires_grad_(True)
+    vr = v.detach().float().requires_grad_(True)
+    oref = _ref_sparse_attn(qr, kr, vr, idx, scale)
+    (oref * g).sum().backward()
+
+    assert torch.isfinite(out).all()
+    assert (out.float() - oref).abs().max().item() < 3e-2
+    for got, ref in ((q.grad, qr.grad), (k.grad, kr.grad), (v.grad, vr.grad)):
+        assert torch.isfinite(got).all()
+        assert (got.float() - ref).abs().max().item() < 3e-2

--- a/tests/kernels/test_op_registry.py
+++ b/tests/kernels/test_op_registry.py
@@ -1,0 +1,352 @@
+"""Tests for custom-op registration of axolotl kernels."""
+
+import pytest
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+class _OpRecorder(TorchDispatchMode):
+    def __init__(self):
+        self.seen = []
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        self.seen.append(str(func))
+        return func(*args, **(kwargs or {}))
+
+
+class TestOpsRegistered:
+    def test_flash_d512_ops_exist(self):
+        import axolotl.monkeypatch.attention.flash_attn_d512  # noqa: F401
+
+        assert torch.ops.axolotl.flash_attn_d512_fwd is not None
+        assert torch.ops.axolotl.flash_attn_d512_bwd is not None
+
+    def test_activation_ops_exist(self):
+        import axolotl.kernels.geglu  # noqa: F401
+        import axolotl.kernels.swiglu  # noqa: F401
+
+        assert torch.ops.axolotl.swiglu_fwd is not None
+        assert torch.ops.axolotl.swiglu_bwd is not None
+        assert torch.ops.axolotl.geglu_fwd is not None
+        assert torch.ops.axolotl.geglu_bwd is not None
+
+    def test_rms_norm_gated_ops_exist(self):
+        import axolotl.kernels.rms_norm_gated  # noqa: F401
+
+        assert torch.ops.axolotl.rms_norm_gated_fwd is not None
+        assert torch.ops.axolotl.rms_norm_gated_bwd is not None
+
+    def test_trainer_utils_ops_exist(self):
+        import axolotl.monkeypatch.trainer.utils  # noqa: F401
+
+        assert torch.ops.axolotl.selective_log_softmax_fwd is not None
+        assert torch.ops.axolotl.selective_log_softmax_bwd is not None
+        assert torch.ops.axolotl.entropy_from_logits is not None
+
+    def test_ebft_ops_exist(self):
+        import axolotl.core.trainers.ebft.kernels  # noqa: F401
+
+        assert torch.ops.axolotl.ebft_fused_log_softmax_gather is not None
+        assert torch.ops.axolotl.ebft_fused_reinforce_loss is not None
+        assert torch.ops.axolotl.ebft_fused_cosine_similarity is not None
+        assert torch.ops.axolotl.ebft_fused_diversity_penalty is not None
+
+
+class TestDispatchVisibility:
+    @requires_cuda
+    def test_swiglu_visible_to_dispatch_mode(self):
+        from axolotl.kernels.swiglu import swiglu_forward
+
+        gate = torch.randn(1, 8, 64, device="cuda")
+        up = torch.randn(1, 8, 64, device="cuda")
+        with _OpRecorder() as rec:
+            swiglu_forward(gate, up)
+        assert any("axolotl.swiglu_fwd" in s for s in rec.seen)
+
+    @requires_cuda
+    def test_flash_d512_visible_to_dispatch_mode(self):
+        from axolotl.monkeypatch.attention.flash_attn_d512 import flash_d512
+
+        q, k, v = (
+            torch.randn(1, 2, 64, 512, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        with _OpRecorder() as rec:
+            flash_d512(q, k, v, causal=True)
+        assert any("axolotl.flash_attn_d512_fwd" in s for s in rec.seen)
+
+
+class TestFakeTensor:
+    @requires_cuda
+    def test_flash_d512_fwd_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.monkeypatch.attention.flash_attn_d512  # noqa: F401
+
+        with FakeTensorMode():
+            q = torch.empty(2, 4, 128, 512, device="cuda", dtype=torch.bfloat16)
+            k = torch.empty_like(q)
+            v = torch.empty_like(q)
+            pos = torch.zeros(2, 128, device="cuda", dtype=torch.int32)
+            o, lse = torch.ops.axolotl.flash_attn_d512_fwd(
+                q, k, v, pos, True, False, 0.044
+            )
+            assert o.shape == q.shape and o.dtype == q.dtype
+            assert lse.shape == (8, 128) and lse.dtype == torch.float32
+
+    @requires_cuda
+    def test_swiglu_fwd_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.kernels.swiglu  # noqa: F401
+
+        with FakeTensorMode():
+            gate = torch.empty(1, 8, 64, device="cuda", dtype=torch.bfloat16)
+            up = torch.empty_like(gate)
+            out = torch.ops.axolotl.swiglu_fwd(gate, up)
+            assert out.shape == gate.shape and out.dtype == gate.dtype
+
+
+class TestNewOpsDispatchVisibility:
+    @requires_cuda
+    def test_rms_norm_gated_visible_to_dispatch_mode(self):
+        from axolotl.kernels.rms_norm_gated import FusedRMSNormGated
+
+        mod = FusedRMSNormGated(64).to("cuda", torch.bfloat16)
+        x = torch.randn(2, 8, 64, device="cuda", dtype=torch.bfloat16)
+        g = torch.randn_like(x)
+        with _OpRecorder() as rec:
+            mod(x, gate=g)
+        assert any("axolotl.rms_norm_gated_fwd" in s for s in rec.seen)
+
+    @requires_cuda
+    def test_selective_log_softmax_visible_to_dispatch_mode(self):
+        from axolotl.monkeypatch.trainer.utils import selective_log_softmax
+
+        logits = torch.randn(2, 16, 512, device="cuda", dtype=torch.bfloat16)
+        index = torch.randint(0, 512, (2, 16), device="cuda")
+        with _OpRecorder() as rec:
+            selective_log_softmax(logits, index)
+        assert any("axolotl.selective_log_softmax_fwd" in s for s in rec.seen)
+
+    @requires_cuda
+    def test_entropy_visible_to_dispatch_mode(self):
+        from axolotl.monkeypatch.trainer.utils import entropy_from_logits
+
+        logits = torch.randn(2, 16, 512, device="cuda", dtype=torch.bfloat16)
+        with _OpRecorder() as rec:
+            entropy_from_logits(logits)
+        assert any("axolotl.entropy_from_logits" in s for s in rec.seen)
+
+    @requires_cuda
+    def test_ebft_ops_visible_to_dispatch_mode(self):
+        from axolotl.core.trainers.ebft.kernels import (
+            fused_cosine_similarity,
+            fused_diversity_penalty,
+            fused_log_softmax_gather,
+            fused_reinforce_loss,
+        )
+
+        logits = torch.randn(2, 8, 512, device="cuda", dtype=torch.bfloat16)
+        labels = torch.randint(0, 512, (2, 8), device="cuda")
+        logps = torch.randn(64, device="cuda")
+        advs = torch.randn(64, device="cuda")
+        mask = torch.rand(64, device="cuda") > 0.5
+        a = torch.randn(4, 128, device="cuda")
+        emb = torch.randn(2, 4, 64, device="cuda")
+        with _OpRecorder() as rec:
+            fused_log_softmax_gather(logits, labels)
+            fused_reinforce_loss(logps, advs, mask)
+            fused_cosine_similarity(a, a.clone())
+            fused_diversity_penalty(emb)
+        for op in (
+            "ebft_fused_log_softmax_gather",
+            "ebft_fused_reinforce_loss",
+            "ebft_fused_cosine_similarity",
+            "ebft_fused_diversity_penalty",
+        ):
+            assert any(f"axolotl.{op}" in s for s in rec.seen), op
+
+
+class TestNewOpsFakeTensor:
+    @requires_cuda
+    def test_rms_norm_gated_fwd_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.kernels.rms_norm_gated  # noqa: F401
+
+        with FakeTensorMode():
+            x = torch.empty(16, 64, device="cuda", dtype=torch.bfloat16)
+            g = torch.empty_like(x)
+            w = torch.empty(64, device="cuda", dtype=torch.bfloat16)
+            y, rstd = torch.ops.axolotl.rms_norm_gated_fwd(x, g, w, 1e-6, 0.0, 64, 4)
+            assert y.shape == x.shape and y.dtype == x.dtype
+            assert rstd.shape == (16,) and rstd.dtype == torch.float32
+
+    @requires_cuda
+    def test_selective_log_softmax_fwd_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.monkeypatch.trainer.utils  # noqa: F401
+
+        with FakeTensorMode():
+            logits = torch.empty(32, 512, device="cuda", dtype=torch.bfloat16)
+            index = torch.empty(32, 1, device="cuda", dtype=torch.int64)
+            out, lse = torch.ops.axolotl.selective_log_softmax_fwd(
+                logits, index, 1, 1, 512, 4096, 8192
+            )
+            assert out.shape == (32, 1) and out.dtype == torch.float32
+            assert lse.shape == (32,) and lse.dtype == torch.float32
+
+    @requires_cuda
+    def test_entropy_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.monkeypatch.trainer.utils  # noqa: F401
+
+        with FakeTensorMode():
+            logits = torch.empty(2, 16, 512, device="cuda", dtype=torch.bfloat16)
+            out = torch.ops.axolotl.entropy_from_logits(logits, 128)
+            assert out.shape == (32,) and out.dtype == torch.float32
+
+    @requires_cuda
+    def test_ebft_fake_shapes(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        import axolotl.core.trainers.ebft.kernels  # noqa: F401
+
+        with FakeTensorMode():
+            logits = torch.empty(2, 8, 512, device="cuda", dtype=torch.bfloat16)
+            labels = torch.empty(2, 8, device="cuda", dtype=torch.int64)
+            out = torch.ops.axolotl.ebft_fused_log_softmax_gather(logits, labels)
+            assert out.shape == (2, 8) and out.dtype == torch.float32
+
+            logps = torch.empty(64, device="cuda")
+            mask = torch.empty(64, device="cuda", dtype=torch.bool)
+            loss = torch.ops.axolotl.ebft_fused_reinforce_loss(logps, logps, mask)
+            assert loss.shape == () and loss.dtype == torch.float32
+
+            a = torch.empty(4, 8, 128, device="cuda")
+            sim = torch.ops.axolotl.ebft_fused_cosine_similarity(a, a)
+            assert sim.shape == (4, 8) and sim.dtype == torch.float32
+
+            emb = torch.empty(2, 4, 64, device="cuda")
+            div = torch.ops.axolotl.ebft_fused_diversity_penalty(emb)
+            assert div.shape == (2, 4) and div.dtype == torch.float32
+
+
+class TestCompile:
+    @requires_cuda
+    def test_swiglu_compiles_fullgraph(self):
+        from axolotl.kernels.swiglu import swiglu_forward
+
+        def fn(gate, up):
+            return swiglu_forward(gate, up).sum()
+
+        gate = torch.randn(1, 8, 64, device="cuda")
+        up = torch.randn(1, 8, 64, device="cuda")
+        eager = fn(gate, up)
+        compiled = torch.compile(fn, fullgraph=True)(gate, up)
+        torch.testing.assert_close(eager, compiled)
+
+    @requires_cuda
+    def test_flash_d512_compiles_fullgraph(self):
+        from axolotl.monkeypatch.attention.flash_attn_d512 import flash_d512
+
+        def fn(q, k, v):
+            return flash_d512(q, k, v, causal=True).sum()
+
+        q, k, v = (
+            torch.randn(1, 2, 64, 512, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        eager = fn(q, k, v)
+        compiled = torch.compile(fn, fullgraph=True)(q, k, v)
+        torch.testing.assert_close(eager, compiled, atol=2e-2, rtol=2e-2)
+
+
+class TestOpcheck:
+    """torch.library.opcheck validates schema, fake fidelity, aliasing, and
+    functionalization in one shot."""
+
+    @requires_cuda
+    def test_swiglu_ops(self):
+        from axolotl.kernels.swiglu import _swiglu_bwd_op, swiglu_forward
+
+        gate = torch.randn(1, 8, 64, device="cuda")
+        up = torch.randn(1, 8, 64, device="cuda")
+        go = torch.randn(1, 8, 64, device="cuda")
+        torch.library.opcheck(swiglu_forward, (gate.clone(), up.clone()))
+        torch.library.opcheck(_swiglu_bwd_op, (go, gate, up))
+
+    @requires_cuda
+    def test_geglu_ops(self):
+        from axolotl.kernels.geglu import _geglu_bwd_op, geglu_forward
+
+        gate = torch.randn(1, 8, 64, device="cuda")
+        up = torch.randn(1, 8, 64, device="cuda")
+        go = torch.randn(1, 8, 64, device="cuda")
+        torch.library.opcheck(geglu_forward, (gate.clone(), up.clone()))
+        torch.library.opcheck(_geglu_bwd_op, (go, gate, up))
+
+    @requires_cuda
+    def test_flash_d512_fwd(self):
+        from axolotl.monkeypatch.attention.flash_attn_d512 import _flash_d512_fwd_op
+
+        q, k, v = (
+            torch.randn(1, 1, 32, 512, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        pos = torch.zeros(1, 32, device="cuda", dtype=torch.int32)
+        torch.library.opcheck(_flash_d512_fwd_op, (q, k, v, pos, True, False, 0.044))
+
+
+class TestMutatingBwdUnderCompile:
+    @requires_cuda
+    def test_swiglu_backward_functionalizes_correctly(self):
+        """The mutate-then-read-back wrapper must survive compile's
+        auto-functionalization (downstream uses of mutated args are remapped)."""
+        from axolotl.kernels.swiglu import swiglu_backward
+
+        def fn(go, gate, up):
+            h, dg, du = swiglu_backward(go, gate, up)
+            return h.sum() + dg.sum() * 2 + du.sum() * 3
+
+        go, gate, up = (torch.randn(1, 16, 128, device="cuda") for _ in range(3))
+        eager = fn(go.clone(), gate.clone(), up.clone())
+        compiled = torch.compile(fn, fullgraph=True)(
+            go.clone(), gate.clone(), up.clone()
+        )
+        torch.testing.assert_close(eager, compiled)
+
+
+class TestFallbackShim:
+    def test_unregistered_op_passthrough(self):
+        from axolotl.kernels.op_registry import _UnregisteredOp
+
+        def raw(x):
+            return x + 1
+
+        shim = _UnregisteredOp(raw)
+        assert shim(torch.tensor(1)).item() == 2
+        # register_fake is a no-op that must not raise
+        shim.register_fake(lambda x: x)
+
+    def test_failed_registration_falls_back(self):
+        from typing import Callable
+
+        from axolotl.kernels.op_registry import _UnregisteredOp, register_kernel_op
+
+        # a callable arg is not an op-schema type: registration fails and the
+        # decorator degrades to the raw callable
+        @register_kernel_op("test_bad_schema_op")
+        def _bad(x: torch.Tensor, fn: Callable) -> torch.Tensor:
+            return fn(x)
+
+        assert isinstance(_bad, _UnregisteredOp)
+        assert _bad(torch.tensor(1), lambda t: t + 2).item() == 3
+        _bad.register_fake(lambda x, fn: x)


### PR DESCRIPTION
## Summary

Registers `torch.library` custom ops (namespace `axolotl::`) for the in-repo Triton kernel entry points that were previously invisible to the dispatcher. Two payoffs:

1. **torch.compile without graph breaks**: kernels become opaque ops with fake-tensor support instead of breaking the graph — verified with `fullgraph=True` compile tests (swiglu and the full `flash_d512` autograd.Function compile cleanly).
2. **Selective checkpointing compatibility** (#3786): policy-based SAC matches ops by name; `axolotl::flash_attn_d512_fwd` is picked up by the existing `attention` matcher as-is, and the dsv4/glm attention ops need only a one-line group extension (follow-up on that branch).

## What's registered (25 ops)

| Surface | Ops |
|:--|:--|
| `monkeypatch/attention/flash_attn_d512.py` | `flash_attn_d512_fwd/_bwd` |
| `kernels/swiglu.py`, `kernels/geglu.py` | `swiglu_fwd/_bwd`, `geglu_fwd/_bwd` (bwd = in-place mutation ops, `mutates_args`) |
| `kernels/rms_norm_gated.py` | `rms_norm_gated_fwd/_bwd` |
| `monkeypatch/trainer/utils.py` | `selective_log_softmax_fwd/_bwd`, `entropy_from_logits` |
| `core/trainers/ebft/kernels.py` | `ebft_fused_{log_softmax_gather,reinforce_loss,cosine_similarity,diversity_penalty}` |
| `integrations/kernels/libs/dsv4/` | `dsv4_{sliding,csa,csa_topk}_attn_fwd/_bwd` |
| `integrations/kernels/libs/glm_dsa/` | `glm_dsa_{mla_absorb,sparse_topk}_attn_fwd/_bwd` |

## Design

- `kernels/op_registry.py`: `register_kernel_op` decorator — `torch.library.custom_op` + warn-once fallback shim on registration failure (kernel keeps working, just unregistered).
- Op boundary = allocations + kernel launches only. Data-dependent host prep (varlen doc scans), dtype decisions, and non-schema args (callables, `torch.dtype` → crossed as bool) stay in the autograd.Functions, whose saved-tensor sets, ctx attrs, and public signatures are unchanged.
- Every op has a `register_fake` matching the real allocations exactly (incl. fp32 lse/delta buffers and post-cast grad dtypes).
- In-place backward kernels (swiglu/geglu) are declared with `mutates_args` and return `None`; the public wrappers return the mutated aliases *outside* the op (op outputs must never alias inputs). Auto-functionalization of this pattern under compile is verified by test.

## Not registered (deliberate)

scattermoe/sonicmoe autograd wrappers (their inner `scattermoe::*` ops are already registered; wrappers are aten-composed), comm wrappers (`_OverlapGather`, DeepEP), tiled-MLP orchestration Functions, and tiny elementwise helpers (`dora`, dsv4 `_RoPE`/`_GatedPool`/mhc mixers).

## Verification

- 474 tests green across all touched surfaces (existing suites now exercising the op-routed paths), incl. new coverage where none existed (dsv4 attention parity vs dense fp32 sink-softmax reference, glm_dsa sparse-topk parity).
- `tests/kernels/test_op_registry.py`: op existence, `TorchDispatchMode` visibility, fake-tensor shapes, `torch.library.opcheck` (schema/aliasing/mutation/fake in one shot), `fullgraph=True` compile parity (incl. the mutating-bwd functionalization case), and the registration-failure fallback.
- Adversarial kernel-correctness review of the full diff; its one substantive finding (mutate-and-read-back under compile) was empirically refuted and is now a pinned regression test; its fake-stride-fidelity nit is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader registration support for custom GPU kernels, improving integration with PyTorch dispatch and compile paths.
  * Added fake-tensor support for several attention and fused MLP operations, enabling shape inference without real execution.

* **Bug Fixes**
  * Improved compatibility for multiple attention, normalization, and activation kernels across forward and backward passes.
  * Standardized several kernel entry points for more reliable runtime behavior.

* **Tests**
  * Added CUDA integration, parity, dispatch, fake-tensor, compile, and registration coverage for the new kernel ops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## E2E compile smoke (manual verification — NOT in CI; committed tests use only small synthetic tensors)

- **Gemma-4-E2B (MoE) + kernels plugin + LoRA + `torch_compile: true`**: trains cleanly; dynamo captures 3988 ops in 5 graphs; all 8 graph breaks are PEFT/HF-side (none in kernel code).
- **Gemma-4-26B-A4B + `gemma4_hybrid_attn_impl` + sample packing** (the d512 kernel's production path): the `axolotl::flash_attn_d512` op executes in-model under compile (Triton autotune observed in the training step; 435 ops / 37 graphs). The only axolotl-attributed graph breaks are two pre-existing data-dependent lines in the routing wrapper (`large_head.py:52/:63` multidoc detection), not the registered ops — follow-up candidate to hoist out of the traced region.

