### PR TITLE
fix fp8: exclude MoE router linears from torchao fp8 conversion

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -627,6 +627,9 @@ class PatchManager:
     def _apply_fp8_patches(self):
         """Apply patches for FP8 support."""
         if self.cfg.fp8:
+            from axolotl.monkeypatch.accelerate.float8_moe_filter import (
+                patch_fp8_exclude_moe_router,
+            )
             from axolotl.monkeypatch.trainer_accelerator_args import (
                 patch_create_accelerate_code_for_fp8,
             )
@@ -634,6 +637,7 @@ class PatchManager:
             patch_create_accelerate_code_for_fp8(
                 self.cfg.fp8_enable_fsdp_float8_all_gather
             )
+            patch_fp8_exclude_moe_router()
 
     def _apply_flash_attention_peft_patches(self):
         """Apply patches for Flash Attention with PEFT."""

--- a/src/axolotl/monkeypatch/accelerate/float8_moe_filter.py
+++ b/src/axolotl/monkeypatch/accelerate/float8_moe_filter.py
@@ -52,12 +52,12 @@ def patch_fp8_exclude_moe_router():
         else:
             inner = module_filter_func
 
-        def module_filter_func(module, fqn, _inner=inner):
+        def _router_aware_filter(module, fqn, _inner=inner):
             if _is_router(fqn):
                 return False
             return _inner(module, fqn)
 
-        return orig(model, config=config, module_filter_func=module_filter_func)
+        return orig(model, config=config, module_filter_func=_router_aware_filter)
 
     acc.convert_model_to_fp8_ao = patched
     _PATCHED = True

--- a/src/axolotl/monkeypatch/accelerate/float8_moe_filter.py
+++ b/src/axolotl/monkeypatch/accelerate/float8_moe_filter.py
@@ -14,20 +14,22 @@ accelerate fp8 helpers are unavailable.
 
 from __future__ import annotations
 
-from functools import partial
+from functools import partial, wraps
 
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
 _PATCHED = False
 
-# Leaf attribute names used for MoE routers across HF architectures. ``gate_proj`` /
-# ``gate_up_proj`` (expert projections we DO want in fp8) don't match — only the exact leaf.
-_ROUTER_LEAF_NAMES = {"gate", "router"}
+# Router/gate module names across HF MoE architectures, matched against every path
+# segment so wrapped routers (DBRX ``ffn.router.layer``, HunYuan ``mlp.gate.wg``,
+# Switch/NLLB ``router.classifier``) are caught too. ``gate_proj`` / ``gate_up_proj``
+# (expert projections we DO want in fp8) don't match — only exact segments.
+_ROUTER_NAMES = {"gate", "router"}
 
 
 def _is_router(fqn: str) -> bool:
-    return fqn.rsplit(".", 1)[-1] in _ROUTER_LEAF_NAMES
+    return not _ROUTER_NAMES.isdisjoint(fqn.split("."))
 
 
 def patch_fp8_exclude_moe_router():
@@ -41,11 +43,16 @@ def patch_fp8_exclude_moe_router():
             find_first_last_linear_layers,
         )
     except ImportError:
+        LOG.warning(
+            "Could not patch accelerate fp8 conversion to exclude MoE routers; "
+            "fp8 full-finetunes of MoE models may diverge to NaN"
+        )
         return
 
     orig = acc.convert_model_to_fp8_ao
 
-    def patched(model, config=None, module_filter_func=None):
+    @wraps(orig)
+    def patched(model, config=None, module_filter_func=None, **kwargs):
         if module_filter_func is None:
             first, last = find_first_last_linear_layers(model)
             inner = partial(filter_linear_layers, layers_to_filter=[first, last])
@@ -54,11 +61,14 @@ def patch_fp8_exclude_moe_router():
 
         def _router_aware_filter(module, fqn, _inner=inner):
             if _is_router(fqn):
+                LOG.debug("fp8: keeping router linear %s in high precision", fqn)
                 return False
             return _inner(module, fqn)
 
-        return orig(model, config=config, module_filter_func=_router_aware_filter)
+        return orig(
+            model, config=config, module_filter_func=_router_aware_filter, **kwargs
+        )
 
     acc.convert_model_to_fp8_ao = patched
     _PATCHED = True
-    LOG.info("Patched accelerate fp8 conversion to keep MoE router (gate) in bf16")
+    LOG.info("Patched accelerate fp8 conversion to skip MoE router/gate linears")

--- a/src/axolotl/monkeypatch/attention/float8_moe_filter.py
+++ b/src/axolotl/monkeypatch/attention/float8_moe_filter.py
@@ -1,0 +1,64 @@
+"""Keep MoE router (gate) linears out of torchao fp8 conversion.
+
+accelerate converts every ``nn.Linear`` except the model's first/last to a torchao
+``Float8Linear``. When an MoE model exposes its router as an ``nn.Linear`` (e.g. Mixtral
+``block_sparse_moe.gate``, Qwen3-MoE ``mlp.gate`` on transformers < 5.x), that casts the
+router logits to fp8; the tensorwise-quantized logits feed ``softmax``/``topk``, so routing
+decisions flip between steps and full-finetune training diverges to NaN grads. torchtitan
+and torchao's own fp8 recipes keep the router in high precision for exactly this reason.
+
+This wraps ``accelerate.accelerator.convert_model_to_fp8_ao`` so router linears are always
+skipped, preserving the existing first/last-linear exclusion. Idempotent; a no-op if the
+accelerate fp8 helpers are unavailable.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+_PATCHED = False
+
+# Leaf attribute names used for MoE routers across HF architectures. ``gate_proj`` /
+# ``gate_up_proj`` (expert projections we DO want in fp8) don't match — only the exact leaf.
+_ROUTER_LEAF_NAMES = {"gate", "router"}
+
+
+def _is_router(fqn: str) -> bool:
+    return fqn.rsplit(".", 1)[-1] in _ROUTER_LEAF_NAMES
+
+
+def patch_fp8_exclude_moe_router():
+    global _PATCHED
+    if _PATCHED:
+        return
+    try:
+        import accelerate.accelerator as acc
+        from accelerate.utils.ao import (
+            filter_linear_layers,
+            find_first_last_linear_layers,
+        )
+    except ImportError:
+        return
+
+    orig = acc.convert_model_to_fp8_ao
+
+    def patched(model, config=None, module_filter_func=None):
+        if module_filter_func is None:
+            first, last = find_first_last_linear_layers(model)
+            inner = partial(filter_linear_layers, layers_to_filter=[first, last])
+        else:
+            inner = module_filter_func
+
+        def module_filter_func(module, fqn, _inner=inner):
+            if _is_router(fqn):
+                return False
+            return _inner(module, fqn)
+
+        return orig(model, config=config, module_filter_func=module_filter_func)
+
+    acc.convert_model_to_fp8_ao = patched
+    _PATCHED = True
+    LOG.info("Patched accelerate fp8 conversion to keep MoE router (gate) in bf16")

--- a/tests/monkeypatch/test_float8_moe_filter.py
+++ b/tests/monkeypatch/test_float8_moe_filter.py
@@ -1,0 +1,97 @@
+"""Unit tests for the accelerate fp8 MoE router exclusion monkeypatch."""
+
+import accelerate.accelerator as acc
+import torch.nn as nn
+
+import axolotl.monkeypatch.accelerate.float8_moe_filter as float8_moe_filter
+from axolotl.monkeypatch.accelerate.float8_moe_filter import (
+    _is_router,
+    patch_fp8_exclude_moe_router,
+)
+
+
+class Expert(nn.Module):
+    """Expert MLP whose projections should stay eligible for fp8."""
+
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.Linear(32, 64, bias=False)
+        self.down_proj = nn.Linear(64, 32, bias=False)
+
+
+class MoeBlock(nn.Module):
+    """MoE block with a router gate linear."""
+
+    def __init__(self):
+        super().__init__()
+        self.gate = nn.Linear(32, 16, bias=False)
+        self.experts = nn.ModuleList([Expert() for _ in range(2)])
+
+
+class ToyMoeModel(nn.Module):
+    """Minimal model with first/last linears around an MoE block."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed_proj = nn.Linear(32, 32, bias=False)
+        self.mlp = MoeBlock()
+        self.lm_head = nn.Linear(32, 32, bias=False)
+
+
+def test_is_router_matches_router_segments():
+    assert _is_router("model.layers.0.mlp.gate")
+    assert _is_router("model.layers.0.block_sparse_moe.gate")
+    assert _is_router("model.layers.0.feed_forward.router")
+    # routers wrapped in a submodule (DBRX, HunYuan, Switch/NLLB)
+    assert _is_router("transformer.blocks.0.ffn.router.layer")
+    assert _is_router("model.layers.0.mlp.gate.wg")
+    assert _is_router("encoder.block.1.layer.1.mlp.router.classifier")
+
+
+def test_is_router_skips_expert_projections():
+    assert not _is_router("model.layers.0.mlp.experts.0.gate_proj")
+    assert not _is_router("model.layers.0.mlp.gate_up_proj")
+    assert not _is_router("model.layers.0.self_attn.q_proj")
+    assert not _is_router("")
+
+
+def _install_capture(monkeypatch):
+    captured = {}
+
+    def fake_convert(model, config=None, module_filter_func=None):
+        captured["filter"] = module_filter_func
+
+    monkeypatch.setattr(float8_moe_filter, "_PATCHED", False)
+    monkeypatch.setattr(acc, "convert_model_to_fp8_ao", fake_convert)
+    patch_fp8_exclude_moe_router()
+    assert acc.convert_model_to_fp8_ao is not fake_convert
+    return captured
+
+
+def test_patched_filter_excludes_router_and_first_last(monkeypatch):
+    captured = _install_capture(monkeypatch)
+
+    model = ToyMoeModel()
+    acc.convert_model_to_fp8_ao(model)
+    module_filter = captured["filter"]
+
+    assert module_filter(model.mlp.gate, "mlp.gate") is False
+    assert module_filter(model.embed_proj, "embed_proj") is False
+    assert module_filter(model.lm_head, "lm_head") is False
+    assert (
+        module_filter(model.mlp.experts[0].gate_proj, "mlp.experts.0.gate_proj") is True
+    )
+    assert (
+        module_filter(model.mlp.experts[0].down_proj, "mlp.experts.0.down_proj") is True
+    )
+
+
+def test_patched_filter_wraps_user_supplied_filter(monkeypatch):
+    captured = _install_capture(monkeypatch)
+
+    model = ToyMoeModel()
+    acc.convert_model_to_fp8_ao(model, module_filter_func=lambda module, fqn: True)
+    module_filter = captured["filter"]
+
+    assert module_filter(model.mlp.gate, "mlp.gate") is False
+    assert module_filter(model.embed_proj, "embed_proj") is True


### PR DESCRIPTION

# Description
fp8 training converted every nn.Linear except first/last to Float8Linear, including the MoE router gate tensorwise-fp8 router logits destabilize softmax/topk routing and diverge to NaN. This patches accelerate's fp8 conversion to skip router/gate linears while keeping experts and attention in fp8.
## Motivation and Context
#3077

## How has this been tested?
runs fine without nan 

## AI Usage Disclaimer
fable 5 helped T_T" 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FP8 training now better supports Mixture-of-Experts models by automatically excluding router/gate layers from FP8 conversion.

* **Bug Fixes**
  * Improved FP8 handling to reduce the risk of numerical issues or unexpected behavior when using expert-routing architectures.
  * FP8 setup now applies the router exclusion consistently alongside existing FP8 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->