### PR TITLE
fix(loaders): pin device_map per-rank for 4-bit/8-bit DDP (multi-GPU QLoRA collapses to world_size 1)

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -625,7 +625,11 @@ class ModelLoader:
             # the device map at bf16 size (before quantization), causing it to offload
             # layers to CPU, which BnB then rejects. Force single-GPU placement to
             # prevent this. Only applies to the non-FSDP, non-ZeRO3 path (DDP/single).
-            if getattr(self.cfg, "quantize_moe_experts", False) and device_map in (
+            if (
+                self.cfg.load_in_4bit
+                or self.cfg.load_in_8bit
+                or getattr(self.cfg, "quantize_moe_experts", False)
+            ) and device_map in (
                 "auto",
                 None,
             ):


### PR DESCRIPTION
## Problem
Multi-GPU QLoRA (`load_in_4bit`) on the **non-FSDP / non-ZeRO3** path silently collapses to `world_size: 1`. A 2-GPU `accelerate launch --num_processes 2` (or `torchrun`) runs single-process; with `fsdp` set it errors `ValueError: Using fsdp only works in distributed training`. bf16 on the *identical* launch gives `world_size: 2`.

## Cause
`ModelLoader._set_device_map_config` sets `device_map = cfg.device_map` (→ `"auto"`) for quantized models on the DDP path. `device_map="auto"` spreads the model across GPUs (model-parallel), so transformers sets `is_model_parallel=True` and disables `DistributedDataParallel`.

The existing `quantize_moe_experts` branch already pins `device_map={"": LOCAL_RANK}` to avoid exactly this — but only for MoE. Plain 4-bit dense QLoRA hits the same collapse.

## Fix
Generalize that branch to all bitsandbytes-quantized loads (`load_in_4bit` / `load_in_8bit` / `quantize_moe_experts`). Each rank then loads a full copy on its local GPU → DDP works (`world_size: N`). Single-GPU is unaffected (`{"":0}` == what `"auto"` resolves to for a fitting model).

## Verification
Qwen3-14B, `adapter: qlora`, `load_in_4bit: true`, no fsdp, `--num_processes 2`: **before** → `world_size: 1` (one GPU used); **after** → `world_size: 2`, both GPUs training. A minimal raw-`torchrun` DDP script using `device_map={"": local_rank}` already trained multi-GPU cleanly, isolating the cause to the loader's `device_map="auto"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device placement when loading models with 4-bit or 8-bit quantization.
  * Ensured quantized models are assigned to a single GPU when automatic placement is unavailable or unsuitable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->