### PR TITLE
fix(lora): correct fp32 NF4 dequant + harden fused GDN LoRA routing

### DIFF
--- a/src/axolotl/kernels/lora.py
+++ b/src/axolotl/kernels/lora.py
@@ -1886,7 +1886,6 @@ class LoRA_FusedProj(torch.autograd.Function):
         has_dropout = ctx.has_dropout
 
         batch, seq_len = X.shape[:2]
-        X = X.view(-1, X.shape[-1])
         X_lora = X_lora.view(-1, X_lora.shape[-1])
         # X_lora aliases X when there is no dropout; keep grad_X out-of-place so
         # this transpose stays valid across every projection's LoRA grads.
@@ -1917,7 +1916,10 @@ class LoRA_FusedProj(torch.autograd.Function):
                 d_A.addmm_(X_lora_t, grad_B, alpha=s, beta=0)
                 d_B.addmm_(A @ X_lora_t, dY, alpha=s, beta=0)
 
-            W_deq = dequantize(W, quant)  # [out, in]
+            # .to(dY.dtype): an NF4 base with an fp32 quant_state dequants to fp32,
+            # which the shared in-place grad_X accumulator cannot mix. No-op in the
+            # supported paths (bf16 quant_state / fp8 / Float8Tensor all give bf16).
+            W_deq = dequantize(W, quant).to(dY.dtype)  # [out, in]
             if grad_X is None:
                 grad_X = torch.mm(dY, W_deq)
             else:

--- a/src/axolotl/kernels/quantize.py
+++ b/src/axolotl/kernels/quantize.py
@@ -10,6 +10,15 @@ from bitsandbytes.functional import QuantState, get_ptr
 cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
 cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
 cdequantize_blockwise_bf16_nf4 = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+cdequantize_blockwise_fp32_nf4 = bnb.functional.lib.cdequantize_blockwise_fp32_nf4
+
+# NF4 dequant kernel per output dtype; the buffer dtype must match or the kernel
+# writes past/short of each element (e.g. a bf16 kernel into an fp32 buffer = garbage).
+_NF4_DEQUANT_KERNELS = {
+    torch.float16: cdequantize_blockwise_fp16_nf4,
+    torch.bfloat16: cdequantize_blockwise_bf16_nf4,
+    torch.float32: cdequantize_blockwise_fp32_nf4,
+}
 
 # Cached per-device: per-call current_stream() measurably slows this hot path.
 CUDA_STREAM: dict[torch.device, torch.cuda.Stream] = {}
@@ -51,11 +60,9 @@ def _ctypes_nf4_dequant(
     )
     out_absmax += offset
 
-    fx = (
-        cdequantize_blockwise_fp16_nf4
-        if dtype == torch.float16
-        else cdequantize_blockwise_bf16_nf4
-    )
+    fx = _NF4_DEQUANT_KERNELS.get(dtype)
+    if fx is None:
+        raise ValueError(f"NF4 dequantization unsupported for output dtype {dtype}")
     fx(
         get_ptr(None),
         get_ptr(W),

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -364,10 +364,11 @@ LINEAR_ATTN_PROJS = LINEAR_ATTN_IN_PROJS + (LINEAR_ATTN_OUT_PROJ,)
 def find_linear_attn_in_layer(layer: nn.Module) -> Generator[nn.Module, None, None]:
     # Qwen3.5 / Qwen3.5-MoE hybrid layers (GatedDeltaNet). qwen3_next fuses its
     # projections (in_proj_qkvz / in_proj_ba) under different names and must not
-    # match here.
+    # match here. Require all four canonical in-projections: the fused node and the
+    # patched forward both index every one, so a partial match falls back to peft.
     if hasattr(layer, "linear_attn"):
         linear_attn = layer.linear_attn
-        if hasattr(linear_attn, LINEAR_ATTN_OUT_PROJ) and any(
+        if hasattr(linear_attn, LINEAR_ATTN_OUT_PROJ) and all(
             hasattr(linear_attn, proj) for proj in LINEAR_ATTN_IN_PROJS
         ):
             yield linear_attn

--- a/tests/e2e/kernels/test_quantize.py
+++ b/tests/e2e/kernels/test_quantize.py
@@ -1,6 +1,7 @@
 """Tests for quantization utility functions."""
 
 import bitsandbytes as bnb
+import pytest
 import torch
 
 from axolotl.kernels.quantize import dequantize
@@ -40,6 +41,23 @@ def test_dequantize_transposed():
     result = dequantize(packed.t(), quant_state)
     assert tuple(result.shape) == (shape[1], shape[0])
     torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_dequantize_matches_bnb(dtype):
+    """Bit-exact vs bnb's own dequant for every supported output dtype. fp32 previously
+    fell through to the bf16 kernel writing into an fp32 buffer and produced garbage."""
+    shape = (128, 64)
+    packed, quant_state = _nf4_pair(shape, dtype=dtype)
+    expected = bnb.functional.dequantize_4bit(packed, quant_state, quant_type="nf4")
+
+    result = dequantize(packed, quant_state)
+    assert result.dtype == dtype
+    torch.testing.assert_close(result, expected)
+
+    # transposed input → transposed output (values, not just shape)
+    result_t = dequantize(packed.t(), quant_state)
+    torch.testing.assert_close(result_t, expected.t())
 
 
 def test_dequantize_non_nested():

--- a/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
+++ b/tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py
@@ -610,6 +610,12 @@ class TestFindLinearAttnInLayer:
         layer = _gdn_layer(_gdn_module_with(["out_proj"]))
         assert list(find_linear_attn_in_layer(layer)) == []
 
+    def test_partial_in_projs_is_excluded(self):
+        # out_proj + only some of the four canonical in-projections: the fused node
+        # and patched forward index all four, so a partial mixer falls back to peft.
+        layer = _gdn_layer(_gdn_module_with(["in_proj_qkv", "in_proj_z", "out_proj"]))
+        assert list(find_linear_attn_in_layer(layer)) == []
+
     def test_missing_linear_attn_attr_is_excluded(self):
         assert list(find_linear_attn_in_layer(nn.Module())) == []
 
@@ -775,6 +781,56 @@ def test_apply_lora_gdn_in_proj_matches_peft_with_dora():
     assert _gdn_rel_l2(gx_fused, gx_ref) < 2e-2
     for name in targets:
         assert _gdn_rel_l2(ga_fused[name], ga_ref[name]) < 2e-2
+
+
+def _wrapped_gdn_block_nf4(targets, in_features=256, base_dtype=torch.bfloat16):
+    """NF4 (4-bit) GDN in-projection block. ``base_dtype`` (set before quantizing) becomes
+    quant_state.dtype — bf16 is the common QLoRA path; fp32 exercises the fp32 NF4 dequant
+    kernel, which used to fall through to the bf16 kernel and dequant to garbage."""
+    bnb = pytest.importorskip("bitsandbytes")
+
+    class _Block(nn.Module):
+        def __init__(self):
+            super().__init__()
+            for name, out_features in _GDN_IN_SIZES.items():
+                setattr(
+                    self,
+                    name,
+                    bnb.nn.Linear4bit(
+                        in_features,
+                        out_features,
+                        bias=False,
+                        compute_dtype=torch.bfloat16,
+                        quant_type="nf4",
+                    ),
+                )
+
+    block = get_peft_model(
+        _Block().to(base_dtype).to("cuda"),
+        LoraConfig(r=16, lora_alpha=32, target_modules=list(targets), lora_dropout=0.0),
+    ).base_model.model
+    block.train()
+    with torch.no_grad():
+        for name, param in block.named_parameters():
+            if "lora_B" in name:
+                param.add_(torch.randn_like(param) * 0.02)
+    return block
+
+
+@pytest.mark.parametrize("base_dtype", [torch.bfloat16, torch.float32])
+def test_apply_lora_gdn_in_proj_matches_peft_nf4(base_dtype):
+    """QLoRA (NF4 4-bit base, W_quant dequant path) fused in-projection matches peft for
+    both bf16 and fp32 quant_state. The committed parity tests only cover unquantized bf16."""
+    targets = ("in_proj_qkv", "in_proj_b")  # one large + one starved; rest base-only
+    block = _wrapped_gdn_block_nf4(targets, base_dtype=base_dtype)
+    out_ref, gx_ref, ga_ref = _run_gdn_block(block, fused=False, targets=targets)
+    out_fused, gx_fused, ga_fused = _run_gdn_block(block, fused=True, targets=targets)
+
+    for name in _GDN_IN_SIZES:
+        assert _gdn_rel_l2(out_fused[name], out_ref[name]) < 5e-3
+    assert _gdn_rel_l2(gx_fused, gx_ref) < 1e-2
+    for name in targets:
+        assert _gdn_rel_l2(ga_fused[name], ga_ref[name]) < 5e-3
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Description
Follow-up hardening for the fused GatedDeltaNet LoRA routing (#3732).

**fp32 NF4 dequant (root fix, all fused kernels).** `_ctypes_nf4_dequant` ran
the **bf16** NF4 kernel for any non-fp16 output dtype while allocating the
output buffer as the requested dtype — so an fp32 `quant_state` dequantized to
garbage (bf16 kernel writing 2-byte values into fp32 slots). Wired in bnb's
native `cdequantize_blockwise_fp32_nf4` via a per-dtype dispatch. This is
subsystem-wide: every fused kernel that calls `dequantize` was affected, not
just GDN.

**GDN kernel cleanups.**
- `LoRA_FusedProj.backward`: drop a dead reshape; cast the dequantized base
  weight to the grad dtype before the shared in-place `grad_X` accumulate
  (an fp32 `quant_state` otherwise mismatches the bf16 accumulator).
- `find_linear_attn_in_layer`: require all four canonical in-projections, so a
  partial/non-canonical GDN mixer cleanly falls back to peft instead of
  erroring downstream.

## How has this been tested?
RTX PRO 6000 (Blackwell).
- `dequantize` bit-exact vs `bnb.functional.dequantize_4bit` for fp16/bf16/fp32,
  direct + transposed, eager + `torch.compile` (rel-L2 = 0).
- fp32 `quant_state` end-to-end (`apply_lora_o` + fused GDN, fwd+bwd) matches
  peft to bf16 noise; fp16/bf16 paths unchanged.
- Suites: `test_quantize.py` 9 · GDN patched 36 · `test_lora_features.py` 44.
- New tests: dtype-parametrized dequant parity; NF4 GDN parity over bf16 + fp32
  `quant_state`; partial-detection guard.

## Types of changes
- [x] Bug fix (fp32 NF4 dequant; non-breaking)
- [x] New tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded 4-bit dequantization support to include additional output precision options, including `float32`.

* **Bug Fixes**
  * Improved gradient stability for fused LoRA paths by keeping tensor types aligned during backward passes.
  * Tightened LoRA kernel selection so partial module matches no longer trigger fused handling, reducing incorrect fallback behavior.

* **Tests**
  * Added end-to-end coverage for dequantization across multiple dtypes and transposed inputs.
  * Added parity checks for fused LoRA behavior against the reference path, including NF4 scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->