### PR TITLE
fix: clone offset/non-contiguous saved tensors on the compute stream

### DIFF
--- a/src/axolotl/core/trainers/mixins/activation_checkpointing.py
+++ b/src/axolotl/core/trainers/mixins/activation_checkpointing.py
@@ -59,6 +59,50 @@ def _patch_trl_offload_current_stream() -> None:
     )
 
 
+def _patch_trl_offload_compute_stream_clone() -> None:
+    """Clone offset/non-contiguous saved tensors on the COMPUTE stream before TRL's pack hook.
+
+    ``pack_tensor`` clones such tensors inside its ``torch.cuda.stream(s1)`` context, so the
+    stash copy is transfer-stream-pool memory written on s1 but consumed by compute kernels with
+    no ordering edge: the consumer can read the block before s1 executes the clone (stale bytes
+    from a recycled block), and once the stash entry is dropped mid-backward the block returns to
+    the s1 pool and the next H2D restore overwrites it while the compute-stream read is still
+    pending. Cross-entropy's saved ``shift_labels`` (storage_offset=1 from the label shift) hits
+    this every step: garbage targets -> device-side assert in nll_loss backward, corrupted CUDA
+    context. Pre-cloning on the compute stream closes both edges — the write is stream-ordered
+    with all consumers and the block never enters the transfer stream's allocator pool.
+    """
+    from trl.models.activation_offloading import OffloadActivations
+
+    if getattr(OffloadActivations, "_axolotl_compute_stream_clone", False):
+        return
+
+    orig_init = OffloadActivations.__init__
+
+    def patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        pack = self.pack_hook
+
+        def pack_contiguous(tensor):
+            if (
+                torch.is_tensor(tensor)
+                and tensor.device.type in ("cuda", "xpu", "npu")
+                and not isinstance(tensor, torch.nn.Parameter)
+                and (not tensor.is_contiguous() or tensor.storage_offset() != 0)
+            ):
+                tensor = tensor.clone(memory_format=torch.contiguous_format)
+            return pack(tensor)
+
+        self.pack_hook = pack_contiguous
+
+    OffloadActivations.__init__ = patched_init
+    OffloadActivations._axolotl_compute_stream_clone = True
+    LOG.info(
+        "Patched TRL OffloadActivations to clone offset/non-contiguous saved tensors "
+        "on the compute stream (fixes cross-stream use-after-free of the pack-time clone)"
+    )
+
+
 class ActivationOffloadingMixin(Trainer):
     """
     Trainer mixin class for activation checkpointing w offloading
@@ -74,6 +118,7 @@ class ActivationOffloadingMixin(Trainer):
             use_streams = self.args.activation_offloading != "legacy"
             if use_streams:
                 _patch_trl_offload_current_stream()
+                _patch_trl_offload_compute_stream_clone()
             if self.args.activation_offloading == "hidden_states":
                 from axolotl.monkeypatch.checkpoint_activation_offload import (
                     get_checkpoint_hidden_states_offloading_ctx_manager,


### PR DESCRIPTION
TRL OffloadActivations.pack_tensor clones offset/non-contiguous saved tensors inside the torch.cuda.stream(s1) context, so the fwd_stash copy is transfer-stream-pool memory: consumers read it on the compute stream with no ordering edge, and once the stash entry drops mid-backward the block returns to the s1 pool, where the next H2D restore is allocated at the same address and overwrites it while the compute-stream read is still pending. Cross-entropy's saved shift_labels (storage_offset=1 from the label shift) hits this every step: garbage targets, device-side assert in nll_loss backward, corrupted CUDA context — the consistent

Pre-cloning on the compute stream before TRL's pack hook closes both races: the write is stream-ordered with all consumers and the block never enters the transfer stream's allocator pool.

Validated on the CI image (L40S, torch 2.11, trl 1.7.0): 0/10 crashes in a regime that crashed 20/20 unpatched; a standalone stock-TRL reproducer goes from 5/6 corrupted steps to 0/6 with the patch.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation offloading reliability when stream-based offloading is enabled.
  * Prevented issues caused by non-contiguous tensors during training.
  * Preserved existing activation checkpointing and offloading behavior while improving compatibility across supported accelerator devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->