### PR TITLE
fix: drop samples with no trainable tokens (all labels -100)

### DIFF
--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -351,7 +351,7 @@ def _load_raw_datasets(
         if (split == "train" and cfg.sample_packing) or (
             split == "test" and cfg.eval_sample_packing
         ):
-            dataset, _ = process_datasets_for_packing(cfg, dataset, None, split=split)
+            dataset, _ = process_datasets_for_packing(cfg, dataset, None)
 
         # Deduplicate before saving so the saved dataset is already de-duplicated
         if cfg.dataset_exact_deduplication:

--- a/src/axolotl/utils/data/sft.py
+++ b/src/axolotl/utils/data/sft.py
@@ -351,7 +351,7 @@ def _load_raw_datasets(
         if (split == "train" and cfg.sample_packing) or (
             split == "test" and cfg.eval_sample_packing
         ):
-            dataset, _ = process_datasets_for_packing(cfg, dataset, None)
+            dataset, _ = process_datasets_for_packing(cfg, dataset, None, split=split)
 
         # Deduplicate before saving so the saved dataset is already de-duplicated
         if cfg.dataset_exact_deduplication:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -271,11 +271,13 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         # If it's a list, we assume we're dealing with a batch
         if isinstance(labels[0], int):
             # Single example: return a single bool
-            return np.any(labels != -100)
+            return bool(np.any(np.asarray(labels) != -100))
 
         # Batched: 'labels' is a list of lists
         # Return a list of booleans, one per sub-list
-        results = [np.any(row_labels != -100) for row_labels in labels]
+        results = [
+            bool(np.any(np.asarray(row_labels) != -100)) for row_labels in labels
+        ]
         return results
 
     try:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -241,7 +241,7 @@ def filter_sequences_by_length(
     return results
 
 
-def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
+def process_datasets_for_packing(cfg, train_dataset, eval_dataset, split="train"):
     drop_attn_mask = cfg.model_config_type in ["mamba", "gemma3"]
     if drop_attn_mask:
         LOG.info("dropping attention_mask column")
@@ -307,9 +307,9 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         dropped = prior_len - len(train_dataset)
         if dropped:
             LOG.warning(
-                f"Dropped {dropped} samples with no trainable tokens from train dataset"
+                f"Dropped {dropped} samples with no trainable tokens from {split} dataset"
             )
-        raise_if_empty(train_dataset, "train")
+        raise_if_empty(train_dataset, split)
 
     if eval_dataset:
         try:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -241,7 +241,7 @@ def filter_sequences_by_length(
     return results
 
 
-def process_datasets_for_packing(cfg, train_dataset, eval_dataset, split="train"):
+def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
     drop_attn_mask = cfg.model_config_type in ["mamba", "gemma3"]
     if drop_attn_mask:
         LOG.info("dropping attention_mask column")
@@ -307,9 +307,9 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset, split="train"
         dropped = prior_len - len(train_dataset)
         if dropped:
             LOG.warning(
-                f"Dropped {dropped} samples with no trainable tokens from {split} dataset"
+                f"Dropped {dropped} samples with no trainable tokens from train dataset"
             )
-        raise_if_empty(train_dataset, split)
+        raise_if_empty(train_dataset, "train")
 
     if eval_dataset:
         try:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -280,8 +280,8 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
             raise ValueError(
                 f"The {split} dataset has no samples left after dropping samples with "
                 "no trainable tokens. Every sample had all of its labels masked to "
-                "-100, so there is nothing to train on. Check `train_on_inputs` and "
-                "your prompt strategy / chat template."
+                "-100, so there is nothing to train on. Check `train_on_inputs`, "
+                "`roles_to_train`, and your prompt strategy / chat template."
             )
 
     try:

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -303,7 +303,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         **filter_map_kwargs,
         **drop_long_kwargs,
     )
-    if prior_len is not None:
+    if prior_len:
         dropped = prior_len - len(train_dataset)
         if dropped:
             LOG.warning(
@@ -322,7 +322,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
             **filter_map_kwargs,
             **drop_long_kwargs,
         )
-        if prior_len is not None:
+        if prior_len:
             dropped = prior_len - len(eval_dataset)
             if dropped:
                 LOG.warning(

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -275,11 +275,11 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         results = [any(v != -100 for v in row_labels) for row_labels in labels]
         return results
 
-    def raise_if_empty(dataset, split):
+    def raise_if_empty(dataset):
         if len(dataset) == 0:
             raise ValueError(
-                f"The {split} dataset has no samples left after dropping samples with "
-                "no trainable tokens. Every sample had all of its labels masked to "
+                "The dataset has no samples left after dropping samples with no "
+                "trainable tokens. Every sample had all of its labels masked to "
                 "-100, so there is nothing to train on. Check `train_on_inputs`, "
                 "`roles_to_train`, and your prompt strategy / chat template."
             )
@@ -309,7 +309,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
             LOG.warning(
                 f"Dropped {dropped} samples with no trainable tokens from train dataset"
             )
-        raise_if_empty(train_dataset, "train")
+        raise_if_empty(train_dataset)
 
     if eval_dataset:
         try:
@@ -328,7 +328,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
                 LOG.warning(
                     f"Dropped {dropped} samples with no trainable tokens from eval dataset"
                 )
-            raise_if_empty(eval_dataset, "eval")
+            raise_if_empty(eval_dataset)
 
     if cfg.group_by_length:
         train_dataset = train_dataset.map(

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -9,7 +9,6 @@ from functools import partial
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
-import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import torch
@@ -271,14 +270,19 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         # If it's a list, we assume we're dealing with a batch
         if isinstance(labels[0], int):
             # Single example: return a single bool
-            return bool(np.any(np.asarray(labels) != -100))
+            return any(v != -100 for v in labels)
 
-        # Batched: 'labels' is a list of lists
-        # Return a list of booleans, one per sub-list
-        results = [
-            bool(np.any(np.asarray(row_labels) != -100)) for row_labels in labels
-        ]
+        results = [any(v != -100 for v in row_labels) for row_labels in labels]
         return results
+
+    def raise_if_empty(dataset, split):
+        if len(dataset) == 0:
+            raise ValueError(
+                f"The {split} dataset has no samples left after dropping samples with "
+                "no trainable tokens. Every sample had all of its labels masked to "
+                "-100, so there is nothing to train on. Check `train_on_inputs` and "
+                "your prompt strategy / chat template."
+            )
 
     try:
         prior_len = len(train_dataset)
@@ -299,12 +303,13 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
         **filter_map_kwargs,
         **drop_long_kwargs,
     )
-    if prior_len:
+    if prior_len is not None:
         dropped = prior_len - len(train_dataset)
         if dropped:
             LOG.warning(
                 f"Dropped {dropped} samples with no trainable tokens from train dataset"
             )
+        raise_if_empty(train_dataset, "train")
 
     if eval_dataset:
         try:
@@ -317,12 +322,13 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
             **filter_map_kwargs,
             **drop_long_kwargs,
         )
-        if prior_len:
+        if prior_len is not None:
             dropped = prior_len - len(eval_dataset)
             if dropped:
                 LOG.warning(
                     f"Dropped {dropped} samples with no trainable tokens from eval dataset"
                 )
+            raise_if_empty(eval_dataset, "eval")
 
     if cfg.group_by_length:
         train_dataset = train_dataset.map(

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -306,9 +306,7 @@ def process_datasets_for_packing(cfg, train_dataset, eval_dataset):
     if prior_len:
         dropped = prior_len - len(train_dataset)
         if dropped:
-            LOG.warning(
-                f"Dropped {dropped} samples with no trainable tokens from train dataset"
-            )
+            LOG.warning(f"Dropped {dropped} samples with no trainable tokens")
         raise_if_empty(train_dataset)
 
     if eval_dataset:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,12 +4,16 @@ test module for the axolotl.utils.data module
 
 import unittest
 
+from datasets import Dataset
 from transformers import LlamaTokenizer
 
 from axolotl.prompt_strategies.pretrain import load as load_pretrain
 from axolotl.utils.data import encode_streaming, md5
 from axolotl.utils.dict import DictDefault
-from axolotl.utils.trainer import filter_sequences_by_length
+from axolotl.utils.trainer import (
+    filter_sequences_by_length,
+    process_datasets_for_packing,
+)
 
 from tests.hf_offline_utils import enable_hf_offline
 
@@ -160,6 +164,32 @@ class TestEncodePretraining(unittest.TestCase):
         # This should keep the first but drop the second entry
         dropped = filter_sequences_by_length(data, 15)
         self.assertEqual(dropped, [True, False])
+
+
+class TestDropNoTrainableTokens(unittest.TestCase):
+    """
+    test that process_datasets_for_packing drops samples with no trainable tokens
+    """
+
+    def _process(self, labels):
+        cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
+        dataset = Dataset.from_dict({"labels": labels})
+        train_dataset, _ = process_datasets_for_packing(cfg, dataset, None)
+        return train_dataset
+
+    def test_fully_masked_sample_is_dropped(self):
+        # a sample whose labels are all -100 has zero trainable tokens and must be dropped
+        result = self._process([[-100, -100, -100], [-100, 7, -100]])
+        self.assertEqual(result["labels"], [[-100, 7, -100]])
+
+    def test_all_samples_masked_drops_everything(self):
+        result = self._process([[-100, -100], [-100, -100, -100]])
+        self.assertEqual(len(result), 0)
+
+    def test_samples_with_trainable_tokens_are_kept(self):
+        labels = [[1, 2, 3], [-100, 4, -100]]
+        result = self._process(labels)
+        self.assertEqual(result["labels"], labels)
 
 
 if __name__ == "__main__":

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -187,12 +187,17 @@ class TestDropNoTrainableTokens(unittest.TestCase):
         self.assertEqual(eval_dataset["labels"], [[-100, 7, -100]])
 
     def test_all_samples_masked_raises(self):
-        with self.assertRaisesRegex(ValueError, "train dataset has no samples left"):
-            self._process([[-100, -100], [-100, -100, -100]])
+        cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
+        with self.assertRaisesRegex(ValueError, "dataset has no samples left"):
+            process_datasets_for_packing(
+                cfg,
+                Dataset.from_dict({"labels": [[-100, -100], [-100, -100, -100]]}),
+                None,
+            )
 
     def test_all_eval_samples_masked_raises(self):
         cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
-        with self.assertRaisesRegex(ValueError, "eval dataset has no samples left"):
+        with self.assertRaisesRegex(ValueError, "dataset has no samples left"):
             process_datasets_for_packing(
                 cfg,
                 Dataset.from_dict({"labels": [[1, 2, 3]]}),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -190,6 +190,16 @@ class TestDropNoTrainableTokens(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "train dataset has no samples left"):
             self._process([[-100, -100], [-100, -100, -100]])
 
+    def test_all_samples_masked_reports_the_split(self):
+        cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
+        with self.assertRaisesRegex(ValueError, "test dataset has no samples left"):
+            process_datasets_for_packing(
+                cfg,
+                Dataset.from_dict({"labels": [[-100, -100]]}),
+                None,
+                split="test",
+            )
+
     def test_all_eval_samples_masked_raises(self):
         cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
         with self.assertRaisesRegex(ValueError, "eval dataset has no samples left"):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -190,16 +190,6 @@ class TestDropNoTrainableTokens(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "train dataset has no samples left"):
             self._process([[-100, -100], [-100, -100, -100]])
 
-    def test_all_samples_masked_reports_the_split(self):
-        cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
-        with self.assertRaisesRegex(ValueError, "test dataset has no samples left"):
-            process_datasets_for_packing(
-                cfg,
-                Dataset.from_dict({"labels": [[-100, -100]]}),
-                None,
-                split="test",
-            )
-
     def test_all_eval_samples_masked_raises(self):
         cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
         with self.assertRaisesRegex(ValueError, "eval dataset has no samples left"):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -199,6 +199,11 @@ class TestDropNoTrainableTokens(unittest.TestCase):
                 Dataset.from_dict({"labels": [[-100, -100]]}),
             )
 
+    def test_already_empty_dataset_does_not_raise(self):
+        # nothing was dropped here, so the all-masked error would misreport the cause
+        train_dataset, _ = self._process([])
+        self.assertEqual(len(train_dataset), 0)
+
     def test_samples_with_trainable_tokens_are_kept(self):
         labels = [[1, 2, 3], [-100, 4, -100]]
         train_dataset, eval_dataset = self._process(labels)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -173,23 +173,37 @@ class TestDropNoTrainableTokens(unittest.TestCase):
 
     def _process(self, labels):
         cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
-        dataset = Dataset.from_dict({"labels": labels})
-        train_dataset, _ = process_datasets_for_packing(cfg, dataset, None)
-        return train_dataset
+        return process_datasets_for_packing(
+            cfg,
+            Dataset.from_dict({"labels": labels}),
+            Dataset.from_dict({"labels": labels}),
+        )
 
     def test_fully_masked_sample_is_dropped(self):
-        # a sample whose labels are all -100 has zero trainable tokens and must be dropped
-        result = self._process([[-100, -100, -100], [-100, 7, -100]])
-        self.assertEqual(result["labels"], [[-100, 7, -100]])
+        train_dataset, eval_dataset = self._process(
+            [[-100, -100, -100], [-100, 7, -100]]
+        )
+        self.assertEqual(train_dataset["labels"], [[-100, 7, -100]])
+        self.assertEqual(eval_dataset["labels"], [[-100, 7, -100]])
 
-    def test_all_samples_masked_drops_everything(self):
-        result = self._process([[-100, -100], [-100, -100, -100]])
-        self.assertEqual(len(result), 0)
+    def test_all_samples_masked_raises(self):
+        with self.assertRaisesRegex(ValueError, "train dataset has no samples left"):
+            self._process([[-100, -100], [-100, -100, -100]])
+
+    def test_all_eval_samples_masked_raises(self):
+        cfg = DictDefault({"dataset_num_proc": 1, "is_preprocess": True})
+        with self.assertRaisesRegex(ValueError, "eval dataset has no samples left"):
+            process_datasets_for_packing(
+                cfg,
+                Dataset.from_dict({"labels": [[1, 2, 3]]}),
+                Dataset.from_dict({"labels": [[-100, -100]]}),
+            )
 
     def test_samples_with_trainable_tokens_are_kept(self):
         labels = [[1, 2, 3], [-100, 4, -100]]
-        result = self._process(labels)
-        self.assertEqual(result["labels"], labels)
+        train_dataset, eval_dataset = self._process(labels)
+        self.assertEqual(train_dataset["labels"], labels)
+        self.assertEqual(eval_dataset["labels"], labels)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

`process_datasets_for_packing` runs a `drop_no_trainable_tokens` filter that is meant to drop training samples whose labels are entirely `-100` (i.e. zero trainable tokens). The filter is currently a no-op: it never drops anything.

### Root cause

The filter compares the raw label sequence to `-100` and wraps it in `np.any`:

```python
if isinstance(labels[0], int):
    return np.any(labels != -100)
results = [np.any(row_labels != -100) for row_labels in labels]
```

When `datasets.Dataset.filter(..., batched=True)` calls this, `sample["labels"]` is a Python `list` (a list of lists in batched mode), not a NumPy array. `some_list != -100` is a plain Python object comparison that always evaluates to the scalar `True`, so `np.any(True)` is always `True`. Every sample is kept regardless of its labels, so fully-masked samples (all `-100`) are never removed. The single-example branch has the same problem.

### Fix

Coerce the labels to a NumPy array before comparing, so `!= -100` is element-wise as intended:

```python
if isinstance(labels[0], int):
    return bool(np.any(np.asarray(labels) != -100))
results = [
    bool(np.any(np.asarray(row_labels) != -100)) for row_labels in labels
]
```

### Verification

Reproduced against a real `datasets.Dataset` with a batched filter: with a batch `[[-100, -100, -100], [-100, 7, -100]]` the current code keeps both rows; after the fix it keeps only the second (the one with a trainable token). Fully-masked samples are now dropped, samples with any trainable token are kept.

Added `TestDropNoTrainableTokens` in `tests/test_data.py`, driving `process_datasets_for_packing` end to end and asserting that fully-masked samples are dropped, all-masked batches drop to empty, and samples with trainable tokens are preserved. These tests fail on the current code and pass with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of masked training examples by consistently identifying samples with no trainable tokens.
  * Ensured fully masked samples are excluded, while samples containing trainable tokens are retained.

* **Tests**
  * Added coverage for single samples, fully masked batches, and mixed trainable data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->