### PR TITLE
fix: multipack drop_last total_slots stale reference

### DIFF
--- a/src/axolotl/utils/samplers/multipack.py
+++ b/src/axolotl/utils/samplers/multipack.py
@@ -364,12 +364,17 @@ class MultipackBatchSampler(BatchSampler):
             bins[i : i + self.batch_size] for i in range(0, len(bins), self.batch_size)
         ]
 
-        # Drop last batch if requested and it's incomplete
-        if self.drop_last and len(batches[-1]) < self.batch_size:
+        # Drop last batch if requested and it's incomplete.
+        # Capture the dropped batch length *before* re-slicing: after
+        # `batches = batches[:-1]`, `batches[-1]` refers to the previous (full)
+        # batch, so the old adjustment became a no-op and left total_token_slots
+        # inflated. Also guard empty batches to avoid IndexError when packing
+        # yields a single incomplete batch that is then dropped (#3848).
+        if self.drop_last and batches and len(batches[-1]) < self.batch_size:
+            dropped_bins = len(batches[-1])
             batches = batches[:-1]
-            # Adjust total_slots if we dropped a batch
             if not self.sequential:
-                total_slots -= (self.batch_size - len(batches[-1])) * self.batch_max_len
+                total_slots -= dropped_bins * self.batch_max_len
 
         # Update statistics if requested
         if set_stats:

--- a/tests/utils/samplers/test_multipack_drop_last_stats.py
+++ b/tests/utils/samplers/test_multipack_drop_last_stats.py
@@ -1,0 +1,96 @@
+"""Unit tests for MultipackBatchSampler drop_last total_slots accounting."""
+
+from __future__ import annotations
+
+import numpy as np
+from torch.utils.data import SequentialSampler
+
+from axolotl.utils.samplers.multipack import MultipackBatchSampler
+
+
+class _ListDataset:
+    def __init__(self, n: int):
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+
+def _make_sampler(
+    lengths: list[int],
+    *,
+    batch_size: int,
+    batch_max_len: int,
+    drop_last: bool,
+    sequential: bool = False,
+) -> MultipackBatchSampler:
+    dataset = _ListDataset(len(lengths))
+    return MultipackBatchSampler(
+        sampler=SequentialSampler(dataset),
+        lengths=np.array(lengths, dtype=np.int32),
+        batch_size=batch_size,
+        batch_max_len=batch_max_len,
+        bin_size=max(1, len(lengths)),
+        group_size=max(1, len(lengths)),
+        sequential=sequential,
+        drop_last=drop_last,
+        num_count_samples=1,
+        num_processes=1,
+        safe_mode=True,
+    )
+
+
+def test_drop_last_reduces_total_token_slots_by_dropped_bins():
+    # lengths=4, capacity=8 => two sequences per bin via first-fit.
+    # 5 sequences => bins [[0,1],[2,3],[4]] (3 bins).
+    # batch_size=2 => batches [full, incomplete]; incomplete last batch dropped.
+    lengths = [4] * 5
+    batch_size = 2
+    batch_max_len = 8
+
+    sampler = _make_sampler(
+        lengths,
+        batch_size=batch_size,
+        batch_max_len=batch_max_len,
+        drop_last=True,
+        sequential=False,
+    )
+    batches = sampler.generate_batches(set_stats=True)
+
+    assert len(batches) == 1
+    assert len(batches[0]) == batch_size
+
+    # Kept bins: 2; dropped bins: 1. total_token_slots must shrink by dropped bins.
+    assert sampler.total_token_slots == 2 * batch_max_len
+
+
+def test_drop_last_old_stale_reference_would_not_adjust():
+    # Without the fix, total_slots adjustment used batches[-1] AFTER the drop,
+    # which pointed at a full batch and subtracted 0. Assert we actually subtract.
+    lengths = [4] * 5
+    batch_max_len = 8
+    sampler = _make_sampler(
+        lengths,
+        batch_size=2,
+        batch_max_len=batch_max_len,
+        drop_last=True,
+        sequential=False,
+    )
+    sampler.generate_batches(set_stats=True)
+    # Pre-drop slots would be 3 * batch_max_len; post-fix must be 2 * batch_max_len.
+    assert sampler.total_token_slots == 2 * batch_max_len
+    assert sampler.total_token_slots != 3 * batch_max_len
+
+
+def test_drop_last_single_incomplete_batch_returns_empty_without_indexerror():
+    lengths = [4]
+    sampler = _make_sampler(
+        lengths,
+        batch_size=2,
+        batch_max_len=8,
+        drop_last=True,
+        sequential=False,
+    )
+    batches = sampler.generate_batches(set_stats=True)
+    assert batches == []
+    assert sampler.total_token_slots == 0


### PR DESCRIPTION
# Description

Fixes a stale-reference bug in `MultipackBatchSampler.generate_batches()` when `drop_last=True` drops an incomplete final batch.

Previously the code did:

```python
if self.drop_last and len(batches[-1]) < self.batch_size:
    batches = batches[:-1]
    if not self.sequential:
        total_slots -= (self.batch_size - len(batches[-1])) * self.batch_max_len
```

After `batches = batches[:-1]`, `batches[-1]` no longer refers to the dropped incomplete batch — it refers to the previous full batch. That made `(batch_size - len(batches[-1]))` evaluate to `0` in the common case, so `total_token_slots` stayed inflated. In the edge case where packing produces exactly one incomplete batch, the re-slice left `batches == []` and the next `batches[-1]` raised `IndexError`.

This PR captures `dropped_bins = len(batches[-1])` before the re-slice, subtracts `dropped_bins * batch_max_len`, and guards empty `batches`.

Fixes #3848

## Motivation and Context

`total_token_slots` feeds packing efficiency estimates (`sampler.efficiency()` / `cfg.sample_packing_eff_est`). Leaving it inflated after `drop_last` silently misreports packing efficiency. The empty-batch path can also crash training startup.

## How has this been tested?

- Added unit tests in `tests/utils/samplers/test_multipack_drop_last_stats.py`
- Ran locally:
  ```bash
  PYTHONPATH=src python3 -m pytest tests/utils/samplers/test_multipack_drop_last_stats.py -q --noconftest
  # 3 passed
  ```

## AI Usage Disclaimer

Yes — assisted with drafting the patch and unit tests (Hermes/agent). Logic and review were checked against the issue repro.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Social Handles (Optional)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token-slot accounting when incomplete final batches are dropped.
  * Prevented errors when dropping the only incomplete batch.
  * Ensured reported capacity reflects the remaining batches accurately.

* **Tests**
  * Added coverage for dropped-batch accounting and empty-batch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->