### PR TITLE
chore: remove deprecated torch.jit usage

### DIFF
--- a/src/axolotl/integrations/kd/topk_logprob/forward_kl.py
+++ b/src/axolotl/integrations/kd/topk_logprob/forward_kl.py
@@ -20,7 +20,6 @@ import torch
 from torch import nn
 
 
-@torch.jit.script
 def loss(
     student_logits: torch.Tensor,
     target_token_ids: torch.Tensor,
@@ -30,7 +29,7 @@ def loss(
     kd_temperature: float = 1.0,
 ) -> torch.Tensor:
     """
-    A KD loss function that is TorchScript-friendly.
+    Top-k forward KL divergence KD loss.
 
     Arguments:
         student_logits (torch.Tensor): The logits of the student model.
@@ -53,27 +52,25 @@ def loss(
     # student_logits shape:   [B, student_seq_len, vocab_size]
     teacher_seq_len = target_token_ids.shape[1]
 
-    # Slice student logits to match teacher-provided sequence length
-    student_logits_for_kd = (
-        student_logits[:, :teacher_seq_len, :] / kd_temperature
-    )  # [B, teacher_seq_len, vocab_size]
-
+    # Slice student logits to match teacher-provided sequence length and
     # keep in full precision for numerical stability of loss
-    student_logits_for_kd = student_logits_for_kd.float()
+    student_logits_for_kd = student_logits[
+        :, :teacher_seq_len, :
+    ].float()  # [B, teacher_seq_len, vocab_size]
 
-    # Gather student logits for teacher's top-K tokens
-    student_logits_topk = torch.gather(
-        student_logits_for_kd, dim=-1, index=target_token_ids
+    if kd_temperature != 1.0:
+        student_logits_for_kd = student_logits_for_kd / kd_temperature
+
+    # log_softmax + gather peaks one full-vocab backward buffer lower than the
+    # gather + logsumexp formulation
+    student_logprobs = torch.log_softmax(student_logits_for_kd, dim=-1)
+
+    # Gather student logprobs for teacher's top-K tokens
+    student_logprobs_topk = torch.gather(
+        student_logprobs, dim=-1, index=target_token_ids
     )  # [B, teacher_seq_len, K]
 
-    # Compute logsumexp across full vocabulary
-    student_lse = torch.logsumexp(student_logits_for_kd, dim=-1, keepdim=True)
-
-    #  Convert just the top-k logits to logprobs
-    student_logprobs_topk = student_logits_topk - student_lse
-
     # Convert teacher_mask to boolean for indexing
-    # In TorchScript, .bool() is sometimes unsupported, so we do:
     valid_mask = target_mask.to(torch.bool)
 
     # Prune tensors to only keep valid tokens

--- a/src/axolotl/utils/optimizers/adopt.py
+++ b/src/axolotl/utils/optimizers/adopt.py
@@ -276,12 +276,6 @@ def _single_tensor_adopt(
 ):
     assert grad_scale is None and found_inf is None
 
-    if torch.jit.is_scripting():
-        # this assert is due to JIT being dumb and not realizing that the ops below
-        # have overloads to handle both float and Tensor lrs, so we just assert it's
-        # a float since most people using JIT are using floats
-        assert isinstance(lr, float)
-
     for i, param in enumerate(params):
         grad = grads[i] if not maximize else -grads[i]
         exp_avg = exp_avgs[i]
@@ -515,15 +509,10 @@ def adopt(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"
         )
 
-    if foreach and torch.jit.is_scripting():
-        raise RuntimeError("torch.jit.script not supported with foreach optimizers")
-    if fused and torch.jit.is_scripting():
-        raise RuntimeError("torch.jit.script not supported with fused optimizers")
-
-    # if fused and not torch.jit.is_scripting():
+    # if fused:
     #     func = _fused_adopt
-    # elif foreach and not torch.jit.is_scripting():
-    if foreach and not torch.jit.is_scripting():
+    # elif foreach:
+    if foreach:
         func = _multi_tensor_adopt
     else:
         func = _single_tensor_adopt

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -27,7 +27,6 @@ from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 LOG = get_logger(__name__)
 
 
-@torch.jit.script
 def weighted_cross_entropy(
     logits: torch.Tensor, labels: torch.Tensor, weights: torch.Tensor
 ):
@@ -45,34 +44,26 @@ def weighted_cross_entropy(
     return (weights * losses).sum()
 
 
-@torch.jit.script
 def create_weighted_mask(labels: torch.Tensor):
-    # Check if the tensor is 2D. If not, unsqueeze it to make it 2D
+    """Weight each contiguous run of unmasked (!= -100) labels so it sums to 1."""
     if len(labels.shape) == 1:
         labels = labels.unsqueeze(0)
+    batch_size, seq_len = labels.shape
 
-    weights = torch.zeros_like(labels).float()
-    for i in range(labels.shape[0]):
-        mask = labels[i] != -100
+    mask = labels != -100
+    # a group starts at an unmasked position whose predecessor is masked
+    starts = mask.clone()
+    starts[:, 1:] &= ~mask[:, :-1]
 
-        # Create a tensor to track group ids
-        group_ids = torch.zeros_like(labels[i]).int()
-        curr_group_id = 0
+    # 0-based group id per row, only meaningful at unmasked positions
+    group_ids = starts.cumsum(dim=1) - 1
+    max_groups = seq_len // 2 + 1
+    row_offsets = torch.arange(batch_size, device=labels.device).unsqueeze(1)
+    flat_ids = (group_ids + row_offsets * max_groups)[mask]
 
-        for j in range(1, len(labels[i])):
-            if mask[j] and not mask[j - 1]:  # switch from masked to unmasked label
-                curr_group_id += 1  # start new group
-            group_ids[j] = (
-                curr_group_id if mask[j] else 0
-            )  # assign group id if unmasked label
-
-        # Count only unmasked labels in each group
-        group_counts = torch.bincount(group_ids[mask])
-
-        mask_weights = torch.zeros_like(labels[i]).float()
-        mask_weights[mask] = 1.0 / group_counts[group_ids[mask]]
-
-        weights[i] = mask_weights
+    group_counts = torch.bincount(flat_ids, minlength=batch_size * max_groups)
+    weights = torch.zeros_like(labels, dtype=torch.float32)
+    weights[mask] = 1.0 / group_counts[flat_ids].float()
 
     return weights.squeeze()  # squeeze the output to match the input dimension
 

--- a/tests/integrations/test_kd_topk_forward_kl.py
+++ b/tests/integrations/test_kd_topk_forward_kl.py
@@ -1,0 +1,127 @@
+"""Tests for the top-k forward-KL KD loss"""
+
+import pytest
+import torch
+
+from axolotl.integrations.kd.topk_logprob.forward_kl import ChunkedTopKKDLoss, loss
+
+
+def reference_loss(
+    student_logits,
+    target_token_ids,
+    target_logprobs,
+    target_mask,
+    num_items_in_batch=-1,
+    kd_temperature=1.0,
+):
+    """Naive reference using a full log_softmax instead of the
+    gather + logsumexp formulation."""
+    teacher_seq_len = target_token_ids.shape[1]
+    student = (student_logits[:, :teacher_seq_len, :] / kd_temperature).float()
+    student_logprobs = torch.log_softmax(student, dim=-1)
+    student_logprobs_topk = torch.gather(
+        student_logprobs, dim=-1, index=target_token_ids
+    )
+
+    valid = target_mask.bool()
+    teacher_logprobs = target_logprobs.float()[valid]
+    student_logprobs_topk = student_logprobs_topk[valid]
+
+    per_token = teacher_logprobs.exp() * (teacher_logprobs - student_logprobs_topk)
+    total = per_token.sum()
+    denom = num_items_in_batch if num_items_in_batch > 0 else per_token.size(0)
+    return total / denom
+
+
+def make_inputs(
+    batch_size=2,
+    student_seq_len=48,
+    teacher_seq_len=40,
+    top_k=8,
+    vocab_size=256,
+    dtype=torch.float32,
+    seed=0,
+):
+    torch.manual_seed(seed)
+    student_logits = torch.randn(batch_size, student_seq_len, vocab_size, dtype=dtype)
+    target_token_ids = torch.randint(
+        0, vocab_size, (batch_size, teacher_seq_len, top_k)
+    )
+    teacher_logits = torch.randn(batch_size, teacher_seq_len, top_k)
+    target_logprobs = torch.log_softmax(teacher_logits, dim=-1)
+    target_mask = (torch.rand(batch_size, teacher_seq_len, top_k) < 0.8).to(torch.int64)
+    target_mask[:, 0, :] = 1  # guarantee at least one valid token
+    return student_logits, target_token_ids, target_logprobs, target_mask
+
+
+@pytest.mark.parametrize("num_items_in_batch", [-1, 7])
+def test_loss_matches_reference(num_items_in_batch):
+    inputs = make_inputs()
+
+    actual = loss(*inputs, num_items_in_batch=num_items_in_batch)
+    expected = reference_loss(*inputs, num_items_in_batch=num_items_in_batch)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_loss_temperature():
+    inputs = make_inputs()
+
+    actual = loss(*inputs, kd_temperature=2.0)
+    expected = reference_loss(*inputs, kd_temperature=2.0)
+
+    torch.testing.assert_close(actual, expected)
+    # temperature must actually change the result
+    assert not torch.allclose(actual, loss(*inputs))
+
+
+def test_masked_entries_do_not_affect_loss():
+    student_logits, target_token_ids, target_logprobs, target_mask = make_inputs()
+    baseline = loss(student_logits, target_token_ids, target_logprobs, target_mask)
+
+    corrupted_logprobs = target_logprobs.clone()
+    corrupted_logprobs[target_mask == 0] = 123.0
+
+    perturbed = loss(student_logits, target_token_ids, corrupted_logprobs, target_mask)
+    torch.testing.assert_close(perturbed, baseline)
+
+
+def test_grad_flow_and_sparsity():
+    student_logits, target_token_ids, target_logprobs, target_mask = make_inputs()
+    target_mask[:, -3:, :] = 0  # fully mask some teacher positions
+    student_logits.requires_grad_(True)
+
+    out = loss(student_logits, target_token_ids, target_logprobs, target_mask)
+    out.backward()
+
+    grad = student_logits.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all()
+    teacher_seq_len = target_token_ids.shape[1]
+    # positions beyond the teacher sequence never enter the loss
+    assert (grad[:, teacher_seq_len:, :] == 0).all()
+    # fully masked positions get no gradient
+    assert (grad[:, teacher_seq_len - 3 : teacher_seq_len, :] == 0).all()
+    # unmasked positions do
+    assert grad[:, 0, :].abs().sum() > 0
+
+
+def test_bf16_student_logits():
+    inputs = make_inputs()
+    expected = loss(*inputs)
+
+    bf16_inputs = (inputs[0].to(torch.bfloat16), *inputs[1:])
+    actual = loss(*bf16_inputs)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=1e-3)
+
+
+@pytest.mark.parametrize("num_items_in_batch", [-1, 11])
+def test_chunked_matches_unchunked(num_items_in_batch):
+    inputs = make_inputs(teacher_seq_len=40, student_seq_len=40)
+    unchunked = loss(*inputs, num_items_in_batch=num_items_in_batch)
+
+    chunked_loss = ChunkedTopKKDLoss(num_output_chunks=4)
+    chunked = chunked_loss(*inputs, num_items_in_batch=num_items_in_batch)
+
+    torch.testing.assert_close(chunked, unchunked, rtol=1e-5, atol=1e-6)

--- a/tests/test_weighted_loss.py
+++ b/tests/test_weighted_loss.py
@@ -1,0 +1,176 @@
+"""Tests for weighted-loss helpers in axolotl.utils.trainer"""
+
+import math
+
+import pytest
+import torch
+
+from axolotl.utils.trainer import (
+    create_weighted_mask,
+    trainer_weighted_loss,
+    weighted_cross_entropy,
+)
+
+
+def reference_weighted_mask(labels: torch.Tensor) -> torch.Tensor:
+    """Naive reference: each contiguous run of unmasked (!= -100) labels is a
+    group, and every token in a group gets weight 1/len(group)."""
+    labels_2d = labels.unsqueeze(0) if labels.dim() == 1 else labels
+    weights = torch.zeros_like(labels_2d, dtype=torch.float32)
+    for i in range(labels_2d.shape[0]):
+        group_positions = []
+        current: list[int] | None = None
+        for j, val in enumerate(labels_2d[i].tolist()):
+            if val != -100:
+                if current is None:
+                    current = []
+                    group_positions.append(current)
+                current.append(j)
+            else:
+                current = None
+        for group in group_positions:
+            for j in group:
+                weights[i, j] = 1.0 / len(group)
+    return weights.squeeze()
+
+
+def test_create_weighted_mask_1d():
+    labels = torch.tensor([-100, 5, 6, -100, -100, 7, 8, 9])
+    expected = torch.tensor([0.0, 0.5, 0.5, 0.0, 0.0, 1 / 3, 1 / 3, 1 / 3])
+
+    weights = create_weighted_mask(labels)
+
+    assert weights.shape == labels.shape
+    torch.testing.assert_close(weights, expected)
+
+
+def test_create_weighted_mask_row_starting_unmasked():
+    labels = torch.tensor([1, 2, -100, 3])
+    expected = torch.tensor([0.5, 0.5, 0.0, 1.0])
+
+    torch.testing.assert_close(create_weighted_mask(labels), expected)
+
+
+def test_create_weighted_mask_batch():
+    labels = torch.tensor(
+        [
+            [-100, 1, 2, 3, -100, 4],
+            [5, -100, -100, 6, 7, -100],
+        ]
+    )
+    expected = torch.tensor(
+        [
+            [0.0, 1 / 3, 1 / 3, 1 / 3, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 0.5, 0.5, 0.0],
+        ]
+    )
+
+    weights = create_weighted_mask(labels)
+
+    assert weights.shape == labels.shape
+    torch.testing.assert_close(weights, expected)
+
+
+def test_create_weighted_mask_all_masked_row():
+    labels = torch.tensor(
+        [
+            [-100, -100, -100, -100],
+            [-100, 1, 2, -100],
+        ]
+    )
+    expected = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.5, 0.5, 0.0],
+        ]
+    )
+
+    torch.testing.assert_close(create_weighted_mask(labels), expected)
+
+
+def test_create_weighted_mask_all_unmasked_row():
+    labels = torch.tensor([[1, 2, 3, 4]])
+    # batch size 1 output is squeezed to 1D, matching the historical behavior
+    expected = torch.tensor([0.25, 0.25, 0.25, 0.25])
+
+    weights = create_weighted_mask(labels)
+
+    assert weights.shape == expected.shape
+    torch.testing.assert_close(weights, expected)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_create_weighted_mask_matches_reference_random(seed):
+    torch.manual_seed(seed)
+    labels = torch.randint(0, 100, (4, 64))
+    labels[torch.rand(labels.shape) < 0.4] = -100
+
+    torch.testing.assert_close(
+        create_weighted_mask(labels), reference_weighted_mask(labels)
+    )
+
+
+def test_weighted_cross_entropy_matches_manual():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 8, 32)
+    labels = torch.randint(0, 32, (2, 8))
+    labels[:, :3] = -100
+    weights = create_weighted_mask(labels)
+
+    loss = weighted_cross_entropy(logits, labels, weights)
+
+    manual = (
+        torch.nn.functional.cross_entropy(
+            logits.view(-1, 32), labels.view(-1), reduction="none"
+        )
+        * weights.view(-1)
+    ).sum()
+    torch.testing.assert_close(loss, manual)
+
+
+def test_weighted_cross_entropy_uniform_logits():
+    # uniform logits: CE is ln(V) per token, and each group's weights sum to 1,
+    # so the weighted sum is ln(V) * num_groups
+    vocab_size = 64
+    logits = torch.zeros(1, 6, vocab_size)
+    labels = torch.tensor([[-100, 1, 2, -100, 3, 4]])  # 2 groups
+    weights = create_weighted_mask(labels)
+
+    loss = weighted_cross_entropy(logits, labels, weights)
+
+    torch.testing.assert_close(loss, torch.tensor(2 * math.log(vocab_size)))
+
+
+@pytest.mark.parametrize("output_as_dict", [True, False])
+def test_trainer_weighted_loss_shifts_labels(output_as_dict):
+    torch.manual_seed(0)
+    logits = torch.randn(2, 9, 32)
+    labels = torch.randint(0, 32, (2, 9))
+    labels[:, :4] = -100
+    model_output = {"logits": logits} if output_as_dict else (logits,)
+
+    loss = trainer_weighted_loss(model_output, labels, shift_labels=True)
+
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+    weights = reference_weighted_mask(shift_labels)
+    expected = (
+        torch.nn.functional.cross_entropy(
+            shift_logits.view(-1, 32), shift_labels.view(-1), reduction="none"
+        )
+        * weights.view(-1)
+    ).sum()
+    torch.testing.assert_close(loss, expected)
+
+
+def test_trainer_weighted_loss_grad_flows():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 8, 32, requires_grad=True)
+    labels = torch.randint(0, 32, (2, 8))
+    labels[:, :2] = -100
+
+    loss = trainer_weighted_loss({"logits": logits}, labels, shift_labels=True)
+    loss.backward()
+
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()


### PR DESCRIPTION
torch.jit.script emits a DeprecationWarning since torch 2.12. Replace the scripted helpers with eager implementations at parity or better:

- create_weighted_mask: vectorize the per-token loops (cumsum + bincount), ~1000x faster than the scripted loop on GPU
- weighted_cross_entropy: drop the decorator, exact speed/memory parity
- kd topk loss: reformulate gather + logsumexp as log_softmax + gather and skip the divide at kd_temperature=1.0; 1.77x faster at memory parity vs the scripted version (fwd+bwd, [4,2048,128k] bf16)
- adopt: remove dead torch.jit.is_scripting() branches

Tests were written against the scripted implementations first, then re-run unchanged after the swap to pin behavior parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved top-k knowledge-distillation loss calculation, including temperature handling, masking, sequence alignment, and BF16 compatibility.
  * Improved weighted loss calculations for contiguous unmasked token groups.
  * Relaxed restrictions affecting optimizer and loss execution in supported runtime configurations.

* **Tests**
  * Added comprehensive coverage for distillation loss accuracy, gradients, masking, chunking, and temperature behavior.
  * Added tests for weighted-loss calculations, batching, shifting, masking, and gradient propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->