### PR TITLE
fix: gemma4 GQA guard breaks under transformers 5.13 (use_gqa_in_sdpa gained a value arg)

### DIFF
--- a/src/axolotl/monkeypatch/gemma4_hybrid_mask.py
+++ b/src/axolotl/monkeypatch/gemma4_hybrid_mask.py
@@ -198,11 +198,12 @@ def _patch_use_gqa_head_dim_guard() -> bool:
     if getattr(original, "_axolotl_head_dim_guarded", False):
         return True
 
-    def use_gqa_in_sdpa_guarded(attention_mask, key):
+    # *args/**kwargs: transformers 5.13 adds a `value` positional arg
+    def use_gqa_in_sdpa_guarded(attention_mask, key, *args, **kwargs):
         # head_dim > 256 -> enable_gqa drops to the MATH backend; force repeat_kv (efficient) instead.
         if key.shape[-1] > 256:
             return False
-        return original(attention_mask, key)
+        return original(attention_mask, key, *args, **kwargs)
 
     use_gqa_in_sdpa_guarded._axolotl_head_dim_guarded = True  # type: ignore[attr-defined]
     use_gqa_in_sdpa_guarded._axolotl_original = original  # type: ignore[attr-defined]

--- a/tests/monkeypatch/test_gemma4_hybrid_mask.py
+++ b/tests/monkeypatch/test_gemma4_hybrid_mask.py
@@ -378,3 +378,33 @@ def test_patch_covers_unified_namespace(restore_gemma4_hybrid_mask_both):
 
     assert modeling_unified.create_causal_mask is not original
     assert modeling_unified.create_causal_mask._axolotl_original is original
+
+
+def test_gqa_guard_accepts_both_transformers_signatures():
+    """transformers 5.13 added a `value` positional to use_gqa_in_sdpa."""
+    import torch
+    import transformers.integrations.sdpa_attention as sdpa_mod
+
+    from axolotl.monkeypatch.gemma4_hybrid_mask import _patch_use_gqa_head_dim_guard
+
+    original = sdpa_mod.use_gqa_in_sdpa
+    unwrapped = getattr(original, "_axolotl_original", original)
+    try:
+        assert _patch_use_gqa_head_dim_guard()
+        guarded = sdpa_mod.use_gqa_in_sdpa
+        key_small = torch.zeros(1, 2, 4, 128)
+        key_large = torch.zeros(1, 2, 4, 512)
+
+        # the head_dim guard must reject under BOTH call conventions without
+        # touching the wrapped original
+        assert guarded(None, key_large) is False
+        assert guarded(None, key_large, key_large) is False
+
+        # pass-through must forward whatever the installed transformers accepts
+        import inspect
+
+        n_params = len(inspect.signature(unwrapped).parameters)
+        args = (None, key_small, key_small)[:n_params]
+        assert isinstance(guarded(*args), bool)
+    finally:
+        sdpa_mod.use_gqa_in_sdpa = unwrapped


### PR DESCRIPTION
## Summary

transformers main (5.13.0.dev0) added a third positional arg (`value`) to `use_gqa_in_sdpa`. The gemma4 hybrid-mask head-dim guard (`_patch_use_gqa_head_dim_guard`, from #3747) wraps it with a fixed 2-arg signature, so any SDPA attention call after the patch is applied fails with:

```
TypeError: use_gqa_in_sdpa_guarded() takes 2 positional arguments but 3 were given
```

This surfaced on PR #3786's `PyTest (3.12, 2.12.0)` job (the matrix cell that installs transformers from git) as `tests/test_perplexity.py` failures — the gemma4 patch is process-global, so any test sharing an xdist worker with a gemma4 test inherits it.

## Fix

Forward `*args/**kwargs` through the wrapper; `key` stays the second positional in both signatures, and the head-dim check is unchanged. Regression test covers the guard rejection under both call conventions and pass-through against the installed transformers signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple library call patterns for attention masking.
  * Ensured the guard logic still works when an extra positional argument is passed.
  * Preserved correct behavior for head-dimension checks across supported signatures.

* **Tests**
  * Added coverage for both supported call conventions to verify the guard behaves consistently and safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->