### PR TITLE
Read completion column in KTO chatml argilla_chat

### DIFF
--- a/src/axolotl/prompt_strategies/kto/chatml.py
+++ b/src/axolotl/prompt_strategies/kto/chatml.py
@@ -33,7 +33,7 @@ def argilla_chat(
 
     def transform_fn(sample):
         sample["prompt"] = (
-            f"<|im_start|>user\n{sample['chosen'][0]['content']}<|im_end|>\n<|im_start|>assistant\n"
+            f"<|im_start|>user\n{sample['completion'][0]['content']}<|im_end|>\n<|im_start|>assistant\n"
         )
         sample["completion"] = f"{sample['completion'][1]['content']}<|im_end|>"
         return sample

--- a/tests/prompt_strategies/test_kto_chatml.py
+++ b/tests/prompt_strategies/test_kto_chatml.py
@@ -1,0 +1,33 @@
+"""
+Tests for KTO dataset transform strategies with chatml formatting
+"""
+
+from axolotl.prompt_strategies.kto.chatml import argilla_chat
+
+
+class TestKTOChatml:
+    """
+    Test kto.chatml transforms
+    """
+
+    def test_argilla_chat_reads_completion_messages(self):
+        """argilla_chat builds the prompt from the conversation stored in the
+        `completion` column. argilla/kto-mix-15k has no `chosen` column, so
+        reading one raised KeyError during preprocessing; the llama-3 sibling
+        already reads `completion`."""
+        transform_fn = argilla_chat(cfg=None)
+        sample = transform_fn(
+            {
+                "prompt": "What is 2 + 2?",
+                "completion": [
+                    {"role": "user", "content": "What is 2 + 2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+                "label": True,
+            }
+        )
+        assert (
+            sample["prompt"]
+            == "<|im_start|>user\nWhat is 2 + 2?<|im_end|>\n<|im_start|>assistant\n"
+        )
+        assert sample["completion"] == "4<|im_end|>"


### PR DESCRIPTION
### Problem

The KTO `chatml` `argilla_chat` transform builds the user prompt from `sample['chosen'][0]['content']`:

```python
def argilla_chat(cfg, **kwargs):
    """
    for argilla/kto-mix-15k conversations
    """
    def transform_fn(sample):
        sample["prompt"] = (
            f"<|im_start|>user\n{sample['chosen'][0]['content']}<|im_end|>\n<|im_start|>assistant\n"
        )
        sample["completion"] = f"{sample['completion'][1]['content']}<|im_end|>"
        return sample
    return transform_fn
```

But the `argilla/kto-mix-15k` dataset it documents has no `chosen` column. Its conversation lives in the `completion` column (a list of user/assistant message dicts). So preprocessing a KTO dataset with `type: chatml.argilla_chat` raises `KeyError('chosen')` inside `dataset.map`.

Two things make the intended column clear:

- The same function already reads `sample['completion'][1]['content']` for the assistant turn, so it treats `completion` as the message list.
- The llama-3 sibling `kto/llama3.py::argilla_chat` reads `completion` for both turns:
  ```python
  sample["prompt"] = f"...{sample['completion'][0]['content']}..."
  sample["completion"] = f"{sample['completion'][1]['content']}..."
  ```

The `chatml` variant looks like a copy from `dpo/chatml.py` (where `chosen` is a real column) that missed swapping `chosen` to `completion`.

### Fix

Read the user turn from `sample['completion'][0]['content']` so the prompt and completion come from the same column, matching the llama-3 strategy and the documented dataset schema. One identifier changes.

### Reproduction

```python
from axolotl.prompt_strategies.kto.chatml import argilla_chat

sample = {
    "prompt": "What is 2 + 2?",
    "completion": [
        {"role": "user", "content": "What is 2 + 2?"},
        {"role": "assistant", "content": "4"},
    ],
    "label": True,
}
argilla_chat(cfg=None)(sample)   # before: KeyError: 'chosen'
```

Before: `KeyError: 'chosen'`. After: the prompt is built from the user message and the completion from the assistant message.

### Test

Adds `tests/prompt_strategies/test_kto_chatml.py`, which calls the transform directly (no tokenizer or dataset download) and asserts the user content lands in `prompt` and the assistant content in `completion`. It fails before (`KeyError`) and passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ChatML prompt formatting for KTO conversations by reading the initial user message from the appropriate completion data.

* **Tests**
  * Added coverage to verify prompt construction and assistant response formatting for KTO ChatML conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->