### PR TITLE
fix: support torch 2.13 checkpoint API in SAC offload

### DIFF
--- a/src/axolotl/monkeypatch/selective_checkpointing_offload.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing_offload.py
@@ -24,10 +24,22 @@ from torch.utils.checkpoint import (
     SAC_IGNORED_OPS,
     CheckpointPolicy,
     SelectiveCheckpointContext,
-    _maybe_detach,
     _policy_from_bool,
     _VersionWrapper,
 )
+
+try:
+    # torch <= 2.12
+    from torch.utils.checkpoint import _maybe_detach
+except ImportError:
+    # torch >= 2.13 replaced _maybe_detach with _detach_helper, dropping the
+    # float/alias-info gate to detach any tensor unconditionally
+    from torch.utils.checkpoint import _detach_helper
+
+    def _maybe_detach(x, any_ret_has_alias_info):
+        del any_ret_has_alias_info
+        return _detach_helper(x)
+
 
 from axolotl.monkeypatch.selective_checkpointing import (
     SacPolicyState,


### PR DESCRIPTION
torch 2.13 replaced torch.utils.checkpoint._maybe_detach with _detach_helper, dropping the float/alias-info gate to detach any tensor unconditionally. Import the old helper when available and otherwise shim it over _detach_helper, matching torch 2.13's own save-path behavior. All other imported names (SAC_IGNORED_OPS, CheckpointPolicy, SelectiveCheckpointContext, _policy_from_bool, _VersionWrapper) are unchanged in 2.13.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across supported PyTorch versions.
  * Fixed selective checkpointing behavior for newer PyTorch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->