### PR TITLE
unpin numpy: floor-only ranges, numba metadata governs the numpy ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
     "wandb",
     "einops",
     "colorama",
-    "numba==0.63.1",
-    "numpy==2.3.5",
+    "numba>=0.63.1,<1.0",
+    "numpy>=2.1,<3.0",
     "typer==0.25.1",
 
     # Evaluation & metrics


### PR DESCRIPTION
numba is the only reason numpy was pinned (it's used solely by the multipack sampler's FFD bin-packing kernels), and numba always lags numpy releases.

this also resolves a uv.lock issue for for various python versions; the dependency tree unresolvable under uv lock: numpy==2.3.5 requires Python ≥3.11 while the project declares requires-python >=3.10, so the py3.10 resolution split had no solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened supported versions of NumPy and Numba within compatible major-version ranges.
  * Enables greater flexibility when installing and updating the application’s numerical computing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->