### PR TITLE
strip out apt libs installs that were moved to base image

### DIFF
--- a/cicd/Dockerfile-uv.jinja
+++ b/cicd/Dockerfile-uv.jinja
@@ -10,9 +10,6 @@ ENV GITHUB_SHA="{{ GITHUB_SHA }}"
 ENV NIGHTLY_BUILD="{{ NIGHTLY_BUILD }}"
 ENV HF_HOME="{{ HF_HOME }}"
 
-RUN apt-get update && \
-    apt-get install -y --allow-change-held-packages vim curl nano zstd libnccl2 libnccl-dev ibverbs-providers ibverbs-utils infiniband-diags librdmacm-dev librdmacm1 rdmacm-utils slurm-wlm
-
 WORKDIR /workspace
 
 RUN git clone --depth=1 https://github.com/axolotl-ai-cloud/axolotl.git


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the container build process by removing an unnecessary system package installation step.
  * Simplified setup so the image proceeds directly to the workspace and repository checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->