### PR TITLE
feat(dpo): support tools and tool_calls in chat_template strategy

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template_utils.py
+++ b/src/axolotl/prompt_strategies/chat_template_utils.py
@@ -1,0 +1,198 @@
+"""
+Shared helpers for rendering OpenAI-format preference (chosen/rejected) messages
+via tokenizer chat templates.
+
+Reused across RL prompt strategies (DPO, ORPO, Bradley-Terry) so tool_calls,
+tools, and reasoning_content handling only needs to be implemented once.
+"""
+
+import json
+
+from axolotl.prompt_strategies.jinja_template_analyzer import JinjaTemplateAnalyzer
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+
+def parse_tools(tools):
+    """Parse tools into a list of dicts, decoding JSON-encoded strings."""
+    if tools is None:
+        return None
+
+    if isinstance(tools, str):
+        try:
+            tools = json.loads(tools)
+        except json.JSONDecodeError as e:
+            LOG.error(f"Error parsing tools as JSON. Error: {e}")
+            raise
+
+    if isinstance(tools, list):
+        parsed_tools = []
+        for tool in tools:
+            # some datasets store each tool as a JSON-encoded string
+            if isinstance(tool, str):
+                try:
+                    tool = json.loads(tool)
+                except json.JSONDecodeError as e:
+                    LOG.error(f"Error parsing tool as JSON. Tool: {tool!r}, Error: {e}")
+                    raise
+            if isinstance(tool, dict) and "function" in tool:
+                function = tool["function"]
+                params = function.get("parameters")
+                if isinstance(params, str):
+                    try:
+                        function["parameters"] = json.loads(params)
+                    except json.JSONDecodeError as e:
+                        LOG.error(
+                            f"Error parsing tool parameters as JSON. "
+                            f"Function: {function.get('name', 'unknown')}, "
+                            f"Parameters string: {params!r}, "
+                            f"Error: {e}"
+                        )
+                        raise
+            parsed_tools.append(tool)
+        return parsed_tools
+
+    raise ValueError(
+        "Unknown tools format. Please convert it into a list[dict].\n"
+        f"Current format: {type(tools)}"
+    )
+
+
+def parse_tool_call_arguments(message):
+    """Decode JSON-encoded tool call arguments so templates receive dicts."""
+    for tool_call in message.get("tool_calls") or []:
+        if "function" in tool_call and "arguments" in tool_call["function"]:
+            args = tool_call["function"]["arguments"]
+            if isinstance(args, str):
+                try:
+                    tool_call["function"]["arguments"] = json.loads(args)
+                except json.JSONDecodeError as e:
+                    LOG.error(
+                        f"Error parsing tool_calls arguments as JSON. "
+                        f"Function: {tool_call.get('function', {}).get('name', 'unknown')}, "
+                        f"Arguments string: {args!r}, "
+                        f"Error: {e}"
+                    )
+                    raise
+
+
+def build_message_transform(message_property_mappings, role_map):
+    """Build a function that maps a raw dataset message to a chat template message,
+    preserving any extra properties the chat template uses (e.g. tool_calls)."""
+
+    def transform_message(message, msg_variables):
+        """Map a raw dataset message to a chat template message."""
+        transformed = {}
+        for target, source in message_property_mappings.items():
+            value = message.get(source)
+            if value is not None:
+                transformed[target] = value
+
+        if "role" in transformed:
+            transformed["role"] = role_map.get(transformed["role"], transformed["role"])
+
+        mapped_sources = set(message_property_mappings.values())
+        for key in msg_variables - mapped_sources:
+            value = message.get(key)
+            if value is not None:
+                transformed[key] = value
+
+        parse_tool_call_arguments(transformed)
+        return transformed
+
+    return transform_message
+
+
+# always preserved: template analysis misses properties accessed via
+# `message.get(...)` (e.g. gemma4), so OpenAI message keys are unioned in
+BASE_MSG_VARIABLES = frozenset(
+    ["tool_calls", "tool_call_id", "name", "reasoning_content", "reasoning"]
+)
+
+
+def make_msg_variables_getter():
+    """Cache chat template message variable analysis per template string."""
+    cache = {}
+
+    def get_msg_variables(chat_template_string):
+        """Return the message properties used by the chat template."""
+        if chat_template_string not in cache:
+            cache[chat_template_string] = (
+                JinjaTemplateAnalyzer(chat_template_string).get_message_vars("messages")
+                | BASE_MSG_VARIABLES
+            )
+        return cache[chat_template_string]
+
+    return get_msg_variables
+
+
+DUMMY_USER_MESSAGE_CONTENT = "[[dummy_message]]"
+
+
+def extract_response(full, prompt_prefix, content):
+    """Strip the rendered dummy-user prompt from a response rendering.
+
+    Strips the longest common prefix rather than requiring an exact prefix
+    match, since a generation prompt can diverge slightly from the completed
+    message rendering (e.g. thinking templates open `<think>` with different
+    whitespace than a rendered `reasoning_content` block).
+    """
+    common = 0
+    for prefix_char, full_char in zip(prompt_prefix, full, strict=False):
+        if prefix_char != full_char:
+            break
+        common += 1
+    response = full[common:]
+    if DUMMY_USER_MESSAGE_CONTENT not in response:
+        return response.rstrip()
+    # Fallback: locate the response content directly
+    if content:
+        strip_index = full.find(content)
+        if strip_index != -1:
+            return full[strip_index:].rstrip()
+    return full.rstrip()
+
+
+def render_preference_sample(
+    tokenizer,
+    messages,
+    chosen,
+    rejected,
+    chat_template_string,
+    chat_template_kwargs,
+    tools,
+):
+    """Render the prompt and extract the chosen/rejected response strings."""
+    template_kwargs = {
+        "chat_template": chat_template_string,
+        "tokenize": False,
+        **chat_template_kwargs,
+    }
+    if tools:
+        template_kwargs["tools"] = tools
+
+    dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
+
+    result = {}
+    result["prompt"] = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+
+    dummy_prompt = tokenizer.apply_chat_template(
+        [dummy_user_message],
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+
+    for key, response in (("chosen", chosen), ("rejected", rejected)):
+        full = tokenizer.apply_chat_template(
+            [dummy_user_message, response],
+            add_generation_prompt=False,
+            **template_kwargs,
+        )
+        result[key] = extract_response(full, dummy_prompt, response.get("content"))
+
+    return result

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -150,6 +150,50 @@ def _extract_response(full, prompt_prefix, content):
     return full.rstrip()
 
 
+def _render_dpo_sample(
+    tokenizer,
+    messages,
+    chosen,
+    rejected,
+    chat_template_string,
+    chat_template_kwargs,
+    tools,
+):
+    """Render the prompt and extract the chosen/rejected response strings."""
+    template_kwargs = {
+        "chat_template": chat_template_string,
+        "tokenize": False,
+        **chat_template_kwargs,
+    }
+    if tools:
+        template_kwargs["tools"] = tools
+
+    dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
+
+    result = {}
+    result["prompt"] = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+
+    dummy_prompt = tokenizer.apply_chat_template(
+        [dummy_user_message],
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+
+    for key, response in (("chosen", chosen), ("rejected", rejected)):
+        full = tokenizer.apply_chat_template(
+            [dummy_user_message, response],
+            add_generation_prompt=False,
+            **template_kwargs,
+        )
+        result[key] = _extract_response(full, dummy_prompt, response.get("content"))
+
+    return result
+
+
 def default(cfg, dataset_idx=0, **kwargs):
     ds_cfg = cfg["datasets"][dataset_idx]
     ds_cfg = handle_legacy_message_fields_logic(ds_cfg)
@@ -229,49 +273,15 @@ def default(cfg, dataset_idx=0, **kwargs):
             rejected_msg = rejected_raw[-1]
         rejected = transform_message(rejected_msg, msg_variables)
 
-        dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
-
-        template_kwargs = {
-            "chat_template": chat_template_string,
-            "tokenize": False,
-            **chat_template_kwargs,
-        }
-        tools = _parse_tools(sample.get(field_tools))
-        if tools:
-            template_kwargs["tools"] = tools
-
-        result = {}
-        result["prompt"] = tokenizer.apply_chat_template(
+        return _render_dpo_sample(
+            tokenizer,
             messages,
-            add_generation_prompt=True,
-            **template_kwargs,
+            chosen,
+            rejected,
+            chat_template_string,
+            chat_template_kwargs,
+            _parse_tools(sample.get(field_tools)),
         )
-
-        dummy_prompt = tokenizer.apply_chat_template(
-            [dummy_user_message],
-            add_generation_prompt=True,
-            **template_kwargs,
-        )
-
-        chosen_full = tokenizer.apply_chat_template(
-            [dummy_user_message, chosen],
-            add_generation_prompt=False,
-            **template_kwargs,
-        )
-        result["chosen"] = _extract_response(
-            chosen_full, dummy_prompt, chosen.get("content")
-        )
-
-        rejected_full = tokenizer.apply_chat_template(
-            [dummy_user_message, rejected],
-            add_generation_prompt=False,
-            **template_kwargs,
-        )
-        result["rejected"] = _extract_response(
-            rejected_full, dummy_prompt, rejected.get("content")
-        )
-
-        return result
 
     return transform_fn, {"remove_columns": [field_messages, field_tools]}
 
@@ -357,48 +367,14 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
         chosen_response = transform_message(chosen_raw[-1], msg_variables)
         rejected_response = transform_message(rejected_raw[-1], msg_variables)
 
-        dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
-
-        template_kwargs = {
-            "chat_template": chat_template_string,
-            "tokenize": False,
-            **chat_template_kwargs,
-        }
-        tools = _parse_tools(sample.get(field_tools))
-        if tools:
-            template_kwargs["tools"] = tools
-
-        result = {}
-        result["prompt"] = tokenizer.apply_chat_template(
+        return _render_dpo_sample(
+            tokenizer,
             chosen_messages,
-            add_generation_prompt=True,
-            **template_kwargs,
+            chosen_response,
+            rejected_response,
+            chat_template_string,
+            chat_template_kwargs,
+            _parse_tools(sample.get(field_tools)),
         )
-
-        dummy_prompt = tokenizer.apply_chat_template(
-            [dummy_user_message],
-            add_generation_prompt=True,
-            **template_kwargs,
-        )
-
-        chosen_full = tokenizer.apply_chat_template(
-            [dummy_user_message, chosen_response],
-            add_generation_prompt=False,
-            **template_kwargs,
-        )
-        result["chosen"] = _extract_response(
-            chosen_full, dummy_prompt, chosen_response.get("content")
-        )
-
-        rejected_full = tokenizer.apply_chat_template(
-            [dummy_user_message, rejected_response],
-            add_generation_prompt=False,
-            **template_kwargs,
-        )
-        result["rejected"] = _extract_response(
-            rejected_full, dummy_prompt, rejected_response.get("content")
-        )
-
-        return result
 
     return transform_fn, {"remove_columns": [field_chosen, field_rejected, field_tools]}

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -2,8 +2,152 @@
 DPO prompt strategies for using tokenizer chat templates.
 """
 
+import json
+
+from axolotl.prompt_strategies.jinja_template_analyzer import JinjaTemplateAnalyzer
 from axolotl.utils.chat_templates import extract_chat_template_args, get_chat_template
+from axolotl.utils.logging import get_logger
 from axolotl.utils.schemas.utils import handle_legacy_message_fields_logic
+
+LOG = get_logger(__name__)
+
+
+def _parse_tools(tools):
+    """Parse tools into a list of dicts, decoding JSON-encoded strings."""
+    if tools is None:
+        return None
+
+    if isinstance(tools, str):
+        try:
+            tools = json.loads(tools)
+        except json.JSONDecodeError as e:
+            LOG.error(f"Error parsing tools as JSON. Error: {e}")
+            raise
+
+    if isinstance(tools, list):
+        parsed_tools = []
+        for tool in tools:
+            # some datasets store each tool as a JSON-encoded string
+            if isinstance(tool, str):
+                try:
+                    tool = json.loads(tool)
+                except json.JSONDecodeError as e:
+                    LOG.error(f"Error parsing tool as JSON. Tool: {tool!r}, Error: {e}")
+                    raise
+            if isinstance(tool, dict) and "function" in tool:
+                function = tool["function"]
+                params = function.get("parameters")
+                if isinstance(params, str):
+                    try:
+                        function["parameters"] = json.loads(params)
+                    except json.JSONDecodeError as e:
+                        LOG.error(
+                            f"Error parsing tool parameters as JSON. "
+                            f"Function: {function.get('name', 'unknown')}, "
+                            f"Parameters string: {params!r}, "
+                            f"Error: {e}"
+                        )
+                        raise
+            parsed_tools.append(tool)
+        return parsed_tools
+
+    raise ValueError(
+        "Unknown tools format. Please convert it into a list[dict].\n"
+        f"Current format: {type(tools)}"
+    )
+
+
+def _parse_tool_call_arguments(message):
+    """Decode JSON-encoded tool call arguments so templates receive dicts."""
+    for tool_call in message.get("tool_calls") or []:
+        if "function" in tool_call and "arguments" in tool_call["function"]:
+            args = tool_call["function"]["arguments"]
+            if isinstance(args, str):
+                try:
+                    tool_call["function"]["arguments"] = json.loads(args)
+                except json.JSONDecodeError as e:
+                    LOG.error(
+                        f"Error parsing tool_calls arguments as JSON. "
+                        f"Function: {tool_call.get('function', {}).get('name', 'unknown')}, "
+                        f"Arguments string: {args!r}, "
+                        f"Error: {e}"
+                    )
+                    raise
+
+
+def _build_message_transform(message_property_mappings, role_map):
+    """Build a function that maps a raw dataset message to a chat template message,
+    preserving any extra properties the chat template uses (e.g. tool_calls)."""
+
+    def transform_message(message, msg_variables):
+        transformed = {}
+        for target, source in message_property_mappings.items():
+            value = message.get(source)
+            if value is not None:
+                transformed[target] = value
+
+        if "role" in transformed:
+            transformed["role"] = role_map.get(transformed["role"], transformed["role"])
+
+        mapped_sources = set(message_property_mappings.values())
+        for key in msg_variables - mapped_sources:
+            value = message.get(key)
+            if value is not None:
+                transformed[key] = value
+
+        _parse_tool_call_arguments(transformed)
+        return transformed
+
+    return transform_message
+
+
+# always preserved: template analysis misses properties accessed via
+# `message.get(...)` (e.g. gemma4), so OpenAI message keys are unioned in
+_BASE_MSG_VARIABLES = frozenset(
+    ["tool_calls", "tool_call_id", "name", "reasoning_content", "reasoning"]
+)
+
+
+def _make_msg_variables_getter():
+    """Cache chat template message variable analysis per template string."""
+    cache = {}
+
+    def get_msg_variables(chat_template_string):
+        if chat_template_string not in cache:
+            cache[chat_template_string] = (
+                JinjaTemplateAnalyzer(chat_template_string).get_message_vars("messages")
+                | _BASE_MSG_VARIABLES
+            )
+        return cache[chat_template_string]
+
+    return get_msg_variables
+
+
+DUMMY_USER_MESSAGE_CONTENT = "[[dummy_message]]"
+
+
+def _extract_response(full, prompt_prefix, content):
+    """Strip the rendered dummy-user prompt from a response rendering.
+
+    Strips the longest common prefix rather than requiring an exact prefix
+    match, since a generation prompt can diverge slightly from the completed
+    message rendering (e.g. thinking templates open `<think>` with different
+    whitespace than a rendered `reasoning_content` block).
+    """
+    common = 0
+    for prefix_char, full_char in zip(prompt_prefix, full, strict=False):
+        if prefix_char != full_char:
+            break
+        common += 1
+    response = full[common:]
+    if DUMMY_USER_MESSAGE_CONTENT not in response:
+        return response.rstrip()
+    # Fallback: locate the response content directly
+    if content:
+        strip_index = full.find(content)
+        if strip_index != -1:
+            return full[strip_index:].rstrip()
+    return full.rstrip()
 
 
 def default(cfg, dataset_idx=0, **kwargs):
@@ -16,6 +160,8 @@ def default(cfg, dataset_idx=0, **kwargs):
     field_messages = ds_cfg.get("field_messages", "messages")
     field_chosen = ds_cfg.get("field_chosen", "chosen")
     field_rejected = ds_cfg.get("field_rejected", "rejected")
+    field_tools = ds_cfg.get("field_tools", "tools")
+    chat_template_kwargs = cfg.get("chat_template_kwargs") or {}
     message_property_mappings = ds_cfg.get(
         "message_property_mappings",
         {
@@ -37,12 +183,16 @@ def default(cfg, dataset_idx=0, **kwargs):
         for source in sources:
             role_map[source] = target
 
+    transform_message = _build_message_transform(message_property_mappings, role_map)
+    get_msg_variables = _make_msg_variables_getter()
+
     def transform_fn(sample, tokenizer=None):
         chat_template_string = get_chat_template(
             user_choice=chat_template_choice,
             jinja_template=chat_template_jinja,
             tokenizer=tokenizer,
         )
+        msg_variables = get_msg_variables(chat_template_string)
 
         messages = sample[field_messages]
         if isinstance(messages, str):
@@ -53,13 +203,7 @@ def default(cfg, dataset_idx=0, **kwargs):
                 }
             ]
 
-        messages = [
-            {
-                "role": role_map[m[message_property_mappings["role"]]],
-                "content": m[message_property_mappings["content"]],
-            }
-            for m in messages
-        ]
+        messages = [transform_message(m, msg_variables) for m in messages]
 
         chosen_raw = sample[field_chosen]
         if isinstance(chosen_raw, str):
@@ -71,10 +215,7 @@ def default(cfg, dataset_idx=0, **kwargs):
             chosen_msg = chosen_raw
         else:
             chosen_msg = chosen_raw[-1]
-        chosen = {
-            "role": role_map[chosen_msg[message_property_mappings["role"]]],
-            "content": chosen_msg[message_property_mappings["content"]],
-        }
+        chosen = transform_message(chosen_msg, msg_variables)
 
         rejected_raw = sample[field_rejected]
         if isinstance(rejected_raw, str):
@@ -86,41 +227,53 @@ def default(cfg, dataset_idx=0, **kwargs):
             rejected_msg = rejected_raw
         else:
             rejected_msg = rejected_raw[-1]
-        rejected = {
-            "role": role_map[rejected_msg[message_property_mappings["role"]]],
-            "content": rejected_msg[message_property_mappings["content"]],
+        rejected = transform_message(rejected_msg, msg_variables)
+
+        dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
+
+        template_kwargs = {
+            "chat_template": chat_template_string,
+            "tokenize": False,
+            **chat_template_kwargs,
         }
-        dummy_user_message = {"role": "user", "content": "[[dummy_message]]"}
+        tools = _parse_tools(sample.get(field_tools))
+        if tools:
+            template_kwargs["tools"] = tools
 
         result = {}
         result["prompt"] = tokenizer.apply_chat_template(
             messages,
             add_generation_prompt=True,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
 
-        result["chosen"] = tokenizer.apply_chat_template(
+        dummy_prompt = tokenizer.apply_chat_template(
+            [dummy_user_message],
+            add_generation_prompt=True,
+            **template_kwargs,
+        )
+
+        chosen_full = tokenizer.apply_chat_template(
             [dummy_user_message, chosen],
             add_generation_prompt=False,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
-        chosen_strip_index = result["chosen"].find(chosen["content"])
-        result["chosen"] = result["chosen"][chosen_strip_index:].rstrip()
+        result["chosen"] = _extract_response(
+            chosen_full, dummy_prompt, chosen.get("content")
+        )
 
-        result["rejected"] = tokenizer.apply_chat_template(
+        rejected_full = tokenizer.apply_chat_template(
             [dummy_user_message, rejected],
             add_generation_prompt=False,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
-        rejected_strip_index = result["rejected"].find(rejected["content"])
-        result["rejected"] = result["rejected"][rejected_strip_index:].rstrip()
+        result["rejected"] = _extract_response(
+            rejected_full, dummy_prompt, rejected.get("content")
+        )
 
         return result
 
-    return transform_fn, {"remove_columns": [field_messages]}
+    return transform_fn, {"remove_columns": [field_messages, field_tools]}
 
 
 def argilla_chat(cfg, dataset_idx=0, **kwargs):
@@ -162,6 +315,8 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
     )
     field_chosen = ds_cfg.get("field_chosen", "chosen")
     field_rejected = ds_cfg.get("field_rejected", "rejected")
+    field_tools = ds_cfg.get("field_tools", "tools")
+    chat_template_kwargs = cfg.get("chat_template_kwargs") or {}
     message_property_mappings = ds_cfg.get(
         "message_property_mappings",
         {
@@ -183,62 +338,67 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
         for source in sources:
             role_map[source] = target
 
+    transform_message = _build_message_transform(message_property_mappings, role_map)
+    get_msg_variables = _make_msg_variables_getter()
+
     def transform_fn(sample, tokenizer=None):
         chat_template_string = get_chat_template(
             user_choice=chat_template_choice,
             jinja_template=chat_template_jinja,
             tokenizer=tokenizer,
         )
+        msg_variables = get_msg_variables(chat_template_string)
 
         chosen_raw = sample[field_chosen]
         rejected_raw = sample[field_rejected]
 
         # Extract messages (all but last) and responses (last message)
-        chosen_messages = [
-            {
-                "role": role_map[m[message_property_mappings["role"]]],
-                "content": m[message_property_mappings["content"]],
-            }
-            for m in chosen_raw[:-1]
-        ]
-        chosen_response = {
-            "role": role_map[chosen_raw[-1][message_property_mappings["role"]]],
-            "content": chosen_raw[-1][message_property_mappings["content"]],
-        }
+        chosen_messages = [transform_message(m, msg_variables) for m in chosen_raw[:-1]]
+        chosen_response = transform_message(chosen_raw[-1], msg_variables)
+        rejected_response = transform_message(rejected_raw[-1], msg_variables)
 
-        rejected_response = {
-            "role": role_map[rejected_raw[-1][message_property_mappings["role"]]],
-            "content": rejected_raw[-1][message_property_mappings["content"]],
-        }
+        dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
 
-        dummy_user_message = {"role": "user", "content": "[[dummy_message]]"}
+        template_kwargs = {
+            "chat_template": chat_template_string,
+            "tokenize": False,
+            **chat_template_kwargs,
+        }
+        tools = _parse_tools(sample.get(field_tools))
+        if tools:
+            template_kwargs["tools"] = tools
 
         result = {}
         result["prompt"] = tokenizer.apply_chat_template(
             chosen_messages,
             add_generation_prompt=True,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
 
-        result["chosen"] = tokenizer.apply_chat_template(
+        dummy_prompt = tokenizer.apply_chat_template(
+            [dummy_user_message],
+            add_generation_prompt=True,
+            **template_kwargs,
+        )
+
+        chosen_full = tokenizer.apply_chat_template(
             [dummy_user_message, chosen_response],
             add_generation_prompt=False,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
-        chosen_strip_index = result["chosen"].find(chosen_response["content"])
-        result["chosen"] = result["chosen"][chosen_strip_index:].rstrip()
+        result["chosen"] = _extract_response(
+            chosen_full, dummy_prompt, chosen_response.get("content")
+        )
 
-        result["rejected"] = tokenizer.apply_chat_template(
+        rejected_full = tokenizer.apply_chat_template(
             [dummy_user_message, rejected_response],
             add_generation_prompt=False,
-            chat_template=chat_template_string,
-            tokenize=False,
+            **template_kwargs,
         )
-        rejected_strip_index = result["rejected"].find(rejected_response["content"])
-        result["rejected"] = result["rejected"][rejected_strip_index:].rstrip()
+        result["rejected"] = _extract_response(
+            rejected_full, dummy_prompt, rejected_response.get("content")
+        )
 
         return result
 
-    return transform_fn, {"remove_columns": [field_chosen, field_rejected]}
+    return transform_fn, {"remove_columns": [field_chosen, field_rejected, field_tools]}

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -80,6 +80,7 @@ def _build_message_transform(message_property_mappings, role_map):
     preserving any extra properties the chat template uses (e.g. tool_calls)."""
 
     def transform_message(message, msg_variables):
+        """Map a raw dataset message to a chat template message."""
         transformed = {}
         for target, source in message_property_mappings.items():
             value = message.get(source)
@@ -113,6 +114,7 @@ def _make_msg_variables_getter():
     cache = {}
 
     def get_msg_variables(chat_template_string):
+        """Return the message properties used by the chat template."""
         if chat_template_string not in cache:
             cache[chat_template_string] = (
                 JinjaTemplateAnalyzer(chat_template_string).get_message_vars("messages")
@@ -195,6 +197,11 @@ def _render_dpo_sample(
 
 
 def default(cfg, dataset_idx=0, **kwargs):
+    """DPO chat template strategy for OpenAI-format datasets.
+
+    Renders `field_messages` (with tools from `field_tools`) into the prompt
+    and extracts the chosen/rejected response strings via the chat template.
+    """
     ds_cfg = cfg["datasets"][dataset_idx]
     ds_cfg = handle_legacy_message_fields_logic(ds_cfg)
 
@@ -231,6 +238,7 @@ def default(cfg, dataset_idx=0, **kwargs):
     get_msg_variables = _make_msg_variables_getter()
 
     def transform_fn(sample, tokenizer=None):
+        """Map a dataset sample to prompt/chosen/rejected strings."""
         chat_template_string = get_chat_template(
             user_choice=chat_template_choice,
             jinja_template=chat_template_jinja,
@@ -352,6 +360,7 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
     get_msg_variables = _make_msg_variables_getter()
 
     def transform_fn(sample, tokenizer=None):
+        """Map a dataset sample to prompt/chosen/rejected strings."""
         chat_template_string = get_chat_template(
             user_choice=chat_template_choice,
             jinja_template=chat_template_jinja,

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -2,7 +2,7 @@
 DPO prompt strategies for using tokenizer chat templates.
 """
 
-from axolotl.prompt_strategies.chat_template_utils import (
+from axolotl.prompt_strategies.preference_chat_template import (
     build_message_transform,
     make_msg_variables_getter,
     parse_tools,

--- a/src/axolotl/prompt_strategies/dpo/chat_template.py
+++ b/src/axolotl/prompt_strategies/dpo/chat_template.py
@@ -2,198 +2,14 @@
 DPO prompt strategies for using tokenizer chat templates.
 """
 
-import json
-
-from axolotl.prompt_strategies.jinja_template_analyzer import JinjaTemplateAnalyzer
-from axolotl.utils.chat_templates import extract_chat_template_args, get_chat_template
-from axolotl.utils.logging import get_logger
-from axolotl.utils.schemas.utils import handle_legacy_message_fields_logic
-
-LOG = get_logger(__name__)
-
-
-def _parse_tools(tools):
-    """Parse tools into a list of dicts, decoding JSON-encoded strings."""
-    if tools is None:
-        return None
-
-    if isinstance(tools, str):
-        try:
-            tools = json.loads(tools)
-        except json.JSONDecodeError as e:
-            LOG.error(f"Error parsing tools as JSON. Error: {e}")
-            raise
-
-    if isinstance(tools, list):
-        parsed_tools = []
-        for tool in tools:
-            # some datasets store each tool as a JSON-encoded string
-            if isinstance(tool, str):
-                try:
-                    tool = json.loads(tool)
-                except json.JSONDecodeError as e:
-                    LOG.error(f"Error parsing tool as JSON. Tool: {tool!r}, Error: {e}")
-                    raise
-            if isinstance(tool, dict) and "function" in tool:
-                function = tool["function"]
-                params = function.get("parameters")
-                if isinstance(params, str):
-                    try:
-                        function["parameters"] = json.loads(params)
-                    except json.JSONDecodeError as e:
-                        LOG.error(
-                            f"Error parsing tool parameters as JSON. "
-                            f"Function: {function.get('name', 'unknown')}, "
-                            f"Parameters string: {params!r}, "
-                            f"Error: {e}"
-                        )
-                        raise
-            parsed_tools.append(tool)
-        return parsed_tools
-
-    raise ValueError(
-        "Unknown tools format. Please convert it into a list[dict].\n"
-        f"Current format: {type(tools)}"
-    )
-
-
-def _parse_tool_call_arguments(message):
-    """Decode JSON-encoded tool call arguments so templates receive dicts."""
-    for tool_call in message.get("tool_calls") or []:
-        if "function" in tool_call and "arguments" in tool_call["function"]:
-            args = tool_call["function"]["arguments"]
-            if isinstance(args, str):
-                try:
-                    tool_call["function"]["arguments"] = json.loads(args)
-                except json.JSONDecodeError as e:
-                    LOG.error(
-                        f"Error parsing tool_calls arguments as JSON. "
-                        f"Function: {tool_call.get('function', {}).get('name', 'unknown')}, "
-                        f"Arguments string: {args!r}, "
-                        f"Error: {e}"
-                    )
-                    raise
-
-
-def _build_message_transform(message_property_mappings, role_map):
-    """Build a function that maps a raw dataset message to a chat template message,
-    preserving any extra properties the chat template uses (e.g. tool_calls)."""
-
-    def transform_message(message, msg_variables):
-        """Map a raw dataset message to a chat template message."""
-        transformed = {}
-        for target, source in message_property_mappings.items():
-            value = message.get(source)
-            if value is not None:
-                transformed[target] = value
-
-        if "role" in transformed:
-            transformed["role"] = role_map.get(transformed["role"], transformed["role"])
-
-        mapped_sources = set(message_property_mappings.values())
-        for key in msg_variables - mapped_sources:
-            value = message.get(key)
-            if value is not None:
-                transformed[key] = value
-
-        _parse_tool_call_arguments(transformed)
-        return transformed
-
-    return transform_message
-
-
-# always preserved: template analysis misses properties accessed via
-# `message.get(...)` (e.g. gemma4), so OpenAI message keys are unioned in
-_BASE_MSG_VARIABLES = frozenset(
-    ["tool_calls", "tool_call_id", "name", "reasoning_content", "reasoning"]
+from axolotl.prompt_strategies.chat_template_utils import (
+    build_message_transform,
+    make_msg_variables_getter,
+    parse_tools,
+    render_preference_sample,
 )
-
-
-def _make_msg_variables_getter():
-    """Cache chat template message variable analysis per template string."""
-    cache = {}
-
-    def get_msg_variables(chat_template_string):
-        """Return the message properties used by the chat template."""
-        if chat_template_string not in cache:
-            cache[chat_template_string] = (
-                JinjaTemplateAnalyzer(chat_template_string).get_message_vars("messages")
-                | _BASE_MSG_VARIABLES
-            )
-        return cache[chat_template_string]
-
-    return get_msg_variables
-
-
-DUMMY_USER_MESSAGE_CONTENT = "[[dummy_message]]"
-
-
-def _extract_response(full, prompt_prefix, content):
-    """Strip the rendered dummy-user prompt from a response rendering.
-
-    Strips the longest common prefix rather than requiring an exact prefix
-    match, since a generation prompt can diverge slightly from the completed
-    message rendering (e.g. thinking templates open `<think>` with different
-    whitespace than a rendered `reasoning_content` block).
-    """
-    common = 0
-    for prefix_char, full_char in zip(prompt_prefix, full, strict=False):
-        if prefix_char != full_char:
-            break
-        common += 1
-    response = full[common:]
-    if DUMMY_USER_MESSAGE_CONTENT not in response:
-        return response.rstrip()
-    # Fallback: locate the response content directly
-    if content:
-        strip_index = full.find(content)
-        if strip_index != -1:
-            return full[strip_index:].rstrip()
-    return full.rstrip()
-
-
-def _render_dpo_sample(
-    tokenizer,
-    messages,
-    chosen,
-    rejected,
-    chat_template_string,
-    chat_template_kwargs,
-    tools,
-):
-    """Render the prompt and extract the chosen/rejected response strings."""
-    template_kwargs = {
-        "chat_template": chat_template_string,
-        "tokenize": False,
-        **chat_template_kwargs,
-    }
-    if tools:
-        template_kwargs["tools"] = tools
-
-    dummy_user_message = {"role": "user", "content": DUMMY_USER_MESSAGE_CONTENT}
-
-    result = {}
-    result["prompt"] = tokenizer.apply_chat_template(
-        messages,
-        add_generation_prompt=True,
-        **template_kwargs,
-    )
-
-    dummy_prompt = tokenizer.apply_chat_template(
-        [dummy_user_message],
-        add_generation_prompt=True,
-        **template_kwargs,
-    )
-
-    for key, response in (("chosen", chosen), ("rejected", rejected)):
-        full = tokenizer.apply_chat_template(
-            [dummy_user_message, response],
-            add_generation_prompt=False,
-            **template_kwargs,
-        )
-        result[key] = _extract_response(full, dummy_prompt, response.get("content"))
-
-    return result
+from axolotl.utils.chat_templates import extract_chat_template_args, get_chat_template
+from axolotl.utils.schemas.utils import handle_legacy_message_fields_logic
 
 
 def default(cfg, dataset_idx=0, **kwargs):
@@ -234,8 +50,8 @@ def default(cfg, dataset_idx=0, **kwargs):
         for source in sources:
             role_map[source] = target
 
-    transform_message = _build_message_transform(message_property_mappings, role_map)
-    get_msg_variables = _make_msg_variables_getter()
+    transform_message = build_message_transform(message_property_mappings, role_map)
+    get_msg_variables = make_msg_variables_getter()
 
     def transform_fn(sample, tokenizer=None):
         """Map a dataset sample to prompt/chosen/rejected strings."""
@@ -281,14 +97,14 @@ def default(cfg, dataset_idx=0, **kwargs):
             rejected_msg = rejected_raw[-1]
         rejected = transform_message(rejected_msg, msg_variables)
 
-        return _render_dpo_sample(
+        return render_preference_sample(
             tokenizer,
             messages,
             chosen,
             rejected,
             chat_template_string,
             chat_template_kwargs,
-            _parse_tools(sample.get(field_tools)),
+            parse_tools(sample.get(field_tools)),
         )
 
     return transform_fn, {"remove_columns": [field_messages, field_tools]}
@@ -356,8 +172,8 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
         for source in sources:
             role_map[source] = target
 
-    transform_message = _build_message_transform(message_property_mappings, role_map)
-    get_msg_variables = _make_msg_variables_getter()
+    transform_message = build_message_transform(message_property_mappings, role_map)
+    get_msg_variables = make_msg_variables_getter()
 
     def transform_fn(sample, tokenizer=None):
         """Map a dataset sample to prompt/chosen/rejected strings."""
@@ -376,14 +192,14 @@ def argilla_chat(cfg, dataset_idx=0, **kwargs):
         chosen_response = transform_message(chosen_raw[-1], msg_variables)
         rejected_response = transform_message(rejected_raw[-1], msg_variables)
 
-        return _render_dpo_sample(
+        return render_preference_sample(
             tokenizer,
             chosen_messages,
             chosen_response,
             rejected_response,
             chat_template_string,
             chat_template_kwargs,
-            _parse_tools(sample.get(field_tools)),
+            parse_tools(sample.get(field_tools)),
         )
 
     return transform_fn, {"remove_columns": [field_chosen, field_rejected, field_tools]}

--- a/src/axolotl/prompt_strategies/preference_chat_template.py
+++ b/src/axolotl/prompt_strategies/preference_chat_template.py
@@ -3,7 +3,9 @@ Shared helpers for rendering OpenAI-format preference (chosen/rejected) messages
 via tokenizer chat templates.
 
 Reused across RL prompt strategies (DPO, ORPO, Bradley-Terry) so tool_calls,
-tools, and reasoning_content handling only needs to be implemented once.
+tools, and reasoning_content handling only needs to be implemented once. The
+tools/tool_calls JSON decoding helpers are also reused by the SFT
+`chat_template` strategy for the same reason.
 """
 
 import json

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -2,6 +2,7 @@
 tests for chat_template prompt strategy
 """
 
+import json
 import unittest
 
 import pytest
@@ -103,6 +104,63 @@ def fixture_argilla_chat_dataset():
                         "content": "party on",
                     },
                 ],
+            }
+        ]
+    )
+
+
+@pytest.fixture(name="toolcalling_dpo_dataset")
+def fixture_toolcalling_dpo_dataset():
+    return Dataset.from_list(
+        [
+            {
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_temperature",
+                            "description": "Get the current temperature in a given location",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"location": {"type": "string"}},
+                                "required": ["location"],
+                            },
+                        },
+                    }
+                ],
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "What's the temperature in Paris?",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_current_temperature",
+                                    "arguments": '{"location": "Paris, France"}',
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "22.0",
+                    },
+                ],
+                "chosen": {
+                    "role": "assistant",
+                    "content": "The temperature in Paris is 22.0 degrees Celsius.",
+                },
+                "rejected": {
+                    "role": "assistant",
+                    "content": "I don't know.",
+                },
             }
         ]
     )
@@ -375,6 +433,187 @@ class TestDPOChatTemplateToolRole:
         )
         result = transform_fn(dataset[0], tokenizer=llama3_tokenizer)
         assert "prompt" in result
+
+
+class TestDPOChatTemplateToolCalling:
+    """
+    Test class for OpenAI-style tool calling datasets with the DPO chat_template strategy.
+    """
+
+    def test_tools_and_tool_calls_rendered(
+        self, llama3_tokenizer, toolcalling_dpo_dataset
+    ):
+        transform_fn, ds_kwargs = default(
+            DictDefault(
+                {
+                    "chat_template": "qwen_25",
+                    "datasets": [{"type": "chat_template"}],
+                }
+            )
+        )
+        assert "tools" in ds_kwargs["remove_columns"]
+
+        result = transform_fn(toolcalling_dpo_dataset[0], tokenizer=llama3_tokenizer)
+        prompt = result["prompt"]
+
+        # tool definitions are rendered into the system prompt
+        assert "<tools>" in prompt
+        assert '"name": "get_current_temperature"' in prompt
+
+        # assistant tool call is preserved and JSON string arguments are decoded
+        assert (
+            '<tool_call>\n{"name": "get_current_temperature", '
+            '"arguments": {"location": "Paris, France"}}\n</tool_call>' in prompt
+        )
+
+        # tool response turn is rendered
+        assert "<tool_response>\n22.0\n</tool_response>" in prompt
+
+        assert prompt.endswith("<|im_start|>assistant\n")
+        assert (
+            result["chosen"]
+            == "The temperature in Paris is 22.0 degrees Celsius.<|im_end|>"
+        )
+        assert result["rejected"] == "I don't know.<|im_end|>"
+
+    def test_tool_call_as_response(self, llama3_tokenizer, toolcalling_dpo_dataset):
+        """chosen/rejected can themselves be tool call messages without content."""
+        sample = dict(toolcalling_dpo_dataset[0])
+        sample["messages"] = sample["messages"][:1]
+        sample["chosen"] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "Paris, France"}',
+                    },
+                }
+            ],
+        }
+        sample["rejected"] = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "London, UK"}',
+                    },
+                }
+            ],
+        }
+
+        transform_fn, _ = default(
+            DictDefault(
+                {
+                    "chat_template": "qwen_25",
+                    "datasets": [{"type": "chat_template"}],
+                }
+            )
+        )
+        result = transform_fn(sample, tokenizer=llama3_tokenizer)
+
+        assert result["chosen"] == (
+            '<tool_call>\n{"name": "get_current_temperature", '
+            '"arguments": {"location": "Paris, France"}}\n</tool_call><|im_end|>'
+        )
+        assert result["rejected"] == (
+            '<tool_call>\n{"name": "get_current_temperature", '
+            '"arguments": {"location": "London, UK"}}\n</tool_call><|im_end|>'
+        )
+        assert "[[dummy_message]]" not in result["chosen"]
+        assert "[[dummy_message]]" not in result["rejected"]
+
+    def test_tools_as_json_strings(self, llama3_tokenizer, toolcalling_dpo_dataset):
+        """tools stored as a list of JSON-encoded strings are decoded before rendering."""
+        sample = dict(toolcalling_dpo_dataset[0])
+        sample["tools"] = [json.dumps(tool) for tool in sample["tools"]]
+
+        transform_fn, _ = default(
+            DictDefault(
+                {
+                    "chat_template": "qwen_25",
+                    "datasets": [{"type": "chat_template"}],
+                }
+            )
+        )
+        result = transform_fn(sample, tokenizer=llama3_tokenizer)
+
+        assert "<tools>" in result["prompt"]
+        assert '"name": "get_current_temperature"' in result["prompt"]
+
+
+class TestDPOChatTemplateReasoning:
+    """
+    Test class for reasoning (thinking) responses with the DPO chat_template strategy.
+    """
+
+    def test_reasoning_content_preserved(self, llama3_tokenizer):
+        """reasoning_content in chosen/rejected renders into the think block."""
+        sample = {
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "chosen": {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "Simple arithmetic: 2+2 equals 4.",
+            },
+            "rejected": {
+                "role": "assistant",
+                "content": "The answer is 5.",
+                "reasoning_content": "2+2 is 5 because I said so.",
+            },
+        }
+
+        transform_fn, _ = default(
+            DictDefault(
+                {
+                    "chat_template": "qwen3_5",
+                    "datasets": [{"type": "chat_template"}],
+                }
+            )
+        )
+        result = transform_fn(sample, tokenizer=llama3_tokenizer)
+
+        # the generation prompt opens the think block; responses continue it
+        assert result["prompt"].endswith("<|im_start|>assistant\n<think>\n\n")
+        assert result["chosen"] == (
+            "Simple arithmetic: 2+2 equals 4.\n</think>\n\nThe answer is 4.<|im_end|>"
+        )
+        assert result["rejected"] == (
+            "2+2 is 5 because I said so.\n</think>\n\nThe answer is 5.<|im_end|>"
+        )
+
+    def test_chat_template_kwargs_passed(self, llama3_tokenizer):
+        """chat_template_kwargs (e.g. enable_thinking) reach apply_chat_template."""
+        sample = {
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "chosen": {"role": "assistant", "content": "The answer is 4."},
+            "rejected": {"role": "assistant", "content": "The answer is 5."},
+        }
+
+        transform_fn, _ = default(
+            DictDefault(
+                {
+                    "chat_template": "qwen3_5",
+                    "chat_template_kwargs": {"enable_thinking": False},
+                    "datasets": [{"type": "chat_template"}],
+                }
+            )
+        )
+        result = transform_fn(sample, tokenizer=llama3_tokenizer)
+
+        # with thinking disabled the generation prompt closes the think block
+        assert result["prompt"].endswith(
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        )
+        assert result["chosen"] == "The answer is 4.<|im_end|>"
+        assert result["rejected"] == "The answer is 5.<|im_end|>"
 
 
 if __name__ == "__main__":

--- a/tests/prompt_strategies/test_dpo_chat_templates.py
+++ b/tests/prompt_strategies/test_dpo_chat_templates.py
@@ -111,6 +111,7 @@ def fixture_argilla_chat_dataset():
 
 @pytest.fixture(name="toolcalling_dpo_dataset")
 def fixture_toolcalling_dpo_dataset():
+    """OpenAI-format tool calling DPO dataset with tools and tool_calls."""
     return Dataset.from_list(
         [
             {
@@ -443,6 +444,7 @@ class TestDPOChatTemplateToolCalling:
     def test_tools_and_tool_calls_rendered(
         self, llama3_tokenizer, toolcalling_dpo_dataset
     ):
+        """tools render into the system prompt and tool_calls are preserved."""
         transform_fn, ds_kwargs = default(
             DictDefault(
                 {


### PR DESCRIPTION
# Description

The DPO `chat_template` strategy only copied `role`/`content` from messages, breaking OpenAI-format tool-calling datasets. This PR brings it to parity with the SFT `chat_template` strategy:

- Preserve message properties the chat template uses (`tool_calls`, `tool_call_id`, `name`, `reasoning_content`, …) via `JinjaTemplateAnalyzer`, skipping `None` values. The standard OpenAI message keys are always unioned in, since some templates access properties via `message.get(...)` which template analysis can't see (e.g. `gemma4`).
- Read `field_tools` (default `"tools"`) from the sample, decode JSON-encoded strings (both a whole-list JSON string and per-tool JSON strings), and pass `tools=` to `apply_chat_template`.
- Decode JSON-string `tool_call.function.arguments` into dicts, matching SFT behavior (templates apply `| tojson`).
- Extract chosen/rejected by stripping the longest common prefix with the rendered dummy-user prompt instead of searching for the response content, so contentless tool-call responses and `reasoning_content` responses extract cleanly (thinking templates open `<think>` blocks with slightly different whitespace than completed renderings).
- Pass the config's `chat_template_kwargs` (e.g. `enable_thinking`) to `apply_chat_template`, matching SFT.

Applies to both `chat_template.default` and `chat_template.argilla_chat`.

## Motivation and Context

Fixes #3824. Training tool calling with DPO on OpenAI-format data currently either crashes (`content: null`) or silently corrupts the training prompt (dropped `tool_calls`, missing tool definitions). See the issue for full failure modes and repro.

## How has this been tested?

- New unit tests in `tests/prompt_strategies/test_dpo_chat_templates.py`: tools rendering into the system prompt, `tool_calls` preservation with JSON-string argument decoding, tool-call chosen/rejected extraction (no dummy-message leakage), tools as a list of JSON strings, `reasoning_content` extraction, and `chat_template_kwargs` passthrough
- Full existing test file passes: `pytest tests/prompt_strategies/test_dpo_chat_templates.py` (13 passed, 2 xpassed, no regressions)
- Manually verified rendering across 9 tool-capable registered templates: `qwen_25`, `qwen3`, `qwen3_5`, `gemma4`, `exaone4`, `llama4`, `llama3_2_vision`, `command_a_tool_use`, `jamba`
- End-to-end `axolotl preprocess --debug` with `rl: dpo` on an OpenAI-format tool-calling jsonl (crash before, correct rendering after)
- `pre-commit run` (ruff, mypy, bandit) passes on changed files

## AI Usage Disclaimer

Yes — implemented with Claude Code (analysis, implementation, and tests), reviewed and verified by me.

## Screenshots (if appropriate)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool definitions and tool calls in DPO and Argilla chat template rendering.
  * Tool data can be provided as structured lists or JSON-encoded strings.
  * Preserves additional message fields referenced by chat templates.
  * Supports reasoning content and configurable thinking behavior during response generation.

* **Bug Fixes**
  * Improved extraction of chosen and rejected responses from rendered templates.
  * Correctly handles tool-call responses and JSON-encoded function arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->