### PR TITLE
fix: correct and streamline multipack packing decontamination across attn backends

### DIFF
--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2306,7 +2306,7 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ("--sdpa-varlen/--no-sdpa-varlen",),
         None,
         None,
-        "With sample packing + attn_implementation=sdpa, route packed rows through torch.nn.attention.varlen.varlen_attn (cu_seqlens) instead of an explicit 4D block-diagonal mask. Skips cross-document blocks (faster + lower memory) with no flash_attn dependency. Requires torch >= 2.10 and head_dim <= 256; non-packed rows and larger head_dim fall back to stock SDPA. Sliding-window attention additionally needs torch >= 2.11 (varlen_attn window_size).",
+        "With sample packing + attn_implementation=sdpa, route packed rows through torch.nn.attention.varlen.varlen_attn (cu_seqlens) instead of an explicit 4D block-diagonal mask. Skips cross-document blocks (faster + lower memory) with no flash_attn dependency. Left unset (null) it auto-enables when supported (torch >= 2.10, head_dim <= 256, no sliding window); set true/false to force. When it can't be used, packed rows still isolate documents via the block-diagonal mask. Sliding-window attention needs torch >= 2.11 (varlen_attn window_size).",
     ),
     (
         ("--fused-attn-kernel/--no-fused-attn-kernel",),

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -273,7 +273,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
 
         training_arguments_kwargs["sample_packing"] = bool(self.cfg.sample_packing)
         training_arguments_kwargs["sample_packing_drop_attention_mask"] = (
-            self.cfg.attn_supports_packing
+            self.cfg.attn_decontaminates_packing
         )
         training_arguments_kwargs["multipack_real_batches"] = (
             self.cfg.multipack_real_batches

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -723,10 +723,57 @@ class PatchManager:
         patch_sdpa_large_head(policy)
 
     def _apply_sdpa_varlen_patch(self):
-        """Route packed-row SDPA through cu_seqlens varlen_attn when ``sdpa_varlen`` is set."""
-        if not self.cfg.sdpa_varlen:
+        """Route packed-row SDPA through cu_seqlens ``varlen_attn`` (no 4D mask).
+
+        Auto-enabled for ``sdpa`` + ``sample_packing`` when the varlen kernel can serve
+        the model (torch >= 2.10, head_dim <= 256, no sliding window). Opt in/out
+        explicitly with ``sdpa_varlen``. When varlen is unavailable/unsuitable, stock SDPA
+        stays and packing is still isolated via the dropped-mask block-diagonal path.
+        """
+        # False -> explicit opt-out; True -> explicit opt-in; None -> auto for sdpa packing.
+        if self.cfg.sdpa_varlen is False:
             return
-        from axolotl.monkeypatch.attention.sdpa_varlen import patch_sdpa_varlen
+        explicit = self.cfg.sdpa_varlen is True
+        auto = (
+            self.cfg.sdpa_varlen is None
+            and self.cfg.attn_implementation == "sdpa"
+            and self.cfg.sample_packing
+        )
+        if not (explicit or auto):
+            return
+
+        from axolotl.monkeypatch.attention.sdpa_varlen import (
+            _VARLEN_MAX_HEAD_DIM,
+            patch_sdpa_varlen,
+            varlen_available,
+        )
+
+        if not varlen_available():
+            return  # torch < 2.10; block-diagonal packing path is correct
+
+        def _attr(name):
+            mc = self.model_config
+            return mc.get(name) if isinstance(mc, dict) else getattr(mc, name, None)
+
+        head_dim = _attr("head_dim")
+        if not head_dim and _attr("hidden_size") and _attr("num_attention_heads"):
+            head_dim = _attr("hidden_size") // _attr("num_attention_heads")
+        sliding = _attr("sliding_window")
+        layer_types = _attr("layer_types")
+        uses_sliding = bool(sliding) and (
+            any(lt == "sliding_attention" for lt in layer_types)
+            if layer_types
+            else True
+        )
+
+        if (head_dim and head_dim > _VARLEN_MAX_HEAD_DIM) or uses_sliding:
+            if explicit:
+                LOG.info(
+                    "sdpa_varlen: model has head_dim > %d or a sliding window; keeping "
+                    "stock SDPA (packing still isolated via the block-diagonal mask).",
+                    _VARLEN_MAX_HEAD_DIM,
+                )
+            return
 
         patch_sdpa_varlen()
 

--- a/src/axolotl/monkeypatch/attention/sdpa_varlen.py
+++ b/src/axolotl/monkeypatch/attention/sdpa_varlen.py
@@ -120,10 +120,7 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
         packed = position_ids is not None and _is_packed(position_ids)
         use_varlen = use_varlen and packed  # single-doc rows -> stock SDPA
         if not use_varlen:
-            # When the mask override is active the interface gets attention_mask=None for
-            # packed rows. If varlen is unusable here (dropout / custom scale) we must
-            # rebuild the block-diagonal mask from position_ids, otherwise stock SDPA would
-            # run pure-causal and leak attention across the packed documents.
+            # Rebuild isolation the dropped mask no longer provides, else stock SDPA leaks.
             if attention_mask is None and packed:
                 attention_mask = _block_diagonal_causal_mask(
                     position_ids, query.shape[2]
@@ -185,15 +182,12 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
 
 
 def _build_varlen_mask(original_mask: Callable) -> Callable:
-    def sdpa_varlen_mask(**kwargs: Any):
-        # Packing carries document boundaries in position_ids. When the 2D padding mask
-        # has been dropped (attention_mask is None), return None so the varlen attention
-        # wrapper takes over via cu_seqlens instead of transformers materializing an
-        # O(S^2) block-diagonal mask here — mirrors transformers' `flash_attention_mask`.
-        # With a real 2D mask present, defer to the stock sdpa mask builder.
+    def sdpa_varlen_mask(*args: Any, **kwargs: Any):
+        # None for packed (mask-dropped) rows lets the varlen wrapper own isolation via
+        # cu_seqlens, mirroring transformers' `flash_attention_mask`; else defer to stock.
         if kwargs.get("attention_mask") is None:
             return None
-        return original_mask(**kwargs)
+        return original_mask(*args, **kwargs)
 
     return sdpa_varlen_mask
 
@@ -221,15 +215,20 @@ def patch_sdpa_varlen() -> bool:
     from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
     original = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    original_mask = ALL_MASK_ATTENTION_FUNCTIONS["sdpa"]
     wrapper = _build_varlen_forward(original)
     wrapper._axolotl_sdpa_original = original  # type: ignore[attr-defined]
-    ALL_ATTENTION_FUNCTIONS.register("sdpa", wrapper)
-    _PATCH_APPLIED = True
-
-    original_mask = ALL_MASK_ATTENTION_FUNCTIONS["sdpa"]
     mask_wrapper = _build_varlen_mask(original_mask)
     mask_wrapper._axolotl_sdpa_mask_original = original_mask  # type: ignore[attr-defined]
-    ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", mask_wrapper)
+
+    # Register both or neither, so a mid-way failure can't leave sdpa half-patched.
+    ALL_ATTENTION_FUNCTIONS.register("sdpa", wrapper)
+    try:
+        ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", mask_wrapper)
+    except Exception:
+        ALL_ATTENTION_FUNCTIONS.register("sdpa", original)
+        raise
+    _PATCH_APPLIED = True
     _MASK_PATCH_APPLIED = True
 
     LOG.info(

--- a/src/axolotl/monkeypatch/attention/sdpa_varlen.py
+++ b/src/axolotl/monkeypatch/attention/sdpa_varlen.py
@@ -10,9 +10,18 @@ When PyTorch exposes ``torch.nn.attention.varlen.varlen_attn`` (>= 2.10) and the
 head_dim is within Flash-Attention's limit (<= 256), we can instead run the
 attention as variable-length with ``cu_seqlens`` derived from ``position_ids``,
 which skips the cross-document blocks entirely — faster and lower memory — with
-no dependency on the ``flash_attn`` package. This is opt-in via ``sdpa_varlen:
-true`` and only activates for genuinely multi-document (packed) rows; everything
-else falls back to the stock SDPA implementation.
+no dependency on the ``flash_attn`` package. It only activates for genuinely
+multi-document (packed) rows; everything else falls back to the stock SDPA
+implementation. Auto-enabled for ``sdpa`` + ``sample_packing`` when the kernel
+can serve the model (see ``PatchManager._apply_sdpa_varlen_patch``); ``sdpa_varlen``
+overrides the choice.
+
+To make varlen actually engage during training (``use_cache=False``), patching
+also overrides the ``sdpa`` mask builder to return ``None`` for packed rows whose
+2D padding mask has been dropped. Otherwise transformers materializes a 4D
+block-diagonal mask from ``position_ids`` and hands it to the attention interface,
+which would keep the stock O(S^2) SDPA path (and, before the padding mask was
+dropped for sdpa packing, silently leak across documents on padded rows).
 """
 
 from __future__ import annotations
@@ -24,6 +33,7 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 _PATCH_APPLIED = False
+_MASK_PATCH_APPLIED = False
 # head_dim limit of the Flash-Attention kernel backing varlen_attn.
 _VARLEN_MAX_HEAD_DIM = 256
 
@@ -34,6 +44,26 @@ def varlen_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+def _is_packed(position_ids) -> bool:
+    """More document starts (position resets to 0) than rows -> packed."""
+    pid = position_ids if position_ids.dim() > 1 else position_ids[None]
+    return int((pid == 0).sum()) > pid.shape[0]
+
+
+def _block_diagonal_causal_mask(position_ids, seq_len: int):
+    """Bool (B, 1, S, S) block-diagonal causal mask (True = attend) built from
+    per-document-resetting position_ids. Used only on the non-varlen fallback so
+    stock SDPA still isolates documents when the 2D padding mask has been dropped."""
+    import torch
+
+    pid = position_ids if position_ids.dim() > 1 else position_ids[None]
+    doc = (pid == 0).cumsum(-1)  # document id per token
+    same_doc = doc[:, :, None] == doc[:, None, :]
+    idx = torch.arange(seq_len, device=pid.device)
+    causal = idx[:, None] >= idx[None, :]
+    return (same_doc & causal[None])[:, None]
 
 
 def _build_varlen_forward(original_sdpa: Callable) -> Callable:
@@ -87,11 +117,17 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
             and position_ids is not None
             and standard_scale
         )
-        if use_varlen:
-            pid = position_ids if position_ids.dim() > 1 else position_ids[None]
-            # genuine packing only (more document starts than rows); single-doc -> stock SDPA.
-            use_varlen = int((pid == 0).sum()) > pid.shape[0]
+        packed = position_ids is not None and _is_packed(position_ids)
+        use_varlen = use_varlen and packed  # single-doc rows -> stock SDPA
         if not use_varlen:
+            # When the mask override is active the interface gets attention_mask=None for
+            # packed rows. If varlen is unusable here (dropout / custom scale) we must
+            # rebuild the block-diagonal mask from position_ids, otherwise stock SDPA would
+            # run pure-causal and leak attention across the packed documents.
+            if attention_mask is None and packed:
+                attention_mask = _block_diagonal_causal_mask(
+                    position_ids, query.shape[2]
+                )
             return original_sdpa(
                 module,
                 query,
@@ -117,6 +153,7 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
             n = Hq // Hkv
             key = key.repeat_interleave(n, dim=1)
             value = value.repeat_interleave(n, dim=1)
+        pid = position_ids if position_ids.dim() > 1 else position_ids[None]
         (cu_q, cu_k), (max_q, max_k) = prepare_fa_kwargs_from_position_ids(pid)
         qf = query.transpose(1, 2).reshape(B * S, Hq, D)
         kf = key.transpose(1, 2).reshape(B * S, Hq, D)
@@ -147,9 +184,31 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
     return sdpa_varlen_forward
 
 
+def _build_varlen_mask(original_mask: Callable) -> Callable:
+    def sdpa_varlen_mask(**kwargs: Any):
+        # Packing carries document boundaries in position_ids. When the 2D padding mask
+        # has been dropped (attention_mask is None), return None so the varlen attention
+        # wrapper takes over via cu_seqlens instead of transformers materializing an
+        # O(S^2) block-diagonal mask here — mirrors transformers' `flash_attention_mask`.
+        # With a real 2D mask present, defer to the stock sdpa mask builder.
+        if kwargs.get("attention_mask") is None:
+            return None
+        return original_mask(**kwargs)
+
+    return sdpa_varlen_mask
+
+
 def patch_sdpa_varlen() -> bool:
-    """Replace the registered ``sdpa`` attention with a varlen-aware wrapper (idempotent)."""
-    global _PATCH_APPLIED
+    """Replace the registered ``sdpa`` attention with a varlen-aware wrapper (idempotent).
+
+    Also overrides the ``sdpa`` mask builder to return ``None`` for packed rows whose
+    padding mask was dropped, so the varlen wrapper actually engages during training
+    (``use_cache=False``) instead of transformers building a 4D block-diagonal mask that
+    would otherwise force the stock O(S^2) SDPA path. Only call this for models the varlen
+    path can serve (head_dim <= 256, no sliding window); other cases keep stock SDPA which
+    decontaminates via the dropped-mask block-diagonal path.
+    """
+    global _PATCH_APPLIED, _MASK_PATCH_APPLIED
     if _PATCH_APPLIED:
         return True
     if not varlen_available():
@@ -158,6 +217,7 @@ def patch_sdpa_varlen() -> bool:
             "leaving stock SDPA in place."
         )
         return False
+    from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
     from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
     original = ALL_ATTENTION_FUNCTIONS["sdpa"]
@@ -165,6 +225,13 @@ def patch_sdpa_varlen() -> bool:
     wrapper._axolotl_sdpa_original = original  # type: ignore[attr-defined]
     ALL_ATTENTION_FUNCTIONS.register("sdpa", wrapper)
     _PATCH_APPLIED = True
+
+    original_mask = ALL_MASK_ATTENTION_FUNCTIONS["sdpa"]
+    mask_wrapper = _build_varlen_mask(original_mask)
+    mask_wrapper._axolotl_sdpa_mask_original = original_mask  # type: ignore[attr-defined]
+    ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", mask_wrapper)
+    _MASK_PATCH_APPLIED = True
+
     LOG.info(
         "sdpa_varlen: patched 'sdpa' to use cu_seqlens varlen_attn for packed rows "
         "(head_dim <= %d), falling back to stock SDPA otherwise",
@@ -174,13 +241,20 @@ def patch_sdpa_varlen() -> bool:
 
 
 def unpatch_sdpa_varlen() -> None:
-    global _PATCH_APPLIED
-    if not _PATCH_APPLIED:
-        return
+    global _PATCH_APPLIED, _MASK_PATCH_APPLIED
+    from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
     from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
-    current = ALL_ATTENTION_FUNCTIONS["sdpa"]
-    original = getattr(current, "_axolotl_sdpa_original", None)
-    if original is not None:
-        ALL_ATTENTION_FUNCTIONS.register("sdpa", original)
-    _PATCH_APPLIED = False
+    if _PATCH_APPLIED:
+        current = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        original = getattr(current, "_axolotl_sdpa_original", None)
+        if original is not None:
+            ALL_ATTENTION_FUNCTIONS.register("sdpa", original)
+        _PATCH_APPLIED = False
+
+    if _MASK_PATCH_APPLIED:
+        current_mask = ALL_MASK_ATTENTION_FUNCTIONS["sdpa"]
+        original_mask = getattr(current_mask, "_axolotl_sdpa_mask_original", None)
+        if original_mask is not None:
+            ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", original_mask)
+        _MASK_PATCH_APPLIED = False

--- a/src/axolotl/monkeypatch/multipack.py
+++ b/src/axolotl/monkeypatch/multipack.py
@@ -2,7 +2,6 @@
 
 import importlib
 
-import transformers
 from accelerate import init_empty_weights
 from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.integrations import is_deepspeed_zero3_enabled
@@ -69,14 +68,14 @@ SUPPORTED_MULTIPACK_MODEL_TYPES = [
 
 
 def patch_for_multipack(model_type, model_name=None, has_remote_code=False):
+    # In-tree HF models handle sample packing natively via position_ids
+    # (transformers `_is_packed_sequence` / `find_packed_sequence_indices`): the 2D
+    # mask is cast to bool before flash attention, so the segment ids we encode in
+    # it never reach `_get_unpad_data` and overriding it there is a no-op. Only
+    # remote-code modeling files that call `_get_unpad_data` directly on the raw
+    # segment-id mask still need the override.
     if has_remote_code:
         patch_remote(model_name)
-    elif hasattr(transformers, "modeling_flash_attention_utils"):
-        # sanity check in case upstream api changes on this
-        assert hasattr(
-            transformers.modeling_flash_attention_utils, "_get_unpad_data"
-        ), "transformers api changed for _get_unpad_data for flash attention"
-        transformers.modeling_flash_attention_utils._get_unpad_data = get_unpad_data
 
     if model_type == "mixtral" and is_deepspeed_zero3_enabled():
         patch_mixtral_moe_forward_zero3()

--- a/src/axolotl/monkeypatch/utils.py
+++ b/src/axolotl/monkeypatch/utils.py
@@ -9,30 +9,47 @@ import torch
 import torch.nn.functional as F
 
 
-@torch.jit.script
 def get_max_seqlen_in_batch(attention_mask: torch.Tensor) -> torch.Tensor:
-    max_num = int(torch.max(attention_mask).item())
-    batch_size, _ = attention_mask.shape
-    counts = torch.zeros((batch_size, max_num), dtype=torch.int32)
-    for i in range(1, max_num + 1):
-        mask = attention_mask == i
-        counts[:, i - 1] = torch.sum(mask, dim=-1).to(dtype=torch.int32)
-    result = counts.flatten()
-    nonzero_indices = torch.nonzero(result).squeeze(-1)
-    return result[nonzero_indices]
+    """Token counts for each packed sub-sequence in a multipack attention mask.
+
+    Multipack encodes every packed document as a distinct positive integer id
+    (``1, 2, 3, ...``) with ``0`` for padding, so a row looks like
+    ``[1, 1, 1, 2, 2, 3, 3, 0, 0]``. This returns the length of each non-pad
+    document, flattened across the batch.
+
+    Vectorized on purpose: the previous implementation used
+    ``int(mask.max().item())`` as a Python loop bound, which forced a
+    device->host sync and broke torch.compile. This variant computes segment
+    boundaries with tensor ops only.
+    """
+    bsz, slen = attention_mask.shape
+    flat = attention_mask.reshape(-1)
+    # A token begins a new document when its id differs from the previous token.
+    seg_start = torch.ones_like(flat, dtype=torch.bool)
+    seg_start[1:] = flat[1:] != flat[:-1]
+    # Force a boundary at every row start so equal ids in adjacent rows (e.g. two
+    # rows each fully filled by a single document) are not merged into one segment.
+    seg_start = seg_start.view(bsz, slen)
+    seg_start[:, 0] = True
+    seg_start = seg_start.reshape(-1)
+
+    start_idx = seg_start.nonzero().flatten()
+    end_idx = torch.cat([start_idx[1:], start_idx.new_full((1,), flat.numel())])
+    lengths = (end_idx - start_idx).to(dtype=torch.int32)
+    # Drop padding runs (id == 0).
+    return lengths[flat[start_idx] != 0]
 
 
-@torch.jit.script
 def get_unpad_data(attention_mask: torch.Tensor):
     device = attention_mask.device
     seqlens_in_batch = get_max_seqlen_in_batch(attention_mask)
     indices = torch.nonzero(attention_mask.flatten()).flatten()
+    # flash_attn's varlen API wants a Python int for max_seqlen; this is the only
+    # remaining device->host sync and is kept solely for that ABI.
     max_seqlen_in_batch = seqlens_in_batch.max().item()
-    cu_seqlens = (
-        F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
-        .to(device=device)
-        .detach()
-    )
+    cu_seqlens = F.pad(
+        torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+    ).to(device=device)
     return (
         indices,
         cu_seqlens,

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1468,11 +1468,7 @@ class AxolotlInputConfig(
     @computed_field  # type: ignore[misc]
     @property
     def attn_decontaminates_packing(self) -> bool:
-        # Backends that isolate packed documents once the 2D attention mask is dropped
-        # and only position_ids remain. Varlen backends (attn_supports_packing) do it via
-        # cu_seqlens; plain sdpa/eager via the block-diagonal mask transformers builds from
-        # position_ids (find_packed_sequence_indices). Anything else cannot, and packing
-        # would silently leak attention across documents.
+        # sdpa/eager isolate packed docs via the dropped-mask block-diagonal; others can't.
         if self.attn_supports_packing:
             return True
         return self.attn_implementation in ("sdpa", "eager")

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -885,9 +885,10 @@ class AxolotlInputConfig(
                 "With sample packing + attn_implementation=sdpa, route packed rows through "
                 "torch.nn.attention.varlen.varlen_attn (cu_seqlens) instead of an explicit 4D "
                 "block-diagonal mask. Skips cross-document blocks (faster + lower memory) with no "
-                "flash_attn dependency. Requires torch >= 2.10 and head_dim <= 256; non-packed rows "
-                "and larger head_dim fall back to stock SDPA. Sliding-window attention additionally "
-                "needs torch >= 2.11 (varlen_attn window_size)."
+                "flash_attn dependency. Left unset (null) it auto-enables when supported (torch >= "
+                "2.10, head_dim <= 256, no sliding window); set true/false to force. When it can't "
+                "be used, packed rows still isolate documents via the block-diagonal mask. "
+                "Sliding-window attention needs torch >= 2.11 (varlen_attn window_size)."
             )
         },
     )
@@ -1463,6 +1464,18 @@ class AxolotlInputConfig(
     @property
     def attn_supports_packing(self) -> bool:
         return self.attn_implementation in ATTN_IMPLS_SUPPORTING_PACKING
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def attn_decontaminates_packing(self) -> bool:
+        # Backends that isolate packed documents once the 2D attention mask is dropped
+        # and only position_ids remain. Varlen backends (attn_supports_packing) do it via
+        # cu_seqlens; plain sdpa/eager via the block-diagonal mask transformers builds from
+        # position_ids (find_packed_sequence_indices). Anything else cannot, and packing
+        # would silently leak attention across documents.
+        if self.attn_supports_packing:
+            return True
+        return self.attn_implementation in ("sdpa", "eager")
 
     @computed_field  # type: ignore[misc]
     @property

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -185,12 +185,12 @@ class AttentionValidationMixin:
 
     @model_validator(mode="after")
     def check_sample_packing_without_attention(self):
-        if self.sample_packing and not self.attn_supports_packing:
+        if self.sample_packing and not self.attn_decontaminates_packing:
             if self.attn_implementation:
                 LOG.warning(
                     "`sample_packing` with `attn_implementation=%r` does not handle "
-                    "cross-sample decontamination. Use a varlen-capable backend "
-                    "(e.g. flash_attention_2, flex_attention, xformers, sage) to "
+                    "cross-sample decontamination. Use a packing-capable backend "
+                    "(e.g. flash_attention_2, flex_attention, sdpa, eager) to "
                     "isolate samples.",
                     self.attn_implementation,
                 )
@@ -198,7 +198,7 @@ class AttentionValidationMixin:
                 LOG.warning(
                     "`sample_packing` without an attention backend does not handle "
                     "cross-sample decontamination. Set `attn_implementation` to a "
-                    "varlen-capable backend (e.g. flash_attention_2)."
+                    "packing-capable backend (e.g. flash_attention_2)."
                 )
         return self
 

--- a/tests/e2e/patched/test_model_patches.py
+++ b/tests/e2e/patched/test_model_patches.py
@@ -86,7 +86,9 @@ class TestModelPatches(unittest.TestCase):
         tokenizer = load_tokenizer(cfg)
         ModelLoader(cfg, tokenizer, inference=False).load()
 
+        # In-tree HF models pack natively via position_ids, so we no longer
+        # override `_get_unpad_data` for them; the stock function must remain.
         assert (
-            "torch.jit"
-            in transformers.modeling_flash_attention_utils._get_unpad_data.__module__
+            transformers.modeling_flash_attention_utils._get_unpad_data.__module__
+            == "transformers.modeling_flash_attention_utils"
         )

--- a/tests/e2e/patched/test_multipack_packing_equivalence.py
+++ b/tests/e2e/patched/test_multipack_packing_equivalence.py
@@ -1,0 +1,60 @@
+"""
+Guards that sample packing does not leak attention across document boundaries.
+
+Axolotl encodes each packed document as a distinct integer id in the 2D attention
+mask, but modern transformers casts that mask to bool before flash attention and
+instead derives per-document ``cu_seqlens`` from the (per-document resetting)
+``position_ids`` (`_is_packed_sequence` / `_prepare_from_posids`). This is why the
+`_get_unpad_data` override was dropped for in-tree models. If that native path ever
+regresses, a packed forward would attend across documents and this test would fail.
+"""
+
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+from transformers.testing_utils import require_flash_attn, require_torch_gpu
+
+
+@require_torch_gpu
+@require_flash_attn
+def test_packed_forward_matches_per_document_forward():
+    torch.manual_seed(0)
+    config = LlamaConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+        max_position_embeddings=128,
+        attn_implementation="flash_attention_2",
+    )
+    model = LlamaForCausalLM(config).to(device="cuda", dtype=torch.bfloat16).eval()
+
+    # Two documents packed into a single row (batch_size == 1), exactly the shape
+    # the multipack collator emits: segment-id attention mask + resetting position ids.
+    doc1 = [11, 12, 13, 14, 15]
+    doc2 = [21, 22, 23, 24]
+    input_ids = torch.tensor([doc1 + doc2], device="cuda")
+    attention_mask = torch.tensor([[1] * len(doc1) + [2] * len(doc2)], device="cuda")
+    position_ids = torch.tensor(
+        [list(range(len(doc1))) + list(range(len(doc2)))], device="cuda"
+    )
+
+    with torch.no_grad():
+        packed = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        ).logits
+        ref1 = model(
+            input_ids=torch.tensor([doc1], device="cuda"),
+            position_ids=torch.tensor([list(range(len(doc1)))], device="cuda"),
+        ).logits
+        ref2 = model(
+            input_ids=torch.tensor([doc2], device="cuda"),
+            position_ids=torch.tensor([list(range(len(doc2)))], device="cuda"),
+        ).logits
+
+    reference = torch.cat([ref1, ref2], dim=1)
+    # Bit-identical: each document must see only itself, so packing changes nothing.
+    assert torch.equal(packed, reference)

--- a/tests/e2e/patched/test_multipack_packing_equivalence.py
+++ b/tests/e2e/patched/test_multipack_packing_equivalence.py
@@ -56,5 +56,5 @@ def test_packed_forward_matches_per_document_forward():
         ).logits
 
     reference = torch.cat([ref1, ref2], dim=1)
-    # Bit-identical: each document must see only itself, so packing changes nothing.
-    assert torch.equal(packed, reference)
+    # Each document must see only itself; flash-attn isn't bit-exact across tiling shapes.
+    assert torch.allclose(packed, reference, atol=1e-2)

--- a/tests/monkeypatch/test_llama_attn_hijack_flash.py
+++ b/tests/monkeypatch/test_llama_attn_hijack_flash.py
@@ -50,6 +50,19 @@ class TestMonkeyPatchUtils(unittest.TestCase):
         target_res = torch.tensor([4, 3, 5, 2], dtype=torch.int32)
         self.assertTrue(torch.allclose(get_max_seqlen_in_batch(attn_mask), target_res))
 
+    def test_get_max_seqlen_in_batch_adjacent_rows_same_id(self):
+        # Rows whose first/last segment ids match across the row boundary must not
+        # be merged into a single segment (each row is a fresh pack).
+        attn_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 1]])
+        target_res = torch.tensor([4, 4], dtype=torch.int32)
+        self.assertTrue(torch.allclose(get_max_seqlen_in_batch(attn_mask), target_res))
+
+        indices, cu_seqlen, max_seqlen_in_batch = get_unpad_data(attn_mask)
+        self.assertTrue(
+            torch.allclose(cu_seqlen, torch.tensor([0, 4, 8], dtype=torch.int32))
+        )
+        self.assertEqual(max_seqlen_in_batch, 4)
+
     def test_get_unpad_data(self):
         attn_mask = torch.tensor([[1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 0, 0]])
         target_indices = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])

--- a/tests/monkeypatch/test_llama_attn_hijack_flash.py
+++ b/tests/monkeypatch/test_llama_attn_hijack_flash.py
@@ -58,6 +58,7 @@ class TestMonkeyPatchUtils(unittest.TestCase):
         self.assertTrue(torch.allclose(get_max_seqlen_in_batch(attn_mask), target_res))
 
         indices, cu_seqlen, max_seqlen_in_batch = get_unpad_data(attn_mask)
+        self.assertTrue(torch.allclose(indices, torch.arange(8)))
         self.assertTrue(
             torch.allclose(cu_seqlen, torch.tensor([0, 4, 8], dtype=torch.int32))
         )

--- a/tests/monkeypatch/test_sdpa_varlen.py
+++ b/tests/monkeypatch/test_sdpa_varlen.py
@@ -188,7 +188,11 @@ def test_falls_back_when_not_packed(patched):
 
 
 def test_falls_back_on_large_head_dim(patched):
-    """head_dim > 256 can't use Flash varlen; must defer to stock SDPA."""
+    """head_dim > 256 can't use Flash varlen, but a packed row whose padding mask was
+    dropped (attention_mask=None) must still be isolated: the wrapper rebuilds the
+    block-diagonal mask rather than running pure-causal (which would leak)."""
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
     pos = _pos([[256, 256]])
     B, S = pos.shape
     Hq, Hkv, D = 8, 2, 512  # head_dim 512
@@ -196,4 +200,79 @@ def test_falls_back_on_large_head_dim(patched):
     q = torch.randn(B, Hq, S, D, device=DEV, dtype=torch.bfloat16)
     k = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
     v = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
-    _assert_defers_to_stock(_Mod(num_key_value_groups=Hq // Hkv), q, k, v, pos)
+    mod = _Mod(num_key_value_groups=Hq // Hkv)
+    scaling = D**-0.5
+
+    wrapper = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    out, _ = wrapper(mod, q, k, v, None, scaling=scaling, position_ids=pos)
+    # matches the block-diagonal reference (documents isolated)...
+    ref = _ref(q, k, v, scaling, pos)
+    assert torch.allclose(out, ref, atol=1e-2)
+    # ...and is NOT the pure-causal result stock SDPA gives with a None mask (a leak).
+    leak, _ = wrapper._axolotl_sdpa_original(
+        mod, q, k, v, None, scaling=scaling, position_ids=pos
+    )
+    assert not torch.allclose(out, leak, atol=1e-2)
+
+
+def test_varlen_engages_in_training_forward():
+    """Regression: in a real training forward (use_cache=False) transformers builds a 4D
+    packed mask from position_ids, which used to bypass the varlen path entirely. The mask
+    override must make ``varlen_attn`` actually fire for a padded packed row, and the
+    result must match per-document forwards (no cross-document leakage)."""
+    import torch.nn.attention.varlen as va
+    from transformers import LlamaConfig, LlamaModel
+
+    calls = {"n": 0}
+    original_varlen = va.varlen_attn
+    va.varlen_attn = lambda *a, **k: (  # spy captured by the wrapper at patch time
+        calls.__setitem__("n", calls["n"] + 1),
+        original_varlen(*a, **k),
+    )[1]
+    try:
+        assert patch_sdpa_varlen()
+        try:
+            cfg = LlamaConfig(
+                hidden_size=256,
+                num_hidden_layers=2,
+                num_attention_heads=8,
+                num_key_value_heads=2,
+                intermediate_size=512,
+                vocab_size=256,
+                head_dim=32,
+                _attn_implementation="sdpa",
+            )
+            torch.manual_seed(0)
+            model = LlamaModel(cfg).to(DEV).to(torch.bfloat16).eval()
+
+            doc1, doc2 = list(range(1, 21)), list(range(21, 37))  # len 20 + 16
+            ids = torch.tensor([doc1 + doc2 + [0, 0, 0, 0]], device=DEV)  # + padding
+            pos = torch.tensor(
+                [list(range(20)) + list(range(16)) + list(range(4))], device=DEV
+            )
+            with torch.no_grad():
+                # attention_mask=None mimics axolotl dropping the mask for packing.
+                packed = model(
+                    input_ids=ids,
+                    attention_mask=None,
+                    position_ids=pos,
+                    use_cache=False,
+                ).last_hidden_state[:, :36]
+                ref1 = model(
+                    input_ids=torch.tensor([doc1], device=DEV),
+                    position_ids=torch.tensor([list(range(20))], device=DEV),
+                    use_cache=False,
+                ).last_hidden_state
+                ref2 = model(
+                    input_ids=torch.tensor([doc2], device=DEV),
+                    position_ids=torch.tensor([list(range(16))], device=DEV),
+                    use_cache=False,
+                ).last_hidden_state
+
+            assert calls["n"] > 0, "varlen_attn did not fire in the training forward"
+            reference = torch.cat([ref1, ref2], dim=1)
+            assert torch.allclose(packed, reference, atol=1e-2)
+        finally:
+            unpatch_sdpa_varlen()
+    finally:
+        va.varlen_attn = original_varlen

--- a/tests/test_attn_implementation.py
+++ b/tests/test_attn_implementation.py
@@ -124,6 +124,25 @@ class TestCapabilityTables:
         assert validated.attn_uses_flash_lib is False
         assert validated.attn_needs_dtype_cast is False
 
+    @pytest.mark.parametrize(
+        "impl,expected",
+        [
+            ("flash_attention_2", True),
+            ("flex_attention", True),
+            (
+                "sdpa",
+                True,
+            ),  # not varlen, but isolates via block-diagonal from position_ids
+            ("eager", True),
+            ("fp8", False),
+        ],
+    )
+    def test_decontaminates_packing(self, min_base_cfg, impl, expected):
+        validated = validate_config(
+            min_base_cfg | DictDefault(attn_implementation=impl)
+        )
+        assert validated.attn_decontaminates_packing is expected
+
     def test_computed_flags_not_overridable_from_yaml(self, min_base_cfg):
         """YAML attempts to override a computed field must not win."""
         cfg = min_base_cfg | DictDefault(
@@ -361,26 +380,30 @@ class TestGemma4HybridMode:
 
 
 class TestSamplePackingValidation:
-    """`sample_packing` warns for non-varlen backends; s2 raises outright."""
+    """`sample_packing` warns only for backends that can't isolate documents.
 
-    def test_eager_warns(self, min_base_cfg, caplog):
+    sdpa/eager decontaminate via the dropped-mask block-diagonal (sdpa additionally
+    through cu_seqlens varlen when available), so they must not warn.
+    """
+
+    def test_eager_does_not_warn(self, min_base_cfg, caplog):
         cfg = min_base_cfg | DictDefault(
             attn_implementation="eager", sample_packing=True
         )
         with _capture_axolotl_warnings(caplog):
             validate_config(cfg)
-        assert any(
+        assert not any(
             "does not handle cross-sample decontamination" in r.getMessage()
             for r in caplog.records
         )
 
-    def test_sdpa_warns(self, min_base_cfg, caplog):
+    def test_sdpa_does_not_warn(self, min_base_cfg, caplog):
         cfg = min_base_cfg | DictDefault(
             attn_implementation="sdpa", sample_packing=True
         )
         with _capture_axolotl_warnings(caplog):
             validate_config(cfg)
-        assert any(
+        assert not any(
             "does not handle cross-sample decontamination" in r.getMessage()
             for r in caplog.records
         )
@@ -392,6 +415,15 @@ class TestSamplePackingValidation:
         with _capture_axolotl_warnings(caplog):
             validate_config(cfg)
         assert not any(
+            "does not handle cross-sample decontamination" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_non_decontaminating_backend_warns(self, min_base_cfg, caplog):
+        cfg = min_base_cfg | DictDefault(attn_implementation="fp8", sample_packing=True)
+        with _capture_axolotl_warnings(caplog):
+            validate_config(cfg)
+        assert any(
             "does not handle cross-sample decontamination" in r.getMessage()
             for r in caplog.records
         )


### PR DESCRIPTION
# Description

Two related fixes for sample-packing cross-document isolation.

**1. Remove the inert `_get_unpad_data` monkeypatch for in-tree models.**
Modern transformers casts the 2D attention mask to bool in `create_causal_mask` before flash attention, so the integer segment-id mask multipack encodes never reaches `_get_unpad_data` — cross-document isolation actually comes from the position_ids path (`_is_packed_sequence` / `find_packed_sequence_indices`), enabled by the micro-batch being packed into a single row. Verified on FA2 that the override is bit-identically inert: for a fully-packed row `_get_unpad_data` is never called, and for a padded row it receives an already-boolified mask and produces output identical to stock. It only reintroduced `.item()` device syncs and a torch.compile graph break (the data-dependent Python loop bound in `get_max_seqlen_in_batch`). Kept for trust-remote-code models via `patch_remote`; `get_max_seqlen_in_batch` is rewritten vectorized and sync-free.

**2. Fix plain `sdpa`/`eager` packing leaking across documents, and make `sdpa_varlen` engage varlen during training.**
`sdpa`/`eager` were excluded from `sample_packing_drop_attention_mask`, so the mask was never dropped and documents attended across each other (previously only *warned*). Added `attn_decontaminates_packing` (sdpa/eager isolate via the block-diagonal mask transformers builds from position_ids) and drop the mask for them; the validation warning now fires only for backends that genuinely cannot decontaminate.

Separately, `sdpa_varlen` never reached `varlen_attn` in training: with `use_cache=False` transformers builds a 4D block-diagonal mask that defeats the `attention_mask is None` fast-path, so varlen only fired in inference / on fully-packed rows while **padded rows silently leaked**. Fixed by registering an sdpa mask override that returns `None` for packed rows (mirroring `flash_attention_mask`), adding a block-diagonal fallback for rows varlen can't serve (dropout / custom scale / head_dim>256), and auto-enabling `sdpa_varlen` for `sdpa` + packing when supported (torch>=2.10, head_dim<=256, no sliding window). `sdpa_varlen` is now tri-state (null=auto, true/false=force).

Composes cleanly with #3789 (large-head routing): clean head_dim partition (varlen owns ≤256, large-head owns >256), and dropping the mask for sdpa is what lets large-head's Triton path see `attention_mask is None`.

## Motivation and Context

Under sample packing, real tokens must never attend across document boundaries. FA2/flex/xformers/sage were already correct (mask dropped → position_ids path). Plain sdpa/eager silently leaked, and `sdpa_varlen` silently fell back to O(S²) SDPA in training (leaking on padded rows) instead of using the cu_seqlens varlen kernel. The `_get_unpad_data` patch was dead code on current transformers that added per-layer device syncs and blocked torch.compile.

## How has this been tested?

All on an RTX PRO 6000 (sm_120), transformers 5.12, verifying against per-document reference forwards:
- FA2 packed forward is bit-identical to per-document forwards; the removed patch is a no-op (never called / identical output).
- sdpa/eager packed rows (incl. trailing padding) match per-document forwards once the mask is dropped (Δ=0).
- `varlen_attn` provably fires in a real training forward (`use_cache=False`) and matches per-document forwards.
- head_dim>256 / dropout fall back to the block-diagonal mask and stay isolated (fp32 Δ≈2e-6; verified it is NOT the leaky pure-causal path).
- Auto-enable gating verified across head_dim / sliding-window / opt-out scenarios.

New/updated tests: `test_multipack_packing_equivalence.py` (FA2 equivalence), `test_sdpa_varlen.py` (varlen fires in training; large-head fallback isolates), `test_attn_implementation.py` (`attn_decontaminates_packing` + warning behavior), `test_llama_attn_hijack_flash.py` (sync-free `get_max_seqlen_in_batch` edge case), `test_model_patches.py` (in-tree models keep stock `_get_unpad_data`). Full suite green; pre-commit clean.

## AI Usage Disclaimer

Yes — Claude Code (Claude Opus 4.8) was used for the investigation, implementation, and tests.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved packed-sequence attention handling so supported setups can auto-enable a faster variable-length path when available.
  * Clarified attention and sample-packing guidance in the CLI and config descriptions.

* **Bug Fixes**
  * Prevented attention leakage across packed documents by preserving document boundaries in fallback behavior.
  * Updated sample-packing warnings to better match backends that already keep packed samples isolated.

* **Tests**
  * Added coverage for packed-forward equivalence, varlen attention activation, and boundary-safe unpadding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->