### PR TITLE
add torch 2.13 to base image build

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -55,11 +55,19 @@ jobs:
             torch_cuda_arch_list: "9.0 10.0 10.3 12.0+PTX"
             dockerfile: "Dockerfile-uv-base"
             platforms: "linux/amd64,linux/arm64"
+          - cuda: "130"
+            cuda_version: 13.0.0
+            cudnn_version: ""
+            python_version: "3.12"
+            pytorch: 2.13.0
+            torch_cuda_arch_list: "9.0 10.0 10.3 12.0+PTX"
+            dockerfile: "Dockerfile-uv-base"
+            platforms: "linux/amd64,linux/arm64"
           - cuda: "132"
             cuda_version: 13.2.1
             cudnn_version: ""
             python_version: "3.12"
-            pytorch: 2.12.1
+            pytorch: 2.13.0
             torch_index_url: "https://download.pytorch.org/whl/cu132"
             torch_cuda_arch_list: "9.0 10.0 10.3 12.0+PTX"
             dockerfile: "Dockerfile-uv-base"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded build coverage to include additional container images for PyTorch 2.13.0 with CUDA 13.0 and CUDA 13.2 on Python 3.12.
  * Added support for multi-architecture builds across Linux x86_64 and ARM64 for these new combinations.

* **Bug Fixes**
  * Replaced an older CUDA 13.2 build combination with the newer PyTorch 2.13.0 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->