### PR TITLE
fix(schemas): honor micro_batch_size/gradient_accumulation_steps defaults in check_batch_size_fields

### DIFF
--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -219,13 +219,6 @@ class TrainingValidationMixin:
     @classmethod
     def check_batch_size_fields(cls, data):
         fields = ("micro_batch_size", "gradient_accumulation_steps", "batch_size")
-        # This runs in mode="before", so field defaults have not been applied
-        # yet. Both `micro_batch_size` and `gradient_accumulation_steps` carry a
-        # documented default of 1, so a config that explicitly sets either one
-        # (relying on the other's default) is fully specified and must not be
-        # rejected. The deprecated `batch_size`, however, still has to be paired
-        # with an explicit `micro_batch_size` or `gradient_accumulation_steps`
-        # so that it can be split; on its own it stays ambiguous.
         if data.get("micro_batch_size") or data.get("gradient_accumulation_steps"):
             return data
 

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -219,9 +219,17 @@ class TrainingValidationMixin:
     @classmethod
     def check_batch_size_fields(cls, data):
         fields = ("micro_batch_size", "gradient_accumulation_steps", "batch_size")
-        non_empty_count = sum(1 for field in fields if data.get(field))
+        # This runs in mode="before", so field defaults have not been applied
+        # yet. Both `micro_batch_size` and `gradient_accumulation_steps` carry a
+        # documented default of 1, so a config that explicitly sets either one
+        # (relying on the other's default) is fully specified and must not be
+        # rejected. The deprecated `batch_size`, however, still has to be paired
+        # with an explicit `micro_batch_size` or `gradient_accumulation_steps`
+        # so that it can be split; on its own it stays ambiguous.
+        if data.get("micro_batch_size") or data.get("gradient_accumulation_steps"):
+            return data
 
-        if non_empty_count < 2:
+        if data.get("batch_size"):
             raise ValueError(f"At least two of {', '.join(fields)} must be set")
         return data
 

--- a/tests/utils/schemas/validation/test_config_validators.py
+++ b/tests/utils/schemas/validation/test_config_validators.py
@@ -252,3 +252,46 @@ class TestGRPOBatchSizeValidator:
         }
         out = self._check(data)
         assert out["gradient_accumulation_steps"] == 8
+
+
+class TestBatchSizeFieldsValidator:
+    """``micro_batch_size`` and ``gradient_accumulation_steps`` both default to
+    1, so a config that sets only one of them (or neither) is still fully
+    specified and must not be rejected by ``check_batch_size_fields``.
+
+    ``check_batch_size_fields`` runs in ``mode="before"`` (before field defaults
+    are applied), so these guard against a regression where relying on the
+    documented defaults raised "At least two of ... must be set".
+    """
+
+    @staticmethod
+    def _base():
+        """``min_base_cfg`` sets both batch fields explicitly, which is exactly
+        the case that already worked; build a config without them instead."""
+        return DictDefault(
+            base_model="HuggingFaceTB/SmolLM2-135M",
+            learning_rate=1e-3,
+            datasets=[
+                {
+                    "path": "mhenrichsen/alpaca_2k_test",
+                    "type": "alpaca",
+                },
+            ],
+        )
+
+    def test_only_gradient_accumulation_steps_passes(self):
+        cfg = self._base() | DictDefault(gradient_accumulation_steps=4)
+        validated = validate_config(cfg)
+        assert validated.gradient_accumulation_steps == 4
+        assert validated.micro_batch_size == 1
+
+    def test_only_micro_batch_size_passes(self):
+        cfg = self._base() | DictDefault(micro_batch_size=4)
+        validated = validate_config(cfg)
+        assert validated.micro_batch_size == 4
+        assert validated.gradient_accumulation_steps == 1
+
+    def test_neither_set_relies_on_defaults(self):
+        validated = validate_config(self._base())
+        assert validated.micro_batch_size == 1
+        assert validated.gradient_accumulation_steps == 1


### PR DESCRIPTION
### Problem

`check_batch_size_fields` (in `src/axolotl/utils/schemas/validation.py`) requires at least two of `micro_batch_size`, `gradient_accumulation_steps`, `batch_size` to be present:

```python
non_empty_count = sum(1 for field in fields if data.get(field))
if non_empty_count < 2:
    raise ValueError(f"At least two of {', '.join(fields)} must be set")
```

But it runs as a `@model_validator(mode="before")`, so it only sees the keys the user actually put in their YAML — field defaults have not been applied yet. Both `micro_batch_size` and `gradient_accumulation_steps` carry a **documented default of `1`** (`schemas/training.py`). So a config that sets only one of the pair and relies on the other's default has `non_empty_count == 1` and is rejected outright:

```python
AxolotlInputConfig(
    base_model="HuggingFaceTB/SmolLM2-135M",
    datasets=[{"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"}],
    gradient_accumulation_steps=4,
)
# ValueError: At least two of micro_batch_size, gradient_accumulation_steps, batch_size must be set
```

Setting only `micro_batch_size` and relying on the `gradient_accumulation_steps` default hits the same error. Either one alone is a perfectly normal config — the point of the documented default is that you shouldn't have to set both. This has not surfaced in CI because the example configs and the `min_base_cfg` fixture happen to set both fields explicitly.

### Fix

Treat an explicit `micro_batch_size` **or** `gradient_accumulation_steps` as sufficient, since whichever one is omitted resolves to its documented default of `1`.

The deprecated `batch_size` is deliberately **not** given the same treatment: it has to be paired with an explicit `micro_batch_size` or `gradient_accumulation_steps` so that it can be split, and on its own it stays ambiguous. This keeps the existing `tests/patched/test_validation.py::test_batch_size_more_params` assertion (lone `batch_size` must raise `"At least two of ..."`) green — a naive "count the declared defaults" fix would have silently regressed it.

### Tests

Adds `TestBatchSizeFieldsValidator` covering the three previously-broken cases: only `gradient_accumulation_steps` set, only `micro_batch_size` set, and neither set (relying on both defaults). It builds its own base config rather than using `min_base_cfg`, because that fixture sets both batch fields explicitly — i.e. exactly the case that already worked.

Fixes #3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
