### PR TITLE
fix: do not force trust remote code during preprocess

### DIFF
--- a/src/axolotl/cli/preprocess.py
+++ b/src/axolotl/cli/preprocess.py
@@ -80,14 +80,15 @@ def do_preprocess(cfg: DictDefault, cli_args: PreprocessCliArgs) -> None:
             # "copying from a non-meta parameter in the checkpoint to a meta parameter in the current model"
             warnings.simplefilter("ignore")
             with init_empty_weights(include_buffers=True):
-                # fmt: off
                 try:
                     AutoModelForCausalLM.from_pretrained(
-                        model_name, trust_remote_code=True
+                        model_name,
+                        trust_remote_code=cfg.trust_remote_code or False,
                     )
-                except Exception:  # nosec B110
-                    pass
-                # fmt: on
+                except Exception as exc:
+                    LOG.warning(
+                        f"Skipping model pre-download for `{model_name}`: {exc}"
+                    )
 
     LOG.info(
         Fore.GREEN

--- a/tests/cli/test_cli_preprocess.py
+++ b/tests/cli/test_cli_preprocess.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from axolotl.cli.args import PreprocessCliArgs
 from axolotl.cli.main import cli
+from axolotl.cli.preprocess import do_preprocess
+from axolotl.utils.dict import DictDefault
 
 
 @pytest.fixture(autouse=True)
@@ -76,3 +79,33 @@ def test_preprocess_custom_path(cli_runner, tmp_path, valid_test_config):
             assert mock_do_cli.call_args.kwargs["dataset_prepared_path"] == str(
                 custom_path.absolute()
             )
+
+
+@pytest.mark.parametrize(
+    "trust_remote_code, expected",
+    [(None, False), (False, False), (True, True)],
+)
+def test_preprocess_download_respects_trust_remote_code(trust_remote_code, expected):
+    """The --download pre-fetch must honor cfg.trust_remote_code, not hardcode True."""
+    cfg = DictDefault(
+        base_model="hf-internal-testing/tiny-random-gpt2",
+        dataset_prepared_path="last_run_prepared",
+        trust_remote_code=trust_remote_code,
+    )
+    cli_args = PreprocessCliArgs(download=True)
+
+    with (
+        patch("axolotl.cli.preprocess.check_accelerate_default_config"),
+        patch("axolotl.cli.preprocess.check_user_token"),
+        patch("axolotl.cli.preprocess.PluginManager") as mock_plugin_manager,
+        patch("axolotl.cli.preprocess.load_datasets"),
+        patch("axolotl.cli.preprocess.AutoModelForCausalLM") as mock_auto_model,
+    ):
+        mock_plugin_manager.get_instance.return_value.load_datasets.return_value = False
+
+        do_preprocess(cfg, cli_args)
+
+    mock_auto_model.from_pretrained.assert_called_once()
+    call = mock_auto_model.from_pretrained.call_args
+    assert call.args[0] == cfg.base_model
+    assert call.kwargs["trust_remote_code"] is expected

--- a/tests/cli/test_cli_preprocess.py
+++ b/tests/cli/test_cli_preprocess.py
@@ -88,7 +88,7 @@ def test_preprocess_custom_path(cli_runner, tmp_path, valid_test_config):
 def test_preprocess_download_respects_trust_remote_code(trust_remote_code, expected):
     """The --download pre-fetch must honor cfg.trust_remote_code, not hardcode True."""
     cfg = DictDefault(
-        base_model="hf-internal-testing/tiny-random-gpt2",
+        base_model="HuggingFaceTB/SmolLM2-135M",
         dataset_prepared_path="last_run_prepared",
         trust_remote_code=trust_remote_code,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

During preprocess, we defaulted to trust remote code = True, when we should actually respect the config like in other areas.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->

Credit: Kenichi Kawaguchi for the report


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model pre-downloads now respect the configured remote-code trust setting.
  - Pre-download failures are handled gracefully with a warning, allowing preprocessing to continue.

- **Tests**
  - Added coverage to verify the configured trust setting is passed correctly during model downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->