### PR TITLE
feat: register plugin CLI commands via entry points

### DIFF
--- a/docs/custom_integrations.qmd
+++ b/docs/custom_integrations.qmd
@@ -119,3 +119,54 @@ It is not necessary to place your integration in the `integrations` folder. It c
 See this repo for an example: [https://github.com/axolotl-ai-cloud/diff-transformer](https://github.com/axolotl-ai-cloud/diff-transformer)
 
 :::
+
+## Adding a CLI command
+
+An integration can contribute its own `axolotl` subcommand. Unlike plugin hooks, which are
+loaded from the `plugins:` list of a config file, a subcommand has to be discoverable before
+any config is read, so it is registered through a packaging entry point instead.
+
+Define a regular `click` command in your package:
+
+```python
+# my_package/cli.py
+import click
+
+@click.command()
+@click.argument("config", type=click.Path(exists=True, path_type=str))
+@click.option("--rank-ratio", type=float, default=0.01)
+def my_command(config: str, rank_ratio: float):
+    """one-line summary shown in `axolotl --help`"""
+    from my_package.core import run  # keep heavy imports inside the function
+
+    run(config, rank_ratio=rank_ratio)
+```
+
+and advertise it under the `axolotl.cli_commands` entry point group:
+
+```toml
+# my_package/pyproject.toml
+[project.entry-points."axolotl.cli_commands"]
+my-command = "my_package.cli:my_command"
+```
+
+Installing your package makes `axolotl my-command` available, and it will be listed in
+`axolotl --help`. The entry point name is the subcommand name, and the value is
+`<module>:<attribute>`.
+
+::: {.callout-warning}
+
+Entry points are written into your package metadata at install time, not read from
+`pyproject.toml` at runtime. After adding or renaming one, reinstall the package
+(`pip install -e .`) or the subcommand will not appear.
+
+:::
+
+::: {.callout-note}
+
+Commands shipped with axolotl take precedence, so a plugin cannot shadow `train` or any
+other core command. Integrations bundled in this repo are registered in
+`BUILTIN_COMMANDS` in `src/axolotl/cli/plugins.py` rather than through entry points, so
+that they work from a source checkout without a reinstall.
+
+:::

--- a/src/axolotl/cli/main.py
+++ b/src/axolotl/cli/main.py
@@ -18,6 +18,7 @@ from axolotl.cli.args import (
 )
 from axolotl.cli.art import print_axolotl_text_art
 from axolotl.cli.config_options import AXOLOTL_CONFIG_CLI_OPTIONS
+from axolotl.cli.plugins import PluginCommandGroup
 from axolotl.cli.utils import (
     add_options_from_config_options,
     add_options_from_dataclass,
@@ -38,7 +39,7 @@ LAUNCHER_COMMAND_MAPPING = {
 }
 
 
-@click.group()
+@click.group(cls=PluginCommandGroup)
 @click.version_option(version=axolotl.__version__, prog_name="axolotl")
 def cli():
     """Axolotl CLI - Train and fine-tune large language models"""
@@ -368,19 +369,6 @@ def generate_cli_config_options(output: Path, check: bool):
     from axolotl.cli.generate_config_options import write_options
 
     write_options(output, check=check)
-
-
-@cli.command("lm-eval")
-@click.argument("config", type=click.Path(exists=True, path_type=str))
-@click.option("--cloud", default=None, type=click.Path(exists=True, path_type=str))
-@click.pass_context
-def lm_eval(ctx: click.Context, config: str, cloud: Optional[str] = None):
-    """
-    use lm eval to evaluate a trained language model
-    """
-    from axolotl.integrations.lm_eval.cli import lm_eval as _lm_eval
-
-    ctx.invoke(_lm_eval, config=config, cloud=cloud)
 
 
 @cli.command("agent-docs")

--- a/src/axolotl/cli/plugins.py
+++ b/src/axolotl/cli/plugins.py
@@ -1,0 +1,124 @@
+"""CLI commands contributed by axolotl integrations and third-party plugins."""
+
+import importlib
+from importlib.metadata import entry_points
+from typing import NamedTuple
+
+import click
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+ENTRY_POINT_GROUP = "axolotl.cli_commands"
+
+
+class PluginCommand(NamedTuple):
+    """A command to import from `target` (`<module>:<attribute>`) when it is used."""
+
+    target: str
+    # duplicated from the command's own docstring so that `axolotl --help` can render
+    # the summary line without importing the module, which for an in-tree integration
+    # pulls in torch via the package's `__init__`
+    short_help: str = ""
+
+
+BUILTIN_COMMANDS: dict[str, PluginCommand] = {
+    "lm-eval": PluginCommand(
+        target="axolotl.integrations.lm_eval.cli:lm_eval",
+        short_help="use lm eval to evaluate a trained language model",
+    ),
+}
+
+
+def _import_command(target: str) -> click.Command:
+    module_name, separator, attribute = target.partition(":")
+    if not separator:
+        raise ValueError(f"expected '<module>:<attribute>', got '{target}'")
+
+    command = getattr(importlib.import_module(module_name), attribute)
+    if not isinstance(command, click.Command):
+        raise TypeError(f"'{target}' is not a click command")
+
+    return command
+
+
+class LazyCommand(click.Command):
+    """Stands in for a plugin command until it is actually used.
+
+    Click resolves every command to render `axolotl --help`, so the real module is
+    imported only once the command is invoked or its own `--help` is requested.
+    """
+
+    def __init__(self, name: str, spec: PluginCommand):
+        super().__init__(name, short_help=spec.short_help)
+        self.spec = spec
+        self._command: click.Command | None = None
+
+    def resolve(self) -> click.Command:
+        if self._command is None:
+            self._command = _import_command(self.spec.target)
+        return self._command
+
+    def get_short_help_str(self, limit: int = 45) -> str:
+        if self.short_help:
+            return self.short_help
+
+        try:
+            return self.resolve().get_short_help_str(limit)
+        except Exception as exc:
+            LOG.warning(
+                "could not load plugin command '%s' from '%s': %s",
+                self.name,
+                self.spec.target,
+                exc,
+            )
+            return ""
+
+    def make_context(self, info_name, args, parent=None, **extra) -> click.Context:
+        return self.resolve().make_context(info_name, args, parent=parent, **extra)
+
+    def invoke(self, ctx: click.Context):
+        return self.resolve().invoke(ctx)
+
+
+class PluginCommandGroup(click.Group):
+    """Click group that also serves commands contributed by plugins.
+
+    Commands come from `BUILTIN_COMMANDS` and from the `axolotl.cli_commands` entry
+    point group. Commands declared on the group take precedence, so plugins cannot
+    shadow core commands.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._plugin_commands: dict[str, PluginCommand] | None = None
+
+    def plugin_commands(self) -> dict[str, PluginCommand]:
+        # cached because entry point discovery reads installed metadata off disk and
+        # click resolves every command to render `--help`
+        if self._plugin_commands is None:
+            commands = dict(BUILTIN_COMMANDS)
+            for entry_point in entry_points(group=ENTRY_POINT_GROUP):
+                if entry_point.name in commands:
+                    LOG.warning(
+                        "ignoring plugin command '%s' from '%s': name is already taken",
+                        entry_point.name,
+                        entry_point.value,
+                    )
+                    continue
+                commands[entry_point.name] = PluginCommand(target=entry_point.value)
+            self._plugin_commands = commands
+
+        return self._plugin_commands
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return sorted({*super().list_commands(ctx), *self.plugin_commands()})
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+
+        spec = self.plugin_commands().get(cmd_name)
+        return LazyCommand(cmd_name, spec) if spec is not None else None

--- a/tests/cli/test_cli_plugins.py
+++ b/tests/cli/test_cli_plugins.py
@@ -1,0 +1,135 @@
+"""Tests for plugin-contributed CLI commands."""
+
+import sys
+from importlib.metadata import EntryPoint
+
+import click
+import pytest
+
+from axolotl.cli import plugins
+from axolotl.cli.main import cli
+from axolotl.cli.plugins import PluginCommand, PluginCommandGroup
+
+
+@click.command()
+@click.option("--rank-ratio", type=float, default=0.01)
+def dummy_command(rank_ratio):
+    """dummy plugin command"""
+    click.echo(f"dummy ran rank_ratio={rank_ratio}")
+
+
+not_a_command = "definitely not a click command"
+
+DUMMY_TARGET = "tests.cli.test_cli_plugins:dummy_command"
+
+
+@pytest.fixture
+def group(monkeypatch):
+    """A group whose plugin commands come only from patched entry points."""
+
+    def _build(entry_points_, builtins=None):
+        monkeypatch.setattr(plugins, "BUILTIN_COMMANDS", builtins or {})
+        monkeypatch.setattr(
+            plugins,
+            "entry_points",
+            lambda group: [
+                EntryPoint(name=name, value=value, group=group)
+                for name, value in entry_points_.items()
+            ],
+        )
+
+        built = PluginCommandGroup(name="axolotl")
+
+        @built.command("core")
+        def _core():
+            """core command"""
+            click.echo("core ran")
+
+        return built
+
+    return _build
+
+
+def test_builtin_command_listed_in_help(cli_runner):
+    result = cli_runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "lm-eval" in result.output
+
+
+def test_help_does_not_import_plugin_module(cli_runner):
+    """`--help` renders summaries from the registry, never importing the module."""
+    sys.modules.pop("axolotl.integrations.lm_eval.cli", None)
+
+    result = cli_runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "axolotl.integrations.lm_eval.cli" not in sys.modules
+
+
+def test_entry_point_command_is_listed_and_invoked(cli_runner, group):
+    built = group({"dummy": DUMMY_TARGET})
+
+    assert "dummy" in built.list_commands(None)
+
+    result = cli_runner.invoke(built, ["dummy", "--rank-ratio", "0.5"])
+
+    assert result.exit_code == 0
+    assert "dummy ran rank_ratio=0.5" in result.output
+
+
+def test_entry_point_command_owns_its_options(cli_runner, group):
+    built = group({"dummy": DUMMY_TARGET})
+
+    result = cli_runner.invoke(built, ["dummy", "--help"])
+
+    assert result.exit_code == 0
+    assert "--rank-ratio" in result.output
+
+
+def test_plugin_cannot_shadow_declared_command(cli_runner, group):
+    built = group({"core": DUMMY_TARGET})
+
+    result = cli_runner.invoke(built, ["core"])
+
+    assert result.exit_code == 0
+    assert "core ran" in result.output
+
+
+def test_builtin_takes_precedence_over_entry_point(group):
+    builtin = PluginCommand(target=DUMMY_TARGET, short_help="builtin")
+    built = group({"dummy": "other.module:command"}, builtins={"dummy": builtin})
+
+    assert built.plugin_commands()["dummy"] == builtin
+
+
+def test_unknown_command_errors(cli_runner, group):
+    built = group({})
+
+    result = cli_runner.invoke(built, ["nope"])
+
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_broken_plugin_does_not_break_help(cli_runner, group):
+    built = group({"broken": "axolotl.does_not_exist:command"})
+
+    result = cli_runner.invoke(built, ["--help"])
+
+    assert result.exit_code == 0
+    assert "broken" in result.output
+
+
+def test_non_command_target_is_rejected(group):
+    built = group({"bogus": "tests.cli.test_cli_plugins:not_a_command"})
+
+    with pytest.raises(TypeError):
+        built.get_command(None, "bogus").resolve()
+
+
+def test_target_without_attribute_is_rejected(group):
+    built = group({"bogus": "tests.cli.test_cli_plugins"})
+
+    with pytest.raises(ValueError):
+        built.get_command(None, "bogus").resolve()


### PR DESCRIPTION
A subcommand has to be discoverable before any config is read, so it cannot come from the `plugins:` list the way training hooks do. Resolve subcommands instead from a builtin registry plus the `axolotl.cli_commands` entry point group, so an installed package can contribute `axolotl <cmd>` without changes here.

Commands resolve lazily through a stand-in that carries the summary line, so rendering `axolotl --help` no longer imports an integration (and transitively torch) just to read its docstring. Commands declared on the group win, so a plugin cannot shadow a core command.

Bundled integrations stay in the registry rather than using entry points, since entry point metadata is written at install time and would otherwise need a reinstall to pick up a new command in a source checkout.

- lm-eval moves off its hand-written wrapper onto the registry

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for integrations to provide custom `axolotl` CLI subcommands through Python packaging entry points.
  * Added lazy loading for integration commands, helping the CLI remain usable even when an optional command cannot load.
  * Built-in commands take precedence over integration-provided commands with the same name.

* **Documentation**
  * Added setup guidance, Click examples, and operational notes for registering custom CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->