### PR TITLE
fix(lora): make fused LoRA backward torch.compile traceable

### DIFF
--- a/src/axolotl/kernels/lora.py
+++ b/src/axolotl/kernels/lora.py
@@ -472,7 +472,6 @@ class LoRA_MLP(torch.autograd.Function):
         ctx.weights = (gate_weight, up_weight, down_weight)
         ctx.activation_fn = activation_fn
         ctx.activation_fn_backward = activation_fn_backward
-        ctx.inplace = inplace
         ctx.has_dropout = has_dropout
         ctx.has_dora = has_dora
 
@@ -639,10 +638,8 @@ class LoRA_MLP(torch.autograd.Function):
         if ctx.needs_input_grad[0]:
             # Base path gradients through gate and up
             up_weight_deq = dequantize(up_weight.t(), up_quant)
-            if ctx.inplace:
-                dX = torch.matmul(grad_up, up_weight_deq.t(), out=X)
-            else:
-                dX = torch.matmul(grad_up, up_weight_deq.t())
+            # writing into saved X is untraceable when X is another Function's view output
+            dX = torch.matmul(grad_up, up_weight_deq.t())
             del up_weight_deq
 
             gate_weight_deq = dequantize(gate_weight, gate_quant)
@@ -985,7 +982,6 @@ class LoRA_QKV(torch.autograd.Function):
         ctx.scales = (q_scale, k_scale, v_scale)
         ctx.quants = (q_quant, k_quant, v_quant)
         ctx.weights = (q_weight, k_weight, v_weight)
-        ctx.inplace = inplace
         ctx.has_dropout = has_dropout
         ctx.has_dora = has_dora
 
@@ -1100,7 +1096,7 @@ class LoRA_QKV(torch.autograd.Function):
         # Initialize LoRA gradients as None
         d_A_q = d_B_q = d_A_k = d_B_k = d_A_v = d_B_v = None
 
-        # Compute LoRA gradients using X_lora (before any inplace ops on X)
+        # Compute LoRA gradients using X_lora
         # A_q, B_q etc. are already in compute dtype (converted in forward)
         # Key optimization: compute grad @ B once, reuse for both dA and dX_lora
         # A has shape [rank, in], B has shape [out, rank]
@@ -1127,11 +1123,9 @@ class LoRA_QKV(torch.autograd.Function):
             d_A_v.addmm_(X_lora_t, grad_B_v, alpha=v_scale, beta=0)
             d_B_v.addmm_(A_v @ X_lora_t, v_grad, alpha=v_scale, beta=0)
 
-        # Base path input gradient (can use inplace on X since X_lora refs are done)
-        out_buffer = X if ctx.inplace else None
-
+        # writing into saved X is untraceable when X is another Function's view output
         q_weight_t = dequantize(q_weight, q_quant)
-        grad_X = torch.mm(q_grad, q_weight_t, out=out_buffer)
+        grad_X = torch.mm(q_grad, q_weight_t)
         del q_weight_t
 
         k_weight_t = dequantize(k_weight, k_quant)
@@ -1421,7 +1415,6 @@ class LoRA_QK(torch.autograd.Function):
         ctx.scales = (q_scale, k_scale)
         ctx.quants = (q_quant, k_quant)
         ctx.weights = (q_weight, k_weight)
-        ctx.inplace = inplace
         ctx.has_dropout = has_dropout
         ctx.has_dora = has_dora
 
@@ -1516,11 +1509,9 @@ class LoRA_QK(torch.autograd.Function):
             d_A_k.addmm_(X_lora_t, grad_B_k, alpha=k_scale, beta=0)
             d_B_k.addmm_(A_k @ X_lora_t, k_grad, alpha=k_scale, beta=0)
 
-        # Base path input gradient
-        out_buffer = X if ctx.inplace else None
-
+        # writing into saved X is untraceable when X is another Function's view output
         q_weight_t = dequantize(q_weight, q_quant)
-        grad_X = torch.mm(q_grad, q_weight_t, out=out_buffer)
+        grad_X = torch.mm(q_grad, q_weight_t)
         del q_weight_t
 
         k_weight_t = dequantize(k_weight, k_quant)

--- a/src/axolotl/kernels/lora.py
+++ b/src/axolotl/kernels/lora.py
@@ -1096,7 +1096,6 @@ class LoRA_QKV(torch.autograd.Function):
         # Initialize LoRA gradients as None
         d_A_q = d_B_q = d_A_k = d_B_k = d_A_v = d_B_v = None
 
-        # Compute LoRA gradients using X_lora
         # A_q, B_q etc. are already in compute dtype (converted in forward)
         # Key optimization: compute grad @ B once, reuse for both dA and dX_lora
         # A has shape [rank, in], B has shape [out, rank]

--- a/tests/e2e/kernels/test_lora.py
+++ b/tests/e2e/kernels/test_lora.py
@@ -18,6 +18,8 @@ from axolotl.kernels.lora import (
 )
 from axolotl.kernels.swiglu import swiglu_backward, swiglu_forward
 
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
 
 @pytest.fixture
 def mock_quantstate():

--- a/tests/e2e/kernels/test_lora.py
+++ b/tests/e2e/kernels/test_lora.py
@@ -585,3 +585,133 @@ def test_inplace_operations(sample_tensors, apply_function):
     out2 = apply_function(mlp, X.clone(), inplace=False)
 
     assert torch.allclose(out1, out2, rtol=1e-3)
+
+
+class ViewOutputFunction(torch.autograd.Function):
+    """Returns a view created inside the Function, like liger RMSNorm does."""
+
+    @staticmethod
+    def forward(ctx, x):
+        flat = x.reshape(-1, x.shape[-1])
+        return (flat * 1.0).view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output
+
+
+def _qkv_params(hidden, rank):
+    torch.manual_seed(42)
+    weights = [
+        torch.randn(hidden, hidden, device="cuda", dtype=torch.float16) * 0.02
+        for _ in range(3)
+    ]
+    adapters = [
+        (
+            torch.randn(
+                rank, hidden, device="cuda", dtype=torch.float16, requires_grad=True
+            ),
+            torch.randn(
+                hidden, rank, device="cuda", dtype=torch.float16, requires_grad=True
+            ),
+        )
+        for _ in range(3)
+    ]
+    return weights, adapters
+
+
+def test_backward_does_not_mutate_saved_activation():
+    """Input gradient must not be written into the saved activation buffer."""
+    hidden, rank = 64, 8
+    (q_w, k_w, v_w), ((q_a, q_b), (k_a, k_b), (v_a, v_b)) = _qkv_params(hidden, rank)
+    X = torch.randn(
+        2, 3, hidden, device="cuda", dtype=torch.float16, requires_grad=True
+    )
+
+    h = ViewOutputFunction.apply(X)
+    h_before = h.detach().clone()
+    q, k, v = LoRA_QKV.apply(
+        h,
+        None,
+        q_w,
+        None,
+        None,
+        q_a,
+        q_b,
+        1.0,
+        None,
+        None,
+        k_w,
+        None,
+        None,
+        k_a,
+        k_b,
+        1.0,
+        None,
+        None,
+        v_w,
+        None,
+        None,
+        v_a,
+        v_b,
+        1.0,
+        None,
+        None,
+        True,
+    )
+    (q.float().sum() + k.float().sum() + v.float().sum()).backward()
+
+    assert torch.equal(h.detach(), h_before)
+
+
+def test_qkv_compile_traceable_with_view_input():
+    """LoRA_QKV must trace under fullgraph compile when its input is a custom-Function view."""
+    hidden, rank = 64, 8
+    (q_w, k_w, v_w), ((q_a, q_b), (k_a, k_b), (v_a, v_b)) = _qkv_params(hidden, rank)
+    X = torch.randn(
+        2, 3, hidden, device="cuda", dtype=torch.float16, requires_grad=True
+    )
+
+    def fn(x):
+        h = ViewOutputFunction.apply(x)
+        return LoRA_QKV.apply(
+            h,
+            None,
+            q_w,
+            None,
+            None,
+            q_a,
+            q_b,
+            1.0,
+            None,
+            None,
+            k_w,
+            None,
+            None,
+            k_a,
+            k_b,
+            1.0,
+            None,
+            None,
+            v_w,
+            None,
+            None,
+            v_a,
+            v_b,
+            1.0,
+            None,
+            None,
+            True,
+        )
+
+    torch._dynamo.reset()
+    suppress_prior = torch._dynamo.config.suppress_errors
+    torch._dynamo.config.suppress_errors = False
+    try:
+        q, k, v = torch.compile(fn, fullgraph=True)(X)
+        (q.float().sum() + k.float().sum() + v.float().sum()).backward()
+    finally:
+        torch._dynamo.config.suppress_errors = suppress_prior
+        torch._dynamo.reset()
+
+    assert X.grad is not None

--- a/tests/e2e/kernels/test_lora.py
+++ b/tests/e2e/kernels/test_lora.py
@@ -9,6 +9,7 @@ from axolotl.kernels.geglu import geglu_backward, geglu_forward
 from axolotl.kernels.lora import (
     LoRA_MLP,
     LoRA_O,
+    LoRA_QK,
     LoRA_QKV,
     apply_lora_mlp_geglu,
     apply_lora_mlp_swiglu,
@@ -600,66 +601,44 @@ class ViewOutputFunction(torch.autograd.Function):
         return grad_output
 
 
-def _qkv_params(hidden, rank):
+def _fused_kernel_args(kernel, hidden, rank):
     torch.manual_seed(42)
-    weights = [
-        torch.randn(hidden, hidden, device="cuda", dtype=torch.float16) * 0.02
-        for _ in range(3)
-    ]
-    adapters = [
-        (
-            torch.randn(
-                rank, hidden, device="cuda", dtype=torch.float16, requires_grad=True
-            ),
-            torch.randn(
-                hidden, rank, device="cuda", dtype=torch.float16, requires_grad=True
-            ),
+    n_proj = {"qkv": 3, "qk": 2, "mlp": 3}[kernel]
+    args = []
+    for _ in range(n_proj):
+        weight = torch.randn(hidden, hidden, device="cuda", dtype=torch.float16) * 0.02
+        lora_a = torch.randn(
+            rank, hidden, device="cuda", dtype=torch.float16, requires_grad=True
         )
-        for _ in range(3)
-    ]
-    return weights, adapters
+        lora_b = torch.randn(
+            hidden, rank, device="cuda", dtype=torch.float16, requires_grad=True
+        )
+        args += [weight, None, None, lora_a, lora_b, 1.0, None, None]
+    return args
 
 
-def test_backward_does_not_mutate_saved_activation():
+def _apply_fused_kernel(kernel, h, proj_args):
+    if kernel == "qkv":
+        return LoRA_QKV.apply(h, None, *proj_args, True)
+    if kernel == "qk":
+        return LoRA_QK.apply(h, None, *proj_args, True)
+    return LoRA_MLP.apply(h, None, *proj_args, swiglu_forward, swiglu_backward, True)
+
+
+@pytest.mark.parametrize("kernel", ["qkv", "qk", "mlp"])
+def test_backward_does_not_mutate_saved_activation(kernel):
     """Input gradient must not be written into the saved activation buffer."""
     hidden, rank = 64, 8
-    (q_w, k_w, v_w), ((q_a, q_b), (k_a, k_b), (v_a, v_b)) = _qkv_params(hidden, rank)
+    proj_args = _fused_kernel_args(kernel, hidden, rank)
     X = torch.randn(
         2, 3, hidden, device="cuda", dtype=torch.float16, requires_grad=True
     )
 
     h = ViewOutputFunction.apply(X)
     h_before = h.detach().clone()
-    q, k, v = LoRA_QKV.apply(
-        h,
-        None,
-        q_w,
-        None,
-        None,
-        q_a,
-        q_b,
-        1.0,
-        None,
-        None,
-        k_w,
-        None,
-        None,
-        k_a,
-        k_b,
-        1.0,
-        None,
-        None,
-        v_w,
-        None,
-        None,
-        v_a,
-        v_b,
-        1.0,
-        None,
-        None,
-        True,
-    )
-    (q.float().sum() + k.float().sum() + v.float().sum()).backward()
+    out = _apply_fused_kernel(kernel, h, proj_args)
+    outputs = out if isinstance(out, tuple) else (out,)
+    sum(o.float().sum() for o in outputs).backward()
 
     assert torch.equal(h.detach(), h_before)
 
@@ -667,42 +646,14 @@ def test_backward_does_not_mutate_saved_activation():
 def test_qkv_compile_traceable_with_view_input():
     """LoRA_QKV must trace under fullgraph compile when its input is a custom-Function view."""
     hidden, rank = 64, 8
-    (q_w, k_w, v_w), ((q_a, q_b), (k_a, k_b), (v_a, v_b)) = _qkv_params(hidden, rank)
+    proj_args = _fused_kernel_args("qkv", hidden, rank)
     X = torch.randn(
         2, 3, hidden, device="cuda", dtype=torch.float16, requires_grad=True
     )
 
     def fn(x):
         h = ViewOutputFunction.apply(x)
-        return LoRA_QKV.apply(
-            h,
-            None,
-            q_w,
-            None,
-            None,
-            q_a,
-            q_b,
-            1.0,
-            None,
-            None,
-            k_w,
-            None,
-            None,
-            k_a,
-            k_b,
-            1.0,
-            None,
-            None,
-            v_w,
-            None,
-            None,
-            v_a,
-            v_b,
-            1.0,
-            None,
-            None,
-            True,
-        )
+        return LoRA_QKV.apply(h, None, *proj_args, True)
 
     torch._dynamo.reset()
     suppress_prior = torch._dynamo.config.suppress_errors


### PR DESCRIPTION
# Description

`LoRA_MLP`/`LoRA_QKV`/`LoRA_QK` backward wrote the input gradient into the saved activation (`torch.mm(..., out=X)` when `ctx.inplace`). Replaced with a fresh allocation at all three sites; the `inplace` params remain as no-ops for API compatibility.

## Motivation and Context

When `X` is a view created inside another custom autograd Function — e.g. liger RMSNorm returns `Y.view(*shape)` — dynamo refuses to trace the Function (`Output 0 of ApplyTemplateBackward is a view ... modified inplace`). With `lora_*_kernel: true` + `torch_compile: true` + `liger_rms_norm: true`, decoder layers silently fragment into small graphs (gradient checkpointing off) or are evicted from compilation entirely (checkpointing on), since axolotl sets `torch._dynamo.config.suppress_errors = True`. The aliasing also corrupted the saved activation for any second backward with `retain_graph=True` (no-dropout path: `X_lora` is `X`).

## How has this been tested?

torch 2.12.0+cu130, transformers 5.9.0, RTX 3090:
- liger RMSNorm → `LoRA_QKV` topology now compiles `fullgraph=True` with zero graph breaks (previously raised the ApplyTemplateBackward error verbatim); whole-layer graphs restored in both checkpointing modes (was 4 fragments + 1 failed frame / total eviction).
- Test suites: `tests/e2e/kernels/` 81 passed; fused-attn monkeypatch tests 31 passed; `tests/e2e/patched/lora_kernels/test_lora_kernel_patching.py` 15 passed.
- New regression tests: saved-activation non-mutation parameterized across all three kernels + fullgraph traceability with a custom-Function-view input — all fail on main without this fix.
- Smoke: 2×10-step SmolLM2-135M LoRA runs (`lora_qkv/o/mlp_kernel` + `torch_compile` + `liger_rms_norm`, dropout 0.05 and 0.0 — the latter exercising the patched `LlamaAttention` QKV/O path): zero dynamo errors, sane loss, compiled grads match eager.

Note: this restores compile coverage but does not work around the separate torch 2.12 inductor bug pytorch/pytorch#181735 (liger in-place triton backwards under dynamic shapes; fixed in torch 2.13).

Unrelated observation, out of scope here: `PatchManager` still gates the attention kernel patch on `lora_dropout == 0` (`patch_manager.py:700`, from #2772, 2025-06), but the fused Functions gained dropout support in #3528 (2026-03, applied outside the Function with a shared QKV mask) — so with `lora_dropout > 0` the QKV/O kernels are silently skipped despite working. Happy to lift the gate in a follow-up PR.

## AI Usage Disclaimer

Yes — Claude Code (diagnosis, fix, and tests; human-reviewed).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA backward behavior so gradients no longer attempt to write into saved or view-based inputs.
  * Fixed a tracing issue so LoRA kernels work correctly with `torch.compile` on view outputs.
  * Added coverage to ensure backpropagation does not mutate saved activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->