### PR TITLE
fix(mistral): don't pass the string "None" as the tokenizer cache_dir

### DIFF
--- a/src/axolotl/utils/mistral/mistral_tokenizer.py
+++ b/src/axolotl/utils/mistral/mistral_tokenizer.py
@@ -268,7 +268,7 @@ class HFMistralTokenizer(MistralCommonBackend):
         if not os.path.isfile(pretrained_model_name_or_path):
             tokenizer_path = download_tokenizer_from_hf_hub(
                 repo_id=str(pretrained_model_name_or_path),
-                cache_dir=str(cache_dir),
+                cache_dir=str(cache_dir) if cache_dir is not None else None,
                 token=token,
                 revision=revision,
                 force_download=force_download,


### PR DESCRIPTION
# Description

`HFMistralTokenizer.from_pretrained` declares `cache_dir: Optional[str | os.PathLike] = None`, then forwards it as `str(cache_dir)`. When a caller omits the argument, `str(None)` evaluates to the string `"None"`, which `download_tokenizer_from_hf_hub` treats as a directory path.

```python
cache_dir=str(cache_dir),   # str(None) == "None"
```

Pass `None` through unchanged instead.

## Motivation and Context

Two consequences, both silent:

1. A `None/` Hugging Face hub cache is created in the current working directory. Running the test suite from the repo root leaves a stray `None/` next to `src/`, untracked and not gitignored.
2. The real Hugging Face cache is bypassed, so these tokenizers re-download on every fresh working directory rather than reusing `~/.cache/huggingface`.

`download_tokenizer_from_hf_hub` is typed `cache_dir: str | Path | None = None` and applies its own default when given `None`, so no caller needs to change.

Reproducible through the existing fixtures in `tests/prompt_strategies/conftest.py`, which call `HFMistralTokenizer.from_pretrained` for `Magistral-Small-2506`, `Devstral-Small-2505`, and `Devstral-Small-2507` without a `cache_dir`.

## How has this been tested?

Environment: Python 3.12, torch 2.11.0+cu130, transformers 5.14.1.

Before the change, running the affected fixtures from any directory left a `None/` hub cache containing `CACHEDIR.TAG`, `.locks/`, and `models--mistralai--*/{refs,blobs,snapshots}`.

After the change, from a clean scratch directory:

```
cwd: /tmp/cachefix
before: []
after : []

stray './None' created: False
tokenizer loaded ok    : True
```

The tokenizer still resolves, now from the default cache.

- `pytest tests/prompt_strategies/ -m 'not slow'` → **209 passed, 3 skipped, 2 xpassed**
- `pre-commit run` (CI-pinned ruff / ruff-format / mypy / bandit) → all passed

## AI Usage Disclaimer

Yes — Claude Code (Opus 4.8). It traced the stray directory to this line, produced the fix, and ran the verification quoted above.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tokenizer downloads from the HuggingFace Hub when no cache directory is specified.
  * Prevented invalid cache path handling in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->