### PR TITLE
fix(pretrain): use non-overlapping chunking so BOS/EOS appear only at true document boundaries

### DIFF
--- a/src/axolotl/prompt_strategies/pretrain.py
+++ b/src/axolotl/prompt_strategies/pretrain.py
@@ -30,23 +30,44 @@ class PretrainTokenizationStrategy(PromptTokenizingStrategy):
     def _tokenize(
         self, prompt: str, add_eos_token: bool = True, strip_bos_token: bool = False
     ) -> BatchEncoding:
-        # keep the overlap below the window size so small sequence_len values don't
-        # violate the tokenizer's `stride < effective max_length` constraint
-        stride = min(256, (self.max_length - 1) // 2)
-        res = self.tokenizer(
+        # Tokenise the full document first (large max_length mirrors completion.py),
+        # then split into non-overlapping chunks.  This ensures BOS appears only at
+        # the start of the first chunk and EOS only at the end of the last chunk,
+        # matching the token distribution produced by `type: completion`.
+        result = self.tokenizer(
             prompt,
             truncation=True,
-            max_length=self.max_length - 1,
-            add_special_tokens=True,
-            return_overflowing_tokens=True,
-            stride=stride,
+            max_length=self.max_length * 64,
+            padding=False,
+            return_tensors=None,
         )
-        res["input_ids"] = [
-            seq + [self.tokenizer.eos_token_id] for seq in res["input_ids"]
-        ]
-        res["attention_mask"] = [seq + [1] for seq in res["attention_mask"]]
+        input_ids = result["input_ids"]
+        attention_mask = result["attention_mask"]
 
-        return res
+        if (
+            add_eos_token
+            and len(input_ids) > 0
+            and input_ids[-1] != self.tokenizer.eos_token_id
+            and len(input_ids) < self.max_length * 64
+        ):
+            input_ids.append(self.tokenizer.eos_token_id)
+            attention_mask.append(1)
+
+        chunked_input_ids = [
+            input_ids[i : i + self.max_length]
+            for i in range(0, len(input_ids), self.max_length)
+        ]
+        chunked_attention_mask = [
+            attention_mask[i : i + self.max_length]
+            for i in range(0, len(attention_mask), self.max_length)
+        ]
+
+        return BatchEncoding(
+            data={
+                "input_ids": chunked_input_ids,
+                "attention_mask": chunked_attention_mask,
+            }
+        )
 
     def tokenize_prompt(self, prompt):
         return self._tokenize(prompt[self.text_column])
@@ -59,8 +80,6 @@ def load(tokenizer, cfg):
         cfg.train_on_inputs,
         cfg.sequence_len,
         text_column=cfg.pretraining_dataset[0]["text_column"] or "text",
-        # windows; larger values produce windows that the downstream
-        # `filter_sequences_by_length` drops wholesale
         max_length=cfg.sequence_len,
     )
     return strat

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -71,48 +71,55 @@ class TestEncodePretraining(unittest.TestCase):
         return load_pretrain(self.tokenizer, cfg)
 
     def test_long_document_is_chunked_not_dropped(self):
-        """Long docs must be chunked into windows that survive the length filter (#3441)."""
+        """Long docs must be chunked into chunks that survive the length filter (#3441)."""
         for sequence_len in (256, 512, 2048):
             with self.subTest(sequence_len=sequence_len):
                 strat = self._pretrain_strategy(sequence_len)
                 long_doc = " ".join(f"token{i}" for i in range(4 * sequence_len))
-                windows = strat._tokenize(long_doc)["input_ids"]
+                chunks = strat._tokenize(long_doc)["input_ids"]
 
-                # the document spans more than one window (i.e. it was chunked)
-                self.assertGreater(len(windows), 1)
+                # the document spans more than one chunk (i.e. it was chunked)
+                self.assertGreater(len(chunks), 1)
 
-                for window in windows:
-                    # every window survives the downstream length filter ...
-                    self.assertLessEqual(len(window), sequence_len)
+                for chunk in chunks:
+                    # every chunk survives the downstream length filter
+                    self.assertLessEqual(len(chunk), sequence_len)
                     self.assertTrue(
                         filter_sequences_by_length(
-                            {"input_ids": window}, sequence_len=sequence_len
+                            {"input_ids": chunk}, sequence_len=sequence_len
                         )
                     )
-                    # ... and ends with EOS
-                    self.assertEqual(window[-1], self.tokenizer.eos_token_id)
+
+                # BOS only at the very start of the document (first chunk)
+                self.assertEqual(chunks[0][0], self.tokenizer.bos_token_id)
+                for chunk in chunks[1:]:
+                    self.assertNotEqual(chunk[0], self.tokenizer.bos_token_id)
+
+                # EOS only at the very end of the document (last chunk)
+                self.assertEqual(chunks[-1][-1], self.tokenizer.eos_token_id)
+                for chunk in chunks[:-1]:
+                    self.assertNotEqual(chunk[-1], self.tokenizer.eos_token_id)
 
     def test_no_tokens_dropped_for_oversized_docs(self):
         """A doc longer than sequence_len must not be dropped entirely (#3441)."""
         sequence_len = 256
         strat = self._pretrain_strategy(sequence_len)
         long_doc = " ".join(f"token{i}" for i in range(2000))
-        windows = strat._tokenize(long_doc)["input_ids"]
+        chunks = strat._tokenize(long_doc)["input_ids"]
 
         kept = [
             w
-            for w in windows
+            for w in chunks
             if filter_sequences_by_length({"input_ids": w}, sequence_len=sequence_len)
         ]
-        self.assertTrue(kept, "all windows were dropped — oversized doc lost entirely")
-        self.assertEqual(len(kept), len(windows))
+        self.assertTrue(kept, "all chunks were dropped — oversized doc lost entirely")
+        self.assertEqual(len(kept), len(chunks))
 
-    def test_stride_below_window_size(self):
-        """Tokenization must not raise from a stride >= effective max length."""
+    def test_long_document_tokenization_does_not_raise(self):
+        """Tokenising a document much longer than sequence_len must not raise."""
         for sequence_len in (256, 2048):
             with self.subTest(sequence_len=sequence_len):
                 strat = self._pretrain_strategy(sequence_len)
-                # would raise ValueError from the tokenizer if stride were too large
                 strat._tokenize(" ".join(f"token{i}" for i in range(sequence_len * 3)))
 
     def test_md5(self):


### PR DESCRIPTION
When `pretraining_dataset: type: pretrain` is used, `PretrainTokenizationStrategy._tokenize()` was calling the HuggingFace tokenizer with `return_overflowing_tokens=True`, a stride of `min(256, (seq_len-1)//2)`, and `add_special_tokens=True`. This caused two bugs that together produced a substantially different initial loss compared to `type: completion` on the same data:

1. **Spurious BOS on every sliding window.** Because `return_overflowing_tokens=True` re-wraps each window as an independent sequence, `add_special_tokens=True` injected a BOS token at the start of *every* window—including mid-document windows. A model that is trained to predict the first token after BOS saw an abnormally high density of BOS tokens in the training stream.

2. **EOS appended to every window.** The code appended `eos_token_id` unconditionally to every window, so mid-document windows were framed as `[BOS, …content…, EOS]` regardless of whether they were actually at a document boundary.

3. **Overlapping tokens.** Each window shared `stride` tokens with the next window, so some tokens were seen twice per document pass, changing the effective token distribution.

`type: completion` (`CompletionPromptTokenizingStrategy`) tokenises each document with a large `max_length` and then chunks non-overlappingly, so BOS appears only at the start of the first chunk and EOS only at the end of the last chunk. The pretrain strategy now mirrors this exactly.

**Change:** Replace the stride-based sliding-window tokenisation with the same approach used by `completion.py`: tokenise the full document (up to `sequence_len * 64` tokens, same cap as `completion.py`), optionally append EOS if the document was not truncated, then split into non-overlapping chunks of `sequence_len`. BOS and EOS appear exactly once, at the true document boundaries.

The tests in `test_data.py` that validated the old per-window EOS behaviour are updated to assert the correct invariants (BOS on first chunk only, EOS on last chunk only). The old `test_stride_below_window_size` is renamed to `test_long_document_tokenization_does_not_raise` to reflect what it is actually testing now that there is no stride.

Fixes #3441

**Testing:**
- Updated unit tests in `tests/test_data.py` (`TestEncodePretraining`) cover: non-overlapping chunking of long documents, BOS/EOS boundary invariants, no token drops, and no exception on very long documents.
- Tests require PyTorch + a cached HuggingFace tokenizer (`huggyllama/llama-7b`) and cannot be run in a CPU-only environment without those dependencies—see NOTES.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pretraining tokenization for long documents so text is chunked more reliably and no longer depends on overflow/stride behavior.
  * Preserved document endings more accurately: only the final chunk now carries the end-of-sequence marker, while the first chunk keeps the start marker.
  * Updated pretraining handling so oversized inputs are split into length-safe chunks without dropping content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->