### PR TITLE
fix(docker): preinstall kernels-data before the editable axolotl build

### DIFF
--- a/cicd/Dockerfile-uv.jinja
+++ b/cicd/Dockerfile-uv.jinja
@@ -21,7 +21,7 @@ RUN git fetch origin +$GITHUB_REF && \
 
 RUN uv pip install packaging==26.0 setuptools==78.1.1
 RUN uv pip uninstall causal_conv1d
-RUN uv pip install "huggingface_hub>=1.5.0" "httpx<1"
+RUN uv pip install "huggingface_hub>=1.5.0" "httpx<1" "kernels-data"
 RUN if [ "$AXOLOTL_EXTRAS" != "" ] ; then \
         uv pip install --no-build-isolation -e .[deepspeed,optimizers,ray,$AXOLOTL_EXTRAS] $AXOLOTL_ARGS; \
     else \

--- a/docker/Dockerfile-uv
+++ b/docker/Dockerfile-uv
@@ -18,7 +18,7 @@ COPY . .
 # If AXOLOTL_EXTRAS is set, append it in brackets; don't install deepspeed with arm64
 RUN uv pip uninstall causal_conv1d
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install "huggingface_hub>=1.5.0" "httpx<1" && \
+    uv pip install "huggingface_hub>=1.5.0" "httpx<1" "kernels-data" && \
     if [ "$TARGETARCH" = "arm64" ]; then \
         BASE_EXTRAS="optimizers,ray"; \
     else \


### PR DESCRIPTION
## Description

Main's multi-arch `ci-cd` docker build fails on arm64 since the `kernels==0.15.2` bump (#3822): `build_editable` dies with `ModuleNotFoundError: No module named 'kernels_data'` ([failing job](https://github.com/axolotl-ai-cloud/axolotl/actions/runs/29530215378/job/87728473226)).

`kernels>=0.14` registers an `egg_info.writers` setuptools entry point (`kernels.lock = kernels.lockfile:write_egg_lockfile`) whose module imports `kernels_data` at load time. setuptools loads every `egg_info.writers` entry point during any editable build, and the image build runs `uv pip install --no-build-isolation -e .` — so when the kernels 0.15.2 upgrade lands in the env mid-transaction before `kernels-data` does, the editable build of axolotl itself crashes. amd64 has been surviving on cache ordering; the qemu-emulated arm64 build loses the race.

Preinstalling `kernels-data` alongside `huggingface_hub` (both in `docker/Dockerfile-uv` and `cicd/Dockerfile-uv.jinja`) makes the entry point importable regardless of transaction ordering.

## Motivation and Context

Unblocks docker image publishing on main (failed on the #3822 merge commit).

## How has this been tested?

Root-caused from the buildkit log (uv transcript shows `Installed 143 packages` → `Building axolotl` interleaved with remaining downloads). The entry-point → `from kernels_data import Metadata` chain verified against the installed kernels 0.15.2 wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds by ensuring required package metadata is available before the editable installation step.
  * Prevented installation failures caused by inconsistent package entry-point registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->