### PR TITLE
fix: FA4 quack0.6 with latest transformers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## 🎉 Latest Updates
 
 - 2026/07:
-  - [NVFP4 (4-bit) MoE LoRA training](https://docs.axolotl.ai/docs/nvfp4_lora.html) is now supported via ScatterMoE (W4A16) and SonicMoE (W4A4), including lossless adapter merge back into a plain NVFP4 checkpoint.
+  - [NVFP4 (4-bit) MoE LoRA training](https://docs.axolotl.ai/docs/nvfp4_lora.html) is now supported via ScatterMoE (W4A16) and SonicMoE (W4A4), including adapter merge back into a plain NVFP4 checkpoint.
 - 2026/06:
   - [Expert Parallelism (EP)](https://docs.axolotl.ai/docs/nd_parallelism.html) for distributed MoE training via DeepEP, remote training through [Tinker-compatible APIs](https://github.com/axolotl-ai-cloud/axolotl/pull/3614), [Context Parallelism for hybrid SSM models](https://github.com/axolotl-ai-cloud/axolotl/pull/3572) (Nemotron-H, Falcon-H1, Bamba), [BitNet 1.58-bit](https://github.com/axolotl-ai-cloud/axolotl/pull/3634) fine-tuning, and a [multimodal assistant-only loss-masking fix](https://github.com/axolotl-ai-cloud/axolotl/pull/3625).
 - 2026/04:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - 2026/07:
   - [NVFP4 (4-bit) MoE LoRA training](https://docs.axolotl.ai/docs/nvfp4_lora.html) is now supported via ScatterMoE (W4A16) and SonicMoE (W4A4), including adapter merge back into a plain NVFP4 checkpoint.
+  - [Flash Attention 4](https://docs.axolotl.ai/docs/attention.html#flash-attention-4) now routes through the native `flash_attention_4` backend and requires `quack-kernels>=0.6.0`. Blackwell (SM100/SM110) additionally needs a patched FA4 until [Dao-AILab/flash-attention#2689](https://github.com/Dao-AILab/flash-attention/pull/2689) lands; Axolotl detects both and prints the install command.
 - 2026/06:
   - [Expert Parallelism (EP)](https://docs.axolotl.ai/docs/nd_parallelism.html) for distributed MoE training via DeepEP, remote training through [Tinker-compatible APIs](https://github.com/axolotl-ai-cloud/axolotl/pull/3614), [Context Parallelism for hybrid SSM models](https://github.com/axolotl-ai-cloud/axolotl/pull/3572) (Nemotron-H, Falcon-H1, Bamba), [BitNet 1.58-bit](https://github.com/axolotl-ai-cloud/axolotl/pull/3634) fine-tuning, and a [multimodal assistant-only loss-masking fix](https://github.com/axolotl-ai-cloud/axolotl/pull/3625).
 - 2026/04:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
 
 - 2026/07:
   - [NVFP4 (4-bit) MoE LoRA training](https://docs.axolotl.ai/docs/nvfp4_lora.html) is now supported via ScatterMoE (W4A16) and SonicMoE (W4A4), including adapter merge back into a plain NVFP4 checkpoint.
-  - [Flash Attention 4](https://docs.axolotl.ai/docs/attention.html#flash-attention-4) now routes through the native `flash_attention_4` backend and requires `quack-kernels>=0.6.0`. Blackwell (SM100/SM110) additionally needs a patched FA4 until [Dao-AILab/flash-attention#2689](https://github.com/Dao-AILab/flash-attention/pull/2689) lands; Axolotl detects both and prints the install command.
 - 2026/06:
   - [Expert Parallelism (EP)](https://docs.axolotl.ai/docs/nd_parallelism.html) for distributed MoE training via DeepEP, remote training through [Tinker-compatible APIs](https://github.com/axolotl-ai-cloud/axolotl/pull/3614), [Context Parallelism for hybrid SSM models](https://github.com/axolotl-ai-cloud/axolotl/pull/3572) (Nemotron-H, Falcon-H1, Bamba), [BitNet 1.58-bit](https://github.com/axolotl-ai-cloud/axolotl/pull/3634) fine-tuning, and a [multimodal assistant-only loss-masking fix](https://github.com/axolotl-ai-cloud/axolotl/pull/3625).
 - 2026/04:

--- a/docs/agents/new_model_support.md
+++ b/docs/agents/new_model_support.md
@@ -148,7 +148,7 @@ Older models that use `_prepare_4d_causal_attention_mask` (Llama, Mistral, Qwen2
 | Backend | Config | head_dim limit | torch_compile | Notes |
 |---------|--------|---------------|---------------|-------|
 | FA2 | `attn_implementation: flash_attention_2` | 256 | ✅ | Fastest when supported |
-| FA4 | auto with `attn_implementation: flash_attention_2` | 256 (SM90+) | ✅ | Auto-detected on H100+ |
+| FA4 | `attn_implementation: flash_attention_4` (or auto-upgrade from FA2) | 128 (SM90+) | ✅ | Auto-detected on H100+; needs `quack-kernels>=0.6.0` |
 | SDPA | `attn_implementation: sdpa` | None | ✅ | Universal fallback |
 | flex | `attn_implementation: flex_attention` | None | ⚠️ Triton OOM for large head_dim | Good for variable head dims |
 | eager | `attn_implementation: eager` | None | ✅ | Slowest, always works |

--- a/docs/attention.qmd
+++ b/docs/attention.qmd
@@ -94,8 +94,13 @@ python setup.py install
 
 #### Flash Attention 4
 
-Requirements: Hopper or Blackwell GPUs. Auto-applied when `attn_uses_flash_lib`
-is true and FA4 is importable.
+Requirements: Hopper or Blackwell GPUs, and `quack-kernels>=0.6.0`. When FA4 is importable
+and compatible with the model, Axolotl upgrades `flash_attention_2`/`flash_attention_3` to
+native `flash_attention_4`. You can also request it explicitly:
+
+```yaml
+attn_implementation: flash_attention_4
+```
 
 FA4 is still a pre-release on PyPI, so `--pre` is required:
 
@@ -115,10 +120,12 @@ pip install -e .
 rm -r $(python -c "import flash_attn; print(flash_attn.__path__[0])")/cute
 ```
 
-::: {.callout-note}
+::: {.callout-important}
 
-**Hopper (SM90) users**: The backward kernel is not yet included in the pip package. To use FA4
-for training on Hopper, install from source using the instructions above.
+FA4 training requires `quack-kernels>=0.6.0` on `nvidia-cutlass-dsl==4.6.0`. With an older
+quack (0.5.x targets the `4.6.0.dev0` prerelease) the FA4 backward raises
+`cudaErrorIllegalInstruction`. Upgrade with `pip install 'quack-kernels>=0.6.0'`; Axolotl
+warns and keeps your requested backend when the installed quack is too old.
 
 :::
 

--- a/docs/attention.qmd
+++ b/docs/attention.qmd
@@ -129,6 +129,23 @@ warns and keeps your requested backend when the installed quack is too old.
 
 :::
 
+::: {.callout-important}
+
+## Blackwell (B200, GB200) needs a patched FA4
+
+On Blackwell the FA4 backward hangs with `nvidia-cutlass-dsl>=4.6.0`. Install the fix
+([Dao-AILab/flash-attention#2689](https://github.com/Dao-AILab/flash-attention/pull/2689))
+over your existing FA4:
+
+```bash
+pip install --no-deps --force-reinstall \
+  'git+https://github.com/dongxiao92/flash-attention@fix/sm100-elect-one-and-div-alignment#subdirectory=flash_attn/cute'
+```
+
+`--no-deps` keeps your existing cutlass and quack pins. Hopper (H100, H200) is unaffected.
+
+:::
+
 ::: {.callout-warning}
 
 FA4 only supports head dimensions up to 128 (`d ≤ 128`). The DeepSeek shape `(192, 128)` is

--- a/docs/attention.qmd
+++ b/docs/attention.qmd
@@ -21,6 +21,8 @@ backends, axolotl-registered backends, or a hub-kernel path.
 | `sdpa` | PyTorch `scaled_dot_product_attention`. No packing support. |
 | `flash_attention_2` | Dao-AILab Flash Attention 2. |
 | `flash_attention_3` | Dao-AILab Flash Attention 3 (Hopper+). |
+| `flash_attention_4` | Dao-AILab Flash Attention 4 (Hopper+, `flash_attn.cute`). |
+| `flash_attention_torch` | Torch in-tree varlen attention (`torch.nn.attention.varlen`, torch ≥ 2.11, CUDA only). No `flash_attn` dependency. No dropout, attention sinks, or softcap. |
 | `flex_attention` | Torch Flex Attention (requires torch ≥ 2.6). |
 | `xformers` | xFormers memory-efficient attention. |
 | `sage` | SageAttention (QK int8 / PV fp16). |

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -139,7 +139,7 @@ Canonical key `attn_implementation:` (legacy boolean flags in parentheses are �
 | Backend | Value / flag | Notes |
 |---|---|---|
 | Flash Attention 2/3 | `flash_attention_2` / `flash_attention_3` (`flash_attention: true`) | FA2 auto-upgrades to FA3 on SM90+; ⚪ Ampere or newer only (not Turing) |
-| Flash Attention 4 🟡 | auto-upgrade when available | pre-release; 🔵 backward not in pip on Hopper (build from source) |
+| Flash Attention 4 🟡 | `flash_attention_4` (auto-upgrade when available) | pre-release; requires `quack-kernels>=0.6.0` (older quack raises `cudaErrorIllegalInstruction` in the backward) |
 | SDPA | `sdpa` (`sdp_attention: true`) | safe default; works everywhere |
 | SDPA varlen | `sdpa_varlen: true` | packing without a mask tensor, PyTorch >= 2.10 |
 | FlexAttention | `flex_attention` (`flex_attention: true`) | PyTorch >= 2.6; enables `scaling_softmax` |
@@ -297,7 +297,6 @@ Not in a tagged release yet:
 - EP + TP/CP
 - Multiple DPO loss types (RPO)
 - Sample packing across multiple streaming datasets
-- FA4 backward on Hopper via pip
 
 ### ⚪ Out-of-scope / won't-fix
 

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -140,6 +140,7 @@ Canonical key `attn_implementation:` (legacy boolean flags in parentheses are �
 |---|---|---|
 | Flash Attention 2/3 | `flash_attention_2` / `flash_attention_3` (`flash_attention: true`) | FA2 auto-upgrades to FA3 on SM90+; ⚪ Ampere or newer only (not Turing) |
 | Flash Attention 4 🟡 | `flash_attention_4` (auto-upgrade when available) | pre-release; requires `quack-kernels>=0.6.0` (older quack raises `cudaErrorIllegalInstruction` in the backward) |
+| Flash Attention (torch) 🟡 | `flash_attention_torch` | torch varlen kernels, no `flash_attn` dependency; needs a transformers release that registers it |
 | SDPA | `sdpa` (`sdp_attention: true`) | safe default; works everywhere |
 | SDPA varlen | `sdpa_varlen: true` | packing without a mask tensor, PyTorch >= 2.10 |
 | FlexAttention | `flex_attention` (`flex_attention: true`) | PyTorch >= 2.6; enables `scaling_softmax` |

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2294,7 +2294,7 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ("--attn-implementation",),
         None,
         None,
-        "Attention backend. Canonical values: eager, sdpa, flash_attention_2, flash_attention_3, flex_attention, xformers, sage, fp8. Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and passed through to transformers.",
+        "Attention backend. Canonical values: eager, sdpa, flash_attention_2, flash_attention_3, flash_attention_4, flex_attention, xformers, sage, fp8. Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and passed through to transformers.",
     ),
     (
         ("--gemma4-hybrid-attn-impl/--no-gemma4-hybrid-attn-impl",),

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2294,7 +2294,7 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ("--attn-implementation",),
         None,
         None,
-        "Attention backend. Canonical values: eager, sdpa, flash_attention_2, flash_attention_3, flash_attention_4, flex_attention, xformers, sage, fp8. Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and passed through to transformers.",
+        "Attention backend. Canonical values: eager, sdpa, flash_attention_2, flash_attention_3, flash_attention_4, flash_attention_torch, flex_attention, xformers, sage, fp8. Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and passed through to transformers.",
     ),
     (
         ("--gemma4-hybrid-attn-impl/--no-gemma4-hybrid-attn-impl",),

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/dequant_grouped.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/dequant_grouped.py
@@ -38,7 +38,8 @@ def _dg():
     if _DG is None:
         from kernels import get_kernel
 
-        _DG = get_kernel("kernels-community/deep-gemm")
+        # kernels>=0.15 requires an explicit version; main has no torch 2.12 build, v1 does.
+        _DG = get_kernel("kernels-community/deep-gemm", version=1)
     return _DG
 
 

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -758,11 +758,37 @@ class ModelLoader:
             hf_impl = _LOAD_TIME_OVERRIDE.get(
                 self.cfg.attn_implementation, self.cfg.attn_implementation
             )
+            hf_impl = self._resolve_flash_attention_4(hf_impl)
             self.model_kwargs["attn_implementation"] = hf_impl
             self.model_config._attn_implementation = hf_impl
 
         if self.cfg.low_cpu_mem_usage:
             self.model_kwargs["low_cpu_mem_usage"] = True
+
+    def _resolve_flash_attention_4(self, hf_impl):
+        """Prefer native FA4 over the FA2 path when FA4 is installed and usable.
+
+        transformers dispatches ``flash_attention_4`` natively; ``flash_attention_2`` only
+        reaches FA4 when the FA2 library is present, otherwise it resolves to an
+        unregistered hub kernel. Upgrade to the native name so FA4 is actually used.
+        """
+        if hf_impl not in (
+            "flash_attention_2",
+            "flash_attention_3",
+            "flash_attention_4",
+        ):
+            return hf_impl
+
+        from axolotl.monkeypatch.attention.flash_attn_4 import configure_fa4, fa4_usable
+
+        if hf_impl == "flash_attention_4":
+            configure_fa4()
+            return hf_impl
+        if fa4_usable(self.model_config):
+            configure_fa4()
+            LOG.info("Flash Attention 4 enabled (upgraded from %s).", hf_impl)
+            return "flash_attention_4"
+        return hf_impl
 
     def _check_model_requirements(self):
         if self.cfg.model_config_type in ["lfm2-vl", "lfm2"]:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -92,7 +92,6 @@ class PatchManager:
         self._apply_flash_attention_patches()
         self._apply_chunked_cross_entropy_patch()
         self._apply_sageattn_patches()
-        self._apply_flash_attn_4_patches()
         self._apply_fsdp_patches()
         self._apply_adapter_patches()
         # Must precede fused-RoPE patches: re-parses ``Attention.forward``
@@ -381,15 +380,6 @@ class PatchManager:
             from axolotl.monkeypatch.attention.sage_attn import patch_sageattn
 
             patch_sageattn()
-
-    def _apply_flash_attn_4_patches(self):
-        """Auto-apply FA4 when flash_attention is enabled and FA4 is available on SM90+."""
-        if not self.cfg.attn_uses_flash_lib:
-            return
-
-        from axolotl.monkeypatch.attention.flash_attn_4 import patch_flash_attn_4
-
-        patch_flash_attn_4(self.model_config)
 
     _FUSED_ATTN_KERNEL_SUPPORTED = (
         "qwen3",

--- a/src/axolotl/monkeypatch/attention/flash_attn_4.py
+++ b/src/axolotl/monkeypatch/attention/flash_attn_4.py
@@ -1,10 +1,13 @@
-"""Transparently upgrade FA2 to FA4 when available on SM90+ hardware."""
+"""Route flash attention through native FA4 when it is available on SM90+ hardware."""
 
 import torch
 
 from axolotl.utils.logging import get_logger
 
 LOG = get_logger(__name__)
+
+# quack < 0.6.0 (built for cutlass 4.6.0.dev0) crashes the FA4 backward on stable 4.6.0.
+FA4_MIN_QUACK_VERSION = "0.6.0"
 
 
 def _get_head_dims(model_config):
@@ -33,15 +36,47 @@ def _get_head_dims(model_config):
     return None, None
 
 
-def patch_flash_attn_4(model_config=None):
-    """Patch _lazy_imports to redirect FA2 imports to FA4 if available on supported hardware."""
+def _quack_supported():
+    """Return (ok, installed_version). ``ok`` is False only when quack-kernels is installed
+    and older than ``FA4_MIN_QUACK_VERSION``; an absent/unreadable quack is treated as ok."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        installed = version("quack-kernels")
+    except PackageNotFoundError:
+        return True, None
+    except Exception:  # pylint: disable=broad-except
+        return True, None
+
+    from packaging.version import Version
+
+    return Version(installed) >= Version(FA4_MIN_QUACK_VERSION), installed
+
+
+def _warn_stale_quack(installed):
+    LOG.warning(
+        "Flash Attention 4 needs quack-kernels>=%s (found %s): the FA4 backward raises "
+        "cudaErrorIllegalInstruction on nvidia-cutlass-dsl 4.6.0 with older quack. "
+        "Upgrade with: pip install 'quack-kernels>=%s'.",
+        FA4_MIN_QUACK_VERSION,
+        installed,
+        FA4_MIN_QUACK_VERSION,
+    )
+
+
+def fa4_usable(model_config=None):
+    """Whether native FA4 can serve attention for this model on this GPU.
+
+    Checks GPU arch (SM90/100/110), ``flash_attn.cute`` import, FA4 head-dim limits, and the
+    quack-kernels floor. Warns (with the fix) when head dims or quack are the blocker.
+    """
     if not torch.cuda.is_available():
-        return
+        return False
 
     major, _ = torch.cuda.get_device_capability()
     # Matches flash_attn/cute/interface.py: arch / 10 in [9, 10, 11]
     if major not in (9, 10, 11):
-        return
+        return False
 
     try:
         from flash_attn.cute import (  # noqa: F401
@@ -50,13 +85,11 @@ def patch_flash_attn_4(model_config=None):
         )
     except ImportError:
         LOG.info(
-            "Flash Attention 4 is available for your GPU and offers faster training speeds. "
-            "To enable: pip install flash-attn-4"
+            "Flash Attention 4 is available for your GPU and offers faster training. "
+            "To enable: pip install --pre flash-attn-4"
         )
-        return
+        return False
 
-    # Validate head dimensions against FA4's own constraints
-    head_dim = None
     if model_config is not None:
         head_dim, head_dim_v = _get_head_dims(model_config)
         if head_dim is not None:
@@ -64,48 +97,46 @@ def patch_flash_attn_4(model_config=None):
                 from flash_attn.cute.interface import _validate_head_dims
             except ImportError:
                 LOG.warning(
-                    "Could not import _validate_head_dims from flash_attn.cute.interface, "
-                    "unable to verify head dimension compatibility, falling back to FA2"
+                    "Could not import _validate_head_dims from flash_attn.cute.interface; "
+                    "cannot verify FA4 head-dim compatibility, keeping the requested backend."
                 )
-                return
+                return False
 
-            # alignment = 16 // element_size; bf16/fp16 = 2 bytes -> alignment = 8
-            alignment = 8
+            # alignment = 16 // element_size; bf16/fp16 = 2 bytes -> 8
             try:
-                _validate_head_dims(head_dim, head_dim_v, major, alignment)
+                _validate_head_dims(head_dim, head_dim_v, major, 8)
             except AssertionError as exc:
                 LOG.warning(
-                    "Model head dimensions not supported by FA4, "
-                    "falling back to FA2: %s",
+                    "Model head dimensions not supported by FA4, keeping the requested "
+                    "backend: %s",
                     exc,
                 )
-                return
+                return False
 
-    import transformers.modeling_flash_attention_utils as fa_utils
+    ok, installed = _quack_supported()
+    if not ok:
+        _warn_stale_quack(installed)
+        return False
 
-    if getattr(fa_utils._lazy_imports, "_axolotl_patched", False):
-        return
+    return True
 
-    try:
-        # flash-attn-4>=4.0.0b7
-        from flash_attn.cute import flash_attn_with_kvcache
-    except ImportError:
-        flash_attn_with_kvcache = None
 
-    def _patched_lazy_imports(
-        implementation, attention_wrapper=None, allow_all_kernels=False
-    ):
-        return (
-            flash_attn_func,
-            flash_attn_varlen_func,
-            flash_attn_with_kvcache,
-            fa_utils._pad_input,
-            fa_utils._unpad_input,
-        )
+def configure_fa4():
+    """Prepare the process to run native FA4.
 
-    _patched_lazy_imports._axolotl_patched = True
-    fa_utils._lazy_imports = _patched_lazy_imports
-    LOG.info(
-        "Flash Attention 4 enabled (head_dim=%s)",
-        head_dim if model_config else "unknown",
+    Silences the harmless first-compile ``AuxData`` warning and, for an explicitly requested
+    ``flash_attention_4``, surfaces the stale-quack warning (the auto-upgrade path checks
+    quack in ``fa4_usable`` before reaching here).
+    """
+    import warnings
+
+    # FA4's unannotated AuxData triggers a harmless CuTe-DSL warning on first compile.
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*aux_data.*JitArgument.*",
+        category=UserWarning,
     )
+
+    ok, installed = _quack_supported()
+    if not ok:
+        _warn_stale_quack(installed)

--- a/src/axolotl/monkeypatch/attention/flash_attn_4.py
+++ b/src/axolotl/monkeypatch/attention/flash_attn_4.py
@@ -9,6 +9,14 @@ LOG = get_logger(__name__)
 # quack < 0.6.0 (built for cutlass 4.6.0.dev0) crashes the FA4 backward on stable 4.6.0.
 FA4_MIN_QUACK_VERSION = "0.6.0"
 
+# FA4's Blackwell backward still elects around its own bulk copies; from cutlass-dsl 4.6.0
+# cute.copy elects internally too, and the nested election hangs the kernel.
+FA4_SM100_ELECT_CUTLASS_VERSION = "4.6.0"
+FA4_SM100_FIX_INSTALL = (
+    "pip install --no-deps --force-reinstall 'git+https://github.com/dongxiao92/"
+    "flash-attention@fix/sm100-elect-one-and-div-alignment#subdirectory=flash_attn/cute'"
+)
+
 
 def _get_head_dims(model_config):
     """Extract (head_dim, head_dim_v) from a model config.
@@ -64,11 +72,56 @@ def _warn_stale_quack(installed):
     )
 
 
+def _fa4_elects_around_bulk_copy():
+    """Whether the installed FA4 still wraps its Blackwell stats bulk copies in ``elect_one``."""
+    import importlib.util
+    import re
+    from pathlib import Path
+
+    try:
+        spec = importlib.util.find_spec("flash_attn.cute.flash_bwd_sm100")
+        source = Path(spec.origin).read_text(encoding="utf-8")
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+    return re.search(r"elect_one\(\):\s*\n\s*copy_stats\(", source) is not None
+
+
+def _sm100_backward_supported():
+    """Return (ok, installed_version) for nvidia-cutlass-dsl. ``ok`` is False only when the
+    installed cutlass-dsl elects inside ``cute.copy`` and FA4 still elects around it."""
+    try:
+        from importlib.metadata import version
+
+        installed = version("nvidia-cutlass-dsl")
+    except Exception:  # pylint: disable=broad-except
+        return True, None
+
+    from packaging.version import Version
+
+    if Version(installed) < Version(FA4_SM100_ELECT_CUTLASS_VERSION):
+        return True, installed
+
+    return not _fa4_elects_around_bulk_copy(), installed
+
+
+def _warn_sm100_elect_hang(installed):
+    LOG.warning(
+        "Flash Attention 4's backward hangs on Blackwell with nvidia-cutlass-dsl>=%s "
+        "(found %s): FA4 elects around the bulk copies that cute.copy now elects internally. "
+        "Install the fix (Dao-AILab/flash-attention#2689) with: %s",
+        FA4_SM100_ELECT_CUTLASS_VERSION,
+        installed,
+        FA4_SM100_FIX_INSTALL,
+    )
+
+
 def fa4_usable(model_config=None):
     """Whether native FA4 can serve attention for this model on this GPU.
 
-    Checks GPU arch (SM90/100/110), ``flash_attn.cute`` import, FA4 head-dim limits, and the
-    quack-kernels floor. Warns (with the fix) when head dims or quack are the blocker.
+    Checks GPU arch (SM90/100/110), ``flash_attn.cute`` import, FA4 head-dim limits, the
+    quack-kernels floor, and the Blackwell nested-election hang. Warns (with the fix) when
+    head dims, quack, or the Blackwell backward are the blocker.
     """
     if not torch.cuda.is_available():
         return False
@@ -118,6 +171,12 @@ def fa4_usable(model_config=None):
         _warn_stale_quack(installed)
         return False
 
+    if major in (10, 11):
+        ok, cutlass_version = _sm100_backward_supported()
+        if not ok:
+            _warn_sm100_elect_hang(cutlass_version)
+            return False
+
     return True
 
 
@@ -125,8 +184,8 @@ def configure_fa4():
     """Prepare the process to run native FA4.
 
     Silences the harmless first-compile ``AuxData`` warning and, for an explicitly requested
-    ``flash_attention_4``, surfaces the stale-quack warning (the auto-upgrade path checks
-    quack in ``fa4_usable`` before reaching here).
+    ``flash_attention_4``, surfaces the stale-quack and Blackwell nested-election warnings
+    (the auto-upgrade path checks both in ``fa4_usable`` before reaching here).
     """
     import warnings
 
@@ -140,3 +199,8 @@ def configure_fa4():
     ok, installed = _quack_supported()
     if not ok:
         _warn_stale_quack(installed)
+
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] in (10, 11):
+        ok, cutlass_version = _sm100_backward_supported()
+        if not ok:
+            _warn_sm100_elect_hang(cutlass_version)

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -841,9 +841,9 @@ class AxolotlInputConfig(
         json_schema_extra={
             "description": (
                 "Attention backend. Canonical values: eager, sdpa, flash_attention_2, "
-                "flash_attention_3, flex_attention, xformers, sage, fp8. Hub-kernel "
-                "paths (e.g. kernels-community/flash-attn3) are also accepted and passed "
-                "through to transformers."
+                "flash_attention_3, flash_attention_4, flex_attention, xformers, sage, fp8. "
+                "Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and "
+                "passed through to transformers."
             )
         },
     )

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -40,6 +40,7 @@ from axolotl.utils.schemas.enums import (
     ChatTemplate,
     RingAttnFunc,
     RLType,
+    attn_impl_base,
 )
 from axolotl.utils.schemas.fsdp import FSDPConfig
 from axolotl.utils.schemas.integrations import (
@@ -841,9 +842,10 @@ class AxolotlInputConfig(
         json_schema_extra={
             "description": (
                 "Attention backend. Canonical values: eager, sdpa, flash_attention_2, "
-                "flash_attention_3, flash_attention_4, flex_attention, xformers, sage, fp8. "
-                "Hub-kernel paths (e.g. kernels-community/flash-attn3) are also accepted and "
-                "passed through to transformers."
+                "flash_attention_3, flash_attention_4, flash_attention_torch, "
+                "flex_attention, xformers, sage, fp8. Hub-kernel paths (e.g. "
+                "kernels-community/flash-attn3) are also accepted and passed through to "
+                "transformers."
             )
         },
     )
@@ -1480,7 +1482,7 @@ class AxolotlInputConfig(
     @computed_field  # type: ignore[misc]
     @property
     def attn_supports_packing(self) -> bool:
-        return self.attn_implementation in ATTN_IMPLS_SUPPORTING_PACKING
+        return attn_impl_base(self.attn_implementation) in ATTN_IMPLS_SUPPORTING_PACKING
 
     @computed_field  # type: ignore[misc]
     @property
@@ -1493,7 +1495,7 @@ class AxolotlInputConfig(
     @computed_field  # type: ignore[misc]
     @property
     def attn_uses_flash_lib(self) -> bool:
-        return self.attn_implementation in ATTN_IMPLS_USING_FLASH_LIB
+        return attn_impl_base(self.attn_implementation) in ATTN_IMPLS_USING_FLASH_LIB
 
     @computed_field  # type: ignore[misc]
     @property
@@ -1715,6 +1717,25 @@ class AxolotlInputConfig(
                 "SageAttention full finetuning has been observed to drop loss to 0. "
                 "Monitor the loss, or switch to LoRA/QLoRA or another attention method."
             )
+        return self
+
+    @model_validator(mode="after")
+    def check_flash_attention_torch_preflight(self):
+        """`flash_attention_torch` is only usable once transformers registers the backend."""
+        if self.attn_implementation != "flash_attention_torch":
+            return self
+
+        import transformers
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        if "flash_attention_torch" not in ALL_ATTENTION_FUNCTIONS:
+            raise ValueError(
+                "attn_implementation=flash_attention_torch requires a transformers "
+                "release that registers torch's varlen attention backend "
+                "(https://github.com/huggingface/transformers/pull/45153). Installed "
+                f"transformers is {transformers.__version__}."
+            )
+
         return self
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -107,6 +107,7 @@ CANONICAL_ATTN_IMPLS = frozenset(
         "sdpa",
         "flash_attention_2",
         "flash_attention_3",
+        "flash_attention_4",
         "flex_attention",
         "xformers",
         "sage",
@@ -136,6 +137,7 @@ ATTN_IMPLS_SUPPORTING_PACKING = frozenset(
     {
         "flash_attention_2",
         "flash_attention_3",
+        "flash_attention_4",
         "flex_attention",
         "xformers",
         "sage",

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -108,6 +108,7 @@ CANONICAL_ATTN_IMPLS = frozenset(
         "flash_attention_2",
         "flash_attention_3",
         "flash_attention_4",
+        "flash_attention_torch",
         "flex_attention",
         "xformers",
         "sage",
@@ -138,6 +139,7 @@ ATTN_IMPLS_SUPPORTING_PACKING = frozenset(
         "flash_attention_2",
         "flash_attention_3",
         "flash_attention_4",
+        "flash_attention_torch",
         "flex_attention",
         "xformers",
         "sage",
@@ -159,6 +161,14 @@ ATTN_IMPLS_USING_FLASH_LIB = frozenset(
 
 # Backends for which embeddings stay in fp32. Everything else needs fp16/bf16.
 ATTN_IMPLS_WITHOUT_DTYPE_CAST = frozenset({"eager", "sdpa"})
+
+
+def attn_impl_base(attn_implementation: str | None) -> str | None:
+    """Strip the `@revision` / `:kernel_name` suffix so `org/name@v2` still matches above."""
+    if attn_implementation is None:
+        return None
+    return attn_implementation.split(":", 1)[0].split("@", 1)[0].strip()
+
 
 # Narrow allowlist of real torch._inductor.config attrs (verified on torch 2.11; sentinel test guards renames).
 INDUCTOR_COMPILE_OPTIONS_ALLOWLIST = frozenset(

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1246,6 +1246,8 @@ class SystemValidationMixin:
             unsupported_npu_impls = {
                 "flash_attention_2",
                 "flash_attention_3",
+                "flash_attention_4",
+                "flash_attention_torch",
                 "sdpa",
             }
             attn_impl = data.get("attn_implementation")

--- a/tests/monkeypatch/test_flash_attn_4.py
+++ b/tests/monkeypatch/test_flash_attn_4.py
@@ -1,0 +1,109 @@
+"""Tests for FA4 backend selection: quack gate, warning suppression, native upgrade."""
+
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+
+import axolotl.monkeypatch.attention.flash_attn_4 as fa4
+from axolotl.loaders.model import ModelLoader
+
+
+class TestQuackVersionGate:
+    @pytest.mark.parametrize(
+        "installed, expected_ok",
+        [
+            ("0.5.0", False),
+            ("0.5.3", False),
+            ("0.6.0", True),
+            ("0.6.1", True),
+            ("1.0.0", True),
+        ],
+    )
+    def test_version_boundary(self, monkeypatch, installed, expected_ok):
+        monkeypatch.setattr("importlib.metadata.version", lambda _pkg: installed)
+        ok, ver = fa4._quack_supported()
+        assert ok is expected_ok
+        assert ver == installed
+
+    def test_absent_quack_is_treated_ok(self, monkeypatch):
+        from importlib.metadata import PackageNotFoundError
+
+        def _raise(_pkg):
+            raise PackageNotFoundError(_pkg)
+
+        monkeypatch.setattr("importlib.metadata.version", _raise)
+        assert fa4._quack_supported() == (True, None)
+
+
+class TestConfigureFa4:
+    def test_suppresses_aux_data_warning(self, monkeypatch):
+        monkeypatch.setattr(fa4, "_quack_supported", lambda: (True, None))
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            fa4.configure_fa4()
+            warnings.warn(
+                "Argument aux_data (position 17) cannot be converted to a JitArgument",
+                UserWarning,
+                stacklevel=2,
+            )
+            warnings.warn("unrelated warning", UserWarning, stacklevel=2)
+        messages = [str(w.message) for w in rec]
+        assert not any("aux_data" in m for m in messages)
+        assert any("unrelated" in m for m in messages)
+
+    def test_warns_on_stale_quack(self, monkeypatch):
+        monkeypatch.setattr(fa4, "_quack_supported", lambda: (False, "0.5.3"))
+        mock_log = MagicMock()
+        monkeypatch.setattr(fa4, "LOG", mock_log)
+        with warnings.catch_warnings():
+            fa4.configure_fa4()
+        mock_log.warning.assert_called_once()
+        assert "0.5.3" in str(mock_log.warning.call_args)
+
+
+class TestResolveFlashAttention4:
+    @staticmethod
+    def _loader():
+        loader = ModelLoader.__new__(ModelLoader)
+        loader.model_config = object()
+        return loader
+
+    @pytest.mark.parametrize("impl", ["sdpa", "eager", "xformers"])
+    def test_non_flash_passthrough(self, monkeypatch, impl):
+        fa4_usable = MagicMock()
+        monkeypatch.setattr(fa4, "fa4_usable", fa4_usable)
+        assert self._loader()._resolve_flash_attention_4(impl) == impl
+        fa4_usable.assert_not_called()
+
+    def test_explicit_fa4_kept_without_capability_check(self, monkeypatch):
+        monkeypatch.setattr(
+            fa4, "fa4_usable", MagicMock(side_effect=AssertionError("must not check"))
+        )
+        configure = MagicMock()
+        monkeypatch.setattr(fa4, "configure_fa4", configure)
+        assert (
+            self._loader()._resolve_flash_attention_4("flash_attention_4")
+            == "flash_attention_4"
+        )
+        configure.assert_called_once()
+
+    def test_fa2_upgraded_when_usable(self, monkeypatch):
+        monkeypatch.setattr(fa4, "fa4_usable", lambda _mc: True)
+        configure = MagicMock()
+        monkeypatch.setattr(fa4, "configure_fa4", configure)
+        assert (
+            self._loader()._resolve_flash_attention_4("flash_attention_2")
+            == "flash_attention_4"
+        )
+        configure.assert_called_once()
+
+    def test_fa2_kept_when_not_usable(self, monkeypatch):
+        monkeypatch.setattr(fa4, "fa4_usable", lambda _mc: False)
+        configure = MagicMock()
+        monkeypatch.setattr(fa4, "configure_fa4", configure)
+        assert (
+            self._loader()._resolve_flash_attention_4("flash_attention_2")
+            == "flash_attention_2"
+        )
+        configure.assert_not_called()

--- a/tests/monkeypatch/test_flash_attn_4.py
+++ b/tests/monkeypatch/test_flash_attn_4.py
@@ -36,6 +36,40 @@ class TestQuackVersionGate:
         assert fa4._quack_supported() == (True, None)
 
 
+class TestSm100ElectGate:
+    @pytest.mark.parametrize(
+        "cutlass, elects, expected_ok",
+        [
+            ("4.6.0.dev0", True, True),  # dev0 predates the internal election
+            ("4.5.3", True, True),
+            ("4.6.0", True, False),
+            ("4.6.1", True, False),
+            ("4.6.0", False, True),  # patched FA4
+        ],
+    )
+    def test_version_and_source_matrix(self, monkeypatch, cutlass, elects, expected_ok):
+        monkeypatch.setattr("importlib.metadata.version", lambda _pkg: cutlass)
+        monkeypatch.setattr(fa4, "_fa4_elects_around_bulk_copy", lambda: elects)
+        ok, ver = fa4._sm100_backward_supported()
+        assert ok is expected_ok
+        assert ver == cutlass
+
+    def test_absent_cutlass_is_treated_ok(self, monkeypatch):
+        from importlib.metadata import PackageNotFoundError
+
+        def _raise(_pkg):
+            raise PackageNotFoundError(_pkg)
+
+        monkeypatch.setattr("importlib.metadata.version", _raise)
+        assert fa4._sm100_backward_supported() == (True, None)
+
+    def test_unreadable_source_is_treated_as_patched(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", MagicMock(side_effect=ImportError("gone"))
+        )
+        assert fa4._fa4_elects_around_bulk_copy() is False
+
+
 class TestConfigureFa4:
     def test_suppresses_aux_data_warning(self, monkeypatch):
         monkeypatch.setattr(fa4, "_quack_supported", lambda: (True, None))

--- a/tests/test_attn_implementation.py
+++ b/tests/test_attn_implementation.py
@@ -52,6 +52,7 @@ class TestCapabilityTables:
         [
             "flash_attention_2",
             "flash_attention_3",
+            "flash_attention_4",
             "flex_attention",
             "xformers",
             "sage",
@@ -69,7 +70,16 @@ class TestCapabilityTables:
         assert impl in ATTN_IMPLS_USING_FLASH_LIB
 
     @pytest.mark.parametrize(
-        "impl", ["eager", "sdpa", "xformers", "flex_attention", "sage", "fp8"]
+        "impl",
+        [
+            "eager",
+            "sdpa",
+            "xformers",
+            "flex_attention",
+            "sage",
+            "fp8",
+            "flash_attention_4",
+        ],
     )
     def test_does_not_use_flash_lib(self, impl):
         assert impl not in ATTN_IMPLS_USING_FLASH_LIB

--- a/tests/test_attn_implementation.py
+++ b/tests/test_attn_implementation.py
@@ -53,6 +53,7 @@ class TestCapabilityTables:
             "flash_attention_2",
             "flash_attention_3",
             "flash_attention_4",
+            "flash_attention_torch",
             "flex_attention",
             "xformers",
             "sage",
@@ -79,6 +80,7 @@ class TestCapabilityTables:
             "sage",
             "fp8",
             "flash_attention_4",
+            "flash_attention_torch",
         ],
     )
     def test_does_not_use_flash_lib(self, impl):
@@ -93,6 +95,8 @@ class TestCapabilityTables:
         [
             "flash_attention_2",
             "flash_attention_3",
+            "flash_attention_4",
+            "flash_attention_torch",
             "flex_attention",
             "xformers",
             "sage",
@@ -334,6 +338,53 @@ class TestCanonicalValueAcceptance:
         assert validated.attn_implementation == "kernels-community/flash-attn3"
         assert validated.attn_uses_flash_lib is True
         assert validated.attn_supports_packing is True
+
+    @pytest.mark.parametrize(
+        "impl",
+        [
+            "kernels-community/flash-attn2@v2",
+            "kernels-community/flash-attn2:flash_attn_varlen_func",
+            "kernels-community/flash-attn2@v2:flash_attn_varlen_func",
+        ],
+    )
+    def test_pinned_hub_kernel_keeps_capabilities(self, min_base_cfg, impl):
+        validated = validate_config(
+            min_base_cfg | DictDefault(attn_implementation=impl)
+        )
+        assert validated.attn_implementation == impl
+        assert validated.attn_supports_packing is True
+        assert validated.attn_uses_flash_lib is True
+
+    def test_flash_attention_torch_accepted_when_registered(
+        self, min_base_cfg, monkeypatch
+    ):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        monkeypatch.setitem(
+            ALL_ATTENTION_FUNCTIONS, "flash_attention_torch", lambda *a, **kw: None
+        )
+        cfg = min_base_cfg | DictDefault(attn_implementation="flash_attention_torch")
+        validated = validate_config(cfg)
+        assert validated.attn_supports_packing is True
+        assert validated.attn_uses_flash_lib is False
+
+    def test_flash_attention_torch_rejected_when_unregistered(
+        self, min_base_cfg, monkeypatch
+    ):
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        monkeypatch.setattr(
+            type(ALL_ATTENTION_FUNCTIONS),
+            "_global_mapping",
+            {
+                key: value
+                for key, value in ALL_ATTENTION_FUNCTIONS._global_mapping.items()
+                if key != "flash_attention_torch"
+            },
+        )
+        cfg = min_base_cfg | DictDefault(attn_implementation="flash_attention_torch")
+        with pytest.raises(ValueError, match="varlen attention backend"):
+            validate_config(cfg)
 
     def test_short_form_alias_rejected_on_full_validation(self, min_base_cfg):
         cfg = min_base_cfg | DictDefault(attn_implementation="flash")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

FA4 incompatibility with quack 0.5, so this updates the doc and fix transformers compatibility.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Flash Attention 4 support for compatible GPUs and model head dimensions.
  * Added automatic upgrades from Flash Attention 2 or 3 when FA4 is available.
  * Added `flash_attention_4` as a supported attention backend and packing option.
  * Added compatibility checks and warnings for outdated kernel packages.

* **Documentation**
  * Updated attention backend requirements, configuration examples, limitations, and troubleshooting guidance.
  * Clarified NVFP4 adapter merging terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->