### PR TITLE
feat(integrations): expert_offload — single-GPU CPU offload of frozen 4-bit MoE experts

### DIFF
--- a/src/axolotl/integrations/expert_offload/README.md
+++ b/src/axolotl/integrations/expert_offload/README.md
@@ -31,9 +31,14 @@ composes with `activation_offloading`; it is orthogonal to `expert_parallel` (wh
   `use_reentrant` to `true` for a QLoRA run when the kwargs are omitted, and the plugin errors on a
   reentrant config. The `gradient_checkpointing: offload` / `offload_disk` variants are untested
   with this integration.
-- A per-expert MoE layout (`experts` is a `ModuleList`): Mixtral, Qwen2/3-MoE, OLMoE, DeepSeek-MoE,
-  Jamba, etc. Fused-expert layouts (GPT-OSS, DBRX) are not 4-bit-quantized as `Linear4bit` and are
-  left untouched.
+- A supported expert layout, either:
+  - **per-expert** (`experts` is a `ModuleList` of `Linear4bit`) — the classic Mixtral /
+    DeepSeek-MoE / Jamba shape; quantized by plain `load_in_4bit`.
+  - **grouped 3D stacks** (one `[n_experts, out, in]` parameter per projection) — OLMoE /
+    Qwen3-MoE on current transformers. Plain `load_in_4bit` does NOT quantize these; set
+    `quantize_moe_experts: true` so the stacks are 4-bit-quantized on load (bitsandbytes
+    parametrization) and there is something to offload. Without it the experts stay bf16 —
+    the model may not even fit resident, and the plugin fails loudly at install.
 
 ## Usage
 
@@ -45,6 +50,7 @@ expert_offload: true
 # expert_offload_pin_memory: true   # default; set false only if pinned RAM is scarce
 
 load_in_4bit: true
+quantize_moe_experts: true   # required for grouped-3D-stack models (OLMoE, Qwen3-MoE)
 adapter: qlora
 gradient_checkpointing: true
 gradient_checkpointing_kwargs:
@@ -76,10 +82,13 @@ Notes:
 
 ## How it works
 
-Each expert is a `Linear4bit` whose big tensor is the packed `weight.data`; its `quant_state`
-scales are ~1/32 the size and stay resident. Every offloaded block's `weight.data` is homed in
-pinned CPU RAM. A forward **pre-hook** on the MoE block copies its experts to the GPU just before
-the block runs. Eviction is driven by a **single-resident-slot** policy — staging a block first
+The big packed 4-bit tensor is either an expert's `weight.data` (`Linear4bit` layout) or the
+stack's `parametrizations.<p>.original.data` (`quantize_moe_experts` layout); the `quant_state`
+scales are ~1/32 the size and stay resident in both. Every offloaded block's packed data is homed
+in pinned CPU RAM. A forward **pre-hook** on the owning module copies its experts to the GPU just
+before it runs. In the parametrized layout the dequant runs under `no_grad` on access, so autograd
+only ever saves the *dequantized* activation — the packed tensor itself is never captured by the
+graph, and checkpoint recompute re-stages it through the same pre-hook. Eviction is driven by a **single-resident-slot** policy — staging a block first
 evicts the previously-staged one — and there is deliberately **no evict post-hook**: a block is
 never dropped until the *next* block stages.
 

--- a/src/axolotl/integrations/expert_offload/README.md
+++ b/src/axolotl/integrations/expert_offload/README.md
@@ -1,0 +1,90 @@
+# Expert Offload Integration
+
+Stream a MoE model's **frozen 4-bit experts** from pinned CPU RAM to the GPU one block at a time,
+so a model whose experts exceed VRAM can QLoRA-train on a single small GPU.
+
+Only the frozen experts move. Attention, the router/gate, norms, and the trainable LoRA adapters
+stay GPU-resident, so per-step PCIe traffic is limited to the experts — which are the bulk of a
+MoE's parameters and the reason it doesn't fit.
+
+## How it differs from `layer_offloading` / `activation_offloading`
+
+| Feature | Offloads | Granularity |
+|---|---|---|
+| `activation_offloading` | activations | per checkpoint boundary |
+| `layer_offloading` | frozen params of **whole decoder layers** | per layer (attention + experts + norms) |
+| **`expert_offload`** | frozen **4-bit experts only** | per MoE block |
+
+For a MoE, the experts dominate memory, so offloading *only* them recovers nearly all the VRAM of
+whole-layer offload while streaming far fewer bytes per step (attention/router/norms never leave the
+GPU). It is tuned for the bitsandbytes `Linear4bit` + gradient-checkpoint-recompute path. It
+composes with `activation_offloading`; it is orthogonal to `expert_parallel` (which shards experts
+*across* GPUs — the opposite regime).
+
+## Requirements
+
+- Single GPU (no FSDP / DeepSpeed / expert-parallel).
+- `load_in_4bit: true` with `adapter: qlora` — it offloads 4-bit `Linear4bit` experts.
+- `gradient_checkpointing: true` with `gradient_checkpointing_kwargs.use_reentrant: false`. This is
+  **required**, not just recommended — see "How it works". Set it explicitly: axolotl defaults
+  `use_reentrant` to `true` for a QLoRA run when the kwargs are omitted, and the plugin errors on a
+  reentrant config. The `gradient_checkpointing: offload` / `offload_disk` variants are untested
+  with this integration.
+- A per-expert MoE layout (`experts` is a `ModuleList`): Mixtral, Qwen2/3-MoE, OLMoE, DeepSeek-MoE,
+  Jamba, etc. Fused-expert layouts (GPT-OSS, DBRX) are not 4-bit-quantized as `Linear4bit` and are
+  left untouched.
+
+## Usage
+
+```yaml
+plugins:
+  - axolotl.integrations.expert_offload.ExpertOffloadPlugin
+
+expert_offload: true
+# expert_offload_pin_memory: true   # default; set false only if pinned RAM is scarce
+
+load_in_4bit: true
+adapter: qlora
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+```
+
+See `examples/` for a full config.
+
+## How it works
+
+Each expert is a `Linear4bit` whose big tensor is the packed `weight.data`; its `quant_state`
+scales are ~1/32 the size and stay resident. Every offloaded block's `weight.data` is homed in
+pinned CPU RAM. A forward **pre-hook** on the MoE block copies its experts to the GPU just before
+the block runs. Eviction is driven by a **single-resident-slot** policy — staging a block first
+evicts the previously-staged one — and there is deliberately **no evict post-hook**: a block is
+never dropped until the *next* block stages.
+
+**Why gradient checkpointing is required.** `bnb.matmul_4bit`'s backward re-reads the packed weight
+(to re-dequantize for the input gradient) via `save_for_backward`, and eviction repoints
+`weight.data` at a 0-element placeholder. Gradient checkpointing (`use_reentrant=False`) discards
+the initial-forward saved tensors and **recomputes** each layer in backward, re-running the block
+pre-hook to re-stage its experts and rebuild the saved tensors from the staged weights. Because
+nothing evicts a block until the next block stages — which, in backward (processed
+last-layer-first), only happens after the current block's recomputed backward has finished — the
+staged weights are always present when read, without depending on exactly when PyTorch stops a
+recompute. Without checkpointing, backward would run against the initial graph whose saved weight is
+now a placeholder, and every staged weight would stay pinned as a saved tensor to the full footprint
+offload exists to avoid.
+
+## Measured effect
+
+OLMoE-1B-7B QLoRA on a single 12 GB RTX A2000 (r=8, seq 256, 60 steps, same seed and data order for
+both arms — so the loss curves are directly comparable):
+
+| config | loaded GPU | peak GPU | held-out eval (before → after) |
+|---|--:|--:|--:|
+| experts resident | 4.70 GB | 6.00 GB | 1.6448 → 1.2213 |
+| experts offloaded | **1.08 GB** | **2.60 GB** | 1.6448 → 1.2270 |
+
+Peak VRAM −57%, load-time footprint −77%; convergence preserved (identical `before`; final-loss gap
+within fp noise of the dequant/reload path). Throughput cost is the per-block host→device copy — a
+memory-for-compute trade — measured at roughly +11% s/step uncontended on this card. OLMoE fits a
+12 GB card either way, so it is the measurable proxy; the same mechanism is what lets the larger
+30B-A3B / 26B-A4B configs fit at all.

--- a/src/axolotl/integrations/expert_offload/README.md
+++ b/src/axolotl/integrations/expert_offload/README.md
@@ -23,7 +23,8 @@ composes with `activation_offloading`; it is orthogonal to `expert_parallel` (wh
 
 ## Requirements
 
-- Single GPU (no FSDP / DeepSpeed / expert-parallel).
+- One GPU per replica: single-GPU, or plain DDP for multi-GPU data parallel (no FSDP /
+  DeepSpeed / expert-parallel — those shard or move the same weights this plugin manages).
 - `load_in_4bit: true` with `adapter: qlora` — it offloads 4-bit `Linear4bit` experts.
 - `gradient_checkpointing: true` with `gradient_checkpointing_kwargs.use_reentrant: false`. This is
   **required**, not just recommended — see "How it works". Set it explicitly: axolotl defaults
@@ -51,6 +52,27 @@ gradient_checkpointing_kwargs:
 ```
 
 See `examples/` for a full config.
+
+### Multi-GPU (plain DDP)
+
+The same config runs data-parallel unmodified — launch across N GPUs and each rank keeps its own
+full replica, homes its own pinned copy of the experts, and streams to its own device:
+
+```bash
+axolotl train examples/olmoe-1b-7b-qlora-expert-offload.yaml   # auto-detects visible GPUs
+```
+
+Notes:
+
+- **CPU RAM scales with world size** (one pinned home set per rank): budget
+  `world_size x total 4-bit expert bytes` of pinned RAM.
+- The offloaded expert weights are registered on DDP's parameter ignore list at install, so
+  DDP's initial module-state sync never touches the evicted 0-element placeholders; they are
+  frozen (`requires_grad=False`) and never enter gradient buckets.
+- The per-step NCCL all-reduce covers only the trainable LoRA parameters (a few tens of MB), so
+  contention with the expert H2D copies over PCIe is small; measure on your topology if the
+  interconnect is shared.
+- FSDP / DeepSpeed / expert-parallel remain unsupported and are refused at config validation.
 
 ## How it works
 

--- a/src/axolotl/integrations/expert_offload/__init__.py
+++ b/src/axolotl/integrations/expert_offload/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Expert-granularity CPU offload integration for axolotl.
+
+Streams the frozen 4-bit experts of a MoE model from pinned CPU RAM to the GPU one block at a time,
+lowering peak VRAM so a MoE whose experts exceed the card can QLoRA-train on a single small GPU.
+Attention, router, norms and the trainable LoRA adapters stay GPU-resident.
+"""
+
+from .args import ExpertOffloadArgs
+from .plugin import ExpertOffloadPlugin
+
+__all__ = [
+    "ExpertOffloadArgs",
+    "ExpertOffloadPlugin",
+]

--- a/src/axolotl/integrations/expert_offload/args.py
+++ b/src/axolotl/integrations/expert_offload/args.py
@@ -8,14 +8,16 @@
 
 """Pydantic args for the expert-offload plugin."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class ExpertOffloadArgs(BaseModel):
     """Input args for the expert_offload plugin. See the integration README.
 
-    Cross-field requirements (4-bit adapter, gradient checkpointing, single-GPU) depend on config
-    fields this model cannot see, so they are validated in the plugin's ``pre_model_load``.
+    Axolotl folds plugin args into the full config by inheritance
+    (``integrations/config.py::merge_input_args``), so the cross-field validator below runs on
+    the merged config and sees the base-config fields (``load_in_4bit``, ``fsdp``, ...); the
+    ``getattr`` defaults keep the model instantiable standalone as well.
     """
 
     expert_offload: bool = False
@@ -28,3 +30,55 @@ class ExpertOffloadArgs(BaseModel):
     """Home the offloaded expert weights in pinned CPU memory so the per-block host->device copy is
     truly asynchronous. Set false only if pinned memory is scarce (falls back to a correct but
     synchronous pageable copy)."""
+
+    @model_validator(mode="after")
+    def validate_expert_offload_requirements(self):
+        if not self.expert_offload:
+            return self
+
+        errors: list[str] = []
+
+        # 4-bit experts: the mechanism swaps ``Linear4bit.weight.data``.
+        if not getattr(self, "load_in_4bit", False):
+            errors.append(
+                "requires load_in_4bit: true (it offloads 4-bit Linear4bit experts)"
+            )
+        if getattr(self, "adapter", None) not in ("lora", "qlora"):
+            errors.append("requires adapter: qlora (or lora with load_in_4bit)")
+
+        # Gradient checkpointing (use_reentrant=False) is load-bearing: the backward recompute
+        # re-stages each block's experts, and it is what lets eviction actually free memory rather
+        # than pin every staged weight alive as a matmul_4bit saved-for-backward tensor.
+        # ``use_reentrant`` must be EXPLICITLY false: this validator runs at config-parse time,
+        # before ``normalize_config`` defaults omitted kwargs to ``{"use_reentrant": True}``.
+        if not getattr(self, "gradient_checkpointing", False):
+            errors.append(
+                "requires gradient_checkpointing: true (the backward recompute re-stages experts; "
+                "without it, offload is neither correct nor memory-saving)"
+            )
+        elif (getattr(self, "gradient_checkpointing_kwargs", None) or {}).get(
+            "use_reentrant"
+        ) is not False:
+            errors.append(
+                "requires an explicit gradient_checkpointing_kwargs.use_reentrant: false "
+                "(axolotl defaults it to true when omitted; reentrant checkpointing does not "
+                "re-run the block pre-hook on recompute)"
+            )
+
+        # Single GPU: FSDP / DeepSpeed / expert-parallel move or shard these same weights and
+        # would race the stage/evict swaps.
+        if getattr(self, "fsdp_config", None) or getattr(self, "fsdp", None):
+            errors.append("is single-GPU only and incompatible with FSDP")
+        if getattr(self, "deepspeed", None):
+            errors.append("is single-GPU only and incompatible with DeepSpeed")
+        if (getattr(self, "expert_parallel_size", None) or 1) > 1:
+            errors.append(
+                "is incompatible with expert_parallel (both manage the expert weights)"
+            )
+
+        if errors:
+            raise ValueError(
+                "expert_offload is enabled but the config is incompatible:\n  - "
+                + "\n  - ".join(errors)
+            )
+        return self

--- a/src/axolotl/integrations/expert_offload/args.py
+++ b/src/axolotl/integrations/expert_offload/args.py
@@ -14,25 +14,18 @@ from pydantic import BaseModel, model_validator
 class ExpertOffloadArgs(BaseModel):
     """Input args for the expert_offload plugin. See the integration README.
 
-    Axolotl folds plugin args into the full config by inheritance
-    (``integrations/config.py::merge_input_args``), so the cross-field validator below runs on
-    the merged config and sees the base-config fields (``load_in_4bit``, ``fsdp``, ...); the
-    ``getattr`` defaults keep the model instantiable standalone as well.
+    ``merge_input_args`` folds plugin args into the full config, so the validator below sees the
+    merged base-config fields; the ``getattr`` defaults keep the model instantiable standalone.
     """
 
     expert_offload: bool = False
-    """Keep frozen 4-bit MoE experts in CPU RAM and stream one block's experts to the GPU at a time,
-    lowering peak VRAM so MoE models whose experts exceed VRAM can QLoRA-train on a small GPU.
-    Requires a 4-bit adapter (``load_in_4bit`` + ``adapter: qlora``) and
-    ``gradient_checkpointing: true`` with ``use_reentrant: false``. One GPU per replica: single-GPU
-    and plain DDP (multi-GPU data parallel) are supported — under DDP each rank homes its own pinned
-    copy of the experts, so CPU RAM cost scales with world size. FSDP / DeepSpeed / expert-parallel
-    shard or move the same weights and are refused."""
+    """Stream frozen 4-bit MoE experts from pinned CPU RAM to the GPU one block at a time, cutting
+    peak VRAM. Requires ``load_in_4bit`` + ``adapter: qlora`` and non-reentrant gradient
+    checkpointing; single-GPU or plain DDP. See the integration README."""
 
     expert_offload_pin_memory: bool = True
-    """Home the offloaded expert weights in pinned CPU memory so the per-block host->device copy is
-    truly asynchronous. Set false only if pinned memory is scarce (falls back to a correct but
-    synchronous pageable copy)."""
+    """Home offloaded experts in pinned CPU memory for async H2D copies; set false only if pinned
+    memory is scarce."""
 
     @model_validator(mode="after")
     def validate_expert_offload_requirements(self):
@@ -41,7 +34,7 @@ class ExpertOffloadArgs(BaseModel):
 
         errors: list[str] = []
 
-        # 4-bit experts: the mechanism swaps ``Linear4bit.weight.data``.
+        # The mechanism swaps packed 4-bit ``weight.data`` — 4-bit only.
         if not getattr(self, "load_in_4bit", False):
             errors.append(
                 "requires load_in_4bit: true (it offloads 4-bit Linear4bit experts)"
@@ -49,11 +42,8 @@ class ExpertOffloadArgs(BaseModel):
         if getattr(self, "adapter", None) not in ("lora", "qlora"):
             errors.append("requires adapter: qlora (or lora with load_in_4bit)")
 
-        # Gradient checkpointing (use_reentrant=False) is load-bearing: the backward recompute
-        # re-stages each block's experts, and it is what lets eviction actually free memory rather
-        # than pin every staged weight alive as a matmul_4bit saved-for-backward tensor.
-        # ``use_reentrant`` must be EXPLICITLY false: this validator runs at config-parse time,
-        # before ``normalize_config`` defaults omitted kwargs to ``{"use_reentrant": True}``.
+        # The recompute is what makes eviction correct and memory-freeing. ``use_reentrant`` must
+        # be EXPLICITLY false: this runs before ``normalize_config`` defaults it to true.
         if not getattr(self, "gradient_checkpointing", False):
             errors.append(
                 "requires gradient_checkpointing: true (the backward recompute re-stages experts; "
@@ -68,13 +58,13 @@ class ExpertOffloadArgs(BaseModel):
                 "re-run the block pre-hook on recompute)"
             )
 
-        # One GPU per replica: plain DDP is fine (per-process replicas; the offloaded weights go
-        # on DDP's ignore list at install), but FSDP / DeepSpeed / expert-parallel move or shard
-        # these same weights and would race the stage/evict swaps.
+        # FSDP / DeepSpeed / expert-parallel move or shard the same weights (plain DDP is fine).
         if getattr(self, "fsdp_config", None) or getattr(self, "fsdp", None):
             errors.append("is incompatible with FSDP (use single-GPU or plain DDP)")
         if getattr(self, "deepspeed", None):
-            errors.append("is incompatible with DeepSpeed (use single-GPU or plain DDP)")
+            errors.append(
+                "is incompatible with DeepSpeed (use single-GPU or plain DDP)"
+            )
         if (getattr(self, "expert_parallel_size", None) or 1) > 1:
             errors.append(
                 "is incompatible with expert_parallel (both manage the expert weights)"

--- a/src/axolotl/integrations/expert_offload/args.py
+++ b/src/axolotl/integrations/expert_offload/args.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Pydantic args for the expert-offload plugin."""
+
+from pydantic import BaseModel
+
+
+class ExpertOffloadArgs(BaseModel):
+    """Input args for the expert_offload plugin. See the integration README.
+
+    Cross-field requirements (4-bit adapter, gradient checkpointing, single-GPU) depend on config
+    fields this model cannot see, so they are validated in the plugin's ``pre_model_load``.
+    """
+
+    expert_offload: bool = False
+    """Keep frozen 4-bit MoE experts in CPU RAM and stream one block's experts to the GPU at a time,
+    lowering peak VRAM so MoE models whose experts exceed VRAM can QLoRA-train on a single small GPU.
+    Requires a 4-bit adapter (``load_in_4bit`` + ``adapter: qlora``), ``gradient_checkpointing: true``
+    with ``use_reentrant: false``, and a single GPU (no FSDP / DeepSpeed / expert-parallel)."""
+
+    expert_offload_pin_memory: bool = True
+    """Home the offloaded expert weights in pinned CPU memory so the per-block host->device copy is
+    truly asynchronous. Set false only if pinned memory is scarce (falls back to a correct but
+    synchronous pageable copy)."""

--- a/src/axolotl/integrations/expert_offload/args.py
+++ b/src/axolotl/integrations/expert_offload/args.py
@@ -22,9 +22,12 @@ class ExpertOffloadArgs(BaseModel):
 
     expert_offload: bool = False
     """Keep frozen 4-bit MoE experts in CPU RAM and stream one block's experts to the GPU at a time,
-    lowering peak VRAM so MoE models whose experts exceed VRAM can QLoRA-train on a single small GPU.
-    Requires a 4-bit adapter (``load_in_4bit`` + ``adapter: qlora``), ``gradient_checkpointing: true``
-    with ``use_reentrant: false``, and a single GPU (no FSDP / DeepSpeed / expert-parallel)."""
+    lowering peak VRAM so MoE models whose experts exceed VRAM can QLoRA-train on a small GPU.
+    Requires a 4-bit adapter (``load_in_4bit`` + ``adapter: qlora``) and
+    ``gradient_checkpointing: true`` with ``use_reentrant: false``. One GPU per replica: single-GPU
+    and plain DDP (multi-GPU data parallel) are supported — under DDP each rank homes its own pinned
+    copy of the experts, so CPU RAM cost scales with world size. FSDP / DeepSpeed / expert-parallel
+    shard or move the same weights and are refused."""
 
     expert_offload_pin_memory: bool = True
     """Home the offloaded expert weights in pinned CPU memory so the per-block host->device copy is
@@ -65,12 +68,13 @@ class ExpertOffloadArgs(BaseModel):
                 "re-run the block pre-hook on recompute)"
             )
 
-        # Single GPU: FSDP / DeepSpeed / expert-parallel move or shard these same weights and
-        # would race the stage/evict swaps.
+        # One GPU per replica: plain DDP is fine (per-process replicas; the offloaded weights go
+        # on DDP's ignore list at install), but FSDP / DeepSpeed / expert-parallel move or shard
+        # these same weights and would race the stage/evict swaps.
         if getattr(self, "fsdp_config", None) or getattr(self, "fsdp", None):
-            errors.append("is single-GPU only and incompatible with FSDP")
+            errors.append("is incompatible with FSDP (use single-GPU or plain DDP)")
         if getattr(self, "deepspeed", None):
-            errors.append("is single-GPU only and incompatible with DeepSpeed")
+            errors.append("is incompatible with DeepSpeed (use single-GPU or plain DDP)")
         if (getattr(self, "expert_parallel_size", None) or 1) > 1:
             errors.append(
                 "is incompatible with expert_parallel (both manage the expert weights)"

--- a/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
+++ b/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
@@ -1,6 +1,7 @@
-# Single-GPU QLoRA of a fused-MoE with the frozen 4-bit experts offloaded to CPU RAM.
+# QLoRA of a fused-MoE with the frozen 4-bit experts offloaded to CPU RAM.
 # The experts stream to the GPU one block at a time, so peak VRAM stays low enough to fit a
-# small card. NOTE: single-GPU only — do NOT add fsdp / deepspeed / expert_parallel here.
+# small card. One GPU per replica: runs single-GPU or plain-DDP data parallel as-is (each rank
+# homes its own pinned expert copy). Do NOT add fsdp / deepspeed / expert_parallel here.
 
 base_model: allenai/OLMoE-1B-7B-0924
 trust_remote_code: true

--- a/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
+++ b/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
@@ -15,6 +15,10 @@ expert_offload: true
 
 load_in_8bit: false
 load_in_4bit: true
+# OLMoE stores its experts as fused 3D stacks on current transformers; plain load_in_4bit
+# leaves those UNQUANTIZED (bf16). This quantizes them on load — required both to fit the
+# model and for expert_offload to have 4-bit experts to home.
+quantize_moe_experts: true
 adapter: qlora
 lora_r: 8
 lora_alpha: 16

--- a/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
+++ b/src/axolotl/integrations/expert_offload/examples/olmoe-1b-7b-qlora-expert-offload.yaml
@@ -1,0 +1,59 @@
+# Single-GPU QLoRA of a fused-MoE with the frozen 4-bit experts offloaded to CPU RAM.
+# The experts stream to the GPU one block at a time, so peak VRAM stays low enough to fit a
+# small card. NOTE: single-GPU only — do NOT add fsdp / deepspeed / expert_parallel here.
+
+base_model: allenai/OLMoE-1B-7B-0924
+trust_remote_code: true
+
+plugins:
+  - axolotl.integrations.expert_offload.ExpertOffloadPlugin
+
+# --- the feature ---
+expert_offload: true
+# expert_offload_pin_memory: true   # default
+
+load_in_8bit: false
+load_in_4bit: true
+adapter: qlora
+lora_r: 8
+lora_alpha: 16
+lora_dropout: 0.05
+# Target attention (and, if you want, the expert projections via lora_target_parameters).
+# lora_target_linear quantizes/targets all linears; keep experts frozen + offloaded.
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+
+datasets:
+  - path: tatsu-lab/alpaca
+    type: alpaca
+dataset_prepared_path:
+val_set_size: 0.05
+output_dir: ./outputs/olmoe-expert-offload
+
+sequence_len: 2048
+sample_packing: true
+
+gradient_accumulation_steps: 4
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_fused
+lr_scheduler: cosine
+learning_rate: 0.0001
+
+bf16: auto
+tf32: true
+
+# Required by expert_offload: the backward recompute re-stages each block's experts.
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+
+logging_steps: 1
+warmup_ratio: 0.1
+evals_per_epoch: 4
+saves_per_epoch: 1
+weight_decay: 0.0
+special_tokens:

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -6,55 +6,17 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Expert-granularity CPU offload for 4-bit MoE QLoRA on a single GPU.
+"""Expert-granularity CPU offload for 4-bit MoE QLoRA.
 
-Only the *frozen 4-bit expert* weights are moved; attention, router/gate, norms and the
-trainable LoRA adapters stay GPU-resident. Two expert layouts are supported:
+Only the frozen 4-bit expert weights move; attention, router/gate, norms and the trainable LoRA
+adapters stay GPU-resident. Two layouts are supported: per-expert ``bitsandbytes`` ``Linear4bit``
+(an ``experts`` ``ModuleList``) and grouped 3D stacks quantized via ``quantize_moe_experts``.
 
-- **Per-expert ``Linear4bit``** (an ``experts`` ``ModuleList``): each expert is a ``bitsandbytes``
-  ``Linear4bit`` whose big packed tensor is ``weight.data`` (the ``quant_state`` scales are ~1/32
-  the size and are left resident).
-- **Grouped 3D stacks quantized via ``quantize_moe_experts``**: models whose experts are fused 3D
-  ``nn.Parameter`` stacks (one ``[n_experts, out, in]`` tensor per projection — OLMoE / Qwen3-MoE
-  style on current transformers). ``quantize_moe_experts: true`` quantizes each stack in place
-  through ``bitsandbytes.nn.parametrize.replace_parameter_4bit``: the packed tensor becomes
-  ``module.parametrizations[name].original`` and a ``Bnb4bitParametrization`` (carrying the small
-  resident ``quant_state``) dequantizes it on access, under ``no_grad`` — so autograd only ever
-  holds the *dequantized* activation, never the packed tensor, and eviction of the packed data is
-  safe outside the module's forward.
-
-In both layouts we home the packed tensor's ``.data`` in *pinned* CPU RAM, and a **forward
-pre-hook** on the owning module copies that block's experts onto the GPU just before it runs.
-
-Eviction is driven entirely by a **single-resident-slot** policy: staging a block first evicts the
-previously-staged one. There is deliberately **no evict post-hook**. Under ``use_reentrant=False``
-gradient checkpointing each decoder layer's forward is *recomputed* in the backward pass; the same
-pre-hook re-stages the block's experts for that recompute, and because nothing evicts a block until
-the *next* block stages — which, in backward (processed last-layer-first), only happens after the
-current block's recomputed backward has finished — the staged weights are always present when the
-recomputed backward reads them. So at most **one block's** experts are GPU-resident at any instant,
-in forward and backward alike, without depending on exactly when PyTorch stops a recompute.
-
-This lets a fused MoE whose 4-bit experts exceed VRAM QLoRA-train on a small card, at the cost of
-one host->device expert transfer per block per pass — a memory-for-compute trade.
-
-**Why gradient checkpointing is required (correctness *and* the memory win).**
-``bnb.matmul_4bit``'s autograd ``Function`` re-reads the packed weight in its backward (to
-re-dequantize for the input gradient) via ``save_for_backward``. Eviction repoints
-``weight.data`` at a 0-element placeholder, so the saved reference would read that placeholder in a
-backward that runs against the *initial* forward's graph. Gradient checkpointing discards the
-initial-forward saved tensors and **recomputes** each layer in backward (re-staging via the
-pre-hook and rebuilding the saved tensors from the staged weights), which is what makes eviction
-both correct and actually memory-freeing rather than pinning every staged weight alive as a saved
-tensor. ``gradient_checkpointing: true`` with an explicit ``use_reentrant: false`` is enforced at
-config validation (the ``ExpertOffloadArgs`` schema validator).
-
-One GPU **per replica**: plain DDP (multi-GPU data parallel) is supported — each rank is its own
-process with a full replica, so each rank homes its own pinned copy of the experts (CPU RAM cost
-scales with world size) and stages to its own device; the offloaded weights are registered on
-DDP's ignore list so the initial module-state sync never touches the 0-element placeholders.
-FSDP / DeepSpeed / expert-parallel move or shard these same weights and would race the
-stage/evict swaps; the config schema refuses to enable under any of them.
+Each block's packed tensors are homed in pinned CPU RAM and staged to the GPU by a forward
+pre-hook; staging evicts the previously staged block (single resident slot, deliberately no evict
+post-hook). Under ``use_reentrant=False`` gradient checkpointing — required and schema-enforced —
+the backward recompute re-runs the pre-hook, so at most one block's experts are GPU-resident in
+forward and backward alike. Single-GPU or plain DDP; see this integration's README for details.
 """
 
 from __future__ import annotations
@@ -71,12 +33,10 @@ LOG = get_logger(__name__)
 
 
 class _Slot(NamedTuple):
-    """One offloadable packed tensor: the frozen ``nn.Parameter`` whose ``.data`` is swapped
-    between its pinned CPU home and the GPU, plus where it appears in ``state_dict``.
+    """One offloadable packed tensor and its candidate ``state_dict`` keys relative to ``owner``.
 
-    ``keys`` are candidate keys relative to ``owner``'s prefix — the parametrized layout needs two
-    because bitsandbytes' own state-dict post-hook renames ``parametrizations.<p>.original`` to the
-    clean ``<p>`` (hook order puts ours after bnb's, but both spellings are covered regardless).
+    The parametrized layout needs two keys: bnb's own state-dict hook renames
+    ``parametrizations.<p>.original`` to ``<p>``.
     """
 
     param: nn.Parameter
@@ -84,12 +44,9 @@ class _Slot(NamedTuple):
     keys: tuple[str, ...]
 
 
-# 0-element GPU placeholders that an evicted expert's ``weight.data`` points at while offloaded.
-# Shared across all offloaded experts (reads never mutate them) and cached per (device, dtype) —
-# the 4-bit storage dtype varies with ``bnb_4bit_quant_storage`` (uint8 / bfloat16 / float32), so
-# the placeholder must match the real tensor's dtype or a restage would change it. Keeping the real
-# "home" data OFF the module — only a 0-element placeholder is registered while evicted — means a
-# stray ``model.to(device)`` never drags the big expert tensors back onto the GPU.
+# Shared 0-element GPU placeholders that evicted experts' ``.data`` points at, cached per
+# (device, dtype) — the storage dtype varies with ``bnb_4bit_quant_storage``. Keeping the real
+# homes off the module means a stray ``model.to(device)`` can't drag the experts back.
 _PLACEHOLDERS: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
 
 
@@ -103,8 +60,7 @@ def _placeholder(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
 
 
 def _is_pinned(t: torch.Tensor) -> bool:
-    """Whether ``t`` is pinned (so a ``non_blocking`` H2D copy is truly async). Robust on hosts
-    where ``is_pinned`` is unavailable/raises without CUDA."""
+    """``t.is_pinned()``, robust on hosts where it raises without CUDA."""
     try:
         return bool(t.is_pinned())
     except (RuntimeError, AssertionError):  # pragma: no cover - platform dependent
@@ -112,40 +68,27 @@ def _is_pinned(t: torch.Tensor) -> bool:
 
 
 def _is_linear4bit(module: nn.Module) -> bool:
-    """A ``bitsandbytes`` ``Linear4bit`` whose ``weight`` is a packed 4-bit ``Params4bit``.
-
-    Matched structurally (by the ``Params4bit`` weight type) rather than by ``isinstance`` so we do
-    not hard-import bitsandbytes here and so PEFT/other subclasses of ``Linear4bit`` still match.
-    """
+    """Structural ``Linear4bit`` check (``Params4bit`` weight type) — no hard bitsandbytes
+    import, and PEFT subclasses still match."""
     weight = getattr(module, "weight", None)
     return weight is not None and type(weight).__name__ == "Params4bit"
 
 
 def _base_layer(module: nn.Module) -> nn.Module:
-    """Unwrap a PEFT adapter wrapper (``lora.Linear4bit`` etc.) to the frozen base ``Linear4bit``.
-
-    PEFT wraps the quantized expert and delegates ``.weight`` to ``.base_layer``; the packed tensor
-    we offload lives on that base, and the (tiny, trainable) LoRA ``A``/``B`` matrices are separate
-    siblings that must stay GPU-resident. Returns ``module`` unchanged if it is not wrapped.
-    """
+    """Unwrap a PEFT adapter wrapper to the frozen base ``Linear4bit`` (the trainable LoRA
+    matrices are separate siblings that stay GPU-resident)."""
     return getattr(module, "base_layer", module)
 
 
 def find_moe_expert_blocks(
     model: nn.Module,
 ) -> list[tuple[str, nn.Module, list[nn.Module]]]:
-    """Discover offloadable MoE blocks and their frozen 4-bit expert base layers.
+    """Discover per-expert MoE blocks: an ``experts`` ``ModuleList`` (len >= 2) with 4-bit leaves.
 
-    A block is any module exposing an ``experts`` ``ModuleList`` of length >= 2 whose leaves include
-    ``Linear4bit`` weights — the classic per-expert layout (``block_sparse_moe.experts`` /
-    ``mlp.experts``). Fused-experts layouts that pack all experts into one 3D parameter (OLMoE /
-    Qwen3-MoE on current transformers, GPT-OSS, DBRX) are **not** matched here — raw 3D parameters
-    are only 4-bit under ``quantize_moe_experts: true``, whose parametrized stacks are discovered by
-    :func:`find_parametrized_expert_stacks` instead.
-
-    Returns ``(block_name, block_module, expert_base_layers)`` triples. Deduplicates base layers so a
-    projection shared across the list is homed once. The hook attaches to ``block_module`` because
-    its ``forward`` runs the experts (and is what gradient checkpointing recomputes).
+    Fused 3D-parameter layouts are only 4-bit under ``quantize_moe_experts`` and are discovered by
+    :func:`find_parametrized_expert_stacks` instead. Returns ``(name, block, base_layers)`` triples
+    with base layers deduped; the block module is the hook site (its ``forward`` runs the experts
+    and is what gradient checkpointing recomputes).
     """
     blocks: list[tuple[str, nn.Module, list[nn.Module]]] = []
     for name, block in model.named_modules():
@@ -172,12 +115,8 @@ def find_parametrized_expert_stacks(
 ) -> list[tuple[str, nn.Module, list[_Slot]]]:
     """Discover grouped 3D expert stacks quantized via ``quantize_moe_experts``.
 
-    Matches any module carrying a ``Bnb4bitParametrization`` (by class name, mirroring
-    ``_is_linear4bit``'s structural matching) — the layout ``quantize_moe_experts: true`` produces
-    for fused-expert models (OLMoE / Qwen3-MoE style ``[n_experts, out, in]`` stacks). The packed
-    tensor is ``module.parametrizations[<p>].original``; the parametrization's ``quant_state``
-    stays resident. The module itself is the hook site: its ``forward`` dequantizes the stacks on
-    access (and is what gradient checkpointing recomputes).
+    Matches modules carrying a ``Bnb4bitParametrization`` (structurally, like ``_is_linear4bit``).
+    The packed tensor is ``parametrizations[<p>].original``; the module is the hook site.
     """
     blocks: list[tuple[str, nn.Module, list[_Slot]]] = []
     for name, module in model.named_modules():
@@ -204,32 +143,22 @@ def find_parametrized_expert_stacks(
 
 
 class _BlockOffload:
-    """Owns the pinned-CPU home copies of one MoE block's expert ``weight.data`` tensors and streams
-    them to ``device`` for the duration of each forward / gradient-checkpoint recompute.
-
-    While evicted, each expert's ``weight.data`` holds a shared 0-element GPU placeholder, so nothing
-    that walks the module tree (``.to()``, checkpoint-save) drags the offloaded data back onto the
-    GPU. ``quant_state`` (the small NF4 scales) stays GPU-resident throughout, as do the LoRA
-    adapters and everything outside ``experts``. A ``state_dict`` post-hook substitutes the CPU homes
-    for the placeholders so a full-model save stays correct (adapter-only saves never touch the base
-    keys, so they are unaffected).
+    """Owns one block's pinned-CPU expert homes and streams them to ``device`` for each forward /
+    checkpoint recompute. While evicted the params hold 0-element placeholders; a ``state_dict``
+    post-hook substitutes the CPU homes so full-model saves stay correct. ``quant_state`` and the
+    LoRA adapters stay GPU-resident throughout.
     """
 
-    # The single block whose experts are currently GPU-staged. Class-wide, so it assumes one
-    # offloaded model per process (the training case — including DDP, where each rank is its own
-    # process with its own replica). Under use_reentrant=False gradient checkpointing the backward
-    # RECOMPUTE re-runs a layer's forward to rebuild its saved tensors; staging a new block first
-    # evicts this previously-staged one, so at most one block is GPU-resident at any instant, in
-    # forward AND backward.
+    # The block currently GPU-staged. Class-wide: assumes one offloaded model per process (each
+    # DDP rank is its own process). Staging a block evicts this one, so at most one block is
+    # resident in forward AND backward (the checkpoint recompute re-stages via the pre-hook).
     _resident: _BlockOffload | None = None
 
     def __init__(self, name: str, slots: list[_Slot], device, pin: bool = True):
         self.name = name
         self.device = torch.device(device)
         self.slots = slots
-        # Capture each packed weight as a SEPARATE (pinned) CPU tensor BEFORE any placeholder swap.
-        # The source is on the GPU at install time, so ``.to("cpu")`` is a real device->host copy
-        # that decouples the home from the live parameter we then overwrite with a placeholder.
+        # ``.to("cpu")`` copies, decoupling each home from the live param before the placeholder swap.
         self.homes: list[torch.Tensor] = [
             self._to_home(slot.param.data.detach(), pin) for slot in slots
         ]
@@ -254,10 +183,8 @@ class _BlockOffload:
         return cpu
 
     def _install_state_dict_hook(self, slot: _Slot, idx: int) -> None:
-        """Keep full-model ``state_dict()`` correct while evicted: substitute the (pinned) CPU home
-        for the 0-element placeholder under any of the slot's candidate keys. References, not
-        copies, so adapter-only saves stay cheap and while *staged* it is a no-op (the entry is the
-        real GPU tensor)."""
+        """Substitute the CPU home for the 0-element placeholder in ``state_dict()`` while evicted
+        (references, not copies; a no-op while staged)."""
 
         def hook(module, state_dict, prefix, local_metadata):
             for key in slot.keys:
@@ -277,10 +204,8 @@ class _BlockOffload:
         return sum(t.numel() * t.element_size() for t in self.homes)
 
     def stage(self) -> None:
-        """Copy this block's packed expert weights onto ``device`` (idempotent), first evicting the
-        previously staged block so at most one block's experts are GPU-resident. The H2D copies are
-        enqueued on the current stream, so the dequant kernels that immediately follow are ordered
-        after them."""
+        """Stage this block's experts on ``device`` (idempotent), evicting the previously staged
+        block. H2D copies go on the current stream, ordering them before the dequant kernels."""
         if self.staged:
             return
         cls = type(self)
@@ -292,8 +217,7 @@ class _BlockOffload:
         cls._resident = self
 
     def evict(self) -> None:
-        """Point this block's expert weights back at shared 0-element placeholders (idempotent),
-        dropping the GPU copies so the caching allocator can reuse the memory for the next block."""
+        """Point the expert weights back at shared 0-element placeholders (idempotent)."""
         for slot in self.slots:
             slot.param.data = _placeholder(self.device, slot.param.data.dtype)
         self.staged = False
@@ -311,17 +235,11 @@ _BNB_CACHE_HOOK_NAMES = (
 def _strip_bnb_parametrize_cache_hooks(module: nn.Module) -> int:
     """Remove bitsandbytes' parametrization-cache hook pair from ``module``.
 
-    bnb registers a forward_pre_hook/forward_hook pair that increments/decrements the
-    GLOBAL ``torch.nn.utils.parametrize._cache_enabled`` counter and clears ``P._cache``
-    only when it returns to 0. Under ``use_reentrant=False`` gradient checkpointing the
-    backward recompute is aborted mid-forward by design (early stop), which SKIPS the
-    forward_hook of the module holding the last recomputed save — the counter leaks
-    upward once per checkpointed region per step, the cache is never cleared again, and
-    every dequantized bf16 expert weight is retained for the rest of training (pool x4
-    bytes: ~13 GiB for OLMoE, ~53 GiB for Qwen3-30B — the latter cannot fit a 24 GB
-    card at all). Expert params are accessed once per forward, so the cache buys these
-    modules nothing; removing the pair makes the leak impossible without touching bnb.
-    The state-dict post-hook (quantization-state save) is intentionally left in place.
+    The pair bumps the global ``parametrize._cache_enabled`` counter and clears the cache when it
+    returns to 0 — but the ``use_reentrant=False`` checkpoint recompute early-stops mid-forward,
+    skipping the forward_hook: the counter leaks and every dequantized expert stays cached (pool
+    x4 bytes). Experts are read once per forward, so the cache buys them nothing anyway. bnb's
+    state-dict post-hook is left in place.
     """
     removed = 0
     for hooks in (
@@ -354,13 +272,9 @@ def _reset_parametrize_cache_state() -> None:
 def install_expert_offload(
     model: nn.Module, device=None, pin: bool = True
 ) -> list[_BlockOffload]:
-    """Offload every discoverable MoE block's frozen 4-bit experts to (pinned) CPU RAM.
-
-    For each block, homes its expert ``weight.data`` tensors on the CPU, evicts them from the GPU,
-    and registers a forward pre-hook (stage) on the block module. The handles are stashed on
-    ``model._expert_offload_handles`` so they live as long as the model. Returns the handles (empty
-    if no offloadable MoE block was found).
-    """
+    """Home every discoverable MoE block's frozen 4-bit experts in (pinned) CPU RAM and register
+    the stage pre-hooks. Handles are stashed on ``model._expert_offload_handles`` so they live as
+    long as the model."""
     slot_blocks: list[tuple[str, nn.Module, list[_Slot]]] = [
         (
             name,
@@ -427,19 +341,10 @@ def install_expert_offload(
 
 
 def _register_ddp_ignore(model: nn.Module, handles: list[_BlockOffload]) -> None:
-    """Register every offloaded expert weight on DDP's ignore list.
-
-    While evicted, those weights are 0-element placeholders; DDP's initial module-state sync
-    (and any buffer broadcast) must never touch them — broadcasting a placeholder is at best a
-    no-op and at worst re-materializes state DDP has no business managing. The offloaded experts
-    are frozen (``requires_grad=False``) so they never participate in gradient buckets either;
-    the ignore list makes that contract explicit. ``_ddp_params_and_buffers_to_ignore`` is the
-    mechanism behind ``DistributedDataParallel._set_params_and_buffers_to_ignore_for_model`` and
-    is read off the module at DDP construction, which happens after ``post_model_load``.
-
-    The frozen weight Parameter objects survive eviction (only ``.data`` is swapped), so identity
-    matching against ``named_parameters`` yields their fully-qualified names.
-    """
+    """Register the offloaded expert weights on DDP's ignore list: the initial module-state sync
+    must not broadcast the evicted 0-element placeholders (frozen, so they never enter gradient
+    buckets either). ``_ddp_params_and_buffers_to_ignore`` is read at DDP construction, which
+    happens after ``post_model_load``."""
     offloaded_ids = {id(param) for handle in handles for param in handle.params}
     names = [
         name

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -34,10 +34,11 @@ backward that runs against the *initial* forward's graph. Gradient checkpointing
 initial-forward saved tensors and **recomputes** each layer in backward (re-staging via the
 pre-hook and rebuilding the saved tensors from the staged weights), which is what makes eviction
 both correct and actually memory-freeing rather than pinning every staged weight alive as a saved
-tensor. The plugin enforces ``gradient_checkpointing: true`` with ``use_reentrant: false``.
+tensor. ``gradient_checkpointing: true`` with an explicit ``use_reentrant: false`` is enforced at
+config validation (the ``ExpertOffloadArgs`` schema validator).
 
 Single-GPU only: FSDP / DeepSpeed / expert-parallel move or shard these same weights and would
-race the stage/evict swaps. The plugin refuses to enable under any of them.
+race the stage/evict swaps. The config schema refuses to enable under any of them.
 """
 
 from __future__ import annotations
@@ -72,7 +73,7 @@ def _is_pinned(t: torch.Tensor) -> bool:
     where ``is_pinned`` is unavailable/raises without CUDA."""
     try:
         return bool(t.is_pinned())
-    except Exception:  # pragma: no cover - platform dependent
+    except (RuntimeError, AssertionError):  # pragma: no cover - platform dependent
         return False
 
 
@@ -242,12 +243,13 @@ def install_expert_offload(
     """
     blocks = find_moe_expert_blocks(model)
     if not blocks:
-        LOG.warning(
-            "expert_offload: no 4-bit MoE expert blocks found. This integration offloads "
-            "per-expert bitsandbytes Linear4bit weights (Mixtral / Qwen-MoE / OLMoE / DeepSeek "
-            "style). Fused-expert or non-quantized models are unaffected."
+        raise RuntimeError(
+            "expert_offload is enabled but no 4-bit MoE expert blocks were found. This "
+            "integration offloads per-expert bitsandbytes Linear4bit weights (an ``experts`` "
+            "ModuleList — Mixtral / Qwen-MoE / OLMoE / DeepSeek style); fused-expert layouts "
+            "(GPT-OSS, DBRX) and non-4bit models have nothing to offload — disable "
+            "expert_offload for this model."
         )
-        return []
 
     if device is None:
         device = blocks[0][2][0].weight.data.device

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -1,0 +1,270 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Expert-granularity CPU offload for 4-bit MoE QLoRA on a single GPU.
+
+Only the *frozen 4-bit expert* weights are moved; attention, router/gate, norms and the
+trainable LoRA adapters stay GPU-resident. Each expert is a ``bitsandbytes`` ``Linear4bit`` whose
+big packed tensor is ``weight.data`` (the ``quant_state`` scales are ~1/32 the size and are left
+resident). We home every offloaded block's ``weight.data`` in *pinned* CPU RAM, and a **forward
+pre-hook** on the MoE block copies that block's experts onto the GPU just before the block runs.
+
+Eviction is driven entirely by a **single-resident-slot** policy: staging a block first evicts the
+previously-staged one. There is deliberately **no evict post-hook**. Under ``use_reentrant=False``
+gradient checkpointing each decoder layer's forward is *recomputed* in the backward pass; the same
+pre-hook re-stages the block's experts for that recompute, and because nothing evicts a block until
+the *next* block stages — which, in backward (processed last-layer-first), only happens after the
+current block's recomputed backward has finished — the staged weights are always present when the
+recomputed backward reads them. So at most **one block's** experts are GPU-resident at any instant,
+in forward and backward alike, without depending on exactly when PyTorch stops a recompute.
+
+This lets a fused MoE whose 4-bit experts exceed VRAM QLoRA-train on a small card, at the cost of
+one host->device expert transfer per block per pass — a memory-for-compute trade.
+
+**Why gradient checkpointing is required (correctness *and* the memory win).**
+``bnb.matmul_4bit``'s autograd ``Function`` re-reads the packed weight in its backward (to
+re-dequantize for the input gradient) via ``save_for_backward``. Eviction repoints
+``weight.data`` at a 0-element placeholder, so the saved reference would read that placeholder in a
+backward that runs against the *initial* forward's graph. Gradient checkpointing discards the
+initial-forward saved tensors and **recomputes** each layer in backward (re-staging via the
+pre-hook and rebuilding the saved tensors from the staged weights), which is what makes eviction
+both correct and actually memory-freeing rather than pinning every staged weight alive as a saved
+tensor. The plugin enforces ``gradient_checkpointing: true`` with ``use_reentrant: false``.
+
+Single-GPU only: FSDP / DeepSpeed / expert-parallel move or shard these same weights and would
+race the stage/evict swaps. The plugin refuses to enable under any of them.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+# 0-element GPU placeholders that an evicted expert's ``weight.data`` points at while offloaded.
+# Shared across all offloaded experts (reads never mutate them) and cached per (device, dtype) —
+# the 4-bit storage dtype varies with ``bnb_4bit_quant_storage`` (uint8 / bfloat16 / float32), so
+# the placeholder must match the real tensor's dtype or a restage would change it. Keeping the real
+# "home" data OFF the module — only a 0-element placeholder is registered while evicted — means a
+# stray ``model.to(device)`` never drags the big expert tensors back onto the GPU.
+_PLACEHOLDERS: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
+
+
+def _placeholder(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    key = (device, dtype)
+    ph = _PLACEHOLDERS.get(key)
+    if ph is None:
+        ph = torch.empty(0, dtype=dtype, device=device)
+        _PLACEHOLDERS[key] = ph
+    return ph
+
+
+def _is_pinned(t: torch.Tensor) -> bool:
+    """Whether ``t`` is pinned (so a ``non_blocking`` H2D copy is truly async). Robust on hosts
+    where ``is_pinned`` is unavailable/raises without CUDA."""
+    try:
+        return bool(t.is_pinned())
+    except Exception:  # pragma: no cover - platform dependent
+        return False
+
+
+def _is_linear4bit(module: nn.Module) -> bool:
+    """A ``bitsandbytes`` ``Linear4bit`` whose ``weight`` is a packed 4-bit ``Params4bit``.
+
+    Matched structurally (by the ``Params4bit`` weight type) rather than by ``isinstance`` so we do
+    not hard-import bitsandbytes here and so PEFT/other subclasses of ``Linear4bit`` still match.
+    """
+    weight = getattr(module, "weight", None)
+    return weight is not None and type(weight).__name__ == "Params4bit"
+
+
+def _base_layer(module: nn.Module) -> nn.Module:
+    """Unwrap a PEFT adapter wrapper (``lora.Linear4bit`` etc.) to the frozen base ``Linear4bit``.
+
+    PEFT wraps the quantized expert and delegates ``.weight`` to ``.base_layer``; the packed tensor
+    we offload lives on that base, and the (tiny, trainable) LoRA ``A``/``B`` matrices are separate
+    siblings that must stay GPU-resident. Returns ``module`` unchanged if it is not wrapped.
+    """
+    return getattr(module, "base_layer", module)
+
+
+def find_moe_expert_blocks(
+    model: nn.Module,
+) -> list[tuple[str, nn.Module, list[nn.Module]]]:
+    """Discover offloadable MoE blocks and their frozen 4-bit expert base layers.
+
+    A block is any module exposing an ``experts`` ``ModuleList`` of length >= 2 whose leaves include
+    ``Linear4bit`` weights — the canonical per-expert layout of Mixtral, Qwen2/3-MoE, OLMoE,
+    DeepSeek-MoE, Jamba, etc. (``block_sparse_moe.experts`` / ``mlp.experts``). Fused-experts
+    layouts that pack all experts into one 3D parameter (GPT-OSS, DBRX, and the
+    ``@use_experts_implementation`` path handled by the ``expert_parallel`` integration) are **not**
+    matched — bitsandbytes does not 4-bit-quantize raw 3D parameters, so there is nothing to offload
+    there; those are out of scope for this integration.
+
+    Returns ``(block_name, block_module, expert_base_layers)`` triples. Deduplicates base layers so a
+    projection shared across the list is homed once. The hook attaches to ``block_module`` because
+    its ``forward`` runs the experts (and is what gradient checkpointing recomputes).
+    """
+    blocks: list[tuple[str, nn.Module, list[nn.Module]]] = []
+    for name, block in model.named_modules():
+        experts = getattr(block, "experts", None)
+        if not isinstance(experts, nn.ModuleList) or len(experts) < 2:
+            continue
+        seen: set[int] = set()
+        base_layers: list[nn.Module] = []
+        for module in experts.modules():
+            if not _is_linear4bit(module):
+                continue
+            base = _base_layer(module)
+            if not _is_linear4bit(base) or id(base) in seen:
+                continue
+            seen.add(id(base))
+            base_layers.append(base)
+        if base_layers:
+            blocks.append((name, block, base_layers))
+    return blocks
+
+
+class _BlockOffload:
+    """Owns the pinned-CPU home copies of one MoE block's expert ``weight.data`` tensors and streams
+    them to ``device`` for the duration of each forward / gradient-checkpoint recompute.
+
+    While evicted, each expert's ``weight.data`` holds a shared 0-element GPU placeholder, so nothing
+    that walks the module tree (``.to()``, checkpoint-save) drags the offloaded data back onto the
+    GPU. ``quant_state`` (the small NF4 scales) stays GPU-resident throughout, as do the LoRA
+    adapters and everything outside ``experts``. A ``state_dict`` post-hook substitutes the CPU homes
+    for the placeholders so a full-model save stays correct (adapter-only saves never touch the base
+    keys, so they are unaffected).
+    """
+
+    # The single block whose experts are currently GPU-staged. Class-wide, so it assumes one
+    # offloaded model per process (the training case). Under use_reentrant=False gradient
+    # checkpointing the backward RECOMPUTE re-runs a layer's forward to rebuild its saved tensors;
+    # staging a new block first evicts this previously-staged one, so at most one block is
+    # GPU-resident at any instant, in forward AND backward.
+    _resident: _BlockOffload | None = None
+
+    def __init__(
+        self, name: str, base_layers: list[nn.Module], device, pin: bool = True
+    ):
+        self.name = name
+        self.device = torch.device(device)
+        self.base_layers = base_layers
+        # Capture each packed weight as a SEPARATE (pinned) CPU tensor BEFORE any placeholder swap.
+        # The source is on the GPU at install time, so ``.to("cpu")`` is a real device->host copy
+        # that decouples the home from the live parameter we then overwrite with a placeholder.
+        self.homes: list[torch.Tensor] = [
+            self._to_home(base.weight.data.detach(), pin) for base in base_layers
+        ]
+        self.pinned = all(_is_pinned(t) for t in self.homes)
+        self.staged = False
+        for base in base_layers:
+            self._install_state_dict_hook(base)
+        self.evict()  # start evicted: experts hold placeholders, ~0 GPU footprint
+
+    @staticmethod
+    def _to_home(t: torch.Tensor, pin: bool) -> torch.Tensor:
+        cpu = t.to("cpu")
+        if pin:
+            try:
+                return cpu.pin_memory()
+            except (RuntimeError, AssertionError):  # pragma: no cover - best-effort
+                pass  # pinning is best-effort; pageable fallback is correct, just no async H2D
+        return cpu
+
+    def _install_state_dict_hook(self, base: nn.Module) -> None:
+        """Keep full-model ``state_dict()`` correct while evicted: substitute the (pinned) CPU home
+        for the 0-element ``weight`` placeholder. References, not copies, so adapter-only saves stay
+        cheap and while *staged* it is a no-op (the entry is the real GPU tensor)."""
+        idx = self.base_layers.index(base)
+
+        def hook(module, state_dict, prefix, local_metadata):
+            key = prefix + "weight"
+            t = state_dict.get(key)
+            if t is not None and t.numel() == 0:
+                state_dict[key] = self.homes[idx]
+
+        register = getattr(base, "register_state_dict_post_hook", None)
+        if (
+            register is None
+        ):  # older torch: private hook, same (mod, sd, prefix, meta) signature
+            register = base._register_state_dict_hook
+        register(hook)
+
+    @property
+    def bytes(self) -> int:
+        return sum(t.numel() * t.element_size() for t in self.homes)
+
+    def stage(self) -> None:
+        """Copy this block's packed expert weights onto ``device`` (idempotent), first evicting the
+        previously staged block so at most one block's experts are GPU-resident. The H2D copies are
+        enqueued on the current stream, so the dequant kernels that immediately follow are ordered
+        after them."""
+        if self.staged:
+            return
+        cls = type(self)
+        if cls._resident is not None and cls._resident is not self:
+            cls._resident.evict()  # single-slot: free the prior block before staging this one
+        for base, home in zip(self.base_layers, self.homes, strict=True):
+            base.weight.data = home.to(self.device, non_blocking=True)
+        self.staged = True
+        cls._resident = self
+
+    def evict(self) -> None:
+        """Point this block's expert weights back at shared 0-element placeholders (idempotent),
+        dropping the GPU copies so the caching allocator can reuse the memory for the next block."""
+        for base in self.base_layers:
+            w = base.weight
+            w.data = _placeholder(self.device, w.data.dtype)
+        self.staged = False
+        cls = type(self)
+        if cls._resident is self:
+            cls._resident = None
+
+
+def install_expert_offload(
+    model: nn.Module, device=None, pin: bool = True
+) -> list[_BlockOffload]:
+    """Offload every discoverable MoE block's frozen 4-bit experts to (pinned) CPU RAM.
+
+    For each block, homes its expert ``weight.data`` tensors on the CPU, evicts them from the GPU,
+    and registers a forward pre-hook (stage) on the block module. The handles are stashed on
+    ``model._expert_offload_handles`` so they live as long as the model. Returns the handles (empty
+    if no offloadable MoE block was found).
+    """
+    blocks = find_moe_expert_blocks(model)
+    if not blocks:
+        LOG.warning(
+            "expert_offload: no 4-bit MoE expert blocks found. This integration offloads "
+            "per-expert bitsandbytes Linear4bit weights (Mixtral / Qwen-MoE / OLMoE / DeepSeek "
+            "style). Fused-expert or non-quantized models are unaffected."
+        )
+        return []
+
+    if device is None:
+        device = blocks[0][2][0].weight.data.device
+    device = torch.device(device)
+
+    handles: list[_BlockOffload] = []
+    for name, block, base_layers in blocks:
+        handle = _BlockOffload(name, base_layers, device, pin=pin)
+        block.register_forward_pre_hook(lambda module, args, h=handle: h.stage())
+        handles.append(handle)
+
+    model._expert_offload_handles = handles
+    total_gb = sum(h.bytes for h in handles) / 1e9
+    n_experts = sum(len(h.base_layers) for h in handles)
+    pinned = "pinned" if all(h.pinned for h in handles) else "pageable (no async H2D)"
+    LOG.info(
+        f"expert_offload: homed {n_experts} expert layers across {len(handles)} MoE blocks "
+        f"({total_gb:.2f} GB) to {pinned} CPU RAM; one block resident on {device} at a time."
+    )
+    return handles

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -37,8 +37,12 @@ both correct and actually memory-freeing rather than pinning every staged weight
 tensor. ``gradient_checkpointing: true`` with an explicit ``use_reentrant: false`` is enforced at
 config validation (the ``ExpertOffloadArgs`` schema validator).
 
-Single-GPU only: FSDP / DeepSpeed / expert-parallel move or shard these same weights and would
-race the stage/evict swaps. The config schema refuses to enable under any of them.
+One GPU **per replica**: plain DDP (multi-GPU data parallel) is supported — each rank is its own
+process with a full replica, so each rank homes its own pinned copy of the experts (CPU RAM cost
+scales with world size) and stages to its own device; the offloaded weights are registered on
+DDP's ignore list so the initial module-state sync never touches the 0-element placeholders.
+FSDP / DeepSpeed / expert-parallel move or shard these same weights and would race the
+stage/evict swaps; the config schema refuses to enable under any of them.
 """
 
 from __future__ import annotations
@@ -147,10 +151,11 @@ class _BlockOffload:
     """
 
     # The single block whose experts are currently GPU-staged. Class-wide, so it assumes one
-    # offloaded model per process (the training case). Under use_reentrant=False gradient
-    # checkpointing the backward RECOMPUTE re-runs a layer's forward to rebuild its saved tensors;
-    # staging a new block first evicts this previously-staged one, so at most one block is
-    # GPU-resident at any instant, in forward AND backward.
+    # offloaded model per process (the training case — including DDP, where each rank is its own
+    # process with its own replica). Under use_reentrant=False gradient checkpointing the backward
+    # RECOMPUTE re-runs a layer's forward to rebuild its saved tensors; staging a new block first
+    # evicts this previously-staged one, so at most one block is GPU-resident at any instant, in
+    # forward AND backward.
     _resident: _BlockOffload | None = None
 
     def __init__(
@@ -262,11 +267,45 @@ def install_expert_offload(
         handles.append(handle)
 
     model._expert_offload_handles = handles
+    _register_ddp_ignore(model, handles)
     total_gb = sum(h.bytes for h in handles) / 1e9
     n_experts = sum(len(h.base_layers) for h in handles)
     pinned = "pinned" if all(h.pinned for h in handles) else "pageable (no async H2D)"
+    rank = (
+        f" [rank {torch.distributed.get_rank()}]"
+        if torch.distributed.is_available() and torch.distributed.is_initialized()
+        else ""
+    )
     LOG.info(
-        f"expert_offload: homed {n_experts} expert layers across {len(handles)} MoE blocks "
+        f"expert_offload{rank}: homed {n_experts} expert layers across {len(handles)} MoE blocks "
         f"({total_gb:.2f} GB) to {pinned} CPU RAM; one block resident on {device} at a time."
     )
     return handles
+
+
+def _register_ddp_ignore(model: nn.Module, handles: list[_BlockOffload]) -> None:
+    """Register every offloaded expert weight on DDP's ignore list.
+
+    While evicted, those weights are 0-element placeholders; DDP's initial module-state sync
+    (and any buffer broadcast) must never touch them — broadcasting a placeholder is at best a
+    no-op and at worst re-materializes state DDP has no business managing. The offloaded experts
+    are frozen (``requires_grad=False``) so they never participate in gradient buckets either;
+    the ignore list makes that contract explicit. ``_ddp_params_and_buffers_to_ignore`` is the
+    mechanism behind ``DistributedDataParallel._set_params_and_buffers_to_ignore_for_model`` and
+    is read off the module at DDP construction, which happens after ``post_model_load``.
+
+    The frozen weight Parameter objects survive eviction (only ``.data`` is swapped), so identity
+    matching against ``named_parameters`` yields their fully-qualified names.
+    """
+    offloaded_ids = {
+        id(base.weight) for handle in handles for base in handle.base_layers
+    }
+    names = [
+        name
+        for name, param in model.named_parameters(remove_duplicate=False)
+        if id(param) in offloaded_ids
+    ]
+    existing = list(getattr(model, "_ddp_params_and_buffers_to_ignore", []) or [])
+    model._ddp_params_and_buffers_to_ignore = existing + [
+        n for n in names if n not in existing
+    ]

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -59,6 +59,7 @@ stage/evict swaps; the config schema refuses to enable under any of them.
 
 from __future__ import annotations
 
+import os
 from typing import NamedTuple
 
 import torch
@@ -301,6 +302,55 @@ class _BlockOffload:
             cls._resident = None
 
 
+_BNB_CACHE_HOOK_NAMES = (
+    "_enable_parametrization_cache",  # forward_pre_hook: parametrize._cache_enabled += 1
+    "_disable_parametrization_cache",  # forward_hook: -= 1, clear cache at 0
+)
+
+
+def _strip_bnb_parametrize_cache_hooks(module: nn.Module) -> int:
+    """Remove bitsandbytes' parametrization-cache hook pair from ``module``.
+
+    bnb registers a forward_pre_hook/forward_hook pair that increments/decrements the
+    GLOBAL ``torch.nn.utils.parametrize._cache_enabled`` counter and clears ``P._cache``
+    only when it returns to 0. Under ``use_reentrant=False`` gradient checkpointing the
+    backward recompute is aborted mid-forward by design (early stop), which SKIPS the
+    forward_hook of the module holding the last recomputed save — the counter leaks
+    upward once per checkpointed region per step, the cache is never cleared again, and
+    every dequantized bf16 expert weight is retained for the rest of training (pool x4
+    bytes: ~13 GiB for OLMoE, ~53 GiB for Qwen3-30B — the latter cannot fit a 24 GB
+    card at all). Expert params are accessed once per forward, so the cache buys these
+    modules nothing; removing the pair makes the leak impossible without touching bnb.
+    The state-dict post-hook (quantization-state save) is intentionally left in place.
+    """
+    removed = 0
+    for hooks in (
+        module._forward_pre_hooks,
+        module._forward_hooks,
+    ):
+        stale = [
+            k
+            for k, fn in hooks.items()
+            if getattr(fn, "__name__", "") in _BNB_CACHE_HOOK_NAMES
+        ]
+        for k in stale:
+            del hooks[k]
+            for extra in ("_forward_hooks_with_kwargs", "_forward_hooks_always_called"):
+                d = getattr(module, extra, None)
+                if d is not None and k in d:
+                    del d[k]
+            removed += 1
+    return removed
+
+
+def _reset_parametrize_cache_state() -> None:
+    """Defensively zero torch's global parametrization cache (idempotent)."""
+    import torch.nn.utils.parametrize as P
+
+    P._cache_enabled = 0
+    P._cache = {}
+
+
 def install_expert_offload(
     model: nn.Module, device=None, pin: bool = True
 ) -> list[_BlockOffload]:
@@ -339,10 +389,25 @@ def install_expert_offload(
     device = torch.device(device)
 
     handles: list[_BlockOffload] = []
+    stripped = 0
+    keep_cache_hooks = os.environ.get("AXOLOTL_EXPERT_OFFLOAD_KEEP_BNB_CACHE_HOOKS", "")
     for name, block, slots in slot_blocks:
         handle = _BlockOffload(name, slots, device, pin=pin)
         block.register_forward_pre_hook(lambda module, args, h=handle: h.stage())
         handles.append(handle)
+        if not keep_cache_hooks:
+            for owner in {id(s.owner): s.owner for s in slots}.values():
+                stripped += _strip_bnb_parametrize_cache_hooks(owner)
+    if not keep_cache_hooks:
+        _reset_parametrize_cache_state()
+        if stripped:
+            LOG.info(
+                "expert_offload: removed %d bnb parametrize-cache hooks from offloaded "
+                "expert modules (checkpoint early-stop leaks the global cache counter; "
+                "dequants would be retained at pool x4 bytes). Set "
+                "AXOLOTL_EXPERT_OFFLOAD_KEEP_BNB_CACHE_HOOKS=1 to keep them.",
+                stripped,
+            )
 
     model._expert_offload_handles = handles
     _register_ddp_ignore(model, handles)

--- a/src/axolotl/integrations/expert_offload/offload.py
+++ b/src/axolotl/integrations/expert_offload/offload.py
@@ -9,10 +9,22 @@
 """Expert-granularity CPU offload for 4-bit MoE QLoRA on a single GPU.
 
 Only the *frozen 4-bit expert* weights are moved; attention, router/gate, norms and the
-trainable LoRA adapters stay GPU-resident. Each expert is a ``bitsandbytes`` ``Linear4bit`` whose
-big packed tensor is ``weight.data`` (the ``quant_state`` scales are ~1/32 the size and are left
-resident). We home every offloaded block's ``weight.data`` in *pinned* CPU RAM, and a **forward
-pre-hook** on the MoE block copies that block's experts onto the GPU just before the block runs.
+trainable LoRA adapters stay GPU-resident. Two expert layouts are supported:
+
+- **Per-expert ``Linear4bit``** (an ``experts`` ``ModuleList``): each expert is a ``bitsandbytes``
+  ``Linear4bit`` whose big packed tensor is ``weight.data`` (the ``quant_state`` scales are ~1/32
+  the size and are left resident).
+- **Grouped 3D stacks quantized via ``quantize_moe_experts``**: models whose experts are fused 3D
+  ``nn.Parameter`` stacks (one ``[n_experts, out, in]`` tensor per projection — OLMoE / Qwen3-MoE
+  style on current transformers). ``quantize_moe_experts: true`` quantizes each stack in place
+  through ``bitsandbytes.nn.parametrize.replace_parameter_4bit``: the packed tensor becomes
+  ``module.parametrizations[name].original`` and a ``Bnb4bitParametrization`` (carrying the small
+  resident ``quant_state``) dequantizes it on access, under ``no_grad`` — so autograd only ever
+  holds the *dequantized* activation, never the packed tensor, and eviction of the packed data is
+  safe outside the module's forward.
+
+In both layouts we home the packed tensor's ``.data`` in *pinned* CPU RAM, and a **forward
+pre-hook** on the owning module copies that block's experts onto the GPU just before it runs.
 
 Eviction is driven entirely by a **single-resident-slot** policy: staging a block first evicts the
 previously-staged one. There is deliberately **no evict post-hook**. Under ``use_reentrant=False``
@@ -47,12 +59,29 @@ stage/evict swaps; the config schema refuses to enable under any of them.
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 from torch import nn
 
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
+
+
+class _Slot(NamedTuple):
+    """One offloadable packed tensor: the frozen ``nn.Parameter`` whose ``.data`` is swapped
+    between its pinned CPU home and the GPU, plus where it appears in ``state_dict``.
+
+    ``keys`` are candidate keys relative to ``owner``'s prefix — the parametrized layout needs two
+    because bitsandbytes' own state-dict post-hook renames ``parametrizations.<p>.original`` to the
+    clean ``<p>`` (hook order puts ours after bnb's, but both spellings are covered regardless).
+    """
+
+    param: nn.Parameter
+    owner: nn.Module
+    keys: tuple[str, ...]
+
 
 # 0-element GPU placeholders that an evicted expert's ``weight.data`` points at while offloaded.
 # Shared across all offloaded experts (reads never mutate them) and cached per (device, dtype) —
@@ -107,12 +136,11 @@ def find_moe_expert_blocks(
     """Discover offloadable MoE blocks and their frozen 4-bit expert base layers.
 
     A block is any module exposing an ``experts`` ``ModuleList`` of length >= 2 whose leaves include
-    ``Linear4bit`` weights — the canonical per-expert layout of Mixtral, Qwen2/3-MoE, OLMoE,
-    DeepSeek-MoE, Jamba, etc. (``block_sparse_moe.experts`` / ``mlp.experts``). Fused-experts
-    layouts that pack all experts into one 3D parameter (GPT-OSS, DBRX, and the
-    ``@use_experts_implementation`` path handled by the ``expert_parallel`` integration) are **not**
-    matched — bitsandbytes does not 4-bit-quantize raw 3D parameters, so there is nothing to offload
-    there; those are out of scope for this integration.
+    ``Linear4bit`` weights — the classic per-expert layout (``block_sparse_moe.experts`` /
+    ``mlp.experts``). Fused-experts layouts that pack all experts into one 3D parameter (OLMoE /
+    Qwen3-MoE on current transformers, GPT-OSS, DBRX) are **not** matched here — raw 3D parameters
+    are only 4-bit under ``quantize_moe_experts: true``, whose parametrized stacks are discovered by
+    :func:`find_parametrized_expert_stacks` instead.
 
     Returns ``(block_name, block_module, expert_base_layers)`` triples. Deduplicates base layers so a
     projection shared across the list is homed once. The hook attaches to ``block_module`` because
@@ -138,6 +166,42 @@ def find_moe_expert_blocks(
     return blocks
 
 
+def find_parametrized_expert_stacks(
+    model: nn.Module,
+) -> list[tuple[str, nn.Module, list[_Slot]]]:
+    """Discover grouped 3D expert stacks quantized via ``quantize_moe_experts``.
+
+    Matches any module carrying a ``Bnb4bitParametrization`` (by class name, mirroring
+    ``_is_linear4bit``'s structural matching) — the layout ``quantize_moe_experts: true`` produces
+    for fused-expert models (OLMoE / Qwen3-MoE style ``[n_experts, out, in]`` stacks). The packed
+    tensor is ``module.parametrizations[<p>].original``; the parametrization's ``quant_state``
+    stays resident. The module itself is the hook site: its ``forward`` dequantizes the stacks on
+    access (and is what gradient checkpointing recomputes).
+    """
+    blocks: list[tuple[str, nn.Module, list[_Slot]]] = []
+    for name, module in model.named_modules():
+        plists = getattr(module, "parametrizations", None)
+        if not isinstance(plists, nn.ModuleDict):
+            continue
+        slots: list[_Slot] = []
+        for pname, plist in plists.items():
+            if not any(type(p).__name__ == "Bnb4bitParametrization" for p in plist):
+                continue
+            packed = plist.original
+            if not isinstance(packed, nn.Parameter) or packed.requires_grad:
+                continue  # trainable parametrized params are not ours to move
+            slots.append(
+                _Slot(
+                    param=packed,
+                    owner=module,
+                    keys=(pname, f"parametrizations.{pname}.original"),
+                )
+            )
+        if slots:
+            blocks.append((name, module, slots))
+    return blocks
+
+
 class _BlockOffload:
     """Owns the pinned-CPU home copies of one MoE block's expert ``weight.data`` tensors and streams
     them to ``device`` for the duration of each forward / gradient-checkpoint recompute.
@@ -158,23 +222,25 @@ class _BlockOffload:
     # forward AND backward.
     _resident: _BlockOffload | None = None
 
-    def __init__(
-        self, name: str, base_layers: list[nn.Module], device, pin: bool = True
-    ):
+    def __init__(self, name: str, slots: list[_Slot], device, pin: bool = True):
         self.name = name
         self.device = torch.device(device)
-        self.base_layers = base_layers
+        self.slots = slots
         # Capture each packed weight as a SEPARATE (pinned) CPU tensor BEFORE any placeholder swap.
         # The source is on the GPU at install time, so ``.to("cpu")`` is a real device->host copy
         # that decouples the home from the live parameter we then overwrite with a placeholder.
         self.homes: list[torch.Tensor] = [
-            self._to_home(base.weight.data.detach(), pin) for base in base_layers
+            self._to_home(slot.param.data.detach(), pin) for slot in slots
         ]
         self.pinned = all(_is_pinned(t) for t in self.homes)
         self.staged = False
-        for base in base_layers:
-            self._install_state_dict_hook(base)
+        for idx, slot in enumerate(slots):
+            self._install_state_dict_hook(slot, idx)
         self.evict()  # start evicted: experts hold placeholders, ~0 GPU footprint
+
+    @property
+    def params(self) -> list[nn.Parameter]:
+        return [slot.param for slot in self.slots]
 
     @staticmethod
     def _to_home(t: torch.Tensor, pin: bool) -> torch.Tensor:
@@ -186,23 +252,23 @@ class _BlockOffload:
                 pass  # pinning is best-effort; pageable fallback is correct, just no async H2D
         return cpu
 
-    def _install_state_dict_hook(self, base: nn.Module) -> None:
+    def _install_state_dict_hook(self, slot: _Slot, idx: int) -> None:
         """Keep full-model ``state_dict()`` correct while evicted: substitute the (pinned) CPU home
-        for the 0-element ``weight`` placeholder. References, not copies, so adapter-only saves stay
-        cheap and while *staged* it is a no-op (the entry is the real GPU tensor)."""
-        idx = self.base_layers.index(base)
+        for the 0-element placeholder under any of the slot's candidate keys. References, not
+        copies, so adapter-only saves stay cheap and while *staged* it is a no-op (the entry is the
+        real GPU tensor)."""
 
         def hook(module, state_dict, prefix, local_metadata):
-            key = prefix + "weight"
-            t = state_dict.get(key)
-            if t is not None and t.numel() == 0:
-                state_dict[key] = self.homes[idx]
+            for key in slot.keys:
+                t = state_dict.get(prefix + key)
+                if t is not None and t.numel() == 0:
+                    state_dict[prefix + key] = self.homes[idx]
 
-        register = getattr(base, "register_state_dict_post_hook", None)
+        register = getattr(slot.owner, "register_state_dict_post_hook", None)
         if (
             register is None
         ):  # older torch: private hook, same (mod, sd, prefix, meta) signature
-            register = base._register_state_dict_hook
+            register = slot.owner._register_state_dict_hook
         register(hook)
 
     @property
@@ -219,17 +285,16 @@ class _BlockOffload:
         cls = type(self)
         if cls._resident is not None and cls._resident is not self:
             cls._resident.evict()  # single-slot: free the prior block before staging this one
-        for base, home in zip(self.base_layers, self.homes, strict=True):
-            base.weight.data = home.to(self.device, non_blocking=True)
+        for slot, home in zip(self.slots, self.homes, strict=True):
+            slot.param.data = home.to(self.device, non_blocking=True)
         self.staged = True
         cls._resident = self
 
     def evict(self) -> None:
         """Point this block's expert weights back at shared 0-element placeholders (idempotent),
         dropping the GPU copies so the caching allocator can reuse the memory for the next block."""
-        for base in self.base_layers:
-            w = base.weight
-            w.data = _placeholder(self.device, w.data.dtype)
+        for slot in self.slots:
+            slot.param.data = _placeholder(self.device, slot.param.data.dtype)
         self.staged = False
         cls = type(self)
         if cls._resident is self:
@@ -246,30 +311,43 @@ def install_expert_offload(
     ``model._expert_offload_handles`` so they live as long as the model. Returns the handles (empty
     if no offloadable MoE block was found).
     """
-    blocks = find_moe_expert_blocks(model)
-    if not blocks:
+    slot_blocks: list[tuple[str, nn.Module, list[_Slot]]] = [
+        (
+            name,
+            block,
+            [
+                _Slot(param=base.weight, owner=base, keys=("weight",))
+                for base in base_layers
+            ],
+        )
+        for name, block, base_layers in find_moe_expert_blocks(model)
+    ]
+    slot_blocks += find_parametrized_expert_stacks(model)
+    if not slot_blocks:
         raise RuntimeError(
-            "expert_offload is enabled but no 4-bit MoE expert blocks were found. This "
+            "expert_offload is enabled but no 4-bit MoE expert weights were found. This "
             "integration offloads per-expert bitsandbytes Linear4bit weights (an ``experts`` "
-            "ModuleList — Mixtral / Qwen-MoE / OLMoE / DeepSeek style); fused-expert layouts "
-            "(GPT-OSS, DBRX) and non-4bit models have nothing to offload — disable "
-            "expert_offload for this model."
+            "ModuleList) or grouped 3D expert stacks quantized via ``quantize_moe_experts: "
+            "true`` (OLMoE / Qwen3-MoE style fused layouts on current transformers). If your "
+            "model stores experts as fused 3D parameters, set ``quantize_moe_experts: true`` — "
+            "plain ``load_in_4bit`` leaves those stacks unquantized, so there is nothing 4-bit "
+            "to offload. Otherwise disable expert_offload for this model."
         )
 
     if device is None:
-        device = blocks[0][2][0].weight.data.device
+        device = slot_blocks[0][2][0].param.data.device
     device = torch.device(device)
 
     handles: list[_BlockOffload] = []
-    for name, block, base_layers in blocks:
-        handle = _BlockOffload(name, base_layers, device, pin=pin)
+    for name, block, slots in slot_blocks:
+        handle = _BlockOffload(name, slots, device, pin=pin)
         block.register_forward_pre_hook(lambda module, args, h=handle: h.stage())
         handles.append(handle)
 
     model._expert_offload_handles = handles
     _register_ddp_ignore(model, handles)
     total_gb = sum(h.bytes for h in handles) / 1e9
-    n_experts = sum(len(h.base_layers) for h in handles)
+    n_experts = sum(len(h.slots) for h in handles)
     pinned = "pinned" if all(h.pinned for h in handles) else "pageable (no async H2D)"
     rank = (
         f" [rank {torch.distributed.get_rank()}]"
@@ -297,9 +375,7 @@ def _register_ddp_ignore(model: nn.Module, handles: list[_BlockOffload]) -> None
     The frozen weight Parameter objects survive eviction (only ``.data`` is swapped), so identity
     matching against ``named_parameters`` yields their fully-qualified names.
     """
-    offloaded_ids = {
-        id(base.weight) for handle in handles for base in handle.base_layers
-    }
+    offloaded_ids = {id(param) for handle in handles for param in handle.params}
     names = [
         name
         for name, param in model.named_parameters(remove_duplicate=False)

--- a/src/axolotl/integrations/expert_offload/plugin.py
+++ b/src/axolotl/integrations/expert_offload/plugin.py
@@ -11,9 +11,6 @@
 from __future__ import annotations
 
 from axolotl.integrations.base import BasePlugin
-from axolotl.utils.logging import get_logger
-
-LOG = get_logger(__name__)
 
 
 class ExpertOffloadPlugin(BasePlugin):
@@ -22,64 +19,13 @@ class ExpertOffloadPlugin(BasePlugin):
     Surgical counterpart to ``layer_offloading``: it moves only the frozen 4-bit experts (the bulk
     of a MoE's parameters) while attention, router, norms and the trainable LoRA adapters stay
     GPU-resident — minimizing per-step PCIe traffic for the same peak-VRAM reduction. Single-GPU
-    QLoRA only. See ``offload.py`` for the mechanism and this integration's README.
+    QLoRA only; the cross-field config requirements are enforced at config-parse time by the
+    ``ExpertOffloadArgs`` schema validator. See ``offload.py`` for the mechanism and this
+    integration's README.
     """
 
     def get_input_args(self):
         return "axolotl.integrations.expert_offload.ExpertOffloadArgs"
-
-    def pre_model_load(self, cfg):
-        """Validate the cross-field requirements the args model can't see, before the model loads."""
-        if not getattr(cfg, "expert_offload", False):
-            return
-        self._validate(cfg)
-
-    @staticmethod
-    def _validate(cfg) -> None:
-        errors: list[str] = []
-
-        # 4-bit experts: the mechanism swaps ``Linear4bit.weight.data``.
-        if not getattr(cfg, "load_in_4bit", False):
-            errors.append(
-                "requires load_in_4bit: true (it offloads 4-bit Linear4bit experts)"
-            )
-        if getattr(cfg, "adapter", None) not in ("lora", "qlora"):
-            errors.append("requires adapter: qlora (or lora with load_in_4bit)")
-
-        # Gradient checkpointing (use_reentrant=False) is load-bearing: the backward recompute
-        # re-stages each block's experts, and it is what lets eviction actually free memory rather
-        # than pin every staged weight alive as a matmul_4bit saved-for-backward tensor.
-        if not getattr(cfg, "gradient_checkpointing", False):
-            errors.append(
-                "requires gradient_checkpointing: true (the backward recompute re-stages experts; "
-                "without it, offload is neither correct nor memory-saving)"
-            )
-        else:
-            use_reentrant = (
-                getattr(cfg, "gradient_checkpointing_kwargs", None) or {}
-            ).get("use_reentrant", False)
-            if use_reentrant:
-                errors.append(
-                    "requires gradient_checkpointing_kwargs.use_reentrant: false "
-                    "(reentrant checkpointing does not re-run the block pre-hook on recompute)"
-                )
-
-        # Single GPU: FSDP / DeepSpeed / expert-parallel move or shard these same weights and would
-        # race the stage/evict swaps.
-        if getattr(cfg, "fsdp_config", None) or getattr(cfg, "fsdp", None):
-            errors.append("is single-GPU only and incompatible with FSDP")
-        if getattr(cfg, "deepspeed", None):
-            errors.append("is single-GPU only and incompatible with DeepSpeed")
-        if (getattr(cfg, "expert_parallel_size", None) or 1) > 1:
-            errors.append(
-                "is incompatible with expert_parallel (both manage the expert weights)"
-            )
-
-        if errors:
-            raise ValueError(
-                "expert_offload is enabled but the config is incompatible:\n  - "
-                + "\n  - ".join(errors)
-            )
 
     def post_model_load(self, cfg, model):
         """Install the offload after the model is built, quantized, PEFT-wrapped and on the GPU."""

--- a/src/axolotl/integrations/expert_offload/plugin.py
+++ b/src/axolotl/integrations/expert_offload/plugin.py
@@ -6,7 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Expert-offload plugin for axolotl: single-GPU CPU offload of frozen 4-bit MoE experts."""
+"""Expert-offload plugin for axolotl: per-replica CPU offload of frozen 4-bit MoE experts."""
 
 from __future__ import annotations
 
@@ -18,10 +18,10 @@ class ExpertOffloadPlugin(BasePlugin):
 
     Surgical counterpart to ``layer_offloading``: it moves only the frozen 4-bit experts (the bulk
     of a MoE's parameters) while attention, router, norms and the trainable LoRA adapters stay
-    GPU-resident — minimizing per-step PCIe traffic for the same peak-VRAM reduction. Single-GPU
-    QLoRA only; the cross-field config requirements are enforced at config-parse time by the
-    ``ExpertOffloadArgs`` schema validator. See ``offload.py`` for the mechanism and this
-    integration's README.
+    GPU-resident — minimizing per-step PCIe traffic for the same peak-VRAM reduction. One GPU per
+    replica (single-GPU or plain DDP; no FSDP / DeepSpeed / expert-parallel); the cross-field
+    config requirements are enforced at config-parse time by the ``ExpertOffloadArgs`` schema
+    validator. See ``offload.py`` for the mechanism and this integration's README.
     """
 
     def get_input_args(self):

--- a/src/axolotl/integrations/expert_offload/plugin.py
+++ b/src/axolotl/integrations/expert_offload/plugin.py
@@ -16,12 +16,8 @@ from axolotl.integrations.base import BasePlugin
 class ExpertOffloadPlugin(BasePlugin):
     """Stream frozen 4-bit MoE experts from pinned CPU RAM one block at a time.
 
-    Surgical counterpart to ``layer_offloading``: it moves only the frozen 4-bit experts (the bulk
-    of a MoE's parameters) while attention, router, norms and the trainable LoRA adapters stay
-    GPU-resident — minimizing per-step PCIe traffic for the same peak-VRAM reduction. One GPU per
-    replica (single-GPU or plain DDP; no FSDP / DeepSpeed / expert-parallel); the cross-field
-    config requirements are enforced at config-parse time by the ``ExpertOffloadArgs`` schema
-    validator. See ``offload.py`` for the mechanism and this integration's README.
+    Moves only the experts (the bulk of a MoE's parameters), unlike whole-layer
+    ``layer_offloading``, so per-step PCIe traffic stays small. See the integration README.
     """
 
     def get_input_args(self):

--- a/src/axolotl/integrations/expert_offload/plugin.py
+++ b/src/axolotl/integrations/expert_offload/plugin.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Expert-offload plugin for axolotl: single-GPU CPU offload of frozen 4-bit MoE experts."""
+
+from __future__ import annotations
+
+from axolotl.integrations.base import BasePlugin
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+class ExpertOffloadPlugin(BasePlugin):
+    """Stream frozen 4-bit MoE experts from pinned CPU RAM one block at a time.
+
+    Surgical counterpart to ``layer_offloading``: it moves only the frozen 4-bit experts (the bulk
+    of a MoE's parameters) while attention, router, norms and the trainable LoRA adapters stay
+    GPU-resident — minimizing per-step PCIe traffic for the same peak-VRAM reduction. Single-GPU
+    QLoRA only. See ``offload.py`` for the mechanism and this integration's README.
+    """
+
+    def get_input_args(self):
+        return "axolotl.integrations.expert_offload.ExpertOffloadArgs"
+
+    def pre_model_load(self, cfg):
+        """Validate the cross-field requirements the args model can't see, before the model loads."""
+        if not getattr(cfg, "expert_offload", False):
+            return
+        self._validate(cfg)
+
+    @staticmethod
+    def _validate(cfg) -> None:
+        errors: list[str] = []
+
+        # 4-bit experts: the mechanism swaps ``Linear4bit.weight.data``.
+        if not getattr(cfg, "load_in_4bit", False):
+            errors.append(
+                "requires load_in_4bit: true (it offloads 4-bit Linear4bit experts)"
+            )
+        if getattr(cfg, "adapter", None) not in ("lora", "qlora"):
+            errors.append("requires adapter: qlora (or lora with load_in_4bit)")
+
+        # Gradient checkpointing (use_reentrant=False) is load-bearing: the backward recompute
+        # re-stages each block's experts, and it is what lets eviction actually free memory rather
+        # than pin every staged weight alive as a matmul_4bit saved-for-backward tensor.
+        if not getattr(cfg, "gradient_checkpointing", False):
+            errors.append(
+                "requires gradient_checkpointing: true (the backward recompute re-stages experts; "
+                "without it, offload is neither correct nor memory-saving)"
+            )
+        else:
+            use_reentrant = (
+                getattr(cfg, "gradient_checkpointing_kwargs", None) or {}
+            ).get("use_reentrant", False)
+            if use_reentrant:
+                errors.append(
+                    "requires gradient_checkpointing_kwargs.use_reentrant: false "
+                    "(reentrant checkpointing does not re-run the block pre-hook on recompute)"
+                )
+
+        # Single GPU: FSDP / DeepSpeed / expert-parallel move or shard these same weights and would
+        # race the stage/evict swaps.
+        if getattr(cfg, "fsdp_config", None) or getattr(cfg, "fsdp", None):
+            errors.append("is single-GPU only and incompatible with FSDP")
+        if getattr(cfg, "deepspeed", None):
+            errors.append("is single-GPU only and incompatible with DeepSpeed")
+        if (getattr(cfg, "expert_parallel_size", None) or 1) > 1:
+            errors.append(
+                "is incompatible with expert_parallel (both manage the expert weights)"
+            )
+
+        if errors:
+            raise ValueError(
+                "expert_offload is enabled but the config is incompatible:\n  - "
+                + "\n  - ".join(errors)
+            )
+
+    def post_model_load(self, cfg, model):
+        """Install the offload after the model is built, quantized, PEFT-wrapped and on the GPU."""
+        if not getattr(cfg, "expert_offload", False):
+            return
+        from .offload import install_expert_offload
+
+        install_expert_offload(
+            model, pin=getattr(cfg, "expert_offload_pin_memory", True)
+        )

--- a/tests/integrations/test_expert_offload.py
+++ b/tests/integrations/test_expert_offload.py
@@ -8,15 +8,15 @@ real ``bitsandbytes.nn.Linear4bit`` experts.
 """
 
 import copy
-from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn.functional as F
+from pydantic import ValidationError
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 
-from axolotl.integrations.expert_offload import ExpertOffloadArgs, ExpertOffloadPlugin
+from axolotl.integrations.expert_offload import ExpertOffloadArgs
 from axolotl.integrations.expert_offload.offload import (
     _PLACEHOLDERS,
     _base_layer,
@@ -112,14 +112,18 @@ def _reset_offload_globals():
 # --------------------------------------------------------------------------- #
 # Args + config validation                                                    #
 # --------------------------------------------------------------------------- #
-class TestArgs:
-    def test_defaults(self):
-        a = ExpertOffloadArgs()
-        assert a.expert_offload is False
-        assert a.expert_offload_pin_memory is True
+class MergedConfig(ExpertOffloadArgs):
+    """Mimics ``integrations/config.py::merge_input_args``, which folds plugin args into the full
+    config by inheritance — so the schema validator sees base-config fields via ``self``."""
 
-    def test_enabled(self):
-        assert ExpertOffloadArgs(expert_offload=True).expert_offload is True
+    load_in_4bit: bool = False
+    adapter: str | None = None
+    gradient_checkpointing: bool | str = False
+    gradient_checkpointing_kwargs: dict | None = None
+    fsdp: list | None = None
+    fsdp_config: dict | None = None
+    deepspeed: str | dict | None = None
+    expert_parallel_size: int = 1
 
 
 def _cfg(**overrides):
@@ -129,24 +133,28 @@ def _cfg(**overrides):
         adapter="qlora",
         gradient_checkpointing=True,
         gradient_checkpointing_kwargs={"use_reentrant": False},
-        fsdp_config=None,
-        fsdp=None,
-        deepspeed=None,
-        expert_parallel_size=1,
     )
     base.update(overrides)
-    return SimpleNamespace(**base)
+    return MergedConfig(**base)
+
+
+class TestArgs:
+    def test_defaults(self):
+        a = ExpertOffloadArgs()
+        assert a.expert_offload is False
+        assert a.expert_offload_pin_memory is True
+
+    def test_enabled(self):
+        assert _cfg().expert_offload is True
 
 
 class TestValidation:
     def test_valid_config_passes(self):
-        ExpertOffloadPlugin._validate(_cfg())  # must not raise
+        _cfg()  # must not raise
 
     def test_disabled_skips_validation(self):
-        # pre_model_load must be a no-op when the feature is off, even with an otherwise bad config.
-        ExpertOffloadPlugin().pre_model_load(
-            _cfg(expert_offload=False, load_in_4bit=False)
-        )
+        # The validator must be a no-op when the feature is off, even with an otherwise bad config.
+        MergedConfig(expert_offload=False, load_in_4bit=False)
 
     @pytest.mark.parametrize(
         "override, needle",
@@ -159,6 +167,9 @@ class TestValidation:
                 dict(gradient_checkpointing_kwargs={"use_reentrant": True}),
                 "use_reentrant",
             ),
+            # omitted kwargs must fail too: normalize_config later defaults them to
+            # {"use_reentrant": True}, after this validator has already run.
+            (dict(gradient_checkpointing_kwargs=None), "use_reentrant"),
             (dict(fsdp_config={"x": 1}), "FSDP"),
             (dict(fsdp=["full_shard"]), "FSDP"),
             (dict(deepspeed="ds.json"), "DeepSpeed"),
@@ -166,13 +177,11 @@ class TestValidation:
         ],
     )
     def test_invalid_configs_raise(self, override, needle):
-        with pytest.raises(ValueError, match=needle):
-            ExpertOffloadPlugin._validate(_cfg(**override))
+        with pytest.raises(ValidationError, match=needle):
+            _cfg(**override)
 
     def test_lora_with_4bit_is_accepted(self):
-        ExpertOffloadPlugin._validate(
-            _cfg(adapter="lora")
-        )  # lora + load_in_4bit is fine
+        _cfg(adapter="lora")  # lora + load_in_4bit is fine
 
 
 # --------------------------------------------------------------------------- #
@@ -206,6 +215,13 @@ class TestDiscovery:
             [nn.Linear(8, 8), nn.Linear(8, 8)]
         )  # not 4bit
         assert find_moe_expert_blocks(model) == []
+
+    def test_install_raises_when_no_offloadable_blocks(self):
+        # expert_offload was explicitly enabled; a layout with nothing to offload is a
+        # misconfiguration and must fail loudly, not proceed without the VRAM reduction.
+        model = nn.Sequential(nn.Linear(8, 8), nn.Linear(8, 8))
+        with pytest.raises(RuntimeError, match="no 4-bit MoE expert blocks"):
+            install_expert_offload(model, device="cpu", pin=False)
 
 
 # --------------------------------------------------------------------------- #
@@ -296,7 +312,7 @@ class TestRecompute:
 class TestCudaLinear4bit:
     @staticmethod
     def _build(d=512, n_experts=16, n_layers=4):
-        import bitsandbytes as bnb
+        bnb = pytest.importorskip("bitsandbytes")
 
         class Block(nn.Module):
             def __init__(self):

--- a/tests/integrations/test_expert_offload.py
+++ b/tests/integrations/test_expert_offload.py
@@ -12,6 +12,7 @@ import copy
 import pytest
 import torch
 import torch.nn.functional as F
+import torch.nn.utils.parametrize as parametrize
 from pydantic import ValidationError
 from torch import nn
 from torch.utils.checkpoint import checkpoint
@@ -23,6 +24,7 @@ from axolotl.integrations.expert_offload.offload import (
     _BlockOffload,
     _is_linear4bit,
     find_moe_expert_blocks,
+    find_parametrized_expert_stacks,
     install_expert_offload,
 )
 
@@ -89,6 +91,66 @@ class FakeMoEModel(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList(
             [FakeMoEBlock(d, n_experts, lora) for _ in range(n_layers)]
+        )
+        self.head = nn.Linear(d, d)
+
+    def forward(self, x, use_ckpt: bool = False):
+        for blk in self.layers:
+            x = x + (checkpoint(blk, x, use_reentrant=False) if use_ckpt else blk(x))
+        return self.head(x)
+
+
+class Bnb4bitParametrization(nn.Module):
+    """Stand-in for bitsandbytes' dequantizing parametrization — detection matches on the class
+    name. Identity "dequant" over a float packed tensor keeps the math checkable on CPU; the real
+    one also runs under ``no_grad``, so autograd never sees the packed tensor in either case."""
+
+    @torch.no_grad()
+    def forward(self, packed):
+        return packed
+
+
+class FakeGroupedExperts(nn.Module):
+    """OLMoE-style fused experts: one frozen 3D stack per projection, parametrized "4-bit"."""
+
+    def __init__(self, d: int, n_experts: int):
+        super().__init__()
+        self.n_experts = n_experts
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(n_experts, d, d) * 0.1, requires_grad=False
+        )
+        self.down_proj = nn.Parameter(
+            torch.randn(n_experts, d, d) * 0.1, requires_grad=False
+        )
+        for pname in ("gate_up_proj", "down_proj"):
+            parametrize.register_parametrization(
+                self, pname, Bnb4bitParametrization(), unsafe=True
+            )
+
+    def forward(self, x, w):
+        out = torch.zeros_like(x)
+        for i in range(self.n_experts):
+            h = torch.tanh(F.linear(x, self.gate_up_proj[i]))
+            out = out + w[..., i : i + 1] * F.linear(h, self.down_proj[i])
+        return out
+
+
+class FakeGroupedMoEBlock(nn.Module):
+    def __init__(self, d: int, n_experts: int):
+        super().__init__()
+        self.router = nn.Linear(d, n_experts)  # trainable, stays resident
+        self.experts = FakeGroupedExperts(d, n_experts)  # a module, NOT a ModuleList
+
+    def forward(self, x):
+        w = torch.softmax(self.router(x), dim=-1)
+        return self.experts(x, w)
+
+
+class FakeGroupedMoEModel(nn.Module):
+    def __init__(self, d: int = 16, n_experts: int = 4, n_layers: int = 3):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [FakeGroupedMoEBlock(d, n_experts) for _ in range(n_layers)]
         )
         self.head = nn.Linear(d, d)
 
@@ -220,7 +282,7 @@ class TestDiscovery:
         # expert_offload was explicitly enabled; a layout with nothing to offload is a
         # misconfiguration and must fail loudly, not proceed without the VRAM reduction.
         model = nn.Sequential(nn.Linear(8, 8), nn.Linear(8, 8))
-        with pytest.raises(RuntimeError, match="no 4-bit MoE expert blocks"):
+        with pytest.raises(RuntimeError, match="no 4-bit MoE expert weights"):
             install_expert_offload(model, device="cpu", pin=False)
 
 
@@ -233,9 +295,7 @@ class TestDDPIgnoreList:
         model = FakeMoEModel(n_experts=4, n_layers=3)
         handles = install_expert_offload(model, device="cpu", pin=False)
         ignore = model._ddp_params_and_buffers_to_ignore
-        offloaded = {
-            id(base.weight) for handle in handles for base in handle.base_layers
-        }
+        offloaded = {id(p) for handle in handles for p in handle.params}
         named = dict(model.named_parameters(remove_duplicate=False))
         # exactly the offloaded expert weights, each resolvable by name on the model DDP wraps
         assert len(ignore) == len(offloaded) == 3 * 4
@@ -322,8 +382,8 @@ class TestRecompute:
         handles = install_expert_offload(model, device="cpu", pin=False)
         # Right after install, every block is evicted: each expert weight is a 0-element placeholder.
         for h in handles:
-            for base in h.base_layers:
-                assert base.weight.data.numel() == 0
+            for p in h.params:
+                assert p.data.numel() == 0
         assert handles[0].bytes > 0  # but the homes hold the real data
 
     def test_state_dict_substitutes_homes_for_placeholders(self):
@@ -336,6 +396,91 @@ class TestRecompute:
         assert len(expert_keys) == 8
         for k in expert_keys:
             assert sd[k].numel() > 0  # home substituted, not the placeholder
+
+
+# --------------------------------------------------------------------------- #
+# Grouped 3D stacks quantized via quantize_moe_experts (parametrized layout)  #
+# --------------------------------------------------------------------------- #
+class TestParametrizedStacks:
+    def test_discovery_finds_parametrized_stacks(self):
+        model = FakeGroupedMoEModel(n_experts=4, n_layers=3)
+        blocks = find_parametrized_expert_stacks(model)
+        assert len(blocks) == 3
+        for _name, module, slots in blocks:
+            assert isinstance(module, FakeGroupedExperts)  # the hook site
+            assert len(slots) == 2  # gate_up_proj + down_proj stacks
+            assert all(not s.param.requires_grad for s in slots)
+
+    def test_moduleList_path_does_not_match_grouped_layout(self):
+        model = FakeGroupedMoEModel(n_experts=4, n_layers=2)
+        assert find_moe_expert_blocks(model) == []  # no double-discovery
+
+    def test_install_evicts_stacks(self):
+        model = FakeGroupedMoEModel(n_experts=4, n_layers=3)
+        handles = install_expert_offload(model, device="cpu", pin=False)
+        assert len(handles) == 3
+        for h in handles:
+            assert len(h.params) == 2
+            for p in h.params:
+                assert p.data.numel() == 0  # evicted to placeholder
+            assert h.bytes > 0  # homes hold the real data
+
+    def test_offloaded_grads_match_reference(self):
+        """Same contract as the Linear4bit path: offloaded + checkpointed training must produce
+        identical outputs and trainable gradients — the recompute pre-hook re-stages the packed
+        stacks before the parametrization dequantizes them."""
+        torch.manual_seed(0)
+        model = FakeGroupedMoEModel(d=16, n_experts=4, n_layers=3)
+        reference = copy.deepcopy(model)
+        x = torch.randn(2, 5, 16)
+
+        reference.zero_grad()
+        out_ref = reference(x, use_ckpt=True)
+        out_ref.sum().backward()
+        ref_grads = {
+            n: p.grad.clone()
+            for n, p in reference.named_parameters()
+            if p.grad is not None
+        }
+
+        install_expert_offload(model, device="cpu", pin=False)
+        model.zero_grad()
+        out_off = model(x, use_ckpt=True)
+        out_off.sum().backward()
+        off_grads = {
+            n: p.grad.clone() for n, p in model.named_parameters() if p.grad is not None
+        }
+
+        assert torch.allclose(out_ref, out_off, atol=1e-6)
+        assert set(ref_grads) == set(off_grads) and len(ref_grads) > 0
+        assert not any("parametrizations" in n for n in off_grads)  # stacks stay frozen
+        for name, g in ref_grads.items():
+            assert torch.allclose(g, off_grads[name], atol=1e-6), (
+                f"grad mismatch for {name}"
+            )
+
+    def test_state_dict_substitutes_homes_for_placeholders(self):
+        model = FakeGroupedMoEModel(d=16, n_experts=4, n_layers=2)
+        install_expert_offload(model, device="cpu", pin=False)
+        sd = model.state_dict()
+        stack_keys = [k for k in sd if ".original" in k]
+        assert len(stack_keys) == 4  # 2 layers x 2 stacks
+        for k in stack_keys:
+            assert sd[k].numel() > 0  # home substituted, not the placeholder
+
+    def test_ddp_ignore_covers_parametrized_stacks(self):
+        model = FakeGroupedMoEModel(n_experts=4, n_layers=3)
+        install_expert_offload(model, device="cpu", pin=False)
+        ignore = model._ddp_params_and_buffers_to_ignore
+        named = dict(model.named_parameters(remove_duplicate=False))
+        assert len(ignore) == 3 * 2
+        assert all(
+            ".parametrizations." in n and n.endswith(".original") for n in ignore
+        )
+        assert all(n in named and not named[n].requires_grad for n in ignore)
+        for name, param in model.named_parameters():
+            if param.requires_grad:  # router/head must stay in DDP's buckets
+                assert name not in ignore
 
 
 # --------------------------------------------------------------------------- #
@@ -404,10 +549,7 @@ class TestCudaLinear4bit:
         assert expert_bytes > 0
         # Everything is evicted between forwards -> no expert data resident on the GPU.
         resident = sum(
-            b.weight.data.numel()
-            for h in handles
-            for b in h.base_layers
-            if b.weight.data.is_cuda
+            p.data.numel() for h in handles for p in h.params if p.data.is_cuda
         )
         assert resident == 0
         # The freed GPU memory accounts for (most of) the experts' packed bytes.
@@ -440,3 +582,128 @@ class TestCudaLinear4bit:
         assert set(ref_grads) == set(off_grads) and len(ref_grads) > 0
         for name, g in ref_grads.items():
             assert torch.allclose(g, off_grads[name], atol=1e-3, rtol=1e-2), name
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA + bitsandbytes"
+)
+class TestCudaParametrized:
+    """The real ``quantize_moe_experts`` layout: grouped 3D stacks quantized in place through
+    ``bitsandbytes.nn.parametrize.replace_parameter_4bit`` (what axolotl's on-load patch calls)."""
+
+    @staticmethod
+    def _build(d=256, n_experts=8, n_layers=3):
+        pytest.importorskip("bitsandbytes")
+        from bitsandbytes.nn.parametrize import replace_parameter_4bit
+
+        class Experts(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.n_experts = n_experts
+                self.gate_up_proj = nn.Parameter(
+                    torch.randn(n_experts, d, d, device="cuda", dtype=torch.float16)
+                    * 0.02,
+                    requires_grad=False,
+                )
+                self.down_proj = nn.Parameter(
+                    torch.randn(n_experts, d, d, device="cuda", dtype=torch.float16)
+                    * 0.02,
+                    requires_grad=False,
+                )
+
+            def forward(self, x, w):
+                out = torch.zeros_like(x)
+                for i in range(self.n_experts):
+                    h = torch.tanh(F.linear(x, self.gate_up_proj[i]))
+                    out = out + w[..., i : i + 1] * F.linear(h, self.down_proj[i])
+                return out
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.router = nn.Linear(d, n_experts)
+                self.experts = Experts()
+
+            def forward(self, x):
+                w = torch.softmax(self.router(x), dim=-1)
+                return self.experts(x, w)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([Block() for _ in range(n_layers)])
+
+            def forward(self, x, use_ckpt=True):
+                for blk in self.layers:
+                    x = x + (
+                        checkpoint(blk, x, use_reentrant=False) if use_ckpt else blk(x)
+                    )
+                return x
+
+        model = Model().cuda().half()
+        for blk in model.layers:
+            for pname in ("gate_up_proj", "down_proj"):
+                replace_parameter_4bit(blk.experts, pname, quant_type="nf4")
+        return model, d
+
+    def test_install_frees_stacks_from_gpu(self):
+        torch.manual_seed(0)
+        model, _d = self._build()
+        blocks = find_parametrized_expert_stacks(model)
+        assert len(blocks) == 3 and all(len(s) == 2 for _n, _m, s in blocks)
+        torch.cuda.synchronize()
+        alloc_before = torch.cuda.memory_allocated()
+
+        handles = install_expert_offload(model, device="cuda", pin=True)
+        torch.cuda.synchronize()
+        alloc_after = torch.cuda.memory_allocated()
+
+        stack_bytes = sum(h.bytes for h in handles)
+        assert stack_bytes > 0
+        resident = sum(
+            p.data.numel() for h in handles for p in h.params if p.data.is_cuda
+        )
+        assert resident == 0
+        assert alloc_before - alloc_after >= 0.8 * stack_bytes
+
+    def test_recompute_grads_match_same_quantized_weights(self):
+        """Reference and offloaded runs share the same quantized model (dequantization is
+        deterministic), so outputs and trainable grads must match across the install."""
+        torch.manual_seed(0)
+        model, d = self._build()
+        x = torch.randn(2, 8, d, device="cuda", dtype=torch.float16)
+
+        model.zero_grad()
+        out_ref = model(x)
+        out_ref.sum().backward()
+        ref_grads = {
+            n: p.grad.clone() for n, p in model.named_parameters() if p.grad is not None
+        }
+
+        install_expert_offload(model, device="cuda", pin=True)
+        model.zero_grad()
+        out_off = model(x)
+        out_off.sum().backward()
+        off_grads = {
+            n: p.grad.clone() for n, p in model.named_parameters() if p.grad is not None
+        }
+
+        assert torch.allclose(out_ref, out_off, atol=1e-3, rtol=1e-2)
+        assert set(ref_grads) == set(off_grads) and len(ref_grads) > 0
+        for name, g in ref_grads.items():
+            assert torch.allclose(g, off_grads[name], atol=1e-3, rtol=1e-2), name
+
+    def test_state_dict_keeps_packed_stacks_while_evicted(self):
+        torch.manual_seed(0)
+        model, _d = self._build()
+        packed_numels = {
+            n: p.numel() for n, p in model.named_parameters() if n.endswith(".original")
+        }
+        install_expert_offload(model, device="cuda", pin=True)
+        sd = model.state_dict()
+        # bitsandbytes' own post-hook renames parametrizations.<p>.original -> <p>; our hook must
+        # still substitute the full-size home wherever the packed tensor landed.
+        for name, numel in packed_numels.items():
+            clean = name.replace(".parametrizations", "").replace(".original", "")
+            t = sd.get(name) if name in sd else sd.get(clean)
+            assert t is not None and t.numel() == numel

--- a/tests/integrations/test_expert_offload.py
+++ b/tests/integrations/test_expert_offload.py
@@ -1,0 +1,391 @@
+"""Tests for the expert-offload integration (single-GPU CPU offload of frozen 4-bit MoE experts).
+
+The scheduling/recompute correctness — the load-bearing, tricky part — is validated on CPU with a
+fake MoE whose experts are plain ``F.linear`` layers carrying a ``Params4bit``-named weight: the
+mechanism only moves ``weight.data``, so this exercises the full stage/evict + gradient-checkpoint
+recompute path without a GPU or bitsandbytes. A CUDA-gated test then confirms it end-to-end against
+real ``bitsandbytes.nn.Linear4bit`` experts.
+"""
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from axolotl.integrations.expert_offload import ExpertOffloadArgs, ExpertOffloadPlugin
+from axolotl.integrations.expert_offload.offload import (
+    _PLACEHOLDERS,
+    _base_layer,
+    _BlockOffload,
+    _is_linear4bit,
+    find_moe_expert_blocks,
+    install_expert_offload,
+)
+
+
+# --------------------------------------------------------------------------- #
+# CPU fakes: the mechanism keys on the weight *type name* and only moves .data #
+# --------------------------------------------------------------------------- #
+class Params4bit(nn.Parameter):
+    """Stand-in for bitsandbytes' packed weight — detection matches on the class name."""
+
+
+class FakeLinear4bit(nn.Module):
+    """Frozen "4-bit" expert: a plain F.linear whose weight is a (frozen) Params4bit."""
+
+    def __init__(self, d_in: int, d_out: int):
+        super().__init__()
+        self.weight = Params4bit(torch.randn(d_out, d_in) * 0.1, requires_grad=False)
+
+    def forward(self, x):
+        return F.linear(x, self.weight)
+
+
+class FakeLoraWrap(nn.Module):
+    """Mimics a PEFT ``lora.Linear4bit``: delegates ``weight`` to a frozen base_layer, adds a
+    trainable A/B that must stay resident."""
+
+    def __init__(self, base: FakeLinear4bit, r: int = 4):
+        super().__init__()
+        self.base_layer = base
+        d_out, d_in = base.weight.shape
+        self.lora_A = nn.Linear(d_in, r, bias=False)
+        self.lora_B = nn.Linear(r, d_out, bias=False)
+        nn.init.zeros_(self.lora_B.weight)
+
+    @property
+    def weight(self):
+        return self.base_layer.weight
+
+    def forward(self, x):
+        return self.base_layer(x) + self.lora_B(self.lora_A(x))
+
+
+class FakeMoEBlock(nn.Module):
+    def __init__(self, d: int, n_experts: int, lora: bool = False):
+        super().__init__()
+        experts = [FakeLinear4bit(d, d) for _ in range(n_experts)]
+        if lora:
+            experts = [FakeLoraWrap(e) for e in experts]
+        self.experts = nn.ModuleList(experts)
+        self.gate = nn.Linear(d, n_experts)  # trainable router, stays resident
+
+    def forward(self, x):
+        w = torch.softmax(self.gate(x), dim=-1)
+        out = torch.zeros_like(x)
+        for i, e in enumerate(self.experts):
+            out = out + w[..., i : i + 1] * e(x)
+        return out
+
+
+class FakeMoEModel(nn.Module):
+    def __init__(
+        self, d: int = 16, n_experts: int = 4, n_layers: int = 3, lora: bool = False
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [FakeMoEBlock(d, n_experts, lora) for _ in range(n_layers)]
+        )
+        self.head = nn.Linear(d, d)
+
+    def forward(self, x, use_ckpt: bool = False):
+        for blk in self.layers:
+            x = x + (checkpoint(blk, x, use_reentrant=False) if use_ckpt else blk(x))
+        return self.head(x)
+
+
+@pytest.fixture(autouse=True)
+def _reset_offload_globals():
+    """The single-resident slot and placeholder cache are class/module globals — reset between
+    tests so residency state does not leak across them."""
+    _BlockOffload._resident = None
+    _PLACEHOLDERS.clear()
+    yield
+    _BlockOffload._resident = None
+    _PLACEHOLDERS.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Args + config validation                                                    #
+# --------------------------------------------------------------------------- #
+class TestArgs:
+    def test_defaults(self):
+        a = ExpertOffloadArgs()
+        assert a.expert_offload is False
+        assert a.expert_offload_pin_memory is True
+
+    def test_enabled(self):
+        assert ExpertOffloadArgs(expert_offload=True).expert_offload is True
+
+
+def _cfg(**overrides):
+    base = dict(
+        expert_offload=True,
+        load_in_4bit=True,
+        adapter="qlora",
+        gradient_checkpointing=True,
+        gradient_checkpointing_kwargs={"use_reentrant": False},
+        fsdp_config=None,
+        fsdp=None,
+        deepspeed=None,
+        expert_parallel_size=1,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestValidation:
+    def test_valid_config_passes(self):
+        ExpertOffloadPlugin._validate(_cfg())  # must not raise
+
+    def test_disabled_skips_validation(self):
+        # pre_model_load must be a no-op when the feature is off, even with an otherwise bad config.
+        ExpertOffloadPlugin().pre_model_load(
+            _cfg(expert_offload=False, load_in_4bit=False)
+        )
+
+    @pytest.mark.parametrize(
+        "override, needle",
+        [
+            (dict(load_in_4bit=False), "load_in_4bit"),
+            (dict(adapter="lora", load_in_4bit=False), "load_in_4bit"),
+            (dict(adapter="full"), "qlora"),
+            (dict(gradient_checkpointing=False), "gradient_checkpointing"),
+            (
+                dict(gradient_checkpointing_kwargs={"use_reentrant": True}),
+                "use_reentrant",
+            ),
+            (dict(fsdp_config={"x": 1}), "FSDP"),
+            (dict(fsdp=["full_shard"]), "FSDP"),
+            (dict(deepspeed="ds.json"), "DeepSpeed"),
+            (dict(expert_parallel_size=2), "expert_parallel"),
+        ],
+    )
+    def test_invalid_configs_raise(self, override, needle):
+        with pytest.raises(ValueError, match=needle):
+            ExpertOffloadPlugin._validate(_cfg(**override))
+
+    def test_lora_with_4bit_is_accepted(self):
+        ExpertOffloadPlugin._validate(
+            _cfg(adapter="lora")
+        )  # lora + load_in_4bit is fine
+
+
+# --------------------------------------------------------------------------- #
+# Discovery                                                                    #
+# --------------------------------------------------------------------------- #
+class TestDiscovery:
+    def test_finds_blocks_and_experts(self):
+        model = FakeMoEModel(n_experts=4, n_layers=3)
+        blocks = find_moe_expert_blocks(model)
+        assert len(blocks) == 3
+        for _name, block, bases in blocks:
+            assert isinstance(block, FakeMoEBlock)
+            assert len(bases) == 4
+            assert all(_is_linear4bit(b) for b in bases)
+
+    def test_unwraps_peft_base_layer(self):
+        model = FakeMoEModel(n_experts=4, n_layers=2, lora=True)
+        blocks = find_moe_expert_blocks(model)
+        assert len(blocks) == 2
+        for _name, _block, bases in blocks:
+            assert len(bases) == 4  # deduped to the 4 base layers, not the wraps
+            assert all(isinstance(b, FakeLinear4bit) for b in bases)
+            assert all(_base_layer(b) is b for b in bases)  # already the base
+
+    def test_ignores_singleton_and_non_4bit(self):
+        model = nn.Module()
+        model.solo = nn.Module()
+        model.solo.experts = nn.ModuleList([FakeLinear4bit(8, 8)])  # len 1 -> skipped
+        model.dense = nn.Module()
+        model.dense.experts = nn.ModuleList(
+            [nn.Linear(8, 8), nn.Linear(8, 8)]
+        )  # not 4bit
+        assert find_moe_expert_blocks(model) == []
+
+
+# --------------------------------------------------------------------------- #
+# The core: gradient-checkpoint recompute correctness + single-resident       #
+# --------------------------------------------------------------------------- #
+class TestRecompute:
+    def test_offloaded_grads_match_reference(self):
+        """With gradient checkpointing, offloaded training must produce the *same* gradients as the
+        non-offloaded reference — proof that the backward recompute reads correctly-staged expert
+        weights (not the 0-element eviction placeholders)."""
+        torch.manual_seed(0)
+        model = FakeMoEModel(d=16, n_experts=4, n_layers=3, lora=True)
+        reference = copy.deepcopy(model)
+        x = torch.randn(2, 5, 16)
+
+        reference.zero_grad()
+        out_ref = reference(x, use_ckpt=True)
+        out_ref.sum().backward()
+        ref_grads = {
+            n: p.grad.clone()
+            for n, p in reference.named_parameters()
+            if p.grad is not None
+        }
+
+        install_expert_offload(model, device="cpu", pin=False)
+        model.zero_grad()
+        out_off = model(x, use_ckpt=True)
+        out_off.sum().backward()
+        off_grads = {
+            n: p.grad.clone() for n, p in model.named_parameters() if p.grad is not None
+        }
+
+        assert torch.allclose(out_ref, out_off, atol=1e-6)
+        assert set(ref_grads) == set(off_grads) and len(ref_grads) > 0
+        # No expert base weight received a grad (they are frozen and offloaded).
+        assert not any("base_layer.weight" in n for n in off_grads)
+        for name, g in ref_grads.items():
+            assert torch.allclose(g, off_grads[name], atol=1e-6), (
+                f"grad mismatch for {name}"
+            )
+
+    def test_at_most_one_block_resident(self):
+        torch.manual_seed(0)
+        model = FakeMoEModel(d=16, n_experts=4, n_layers=4)
+        handles = install_expert_offload(model, device="cpu", pin=False)
+        max_resident = 0
+
+        def probe(_module, _args):
+            nonlocal max_resident
+            max_resident = max(max_resident, sum(h.staged for h in handles))
+
+        for _name, block, _bases in find_moe_expert_blocks(model):
+            block.register_forward_pre_hook(
+                probe
+            )  # runs right after the stage pre-hook
+
+        model(torch.randn(2, 5, 16), use_ckpt=True).sum().backward()
+        assert max_resident == 1  # exactly one block staged during any block's forward
+        assert sum(h.staged for h in handles) <= 1  # settled state after backward
+
+    def test_evicted_weights_are_offloaded_between_forwards(self):
+        model = FakeMoEModel(d=16, n_experts=4, n_layers=3)
+        handles = install_expert_offload(model, device="cpu", pin=False)
+        # Right after install, every block is evicted: each expert weight is a 0-element placeholder.
+        for h in handles:
+            for base in h.base_layers:
+                assert base.weight.data.numel() == 0
+        assert handles[0].bytes > 0  # but the homes hold the real data
+
+    def test_state_dict_substitutes_homes_for_placeholders(self):
+        """A full state_dict() while evicted must still contain the real expert weights (via the
+        home-substitution hook), not the 0-element placeholders."""
+        model = FakeMoEModel(d=16, n_experts=4, n_layers=2)
+        install_expert_offload(model, device="cpu", pin=False)
+        sd = model.state_dict()
+        expert_keys = [k for k in sd if ".experts." in k and k.endswith(".weight")]
+        assert len(expert_keys) == 8
+        for k in expert_keys:
+            assert sd[k].numel() > 0  # home substituted, not the placeholder
+
+
+# --------------------------------------------------------------------------- #
+# CUDA + bitsandbytes: the real Linear4bit path                               #
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA + bitsandbytes"
+)
+class TestCudaLinear4bit:
+    @staticmethod
+    def _build(d=512, n_experts=16, n_layers=4):
+        import bitsandbytes as bnb
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.experts = nn.ModuleList(
+                    [
+                        bnb.nn.Linear4bit(
+                            d,
+                            d,
+                            bias=False,
+                            compute_dtype=torch.float16,
+                            quant_type="nf4",
+                        )
+                        for _ in range(n_experts)
+                    ]
+                )
+                self.gate = nn.Linear(d, n_experts)
+
+            def forward(self, x):
+                w = torch.softmax(self.gate(x), dim=-1)
+                out = torch.zeros_like(x)
+                for i, e in enumerate(self.experts):
+                    out = out + w[..., i : i + 1] * e(x)
+                return out
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([Block() for _ in range(n_layers)])
+
+            def forward(self, x, use_ckpt=True):
+                for blk in self.layers:
+                    x = x + (
+                        checkpoint(blk, x, use_reentrant=False) if use_ckpt else blk(x)
+                    )
+                return x
+
+        return Model().cuda().half(), d
+
+    def test_install_frees_experts_from_gpu(self):
+        """Installing the offload must move the packed 4-bit experts off the GPU: live GPU memory
+        drops by (approximately) the experts' bytes, and every expert weight becomes a 0-element
+        placeholder while evicted."""
+        torch.manual_seed(0)
+        model, _d = self._build()
+        torch.cuda.synchronize()
+        alloc_before = torch.cuda.memory_allocated()
+
+        handles = install_expert_offload(model, device="cuda", pin=True)
+        torch.cuda.synchronize()
+        alloc_after = torch.cuda.memory_allocated()
+
+        expert_bytes = sum(h.bytes for h in handles)
+        assert expert_bytes > 0
+        # Everything is evicted between forwards -> no expert data resident on the GPU.
+        resident = sum(
+            b.weight.data.numel()
+            for h in handles
+            for b in h.base_layers
+            if b.weight.data.is_cuda
+        )
+        assert resident == 0
+        # The freed GPU memory accounts for (most of) the experts' packed bytes.
+        assert alloc_before - alloc_after >= 0.8 * expert_bytes
+
+    def test_recompute_grads_match_reference(self):
+        """With real bitsandbytes Linear4bit + gradient checkpointing, offloaded training produces
+        the same trainable gradients as the non-offloaded reference — the recompute reads staged
+        4-bit weights through the real matmul_4bit backward, not the eviction placeholders."""
+        torch.manual_seed(0)
+        model, d = self._build()
+        reference = copy.deepcopy(model)
+        x = torch.randn(2, 8, d, device="cuda", dtype=torch.float16)
+
+        reference.zero_grad()
+        reference(x).sum().backward()
+        ref_grads = {
+            n: p.grad.clone()
+            for n, p in reference.named_parameters()
+            if p.grad is not None
+        }
+
+        install_expert_offload(model, device="cuda", pin=True)
+        model.zero_grad()
+        model(x).sum().backward()
+        off_grads = {
+            n: p.grad.clone() for n, p in model.named_parameters() if p.grad is not None
+        }
+
+        assert set(ref_grads) == set(off_grads) and len(ref_grads) > 0
+        for name, g in ref_grads.items():
+            assert torch.allclose(g, off_grads[name], atol=1e-3, rtol=1e-2), name

--- a/tests/integrations/test_expert_offload.py
+++ b/tests/integrations/test_expert_offload.py
@@ -224,6 +224,41 @@ class TestDiscovery:
             install_expert_offload(model, device="cpu", pin=False)
 
 
+class TestDDPIgnoreList:
+    # DDP's initial module-state sync must never touch the evicted 0-element placeholders, so
+    # install registers every offloaded weight on ``_ddp_params_and_buffers_to_ignore`` (read by
+    # DistributedDataParallel at construction, which happens after post_model_load).
+
+    def test_install_registers_offloaded_weights(self):
+        model = FakeMoEModel(n_experts=4, n_layers=3)
+        handles = install_expert_offload(model, device="cpu", pin=False)
+        ignore = model._ddp_params_and_buffers_to_ignore
+        offloaded = {
+            id(base.weight) for handle in handles for base in handle.base_layers
+        }
+        named = dict(model.named_parameters(remove_duplicate=False))
+        # exactly the offloaded expert weights, each resolvable by name on the model DDP wraps
+        assert len(ignore) == len(offloaded) == 3 * 4
+        assert all(name in named and id(named[name]) in offloaded for name in ignore)
+
+    def test_ignore_list_appends_without_duplicating(self):
+        model = FakeMoEModel(n_experts=2, n_layers=1)
+        model._ddp_params_and_buffers_to_ignore = ["pre.existing"]
+        install_expert_offload(model, device="cpu", pin=False)
+        ignore = model._ddp_params_and_buffers_to_ignore
+        assert ignore[0] == "pre.existing"
+        assert len(ignore) == 1 + 2
+        assert len(ignore) == len(set(ignore))
+
+    def test_trainable_lora_params_not_ignored(self):
+        model = FakeMoEModel(n_experts=2, n_layers=2, lora=True)
+        install_expert_offload(model, device="cpu", pin=False)
+        ignore = set(model._ddp_params_and_buffers_to_ignore)
+        for name, param in model.named_parameters():
+            if param.requires_grad:  # LoRA A/B must stay in DDP's gradient buckets
+                assert name not in ignore
+
+
 # --------------------------------------------------------------------------- #
 # The core: gradient-checkpoint recompute correctness + single-resident       #
 # --------------------------------------------------------------------------- #

--- a/tests/integrations/test_parametrize_cache_leak.py
+++ b/tests/integrations/test_parametrize_cache_leak.py
@@ -1,0 +1,100 @@
+"""The bnb parametrize-cache leak and its expert_offload-side neutralization.
+
+bitsandbytes' ``replace_parameter_4bit`` registers a forward_pre_hook/forward_hook
+pair that increments/decrements torch's GLOBAL ``parametrize._cache_enabled`` and
+clears ``parametrize._cache`` only when the counter reaches 0. torch's
+``use_reentrant=False`` checkpointing aborts the backward recompute mid-forward by
+design (early stop) — the post-hook of the module holding the last recomputed save
+is SKIPPED, the counter leaks upward every step, and once it is stuck above zero
+every dequantized weight is cached globally for the rest of training (pool x4
+bytes). These tests reproduce the torch-level skip with bnb-shaped stub hooks (no
+bitsandbytes import needed) and pin the stripper's behavior.
+"""
+
+import pytest
+import torch
+import torch.nn.utils.parametrize as P
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from axolotl.integrations.expert_offload.offload import (
+    _BNB_CACHE_HOOK_NAMES,
+    _reset_parametrize_cache_state,
+    _strip_bnb_parametrize_cache_hooks,
+)
+
+
+# bnb-shaped stubs: same names, same global side effects (bitsandbytes/nn/parametrize.py)
+def _enable_parametrization_cache(module, inputs):
+    P._cache_enabled += 1
+
+
+def _disable_parametrization_cache(module, inputs, output):
+    P._cache_enabled -= 1
+    if not P._cache_enabled:
+        P._cache = {}
+
+
+class _Chain(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a, self.b, self.tail = (nn.Linear(8, 8) for _ in range(3))
+
+    def forward(self, x):
+        return self.tail(self.b(self.a(x)))
+
+
+def _register_bnb_shaped_hooks(module):
+    module.register_forward_pre_hook(_enable_parametrization_cache)
+    module.register_forward_hook(_disable_parametrization_cache)
+
+
+@pytest.fixture(autouse=True)
+def _clean_global_cache():
+    _reset_parametrize_cache_state()
+    yield
+    _reset_parametrize_cache_state()
+
+
+def test_checkpoint_early_stop_leaks_the_counter():
+    """The torch-level mechanism: the tail module's post-hook is skipped during the
+    early-stopped backward recompute, so the bnb-shaped counter never returns to 0."""
+    m = _Chain()
+    _register_bnb_shaped_hooks(m.tail)
+    x = torch.randn(2, 8, requires_grad=True)
+    checkpoint(m, x, use_reentrant=False).sum().backward()
+    assert P._cache_enabled > 0, (
+        "expected the early-stopped recompute to skip the forward_hook and leak the "
+        "counter; if this now passes with 0, torch fixed the skip and the strip "
+        "workaround can be retired"
+    )
+
+
+def test_strip_removes_exactly_the_bnb_pair_and_keeps_others():
+    m = _Chain()
+    _register_bnb_shaped_hooks(m.tail)
+    seen = []
+    m.tail.register_forward_hook(lambda mod, i, o: seen.append("kept"))
+
+    removed = _strip_bnb_parametrize_cache_hooks(m.tail)
+    assert removed == 2
+    names = [getattr(fn, "__name__", "") for fn in m.tail._forward_pre_hooks.values()]
+    names += [getattr(fn, "__name__", "") for fn in m.tail._forward_hooks.values()]
+    assert not set(names) & set(_BNB_CACHE_HOOK_NAMES)
+
+    m.tail(torch.randn(2, 8))
+    assert seen == ["kept"]  # unrelated hooks survive
+    assert _strip_bnb_parametrize_cache_hooks(m.tail) == 0  # idempotent
+
+
+def test_stripped_module_cannot_leak_under_checkpointing():
+    m = _Chain()
+    for mod in (m.a, m.b, m.tail):
+        _register_bnb_shaped_hooks(mod)
+        _strip_bnb_parametrize_cache_hooks(mod)
+    _reset_parametrize_cache_state()
+    for _ in range(3):  # multi-step training shape
+        x = torch.randn(2, 8, requires_grad=True)
+        checkpoint(m, x, use_reentrant=False).sum().backward()
+    assert P._cache_enabled == 0
+    assert P._cache == {}


### PR DESCRIPTION
For #3787 (as requested there — a demonstrating PR).

Adds an `axolotl.integrations.expert_offload` plugin that streams a MoE's **frozen 4-bit experts** from pinned CPU RAM to the GPU one block at a time, so a model whose experts exceed VRAM can QLoRA-train on a single small card. Only the experts move — attention, router/gate, norms and the trainable LoRA adapters stay GPU-resident, so per-step PCIe traffic is limited to the experts (the bulk of a MoE's parameters, and the reason it doesn't fit).

### Measured (seed-matched A/B, OLMoE-1B-7B QLoRA, single 12 GB RTX A2000)

| config | loaded GPU | peak GPU | held-out eval (before → after) |
|---|--:|--:|--:|
| experts resident | 4.70 GB | 6.00 GB | 1.6448 → 1.2213 |
| experts offloaded | **1.08 GB** | **2.60 GB** | 1.6448 → 1.2270 |

Peak VRAM **−57%**, load footprint **−77%**; both arms share a seed (identical data order), and the loss curves overlay — convergence is preserved. Throughput cost is the per-block H2D copy, ~+11% s/step uncontended on this card. Full telemetry (per-step JSONL, `wandb sync`-able offline runs, charts, the A/B runner + methodology) is in [`ab-telemetry/`](https://github.com/pjordanandrsn/experts4bit-qlora/tree/main/ab-telemetry).

![loss](https://raw.githubusercontent.com/pjordanandrsn/experts4bit-qlora/main/ab-telemetry/charts/loss_curve.png)
![vram](https://raw.githubusercontent.com/pjordanandrsn/experts4bit-qlora/main/ab-telemetry/charts/vram.png)

### How it works

Each expert is a bitsandbytes `Linear4bit` whose big tensor is the packed `weight.data` (the `quant_state` scales are ~1/32 the size and stay resident). Every offloaded block's `weight.data` is homed in pinned CPU RAM; a forward **pre-hook** on the MoE block stages its experts just before it runs, and eviction is a **single-resident-slot** policy — staging a block evicts the previously-staged one; there is deliberately no evict post-hook. Under `use_reentrant=False` gradient checkpointing, the backward recompute re-runs the pre-hook, so exactly one block's experts are GPU-resident in forward *and* backward — without depending on when PyTorch stops a recompute.

Gradient checkpointing is **required and enforced** (not just recommended): `matmul_4bit`'s backward re-reads the packed weight via `save_for_backward`, and eviction repoints `weight.data` at a 0-element placeholder. The recompute is what makes eviction both correct and actually memory-freeing (instead of pinning every staged weight alive as a saved tensor). While evicted, modules hold only the 0-element placeholder, so a stray `.to()` or checkpoint-save never drags the experts back to the GPU; a `state_dict` post-hook substitutes the CPU homes so full-model saves stay correct.

### Scope and guards

- Single-GPU QLoRA only — `pre_model_load` refuses under FSDP / DeepSpeed / `expert_parallel`, and requires `load_in_4bit` + `adapter: qlora` + `gradient_checkpointing: true` with `use_reentrant: false`, each with an actionable error message.
- Per-expert `Linear4bit` layouts (`experts` `ModuleList`): Mixtral, Qwen2/3-MoE, OLMoE, DeepSeek-MoE, Jamba, … PEFT `base_layer` wrappers are unwrapped. Fused-expert layouts (GPT-OSS, DBRX) aren't 4-bit-quantized per-expert and are left untouched.
- Complements `layer_offloading` (whole-layer) — this moves only the experts, so it streams far fewer bytes per step for nearly the same VRAM win on a MoE. Orthogonal to `expert_parallel` (multi-GPU sharding — the opposite regime). Chose the standalone-plugin shape to keep it self-contained; happy to refold it into the `layer_offloading` mixin instead if you'd prefer.

### Tests

`tests/integrations/test_expert_offload.py` — 23 tests (21 CPU + 2 CUDA-gated):

- args + cross-field config validation (each rejected combination asserted)
- MoE-block discovery incl. PEFT `base_layer` unwrap, dedup, and non-4bit/singleton skip
- **the core proof on CPU**: with gradient checkpointing, offloaded training produces gradients identical to the non-offloaded reference (the recompute reads staged weights, not eviction placeholders); exactly one block resident at any instant; `state_dict` home-substitution
- CUDA (real bitsandbytes `Linear4bit`): install frees the experts' bytes off the GPU; offloaded grads match the non-offloaded reference through the real `matmul_4bit` backward

Run on a 12 GB RTX A2000: 23/23 pass. Example config in `src/axolotl/integrations/expert_offload/examples/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Expert Offload integration for single-GPU MoE QLoRA training, helping move frozen 4-bit experts out of GPU memory while training continues.
  * Added a new configuration option to enable expert offloading and control CPU memory pinning.
  * Added an example setup for using the feature with a supported model and training configuration.

* **Bug Fixes**
  * Improved compatibility checks to prevent unsupported training setups from being used with expert offload.

* **Documentation**
  * Added usage notes, setup requirements, and expected performance impact details.

* **Tests**
  * Added coverage for configuration validation, offload behavior, gradient correctness, and state saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Developed with [Claude Code](https://claude.com/claude-code) (Anthropic) — implementation, tests, and the validation runs described in this PR were produced with AI assistance under the author's direction and review.
