### PR TITLE
feat: compile-clean multidoc routing for large-head attention

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -206,6 +206,7 @@ class PatchManager:
 
         from axolotl.monkeypatch.attention.large_head import (
             resolve_large_head_policy,
+            set_large_head_packed,
             set_large_head_policy,
         )
         from axolotl.monkeypatch.gemma4_hybrid_mask import (
@@ -217,6 +218,7 @@ class PatchManager:
         # Gemma-4 global layers reuse the generic large-head router. Default policy 'sdpa' (flash is
         # opt-in via large_head_attention / the deprecated flash_attn_d512), preserving prior default.
         set_large_head_policy(resolve_large_head_policy(self.cfg))
+        set_large_head_packed(bool(self.cfg.sample_packing))
 
         # Navigate to the module that has 'layers' - varies by model structure:
         # Gemma4ForConditionalGeneration -> .model (Gemma4Model) -> .language_model (Gemma4TextModel) -> .layers
@@ -707,6 +709,7 @@ class PatchManager:
         globals through its own impl, so skip the generic sdpa wrapper there to avoid double-wiring."""
         from axolotl.monkeypatch.attention.large_head import (
             resolve_large_head_policy,
+            set_large_head_packed,
             set_large_head_policy,
             unpatch_sdpa_large_head,
         )
@@ -715,6 +718,7 @@ class PatchManager:
         # Always (re)set the policy global from this run's config so a long-lived process can't
         # inherit a previous run's stale auto/triton_flash policy on an sdpa run.
         set_large_head_policy(policy)
+        set_large_head_packed(bool(self.cfg.sample_packing))
         if policy == "sdpa" or self.cfg.gemma4_hybrid_attn_impl:
             unpatch_sdpa_large_head()
             return

--- a/src/axolotl/monkeypatch/attention/flash_attn_d512.py
+++ b/src/axolotl/monkeypatch/attention/flash_attn_d512.py
@@ -507,15 +507,16 @@ class _FlashD512(torch.autograd.Function):
                 .contiguous()
             )
         if VARLEN:
-            doc_end = torch.empty_like(pos)
-            for b in range(B):
-                starts = (pos[b] == 0).nonzero().flatten()
-                bounds = torch.cat(
-                    [starts, torch.tensor([N], device=pos.device, dtype=starts.dtype)]
-                )
-                doc_end[b] = (
-                    bounds[1:].repeat_interleave(bounds[1:] - bounds[:-1]).to(pos.dtype)
-                )
+            # doc_end[b, i] = index of the next document start after i (or N).
+            # Computed as a suffix-min of "j if pos[j]==0 else N" shifted left by
+            # one — fully tensorized so torch.compile can trace it (the previous
+            # per-row .nonzero() loop was a data-dependent graph break).
+            idx = torch.arange(N, device=pos.device, dtype=pos.dtype)
+            starts_or_n = torch.where(pos == 0, idx.expand_as(pos), pos.new_full((), N))
+            shifted = torch.cat([starts_or_n[:, 1:], pos.new_full((B, 1), N)], dim=1)
+            doc_end = torch.flip(
+                torch.cummin(torch.flip(shifted, dims=[1]), dim=1).values, dims=[1]
+            )
         else:
             doc_end = pos
         scale = D**-0.5 if scale is None else float(scale)

--- a/src/axolotl/monkeypatch/attention/flash_attn_d512.py
+++ b/src/axolotl/monkeypatch/attention/flash_attn_d512.py
@@ -487,6 +487,21 @@ def _(do, q, k, v, o, L, pos, doc_end, causal, varlen, scale):
     return torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
 
 
+def _compute_doc_end(pos: torch.Tensor) -> torch.Tensor:
+    """Per-row index of the next document start after each position (or N).
+
+    Suffix-min of "j if pos[j]==0 else N" shifted left by one — fully tensorized so
+    torch.compile can trace it (the per-row ``.nonzero()`` loop graph-breaks).
+    """
+    B, N = pos.shape
+    idx = torch.arange(N, device=pos.device, dtype=pos.dtype)
+    starts_or_n = torch.where(pos == 0, idx.expand_as(pos), pos.new_full((), N))
+    shifted = torch.cat([starts_or_n[:, 1:], pos.new_full((B, 1), N)], dim=1)
+    return torch.flip(
+        torch.cummin(torch.flip(shifted, dims=[1]), dim=1).values, dims=[1]
+    )
+
+
 class _FlashD512(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, causal, position_ids, scale=None):
@@ -507,16 +522,7 @@ class _FlashD512(torch.autograd.Function):
                 .contiguous()
             )
         if VARLEN:
-            # doc_end[b, i] = index of the next document start after i (or N).
-            # Computed as a suffix-min of "j if pos[j]==0 else N" shifted left by
-            # one — fully tensorized so torch.compile can trace it (the previous
-            # per-row .nonzero() loop was a data-dependent graph break).
-            idx = torch.arange(N, device=pos.device, dtype=pos.dtype)
-            starts_or_n = torch.where(pos == 0, idx.expand_as(pos), pos.new_full((), N))
-            shifted = torch.cat([starts_or_n[:, 1:], pos.new_full((B, 1), N)], dim=1)
-            doc_end = torch.flip(
-                torch.cummin(torch.flip(shifted, dims=[1]), dim=1).values, dims=[1]
-            )
+            doc_end = _compute_doc_end(pos)
         else:
             doc_end = pos
         scale = D**-0.5 if scale is None else float(scale)

--- a/src/axolotl/monkeypatch/attention/large_head.py
+++ b/src/axolotl/monkeypatch/attention/large_head.py
@@ -21,12 +21,25 @@ LOG = get_logger(__name__)
 
 _LARGE_HEAD_MIN_DIM = 256
 _POLICY = "sdpa"
+_PACKED: bool | None = None
 _SDPA_ORIG_ATTR = "_axolotl_large_head_sdpa_original"
 
 
 def set_large_head_policy(policy: str | None) -> None:
     global _POLICY
     _POLICY = str(policy).lower() if policy else "sdpa"
+
+
+def set_large_head_packed(packed: bool | None) -> None:
+    """Declare statically whether batches carry packed (multi-document) rows.
+
+    Known at config time (``sample_packing``); declaring it lets the router skip
+    the per-call GPU-sync probe in ``_multidoc_position_ids``, which is a
+    data-dependent graph break under torch.compile. ``None`` keeps the runtime
+    probe (eager-only callers).
+    """
+    global _PACKED
+    _PACKED = packed
 
 
 def get_large_head_policy() -> str:
@@ -45,10 +58,14 @@ def resolve_large_head_policy(cfg) -> str:
 
 
 def _multidoc_position_ids(position_ids):
-    """Return [B,S] position_ids iff they encode genuine (multi-document) packing, else None."""
+    """Return [B,S] position_ids iff they encode (multi-document) packing, else None."""
     if position_ids is None:
         return None
     p = position_ids if position_ids.dim() > 1 else position_ids[None]
+    if _PACKED is not None:
+        # single-doc rows under a packed config still run the varlen path
+        # (correct, marginally slower) in exchange for a compile-clean branch
+        return p if _PACKED else None
     return p if int((p == 0).sum()) > p.shape[0] else None
 
 

--- a/src/axolotl/monkeypatch/attention/large_head.py
+++ b/src/axolotl/monkeypatch/attention/large_head.py
@@ -63,8 +63,7 @@ def _multidoc_position_ids(position_ids):
         return None
     p = position_ids if position_ids.dim() > 1 else position_ids[None]
     if _PACKED is not None:
-        # single-doc rows under a packed config still run the varlen path
-        # (correct, marginally slower) in exchange for a compile-clean branch
+        # packed config: single-doc rows still run varlen (slower, compile-clean)
         return p if _PACKED else None
     return p if int((p == 0).sum()) > p.shape[0] else None
 

--- a/src/axolotl/monkeypatch/gemma4_hybrid_mask.py
+++ b/src/axolotl/monkeypatch/gemma4_hybrid_mask.py
@@ -106,12 +106,14 @@ def _register_global_packed_sdpa() -> None:
             )
             if routed is not None:
                 return routed
-        # Detect genuine (multi-document) packing: more doc-starts than batch rows.
+        # Packing detection: static under a declared config (compile-clean), runtime probe otherwise.
         pid = None
-        if attention_mask is None and position_ids is not None:
-            p = position_ids if position_ids.dim() > 1 else position_ids[None]
-            if int((p == 0).sum()) > p.shape[0]:
-                pid = p
+        if attention_mask is None:
+            from axolotl.monkeypatch.attention.large_head import (
+                _multidoc_position_ids,
+            )
+
+            pid = _multidoc_position_ids(position_ids)
         # Packed without the kernel -> block-diagonal mask so globals respect doc boundaries.
         # Single-document -> mask stays None (SDPA is_causal, the fast path).
         if pid is not None:

--- a/tests/monkeypatch/test_large_head_compile_hoist.py
+++ b/tests/monkeypatch/test_large_head_compile_hoist.py
@@ -1,0 +1,122 @@
+"""Tests for compile-friendly multidoc detection and doc_end vectorization."""
+
+import pytest
+import torch
+
+from axolotl.monkeypatch.attention.large_head import (
+    _multidoc_position_ids,
+    set_large_head_packed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_packed():
+    yield
+    set_large_head_packed(None)
+
+
+class TestStaticPackedFlag:
+    def _packed_pos(self):
+        return torch.tensor([[0, 1, 2, 0, 1, 0, 1, 2]])
+
+    def _single_doc_pos(self):
+        return torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]])
+
+    def test_runtime_probe_when_undeclared(self):
+        set_large_head_packed(None)
+        assert _multidoc_position_ids(self._packed_pos()) is not None
+        assert _multidoc_position_ids(self._single_doc_pos()) is None
+
+    def test_static_packed_true_skips_probe(self):
+        set_large_head_packed(True)
+        # even a single-doc row routes varlen: no data-dependent branch
+        assert _multidoc_position_ids(self._single_doc_pos()) is not None
+        assert _multidoc_position_ids(self._packed_pos()) is not None
+
+    def test_static_packed_false(self):
+        set_large_head_packed(False)
+        assert _multidoc_position_ids(self._packed_pos()) is None
+
+    def test_none_position_ids(self):
+        set_large_head_packed(True)
+        assert _multidoc_position_ids(None) is None
+
+
+def _doc_end_loop_reference(pos: torch.Tensor) -> torch.Tensor:
+    B, N = pos.shape
+    doc_end = torch.empty_like(pos)
+    for b in range(B):
+        starts = (pos[b] == 0).nonzero().flatten()
+        bounds = torch.cat(
+            [starts, torch.tensor([N], device=pos.device, dtype=starts.dtype)]
+        )
+        doc_end[b] = (
+            bounds[1:].repeat_interleave(bounds[1:] - bounds[:-1]).to(pos.dtype)
+        )
+    return doc_end
+
+
+def _doc_end_vectorized(pos: torch.Tensor) -> torch.Tensor:
+    B, N = pos.shape
+    idx = torch.arange(N, device=pos.device, dtype=pos.dtype)
+    starts_or_n = torch.where(pos == 0, idx.expand_as(pos), pos.new_full((), N))
+    shifted = torch.cat([starts_or_n[:, 1:], pos.new_full((B, 1), N)], dim=1)
+    return torch.flip(
+        torch.cummin(torch.flip(shifted, dims=[1]), dim=1).values, dims=[1]
+    )
+
+
+class TestDocEndVectorization:
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3])
+    def test_parity_random_packing(self, seed):
+        gen = torch.Generator().manual_seed(seed)
+        B, N = 3, 64
+        rows = []
+        for _ in range(B):
+            lengths = []
+            remaining = N
+            while remaining > 0:
+                length = int(torch.randint(1, 17, (1,), generator=gen))
+                length = min(length, remaining)
+                lengths.append(length)
+                remaining -= length
+            rows.append(torch.cat([torch.arange(n) for n in lengths]))
+        pos = torch.stack(rows).to(torch.int32)
+        torch.testing.assert_close(
+            _doc_end_vectorized(pos), _doc_end_loop_reference(pos)
+        )
+
+    def test_parity_single_doc(self):
+        pos = torch.arange(32, dtype=torch.int32)[None]
+        torch.testing.assert_close(
+            _doc_end_vectorized(pos), _doc_end_loop_reference(pos)
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_flash_d512_varlen_uses_vectorized_doc_end(self):
+        # end-to-end: packed flash_d512 still matches per-document SDPA
+        from axolotl.monkeypatch.attention.flash_attn_d512 import flash_d512
+
+        torch.manual_seed(0)
+        B, H, D = 1, 2, 512
+        lengths = [24, 40]
+        N = sum(lengths)
+        pos = torch.cat([torch.arange(n) for n in lengths])[None].cuda().to(torch.int32)
+        q, k, v = (
+            torch.randn(B, H, N, D, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        out = flash_d512(q, k, v, causal=True, position_ids=pos)
+
+        ref = torch.empty_like(out)
+        start = 0
+        for n in lengths:
+            sl = slice(start, start + n)
+            ref[:, :, sl] = torch.nn.functional.scaled_dot_product_attention(
+                q[:, :, sl].float(),
+                k[:, :, sl].float(),
+                v[:, :, sl].float(),
+                is_causal=True,
+            ).to(out.dtype)
+            start += n
+        torch.testing.assert_close(out.float(), ref.float(), atol=2e-2, rtol=2e-2)

--- a/tests/monkeypatch/test_large_head_compile_hoist.py
+++ b/tests/monkeypatch/test_large_head_compile_hoist.py
@@ -3,6 +3,11 @@
 import pytest
 import torch
 
+# Import the production helper directly so the parity tests exercise the real
+# vectorized path instead of a duplicate that could silently drift.
+from axolotl.monkeypatch.attention.flash_attn_d512 import (
+    _compute_doc_end as _doc_end_vectorized,
+)
 from axolotl.monkeypatch.attention.large_head import (
     _multidoc_position_ids,
     set_large_head_packed,
@@ -54,16 +59,6 @@ def _doc_end_loop_reference(pos: torch.Tensor) -> torch.Tensor:
             bounds[1:].repeat_interleave(bounds[1:] - bounds[:-1]).to(pos.dtype)
         )
     return doc_end
-
-
-def _doc_end_vectorized(pos: torch.Tensor) -> torch.Tensor:
-    B, N = pos.shape
-    idx = torch.arange(N, device=pos.device, dtype=pos.dtype)
-    starts_or_n = torch.where(pos == 0, idx.expand_as(pos), pos.new_full((), N))
-    shifted = torch.cat([starts_or_n[:, 1:], pos.new_full((B, 1), N)], dim=1)
-    return torch.flip(
-        torch.cummin(torch.flip(shifted, dims=[1]), dim=1).values, dims=[1]
-    )
 
 
 class TestDocEndVectorization:


### PR DESCRIPTION
## Summary

Removes the last axolotl-owned graph breaks in the large-head (d512) attention path under `torch.compile`. Stacked on #3788 (which registered the kernel as a custom op); this PR fixes the *routing host code* around it.

Two data-dependent sites hoisted:

1. **Multidoc detection** (`large_head.py`): `int((p == 0).sum()) > B` was a GPU→CPU sync + Python branch per attention call — a guaranteed graph break. Now the decision is **static when the config declares it**: `set_large_head_packed(cfg.sample_packing)` is wired at both router install points, so packed configs skip the probe entirely (single-doc rows still run the varlen path — correct, marginally slower, and rare under packing). The runtime probe remains only for undeclared/eager callers. The duplicated probe in `gemma4_hybrid_mask.py` now reuses the same helper. Note the `auto` policy's per-batch adaptivity becomes config-level under a declared config — behavior change, documented in the docstring.
2. **`doc_end` computation** (`flash_attn_d512.py`): the per-row `.nonzero()` Python loop is replaced by a tensorized suffix-min (`where(starts, idx, N)` shifted → reverse `cummin`), so the varlen host prep traces cleanly.

## Verification

- New `tests/monkeypatch/test_large_head_compile_hoist.py`: static-flag behavior, doc_end parity vs the old loop across random packing layouts (+ single-doc edge), and an e2e packed `flash_d512` vs per-document SDPA check on GPU.
- Existing d512 (8), gemma4 hybrid mask + large-head (21) suites pass unchanged.
- E2E (manual, not CI): Gemma-4-26B-A4B, `gemma4_hybrid_attn_impl` + packing + `torch_compile: true` — **zero axolotl-attributed graph-break frames** (was 2), dynamo captures 580 ops in 33 graphs (was 435 in 37 — regions fused across the removed breaks), kernel still routes and trains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved attention handling for packed multi-document inputs, with better support when sample packing is enabled.
  * Added a more compile-friendly path for vectorized attention computations.

* **Bug Fixes**
  * Fixed packed attention routing so it now behaves consistently across different attention paths.
  * Replaced a slower, loop-based document-boundary calculation with a tensorized version to improve reliability and reduce graph breaks.

* **Tests**
  * Added coverage for packed/unpacked detection and attention output correctness on packed sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->