### PR TITLE
fix: correct total_token_slots accounting when dropping incomplete multipack batch

### DIFF
--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -365,11 +365,12 @@ class MultipackBatchSampler(BatchSampler):
         ]
 
         # Drop last batch if requested and it's incomplete
-        if self.drop_last and len(batches[-1]) < self.batch_size:
+        if self.drop_last and batches and len(batches[-1]) < self.batch_size:
+            dropped_batch = batches[-1]
             batches = batches[:-1]
-            # Adjust total_slots if we dropped a batch
+            # Adjust total_slots for the bins that were dropped along with the batch
             if not self.sequential:
-                total_slots -= (self.batch_size - len(batches[-1])) * self.batch_max_len
+                total_slots -= len(dropped_batch) * self.batch_max_len
 
         # Update statistics if requested
         if set_stats:

--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -368,9 +368,13 @@ class MultipackBatchSampler(BatchSampler):
         if self.drop_last and batches and len(batches[-1]) < self.batch_size:
             dropped_batch = batches[-1]
             batches = batches[:-1]
-            # Adjust total_slots for the bins that were dropped along with the batch
-            if not self.sequential:
-                total_slots -= len(dropped_batch) * self.batch_max_len
+            # Adjust the packing stats for the bins that were dropped along with
+            # the batch, so efficiency() is not overstated. Each dropped bin
+            # accounts for batch_max_len slots and its examples' token lengths.
+            total_slots -= len(dropped_batch) * self.batch_max_len
+            total_used -= sum(
+                int(self.lengths[idx]) for bin_ in dropped_batch for idx in bin_
+            )
 
         # Update statistics if requested
         if set_stats:

--- a/tests/test_multipack_drop_last.py
+++ b/tests/test_multipack_drop_last.py
@@ -1,0 +1,49 @@
+"""Tests for MultipackBatchSampler.generate_batches drop_last accounting."""
+
+import numpy as np
+
+from axolotl.utils.samplers import multipack
+from axolotl.utils.samplers import MultipackBatchSampler
+
+
+def _make_sampler(num_items, batch_size, batch_max_len, drop_last):
+    return MultipackBatchSampler(
+        sampler=list(range(num_items)),
+        lengths=np.ones(num_items, dtype=np.int32),
+        batch_size=batch_size,
+        batch_max_len=batch_max_len,
+        bin_size=batch_max_len,
+        sequential=False,
+        drop_last=drop_last,
+    )
+
+
+def test_drop_last_subtracts_dropped_bins_from_slots(monkeypatch):
+    # 7 bins, batch_size 3 -> batches of [3, 3, 1]; the final batch of 1 bin is dropped.
+    batch_max_len = 100
+    monkeypatch.setattr(
+        multipack, "pack_parallel", lambda lengths, **_: [[i] for i in range(7)]
+    )
+
+    sampler = _make_sampler(
+        num_items=7, batch_size=3, batch_max_len=batch_max_len, drop_last=True
+    )
+    batches = sampler.generate_batches(set_stats=True)
+
+    # Only the two full batches survive.
+    assert [len(b) for b in batches] == [3, 3]
+    # 6 remaining bins each contribute batch_max_len slots; the dropped bin is removed.
+    assert sampler.total_token_slots == 6 * batch_max_len
+
+
+def test_drop_last_does_not_crash_on_single_incomplete_batch(monkeypatch):
+    # 1 bin, batch_size 3 -> a single incomplete batch that is dropped entirely.
+    monkeypatch.setattr(multipack, "pack_parallel", lambda lengths, **_: [[0]])
+
+    sampler = _make_sampler(
+        num_items=1, batch_size=3, batch_max_len=100, drop_last=True
+    )
+    batches = sampler.generate_batches(set_stats=True)
+
+    assert batches == []
+    assert sampler.total_token_slots == 0

--- a/tests/test_multipack_drop_last.py
+++ b/tests/test_multipack_drop_last.py
@@ -34,6 +34,8 @@ def test_drop_last_subtracts_dropped_bins_from_slots(monkeypatch):
     assert [len(b) for b in batches] == [3, 3]
     # 6 remaining bins each contribute batch_max_len slots; the dropped bin is removed.
     assert sampler.total_token_slots == 6 * batch_max_len
+    # The dropped bin's token is also removed from the used-token total.
+    assert sampler.total_tokens_used == 6
 
 
 def test_drop_last_does_not_crash_on_single_incomplete_batch(monkeypatch):
@@ -47,3 +49,5 @@ def test_drop_last_does_not_crash_on_single_incomplete_batch(monkeypatch):
 
     assert batches == []
     assert sampler.total_token_slots == 0
+    # Dropping the only bin removes its token too, leaving nothing used.
+    assert sampler.total_tokens_used == 0


### PR DESCRIPTION
# Description

`MultipackBatchSampler.generate_batches()` drops the final batch when `drop_last` is set and that batch is incomplete, but the follow-up `total_slots` adjustment reads `batches[-1]` after the slice, so it points at the new (full) last batch instead of the dropped one. `self.batch_size - len(batches[-1])` is then `0`, and the dropped bins are never removed from `total_slots`, leaving `total_token_slots` (and `efficiency()` / `sample_packing_eff_est`) inflated. When the incomplete batch is the only batch, the slice empties `batches` and `batches[-1]` raises `IndexError`.

The fix captures the dropped batch before slicing, subtracts its actual bin count (`len(dropped_batch) * batch_max_len`), and guards the empty-`batches` case so an all-dropped result returns a no-op instead of crashing.

## Motivation and Context

Fixes #3848.

## How has this been tested?

Added `tests/test_multipack_drop_last.py`, which patches `pack_parallel` to a fixed bin layout and checks that (1) dropping an incomplete batch reduces `total_token_slots` by exactly the dropped bins and (2) a single incomplete batch is dropped without raising. Both tests fail on `main` (the second with the reported `IndexError`) and pass with this change.

## AI Usage Disclaimer

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected drop-last batch handling so incomplete final batches are removed properly.
  * Fixed token slot totals to reflect only retained batches.
  * Prevented errors when all generated batches are incomplete.

* **Tests**
  * Added coverage for partial final batches and the single-incomplete-batch edge case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->