### PR TITLE
fix: improve validation error for jinja chat template

### DIFF
--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1295,7 +1295,8 @@ class ChatTemplateValidationMixin:
             "chat_template_jinja"
         ):
             raise ValueError(
-                "chat_template_jinja is required when chat_template is set to jinja"
+                "chat_template_jinja is required when chat_template is set to 'jinja'. "
+                "Please provide the Jinja template string in chat_template_jinja field."
             )
 
         # If chat_template_jinja is set, set chat_template to jinja


### PR DESCRIPTION
## Summary
Improve validation error message for jinja chat template configuration to provide clearer guidance.

## Changes
- Enhanced ValueError message in `validation.py` to clarify that `chat_template_jinja` requires the actual template string
- Added actionable guidance for users to understand what needs to be provided
- Improves user experience when configuring jinja-based chat templates

## Motivation
When users set `chat_template: jinja` without providing `chat_template_jinja`, the error message should clearly explain what's needed. This change makes the error more helpful and reduces confusion.

## Testing
- [x] Code follows the project's coding standards
- [x] No new dependencies added
- [x] Error message is clear and actionable
- [x] Change is minimal and focused


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the validation error shown when a chat template is configured incorrectly, making the message clearer and easier to read.
  * No validation behavior changed; only the displayed error text was adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->