### PR TITLE
feat : gkd OPd v1

### DIFF
--- a/examples/gkd/qwen3-0.6B-gkd.yaml
+++ b/examples/gkd/qwen3-0.6B-gkd.yaml
@@ -1,0 +1,47 @@
+# On-policy distillation (GKD): a small student learns from a larger same-vocab
+# teacher on its own rollouts. See src/axolotl/integrations/gkd/README.md.
+base_model: Qwen/Qwen3-0.6B
+
+plugins:
+  - axolotl.integrations.gkd.GKDPlugin
+
+gkd_trainer: true
+gkd_teacher: Qwen/Qwen3-4B        # must share the student's tokenizer/vocab
+gkd_lmbda: 1.0                    # fully on-policy (student rollouts)
+gkd_beta: 0.5                     # 0=forward-KL, 1=reverse-KL, between=JSD
+gkd_temperature: 0.9
+gkd_max_new_tokens: 256
+
+chat_template: qwen3
+datasets:
+  - path: mlabonne/FineTome-100k
+    type: chat_template
+    split: train[:2000]
+    field_messages: conversations
+    message_property_mappings:
+      role: from
+      content: value
+
+# on-policy generation requires an unpacked, prompt/completion-separable batch
+sample_packing: false
+train_on_inputs: false
+
+val_set_size: 0.0
+sequence_len: 2048
+output_dir: ./outputs/gkd-qwen3-out
+
+micro_batch_size: 1
+gradient_accumulation_steps: 4
+num_epochs: 1
+optimizer: adamw_torch_fused
+lr_scheduler: cosine
+learning_rate: 1.0e-5
+
+bf16: auto
+gradient_checkpointing: true
+flash_attention: true
+
+logging_steps: 1
+warmup_ratio: 0.03
+
+wandb_project:

--- a/src/axolotl/integrations/gkd/README.md
+++ b/src/axolotl/integrations/gkd/README.md
@@ -1,0 +1,57 @@
+# On-Policy Distillation (GKD)
+
+On-policy distillation (OPD) has the **student generate its own rollouts** and a
+**teacher provide dense, token-level supervision** on those student-visited
+states. It is the "missing middle" between GRPO (on-policy, but sparse scalar
+reward) and off-policy [KD](../kd/README.md) (dense token-KL, but on fixed
+teacher/ground-truth prefixes). The core follows GKD
+([2306.13649](https://huggingface.co/papers/2306.13649)).
+
+## Usage
+
+```yaml
+plugins:
+  - "axolotl.integrations.gkd.GKDPlugin"
+
+gkd_trainer: true
+gkd_teacher: meta-llama/Llama-3.1-70B-Instruct   # Axis C: teacher (shared vocab)
+
+gkd_lmbda: 1.0          # Axis B: fraction of steps on student rollouts (1.0 = fully on-policy)
+gkd_beta: 0.5           # Axis A: 0 = forward-KL, 1 = reverse-KL, between = JSD
+gkd_temperature: 0.9
+gkd_max_new_tokens: 256
+gkd_seq_kd: false       # for the off-policy fraction, distill teacher-generated sequences
+
+# GKD generates from the prompt, so packing must be off and the prompt must be masked.
+sample_packing: false
+train_on_inputs: false
+
+datasets:
+  - path: your/sft-dataset
+    type: chat_template
+```
+
+Any standard SFT dataset works — the prompt is recovered from the tokens masked
+with `-100`, so no special preprocessing or logprob precomputation is required
+(unlike the offline KD plugin).
+
+## The four axes
+
+Every OPD method in the literature is a point in this space; the plugin names each
+as a replaceable seam so new papers land as config, not a new trainer.
+
+| Axis | Question | Config | v1 |
+|------|----------|--------|----|
+| A. Divergence | student scored vs teacher how? | `gkd_beta`, `gkd_divergence` | fwd/rev-KL, JSD (`divergence.py`) |
+| B. Rollout | whose prefixes? | `gkd_lmbda`, `gkd_seq_kd` | on-policy fraction (`rollout.py`) |
+| C. Teacher | where does supervision come from? | `gkd_teacher` | external HF model (`trainer._resolve_teacher`) |
+| D. Weighting | which tokens get the loss? | — | uniform (`trainer._token_weights`, seam for v2) |
+
+## Notes / constraints
+
+- **Shared vocabulary.** Teacher and student must share a tokenizer/vocab; the
+  trainer validates `vocab_size` and raises otherwise.
+- **Teacher cost.** The full teacher is held in-process and run every step. Budget
+  memory accordingly (quantize via `gkd_teacher_init_kwargs`, or use DeepSpeed/FSDP).
+- **Stability.** OPD can inflate length or collapse diversity; tune
+  `gkd_temperature` and `gkd_beta` (reverse-KL is mode-seeking) to mitigate.

--- a/src/axolotl/integrations/gkd/README.md
+++ b/src/axolotl/integrations/gkd/README.md
@@ -17,7 +17,7 @@ gkd_trainer: true
 gkd_teacher: meta-llama/Llama-3.1-70B-Instruct   # Axis C: teacher (shared vocab)
 
 gkd_lmbda: 1.0          # Axis B: fraction of steps on student rollouts (1.0 = fully on-policy)
-gkd_beta: 0.5           # Axis A: 0 = forward-KL, 1 = reverse-KL, between = JSD
+gkd_beta: 1.0           # Axis A: 0 = forward-KL, 1 = reverse-KL, between = JSD
 gkd_temperature: 0.9
 gkd_max_new_tokens: 256
 gkd_seq_kd: false       # for the off-policy fraction, distill teacher-generated sequences

--- a/src/axolotl/integrations/gkd/__init__.py
+++ b/src/axolotl/integrations/gkd/__init__.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Plugin for on-policy distillation (GKD / OPD) in Axolotl.
+
+The student generates its own rollouts and a teacher provides dense, token-level
+supervision on those student-visited states — the "missing middle" between GRPO
+(on-policy, sparse reward) and off-policy KD (dense KL, fixed prefixes).
+"""
+
+from axolotl.integrations.base import BasePlugin
+
+from .args import GKDArgs as GKDArgs
+
+
+class GKDPlugin(BasePlugin):
+    """Plugin for GKD / on-policy distillation support in Axolotl."""
+
+    def get_input_args(self):
+        return "axolotl.integrations.gkd.GKDArgs"
+
+    def get_training_args_mixin(self):
+        return "axolotl.integrations.gkd.args.GKDTrainingArgsMixin"
+
+    def get_trainer_cls(self, cfg):
+        if cfg.gkd_trainer:
+            from .trainer import AxolotlGKDTrainer
+
+            return AxolotlGKDTrainer
+        return None
+
+    def get_training_args(self, cfg):
+        if not cfg.gkd_trainer:
+            return None
+        return {
+            "gkd_teacher": cfg.gkd_teacher,
+            "gkd_teacher_init_kwargs": cfg.gkd_teacher_init_kwargs,
+            "gkd_lmbda": cfg.gkd_lmbda,
+            "gkd_seq_kd": cfg.gkd_seq_kd,
+            "gkd_max_new_tokens": cfg.gkd_max_new_tokens,
+            "gkd_top_k": cfg.gkd_top_k,
+            "gkd_beta": cfg.gkd_beta,
+            "gkd_divergence": cfg.gkd_divergence,
+            "gkd_temperature": cfg.gkd_temperature,
+        }

--- a/src/axolotl/integrations/gkd/args.py
+++ b/src/axolotl/integrations/gkd/args.py
@@ -1,0 +1,79 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Plugin args for on-policy distillation (GKD). Each arg maps to an OPD axis:
+A divergence (gkd_beta, gkd_divergence), B rollout (gkd_lmbda, gkd_seq_kd,
+gkd_max_new_tokens, gkd_top_k), C teacher (gkd_teacher, gkd_teacher_init_kwargs).
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, model_validator
+
+
+class GKDArgs(BaseModel):
+    """Input args for on-policy (generalized) knowledge distillation."""
+
+    gkd_trainer: bool | None = None
+    gkd_teacher: str | None = None  # HF model id/path; must share the student's vocab
+    gkd_teacher_init_kwargs: dict[str, Any] | None = None
+    gkd_lmbda: float | None = 0.5  # fraction of steps trained on student rollouts
+    gkd_seq_kd: bool | None = (
+        False  # off-policy fraction distills teacher-generated seqs
+    )
+    gkd_max_new_tokens: int | None = 128
+    gkd_top_k: int | None = 0
+    gkd_beta: float | None = 0.5  # 0=forward-KL, 1=reverse-KL, between=JSD
+    gkd_divergence: str | None = None
+    gkd_temperature: float | None = 0.9
+
+    @model_validator(mode="after")
+    def _validate_gkd(self):
+        if not self.gkd_trainer:
+            return self
+        if not self.gkd_teacher:
+            raise ValueError("gkd_trainer requires gkd_teacher to be set.")
+        if self.gkd_beta is not None and not 0.0 <= self.gkd_beta <= 1.0:
+            raise ValueError("gkd_beta must be in [0, 1].")
+        if self.gkd_lmbda is not None and not 0.0 <= self.gkd_lmbda <= 1.0:
+            raise ValueError("gkd_lmbda must be in [0, 1].")
+        if self.gkd_temperature is not None and self.gkd_temperature <= 0.0:
+            raise ValueError("gkd_temperature must be > 0.")
+        # On-policy rollouts need one prompt per unpacked sequence, with the prompt masked.
+        if getattr(self, "sample_packing", None):
+            raise ValueError(
+                "gkd_trainer is incompatible with sample_packing; set sample_packing: false."
+            )
+        if getattr(self, "train_on_inputs", None):
+            raise ValueError(
+                "gkd_trainer requires train_on_inputs: false to separate prompt from completion."
+            )
+        return self
+
+
+@dataclass
+class GKDTrainingArgsMixin:
+    """Training args consumed by ``AxolotlGKDTrainer`` off ``self.args``."""
+
+    gkd_teacher: str | None = None
+    gkd_teacher_init_kwargs: dict[str, Any] | None = None
+    gkd_lmbda: float = 0.5
+    gkd_seq_kd: bool = False
+    gkd_max_new_tokens: int = 128
+    gkd_top_k: int = 0
+    gkd_beta: float = 0.5
+    gkd_divergence: str | None = None
+    gkd_temperature: float = 0.9

--- a/src/axolotl/integrations/gkd/args.py
+++ b/src/axolotl/integrations/gkd/args.py
@@ -30,13 +30,13 @@ class GKDArgs(BaseModel):
     gkd_trainer: bool | None = None
     gkd_teacher: str | None = None  # HF model id/path; must share the student's vocab
     gkd_teacher_init_kwargs: dict[str, Any] | None = None
-    gkd_lmbda: float | None = 0.5  # fraction of steps trained on student rollouts
+    gkd_lmbda: float | None = 1.0  # fraction of steps trained on student rollouts
     gkd_seq_kd: bool | None = (
         False  # off-policy fraction distills teacher-generated seqs
     )
     gkd_max_new_tokens: int | None = 128
     gkd_top_k: int | None = 0
-    gkd_beta: float | None = 0.5  # 0=forward-KL, 1=reverse-KL, between=JSD
+    gkd_beta: float | None = 1.0  # 0=forward-KL, 1=reverse-KL, between=JSD
     gkd_divergence: str | None = None
     gkd_temperature: float | None = 0.9
 
@@ -45,7 +45,7 @@ class GKDArgs(BaseModel):
         if not self.gkd_trainer:
             return self
         if not self.gkd_teacher:
-            raise ValueError("gkd_trainer requires gkd_teacher to be set.")
+            raise ValueError("gkd_teacher is required when gkd_trainer is set.")
         if self.gkd_beta is not None and not 0.0 <= self.gkd_beta <= 1.0:
             raise ValueError("gkd_beta must be in [0, 1].")
         if self.gkd_lmbda is not None and not 0.0 <= self.gkd_lmbda <= 1.0:
@@ -70,10 +70,10 @@ class GKDTrainingArgsMixin:
 
     gkd_teacher: str | None = None
     gkd_teacher_init_kwargs: dict[str, Any] | None = None
-    gkd_lmbda: float = 0.5
+    gkd_lmbda: float = 1.0
     gkd_seq_kd: bool = False
     gkd_max_new_tokens: int = 128
     gkd_top_k: int = 0
-    gkd_beta: float = 0.5
+    gkd_beta: float = 1.0
     gkd_divergence: str | None = None
     gkd_temperature: float = 0.9

--- a/src/axolotl/integrations/gkd/divergence.py
+++ b/src/axolotl/integrations/gkd/divergence.py
@@ -1,0 +1,111 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Axis A (divergence) seam. ``generalized_jsd_loss`` is the GKD core
+(https://huggingface.co/papers/2306.13649): ``beta=0`` forward-KL, ``beta=1``
+reverse-KL, between = Jensen-Shannon. New divergences register into
+``DIVERGENCE_REGISTRY`` and are selected via ``gkd_divergence``.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+
+# (student_logits, teacher_logits, labels, temperature, num_items_in_batch) -> loss
+DivergenceFn = Callable[..., torch.Tensor]
+
+
+def generalized_jsd_loss(
+    student_logits: torch.Tensor,
+    teacher_logits: torch.Tensor,
+    labels: torch.Tensor | None = None,
+    beta: float = 0.5,
+    temperature: float = 1.0,
+    reduction: str = "batchmean",
+    num_items_in_batch: int | torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Generalized JSD loss (GKD Eq. 1); ``kl_div`` arg order matches TRL (swapped vs the paper)."""
+    student_log_probs = F.log_softmax(student_logits / temperature, dim=-1)
+    teacher_log_probs = F.log_softmax(teacher_logits / temperature, dim=-1)
+
+    if beta == 0:
+        jsd = F.kl_div(
+            student_log_probs, teacher_log_probs, reduction="none", log_target=True
+        )
+    elif beta == 1:
+        jsd = F.kl_div(
+            teacher_log_probs, student_log_probs, reduction="none", log_target=True
+        )
+    else:
+        beta_t = torch.tensor(
+            beta, dtype=student_log_probs.dtype, device=student_log_probs.device
+        )
+        mixture = torch.logsumexp(
+            torch.stack(
+                [
+                    student_log_probs + torch.log1p(-beta_t),
+                    teacher_log_probs + torch.log(beta_t),
+                ]
+            ),
+            dim=0,
+        )
+        jsd = beta * F.kl_div(
+            mixture, teacher_log_probs, reduction="none", log_target=True
+        ) + (1 - beta) * F.kl_div(
+            mixture, student_log_probs, reduction="none", log_target=True
+        )
+
+    mask = None if labels is None else labels != -100
+    if mask is not None:
+        jsd = jsd[mask]
+
+    if num_items_in_batch is not None:
+        if isinstance(num_items_in_batch, torch.Tensor):
+            num_items_in_batch = num_items_in_batch.to(jsd.device)
+        return jsd.sum() / num_items_in_batch
+    if reduction == "batchmean":
+        # clamp_min(1) avoids 0/0 -> nan when a sample has no unmasked positions.
+        denom = mask.sum().clamp_min(1) if mask is not None else max(jsd.size(0), 1)
+        return jsd.sum() / denom
+    if reduction == "sum":
+        return jsd.sum()
+    if reduction == "mean":
+        return jsd.mean()
+    return jsd
+
+
+# name -> factory(beta) -> divergence callable. Extend by assigning new entries.
+DIVERGENCE_REGISTRY: dict[str, Callable[[float], DivergenceFn]] = {
+    "jsd": lambda beta: partial(generalized_jsd_loss, beta=beta),
+    "generalized_jsd": lambda beta: partial(generalized_jsd_loss, beta=beta),
+    "forward_kl": lambda beta: partial(generalized_jsd_loss, beta=0.0),
+    "fkl": lambda beta: partial(generalized_jsd_loss, beta=0.0),
+    "reverse_kl": lambda beta: partial(generalized_jsd_loss, beta=1.0),
+    "rkl": lambda beta: partial(generalized_jsd_loss, beta=1.0),
+}
+
+
+def resolve_divergence(name: str | None, beta: float) -> DivergenceFn:
+    """``name=None`` defaults to generalized JSD via ``beta`` (spans fwd/rev-KL and between)."""
+    factory = DIVERGENCE_REGISTRY.get(name or "jsd")
+    if factory is None:
+        raise ValueError(
+            f"Unknown gkd_divergence '{name}'. Available: {sorted(DIVERGENCE_REGISTRY)}"
+        )
+    return factory(beta)

--- a/src/axolotl/integrations/gkd/rollout.py
+++ b/src/axolotl/integrations/gkd/rollout.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Axis B (rollout) seam: recover the prompt (the ``-100``-masked prefix of an
+Axolotl-tokenized sample) and left-pad it into the batch shape ``model.generate``
+expects, so no bespoke collator is needed.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def extract_prompt_batch(
+    input_ids: torch.Tensor,
+    labels: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    pad_token_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Left-padded ``(prompt_ids, prompt_attention_mask)`` from ``input_ids`` up to the
+    first supervised label; attended tokens within that prefix are kept."""
+    batch_size, seq_len = input_ids.shape
+    device = input_ids.device
+
+    rows = []
+    for i in range(batch_size):
+        supervised = (labels[i] != -100).nonzero(as_tuple=True)[0]
+        cut = int(supervised[0]) if supervised.numel() else seq_len
+        row = input_ids[i, :cut]
+        if attention_mask is not None:
+            row = row[attention_mask[i, :cut].bool()]
+        rows.append(row)
+
+    max_len = max((row.numel() for row in rows), default=1) or 1
+    prompt_ids = torch.full(
+        (batch_size, max_len), pad_token_id, dtype=input_ids.dtype, device=device
+    )
+    prompt_mask = torch.zeros((batch_size, max_len), dtype=torch.long, device=device)
+    for i, row in enumerate(rows):
+        if row.numel():
+            prompt_ids[i, max_len - row.numel() :] = row
+            prompt_mask[i, max_len - row.numel() :] = 1
+    return prompt_ids, prompt_mask

--- a/src/axolotl/integrations/gkd/trainer.py
+++ b/src/axolotl/integrations/gkd/trainer.py
@@ -1,0 +1,180 @@
+# Copyright 2024 Axolotl AI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+On-policy distillation (GKD) trainer. An ``AxolotlTrainer`` subclass over the
+standard pre-tokenized pipeline: ``training_step`` swaps the ground-truth
+completion for a student (or teacher, under ``seq_kd``) rollout with probability
+``lmbda`` (Axis B); ``compute_loss`` scores student vs teacher logits with the
+configured divergence over the completion tokens (Axis A). ``_resolve_teacher``
+(Axis C) and ``_token_weights`` (Axis D, uniform in v1) are extension seams.
+"""
+
+from __future__ import annotations
+
+import random
+
+import torch
+from transformers import AutoModelForCausalLM, GenerationConfig
+from trl.models import prepare_deepspeed, unwrap_model_for_generation
+from trl.trainer.utils import disable_dropout_in_model
+from typing_extensions import override
+
+from axolotl.core.trainers.base import AxolotlTrainer
+
+from .divergence import resolve_divergence
+from .rollout import extract_prompt_batch
+
+
+class AxolotlGKDTrainer(AxolotlTrainer):
+    """On-policy (generalized) knowledge distillation trainer."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # We own the loss (divergence vs teacher), so opt out of HF's CE loss-kwargs path.
+        self.model_accepts_loss_kwargs = False
+
+        a = self.args
+        self.gkd_lmbda = a.gkd_lmbda
+        self.gkd_temperature = a.gkd_temperature
+        self.gkd_seq_kd = bool(a.gkd_seq_kd)
+        self.divergence_fn = resolve_divergence(a.gkd_divergence, a.gkd_beta)
+
+        teacher_model = self._resolve_teacher()
+        self._check_shared_vocab(teacher_model)
+        disable_dropout_in_model(self.model)
+        disable_dropout_in_model(teacher_model)
+        if self.is_deepspeed_enabled:
+            self.teacher_model = prepare_deepspeed(teacher_model, self.accelerator)
+        else:
+            self.teacher_model = self.accelerator.prepare_model(
+                teacher_model, evaluation_mode=True
+            )
+
+        self.generation_kwargs = {
+            "max_new_tokens": a.gkd_max_new_tokens,
+            "temperature": a.gkd_temperature,
+            "do_sample": True,
+            "top_k": a.gkd_top_k or 0,
+            "use_cache": not self.args.gradient_checkpointing,
+            "pad_token_id": self.processing_class.pad_token_id,
+        }
+        if self.processing_class.eos_token_id is not None:
+            self.generation_kwargs["eos_token_id"] = self.processing_class.eos_token_id
+        self.generation_config = GenerationConfig(**self.generation_kwargs)
+
+    def _resolve_teacher(self) -> torch.nn.Module:
+        """Axis C seam: the supervising model. v1 loads one external HF model; v3
+        (self-distill) overrides to return the student under a privileged context."""
+        init_kwargs = dict(self.args.gkd_teacher_init_kwargs or {})
+        dtype = init_kwargs.get("dtype", next(self.model.parameters()).dtype)
+        init_kwargs["dtype"] = (
+            getattr(torch, dtype) if isinstance(dtype, str) else dtype
+        )
+        init_kwargs.setdefault(
+            "trust_remote_code", getattr(self.args, "trust_remote_code", False)
+        )
+        return AutoModelForCausalLM.from_pretrained(
+            self.args.gkd_teacher, **init_kwargs
+        )
+
+    def _check_shared_vocab(self, teacher_model: torch.nn.Module) -> None:
+        student, teacher = self.model.config.vocab_size, teacher_model.config.vocab_size
+        if student != teacher:
+            raise ValueError(
+                f"GKD needs a shared vocabulary: student vocab_size={student} but teacher "
+                f"vocab_size={teacher}. Use a teacher with the same tokenizer/vocab."
+            )
+
+    def _token_weights(self, shift_labels, shift_student_logits, shift_teacher_logits):
+        """Axis D seam: per-token loss weights. Uniform (``None``) in v1."""
+        return None
+
+    def _generate_on_policy(self, model, prompt_ids, prompt_mask):
+        tokens = model.generate(
+            input_ids=prompt_ids,
+            attention_mask=prompt_mask,
+            generation_config=self.generation_config,
+            return_dict_in_generate=True,
+        ).sequences
+        attn = torch.ones_like(tokens)
+        labels = tokens.clone()
+        pad = self.processing_class.pad_token_id
+        if pad is not None:
+            labels[labels == pad] = -100
+            attn[tokens == pad] = 0
+        # generate echoes the prompt back; mask it so only the completion is scored.
+        labels[:, : prompt_ids.shape[1]] = -100
+        return tokens, attn, labels
+
+    @override
+    def training_step(self, model, inputs, num_items_in_batch=None):
+        gen_model = None
+        if random.random() <= self.gkd_lmbda:  # nosec B311
+            gen_model = model
+        elif self.gkd_seq_kd:
+            gen_model = self.teacher_model
+
+        if gen_model is not None:
+            prompt_ids, prompt_mask = extract_prompt_batch(
+                inputs["input_ids"],
+                inputs["labels"],
+                inputs.get("attention_mask"),
+                self.processing_class.pad_token_id,
+            )
+            with unwrap_model_for_generation(
+                gen_model, self.accelerator, generation_kwargs=self.generation_kwargs
+            ) as unwrapped_model:
+                new_ids, new_attn, new_labels = self._generate_on_policy(
+                    unwrapped_model, prompt_ids, prompt_mask
+                )
+            inputs = dict(inputs)
+            inputs["input_ids"] = new_ids
+            inputs["attention_mask"] = new_attn
+            inputs["labels"] = new_labels
+            inputs.pop("position_ids", None)  # stale for the regenerated sequence
+
+        return super().training_step(model, inputs, num_items_in_batch)
+
+    @override
+    def compute_loss(
+        self, model, inputs, return_outputs=False, num_items_in_batch=None
+    ):
+        inputs = dict(inputs)
+        inputs.pop("position_ids", None)
+        inputs.pop("num_items_in_batch", None)
+
+        labels = inputs["labels"]
+        if num_items_in_batch is None:
+            num_items_in_batch = (labels[:, 1:] != -100).sum().clamp_min(1)
+
+        attention_mask = inputs.get("attention_mask")
+        student_outputs = model(
+            input_ids=inputs["input_ids"], attention_mask=attention_mask
+        )
+        self.teacher_model.eval()
+        with torch.no_grad():
+            teacher_outputs = self.teacher_model(
+                input_ids=inputs["input_ids"], attention_mask=attention_mask
+            )
+
+        # Causal shift: logits at i predict token i+1; the -100 label mask drops prompt/pad.
+        loss = self.divergence_fn(
+            student_logits=student_outputs.logits[:, :-1, :],
+            teacher_logits=teacher_outputs.logits[:, :-1, :],
+            labels=labels[:, 1:],
+            temperature=self.gkd_temperature,
+            num_items_in_batch=num_items_in_batch,
+        )
+        return (loss, student_outputs) if return_outputs else loss

--- a/src/axolotl/integrations/kd/README.md
+++ b/src/axolotl/integrations/kd/README.md
@@ -21,3 +21,14 @@ datasets:
 ```
 
 An example dataset can be found at [`axolotl-ai-co/evolkit-logprobs-pipeline-75k-v2-sample`](https://huggingface.co/datasets/axolotl-ai-co/evolkit-logprobs-pipeline-75k-v2-sample)
+
+## Implementation notes
+
+The live KD loss is the fused Liger kernel
+(`kernels/liger.py::LigerFusedLinearKLTopKLogprobLoss`). A readable, dependency-free
+reference of the same top-k forward-KL is kept in
+[`topk_logprob/forward_kl.py`](topk_logprob/forward_kl.py) for correctness
+comparisons and as a non-Liger fallback; it is not wired into the trainer by default.
+
+For **on-policy** distillation (student rollouts + in-process teacher), see the
+[GKD plugin](../gkd/README.md).

--- a/src/axolotl/integrations/kd/args.py
+++ b/src/axolotl/integrations/kd/args.py
@@ -36,7 +36,7 @@ class KDArgs(BaseModel):
     Input args for knowledge distillation.
     """
 
-    kd_trainer: float | None = None  # whether to use KD trainer
+    kd_trainer: bool | None = None  # whether to use KD trainer
     kd_ce_alpha: float | None = (
         None  # loss coefficient for cross-entropy loss during KD
     )

--- a/src/axolotl/integrations/kd/topk_logprob/forward_kl.py
+++ b/src/axolotl/integrations/kd/topk_logprob/forward_kl.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 """
-loss for top_k KL divergence
+Reference (pure-PyTorch) top-k forward-KL KD loss.
+
+This is the readable, dependency-free reference for the fused KD loss used on
+the live training path (``axolotl.integrations.kd.kernels.liger.LigerFusedLinearKLTopKLogprobLoss``). It is kept for correctness comparisons
+and as a fallback for environments without the Liger kernel; it is not wired
+into the trainer by default.
 """
 
 import torch

--- a/tests/e2e/integrations/test_gkd.py
+++ b/tests/e2e/integrations/test_gkd.py
@@ -1,0 +1,116 @@
+"""
+e2e tests for GKD / on-policy distillation trainer support in Axolotl.
+
+Smoke tests: the student generates on-policy rollouts (lmbda=1.0), a same-vocab
+teacher scores them with the generalized JSD, and the run trains and saves. The
+divergence/rollout correctness is covered by the CPU unit tests in
+tests/integrations/test_gkd_*.py.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from accelerate.test_utils import execute_subprocess_async, get_torch_dist_unique_port
+
+from axolotl.utils.dict import DictDefault
+
+from tests.e2e.utils import check_tensorboard
+
+
+@pytest.fixture(name="gkd_min_cfg")
+def min_cfg(temp_dir):
+    return {
+        "base_model": "axolotl-ai-co/tiny-llama-50m",
+        "plugins": [
+            "axolotl.integrations.gkd.GKDPlugin",
+        ],
+        "gkd_trainer": True,
+        "gkd_teacher": "axolotl-ai-co/tiny-llama-50m",
+        "gkd_lmbda": 1.0,
+        "gkd_beta": 0.5,
+        "gkd_temperature": 0.9,
+        "gkd_max_new_tokens": 64,
+        "chat_template": "llama3",
+        "datasets": [
+            {
+                "path": "mhenrichsen/alpaca_2k_test",
+                "type": "alpaca",
+                "split": "train",
+            },
+        ],
+        "train_on_inputs": False,
+        "val_set_size": 0.0,
+        "sequence_len": 512,
+        "sample_packing": False,
+        "gradient_accumulation_steps": 2,
+        "micro_batch_size": 1,
+        "num_epochs": 1,
+        "optimizer": "adamw_8bit",
+        "lr_scheduler": "cosine",
+        "learning_rate": 0.00001,
+        "bf16": "auto",
+        "gradient_checkpointing": True,
+        "flash_attention": True,
+        "max_steps": 5,
+        "output_dir": temp_dir,
+        "use_tensorboard": True,
+        "save_first_step": False,
+    }
+
+
+class TestGKD:
+    """Test case for on-policy distillation (GKD)."""
+
+    def test_gkd_full_finetune(self, temp_dir, gkd_min_cfg):
+        cfg = DictDefault(gkd_min_cfg)
+
+        Path(temp_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+            fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+        execute_subprocess_async(
+            [
+                "axolotl",
+                "train",
+                str(Path(temp_dir) / "config.yaml"),
+                "--num-processes",
+                "1",
+                "--main-process-port",
+                f"{get_torch_dist_unique_port()}",
+            ]
+        )
+
+        assert (Path(temp_dir) / "model.safetensors").exists()
+        check_tensorboard(
+            temp_dir + "/runs", "train/loss", 2.0, "Train Loss (%s) is too high"
+        )
+
+    def test_gkd_lora(self, temp_dir, gkd_min_cfg):
+        cfg = DictDefault(
+            {
+                "adapter": "lora",
+                "lora_target_linear": True,
+                "lora_r": 16,
+                "lora_alpha": 32,
+                "lora_dropout": 0.0,
+            }
+            | gkd_min_cfg
+        )
+
+        Path(temp_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+            fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+        execute_subprocess_async(
+            [
+                "axolotl",
+                "train",
+                str(Path(temp_dir) / "config.yaml"),
+                "--num-processes",
+                "1",
+                "--main-process-port",
+                f"{get_torch_dist_unique_port()}",
+            ]
+        )
+        assert (Path(temp_dir) / "adapter_model.safetensors").exists()

--- a/tests/integrations/test_gkd_config.py
+++ b/tests/integrations/test_gkd_config.py
@@ -1,0 +1,58 @@
+"""Config validation tests for the GKD plugin args."""
+
+import pydantic
+import pytest
+
+from axolotl.integrations.gkd.args import GKDArgs
+
+
+def _merged_cls():
+    """Replicate merge_input_args(): AxolotlInputConfig + GKDArgs."""
+    from axolotl.utils.schemas.config import AxolotlInputConfig as Base
+
+    class _Merged(Base, GKDArgs):
+        pass
+
+    return _Merged
+
+
+def _minimal(**overrides):
+    cfg = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "datasets": [{"path": "tatsu-lab/alpaca", "type": "alpaca"}],
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "learning_rate": 0.0001,
+        "gkd_trainer": True,
+        "gkd_teacher": "HuggingFaceTB/SmolLM2-1.7B",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_defaults_match_reverse_kl_fully_on_policy():
+    args = GKDArgs()
+    assert args.gkd_lmbda == 1.0
+    assert args.gkd_beta == 1.0
+
+
+def test_teacher_required_when_trainer_enabled():
+    with pytest.raises(pydantic.ValidationError, match="gkd_teacher is required"):
+        GKDArgs(gkd_trainer=True)
+
+
+def test_no_validation_when_trainer_disabled():
+    GKDArgs(gkd_trainer=False)  # gkd_teacher unset is fine
+
+
+def test_merged_config_rejects_sample_packing():
+    with pytest.raises(
+        pydantic.ValidationError, match="incompatible with sample_packing"
+    ):
+        _merged_cls().model_validate(_minimal(sample_packing=True))
+
+
+def test_merged_config_accepts_unpacked():
+    cfg = _merged_cls().model_validate(_minimal(sample_packing=False))
+    assert cfg.gkd_trainer is True
+    assert cfg.gkd_teacher == "HuggingFaceTB/SmolLM2-1.7B"

--- a/tests/integrations/test_gkd_divergence.py
+++ b/tests/integrations/test_gkd_divergence.py
@@ -1,0 +1,100 @@
+"""Tests for the GKD Axis A divergence seam."""
+
+import os
+
+import pytest
+import torch
+
+os.environ.setdefault("TRL_EXPERIMENTAL_SILENCE", "1")
+
+from axolotl.integrations.gkd.divergence import (  # noqa: E402
+    DIVERGENCE_REGISTRY,
+    generalized_jsd_loss,
+    resolve_divergence,
+)
+
+VOCAB = 32
+SEQ = 5
+BSZ = 2
+
+
+def _batch(seed=0):
+    torch.manual_seed(seed)
+    student = torch.randn(BSZ, SEQ, VOCAB)
+    teacher = torch.randn(BSZ, SEQ, VOCAB)
+    labels = torch.full((BSZ, SEQ), -100)
+    labels[:, 3:] = torch.randint(0, VOCAB, (BSZ, 2))
+    return student, teacher, labels
+
+
+@pytest.mark.parametrize("beta", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_matches_trl_reference(beta):
+    gkd = pytest.importorskip("trl.experimental.gkd")
+    student, teacher, labels = _batch()
+    ours = generalized_jsd_loss(
+        student, teacher, labels=labels, beta=beta, temperature=0.9
+    )
+    ref = gkd.GKDTrainer.generalized_jsd_loss(
+        student, teacher, labels=labels, beta=beta, temperature=0.9
+    )
+    assert torch.allclose(ours, ref, atol=1e-6)
+
+
+def test_num_items_in_batch_matches_trl():
+    gkd = pytest.importorskip("trl.experimental.gkd")
+    student, teacher, labels = _batch()
+    ours = generalized_jsd_loss(
+        student, teacher, labels=labels, beta=0.5, num_items_in_batch=4
+    )
+    ref = gkd.GKDTrainer.generalized_jsd_loss(
+        student, teacher, labels=labels, beta=0.5, num_items_in_batch=4
+    )
+    assert torch.allclose(ours, ref, atol=1e-6)
+
+
+def test_identical_logits_zero_loss():
+    torch.manual_seed(1)
+    logits = torch.randn(BSZ, SEQ, VOCAB)
+    labels = torch.zeros(BSZ, SEQ, dtype=torch.long)
+    for beta in (0.0, 0.5, 1.0):
+        loss = generalized_jsd_loss(logits, logits.clone(), labels=labels, beta=beta)
+        assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_fully_masked_batch_no_nan():
+    student, teacher, _ = _batch()
+    labels = torch.full((BSZ, SEQ), -100)
+    loss = generalized_jsd_loss(student, teacher, labels=labels, beta=0.5)
+    assert torch.isfinite(loss).all()
+    assert torch.isclose(loss, torch.tensor(0.0))
+
+
+def test_resolve_forward_and_reverse_kl():
+    student, teacher, labels = _batch()
+    # beta arg is ignored by the fkl/rkl entries: they pin beta to 0/1.
+    fkl = resolve_divergence("fkl", beta=0.7)(student, teacher, labels=labels)
+    rkl = resolve_divergence("rkl", beta=0.3)(student, teacher, labels=labels)
+    assert torch.allclose(
+        fkl, generalized_jsd_loss(student, teacher, labels=labels, beta=0.0)
+    )
+    assert torch.allclose(
+        rkl, generalized_jsd_loss(student, teacher, labels=labels, beta=1.0)
+    )
+
+
+def test_resolve_default_uses_beta():
+    student, teacher, labels = _batch()
+    got = resolve_divergence(None, beta=0.4)(student, teacher, labels=labels)
+    assert torch.allclose(
+        got, generalized_jsd_loss(student, teacher, labels=labels, beta=0.4)
+    )
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown gkd_divergence"):
+        resolve_divergence("not_a_divergence", beta=0.5)
+
+
+def test_registry_aliases_present():
+    for name in ("jsd", "forward_kl", "fkl", "reverse_kl", "rkl"):
+        assert name in DIVERGENCE_REGISTRY

--- a/tests/integrations/test_gkd_rollout.py
+++ b/tests/integrations/test_gkd_rollout.py
@@ -1,0 +1,78 @@
+"""Tests for the GKD Axis B rollout prompt-extraction helper."""
+
+import torch
+
+from axolotl.integrations.gkd.rollout import extract_prompt_batch
+
+
+def test_right_padded_variable_length_prompts():
+    input_ids = torch.tensor(
+        [
+            [10, 11, 12, 20, 21, 0],  # prompt [10,11,12], completion [20,21], pad
+            [30, 31, 40, 41, 42, 43],  # prompt [30,31], completion [40,41,42,43]
+        ]
+    )
+    labels = torch.tensor(
+        [
+            [-100, -100, -100, 20, 21, -100],
+            [-100, -100, 40, 41, 42, 43],
+        ]
+    )
+    attn = torch.tensor([[1, 1, 1, 1, 1, 0], [1, 1, 1, 1, 1, 1]])
+
+    prompt_ids, prompt_mask = extract_prompt_batch(
+        input_ids, labels, attn, pad_token_id=0
+    )
+
+    # left-padded to the longest prompt (len 3)
+    assert prompt_ids.tolist() == [[10, 11, 12], [0, 30, 31]]
+    assert prompt_mask.tolist() == [[1, 1, 1], [0, 1, 1]]
+
+
+def test_left_padding_within_prompt_is_stripped():
+    # padding_side="left": leading pads sit before the prompt and must be dropped.
+    input_ids = torch.tensor([[0, 0, 5, 6, 7, 8]])
+    labels = torch.tensor([[-100, -100, -100, -100, 7, 8]])
+    attn = torch.tensor([[0, 0, 1, 1, 1, 1]])
+
+    prompt_ids, prompt_mask = extract_prompt_batch(
+        input_ids, labels, attn, pad_token_id=0
+    )
+
+    assert prompt_ids.tolist() == [[5, 6]]
+    assert prompt_mask.tolist() == [[1, 1]]
+
+
+def test_no_completion_uses_full_row_as_prompt():
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    labels = torch.full((1, 4), -100)
+    attn = torch.ones(1, 4, dtype=torch.long)
+
+    prompt_ids, prompt_mask = extract_prompt_batch(
+        input_ids, labels, attn, pad_token_id=0
+    )
+
+    assert prompt_ids.tolist() == [[1, 2, 3, 4]]
+    assert prompt_mask.tolist() == [[1, 1, 1, 1]]
+
+
+def test_none_attention_mask_treats_all_attended():
+    input_ids = torch.tensor([[1, 2, 3, 9]])
+    labels = torch.tensor([[-100, -100, 3, 9]])
+
+    prompt_ids, prompt_mask = extract_prompt_batch(
+        input_ids, labels, None, pad_token_id=0
+    )
+
+    assert prompt_ids.tolist() == [[1, 2]]
+    assert prompt_mask.tolist() == [[1, 1]]
+
+
+def test_preserves_dtype_and_device():
+    input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+    labels = torch.tensor([[-100, -100, 3, 4]])
+    prompt_ids, prompt_mask = extract_prompt_batch(
+        input_ids, labels, None, pad_token_id=7
+    )
+    assert prompt_ids.dtype == input_ids.dtype
+    assert prompt_mask.dtype == torch.long


### PR DESCRIPTION
# Description

On-policy distillation (GKD) plugin
Adds a `GKDPlugin` integration for **on-policy / generalized knowledge
distillation** 

 a small student learns from a larger, same-vocab teacher on the
student's *own* rollouts. 



## How has this been tested?
unit tests sand manual runs 

## AI Usage Disclaimer
consulted claude
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/ba5d4191-831d-4266-9926-42822bb77e1e" />







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-policy knowledge distillation (GKD) training.
  * Added configurable teacher models, rollout behavior, divergence methods, temperature, token limits, and distillation weighting.
  * Added support for both full fine-tuning and LoRA training with GKD.
* **Documentation**
  * Added setup guidance, configuration examples, compatibility requirements, and tuning recommendations.
  * Expanded KD documentation with implementation notes and GKD guidance.
* **Bug Fixes**
  * Updated KD trainer configuration to use a boolean enablement flag.
* **Tests**
  * Added coverage for GKD configuration, divergence calculations, rollouts, and end-to-end training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->