### PR TITLE
fix(moe): promote expert offsets to int64 in scattermoe/nvfp4 triton kernels

### DIFF
--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/lora_ops.py
@@ -296,9 +296,10 @@ def _compute_expert_block_lora(
 
     # Base weight pointers: W[E_idx, :, :] is [K, N], load [BLOCK_K, BLOCK_N]
     X_blk_ptrs = X_ptr + M_in_idx[:, None] * stride_xm + K_block[None, :] * stride_xk
+    # i64 expert offset: E_idx * stride_we overflows i32 on a >2^31-element expert stack
     W_blk_ptrs = (
         W_ptr
-        + E_idx * stride_we
+        + E_idx.to(tl.int64) * stride_we
         + K_block[:, None] * stride_wk
         + N_block[None, :] * stride_wn
     )
@@ -897,7 +898,7 @@ def _compute_expert_block_lora_dX(
     # As [BLOCK_N, BLOCK_K] tile: row=n, col=k
     WT_blk_ptrs = (
         W_ptr
-        + E_idx * stride_we
+        + E_idx.to(tl.int64) * stride_we
         + N_block[:, None] * stride_wn  # row = n dimension
         + K_block[None, :] * stride_wk
     )  # col = k dimension
@@ -2445,14 +2446,14 @@ def _compute_expert_block_lora_mxfp4(
     # Packed W pointers: tile shape [BLOCK_N, BLOCK_K] (each byte loaded twice)
     Wp_blk_ptrs = (
         Wp_ptr
-        + E_idx * stride_wpe
+        + E_idx.to(tl.int64) * stride_wpe
         + N_block[:, None] * stride_wpn
         + K_byte_block[None, :] * stride_wpk
     )
     # Scale pointers: tile shape [BLOCK_N, BLOCK_K] (broadcast within block)
     Ws_blk_ptrs = (
         Ws_ptr
-        + E_idx * stride_wse
+        + E_idx.to(tl.int64) * stride_wse
         + N_block[:, None] * stride_wsn
         + K_scale_block[None, :] * stride_wsk
     )
@@ -3001,14 +3002,14 @@ def _compute_expert_block_lora_dX_mxfp4(
     # stride_wpn (= K/2) is large, but the K row stride is 1.
     Wp_blk_ptrs = (
         Wp_ptr
-        + E_idx * stride_wpe
+        + E_idx.to(tl.int64) * stride_wpe
         + N_block[None, :] * stride_wpn
         + K_byte_block[:, None] * stride_wpk
     )
     # Scale [E, N, K/32]; row=K_scale_idx (broadcast within MX_BLOCK_SIZE), col=N
     Ws_blk_ptrs = (
         Ws_ptr
-        + E_idx * stride_wse
+        + E_idx.to(tl.int64) * stride_wse
         + N_block[None, :] * stride_wsn
         + K_scale_block[:, None] * stride_wsk
     )

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/ops.py
@@ -36,11 +36,13 @@ def _compute_expert_block(
 ):
     K_block = tl.arange(0, BLOCK_K)
     X_blk_ptrs = X_ptr + M_in_idx[:, None] * stride_xm + K_block[None, :] * stride_xk
+    # i64 expert offset: E_idx * stride_we overflows i32 once the expert stack exceeds
+    # 2^31 elements (e.g. nemotron-3-ultra [512, 5120, 2048] = 5.4e9).
     W_blk_ptrs = (
         W_ptr
         + K_block[:, None] * stride_wk
         + N_block[None, :] * stride_wn
-        + E_idx * stride_we
+        + E_idx.to(tl.int64) * stride_we
     )
     iters = tl.cdiv(K, BLOCK_K)
 
@@ -556,9 +558,10 @@ def _xty_and_bias(
         if compute_bias:
             db_acc += tl.sum(dy, axis=0)
 
+    # i64 expert offset: E_idx * stride_dwe overflows i32 on a >2^31-element dW stack
     DW_blk_ptrs = (
         DW_ptr
-        + E_idx * stride_dwe
+        + E_idx.to(tl.int64) * stride_dwe
         + K_block[:, None] * stride_dwk
         + N_block[None, :] * stride_dwn
     )

--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/single.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/kernels/single.py
@@ -49,7 +49,7 @@ def _single2scatter(
     X_blk_ptrs = X_ptr + in_idx * stride_xm + K_block[:, None] * stride_xk
     W_blk_ptrs = (
         W_ptr
-        + E_idx * stride_we
+        + E_idx.to(tl.int64) * stride_we
         + K_block[:, None] * stride_wk
         + N_block[None, :] * stride_wn
     )

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/triton_nvfp4.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/triton_nvfp4.py
@@ -91,7 +91,8 @@ def _kernels():
         HAS_PTS: tl.constexpr,
         BLOCK_B: tl.constexpr,  # bytes per program
     ):
-        row = tl.program_id(0)
+        # i64: row*K products overflow i32 on >2^31-element weight stacks (e.g. 896x4096x2048)
+        row = tl.program_id(0).to(tl.int64)
         blk = tl.program_id(1)
         offs_b = blk * BLOCK_B + tl.arange(0, BLOCK_B)
         mask_b = offs_b < K2
@@ -123,7 +124,8 @@ def _kernels():
         SF_K: tl.constexpr,
         BLOCK_SF: tl.constexpr,  # scale blocks per program
     ):
-        row = tl.program_id(0)
+        # i64: row*K products overflow i32 on >2^31-element weight stacks (e.g. 896x4096x2048)
+        row = tl.program_id(0).to(tl.int64)
         blk = tl.program_id(1)
         offs_sf = blk * BLOCK_SF + tl.arange(0, BLOCK_SF)
         mask_sf = offs_sf < SF_K
@@ -184,7 +186,8 @@ def _kernels():
         # identical quantization math to _quant_kernel, but the e4m3 scales are
         # stored straight into the dQaccum-padded swizzled SFA layout: padded
         # row p, sf col c -> tile (p//128, c//4), byte (p%32)*16 + ((p//32)%4)*4 + c%4
-        row = tl.program_id(0)
+        # i64: row*K products overflow i32 on >2^31-element weight stacks (e.g. 896x4096x2048)
+        row = tl.program_id(0).to(tl.int64)
         blk = tl.program_id(1)
         offs_sf = blk * BLOCK_SF + tl.arange(0, BLOCK_SF)
         mask_sf = offs_sf < SF_K
@@ -248,7 +251,8 @@ def _kernels():
         # unlike _quant_kernel above which follows quantize_nvfp4_ref.
         # Every division is div_rn: triton's `/` may lower to
         # reciprocal-multiply and flip values on rounding boundaries.
-        row = tl.program_id(0)
+        # i64: row*K products overflow i32 on >2^31-element weight stacks (e.g. 896x4096x2048)
+        row = tl.program_id(0).to(tl.int64)
         blk = tl.program_id(1)
         offs_sf = blk * BLOCK_SF + tl.arange(0, BLOCK_SF)
         mask_sf = offs_sf < SF_K
@@ -305,7 +309,8 @@ def _kernels():
     ):
         # in-place x[r, :] = bf16(f32(x[r, :]) * pts[r]); one pass instead of
         # float() -> mul -> to(bf16)
-        row = tl.program_id(0)
+        # i64: row*K products overflow i32 on >2^31-element weight stacks (e.g. 896x4096x2048)
+        row = tl.program_id(0).to(tl.int64)
         blk = tl.program_id(1)
         offs = blk * BLOCK_N + tl.arange(0, BLOCK_N)
         mask = offs < N

--- a/tests/e2e/kernels/test_scattermoe_int64_offsets.py
+++ b/tests/e2e/kernels/test_scattermoe_int64_offsets.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+
+"""Regression: expert stacks over 2^31 elements overflowed the i32 ``E_idx * stride``
+pointer math in the scattermoe Triton kernels — an illegal memory access in the dW
+kernel and silent out-of-bounds reads/writes in the forward (observed corrupting
+neighboring allocations at Nemotron-3-Ultra / Kimi-K3-scale expert shapes).
+
+The weight here is [40, 4096, 16384] = 2.68e9 elements (~5.4GB bf16); the last
+expert's base offset (39 x 67.1M = 2.62e9) wraps negative in i32, so correctness
+is checked on the LAST experts.
+"""
+
+import pytest
+import torch
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required"),
+    pytest.mark.skipif(
+        torch.cuda.is_available()
+        and torch.cuda.get_device_properties(0).total_memory < 24e9,
+        reason="needs ~16GB free VRAM",
+    ),
+]
+
+E, K_IN, N_OUT, T = 40, 4096, 16384, 64
+
+
+def _setup():
+    from axolotl.integrations.kernels.libs.scattermoe_lora.parallel_experts import (
+        flatten_sort_count,
+    )
+
+    g = torch.Generator(device="cuda").manual_seed(0)
+    x = torch.randn(T, K_IN, device="cuda", dtype=torch.bfloat16, generator=g)
+    w = (
+        torch.randn(E, K_IN, N_OUT, device="cuda", dtype=torch.bfloat16, generator=g)
+        * 0.02
+    )
+    # route half the tokens to the LAST expert (offsets past 2^31)
+    idx = torch.randint(0, E, (T, 1), device="cuda", generator=g)
+    idx[::2] = E - 1
+    sei, ssi, eo = flatten_sort_count(idx, E)
+    return x, w, idx, sei, ssi, eo
+
+
+def test_forward_last_expert_matches_reference():
+    from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
+        scatter2scatter,
+    )
+
+    x, w, idx, sei, ssi, eo = _setup()
+    y = scatter2scatter(x, w, sei, ssi, k=1)
+    for e in (E - 1, E - 2):
+        rows = (idx[:, 0] == e).nonzero(as_tuple=True)[0]
+        if not rows.numel():
+            continue
+        ref = x[rows].float() @ w[e].float()
+        got = y[rows].float()
+        rel = (got - ref).abs().max() / ref.abs().max().clamp(min=1e-6)
+        assert rel.item() < 5e-2, f"expert {e}: rel={rel.item():.4e}"
+    assert torch.isfinite(y).all()
+
+
+def test_group_bwd_w_last_expert_matches_reference():
+    from axolotl.integrations.kernels.libs.scattermoe_lora.kernels.ops import (
+        group_bwd_W,
+    )
+
+    x, w, idx, sei, ssi, eo = _setup()
+    del w
+    # grouped rows sorted by expert; dW stack is the same >2^31-element shape
+    order = torch.argsort(idx[:, 0])
+    xg = x[order].contiguous()
+    dyg = torch.randn(
+        T,
+        N_OUT,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=torch.Generator(device="cuda").manual_seed(1),
+    )
+    counts = torch.bincount(idx[:, 0], minlength=E)
+    offsets = counts.cumsum(0)
+    dw, _ = group_bwd_W(dyg, xg, offsets, E)
+    assert tuple(dw.shape) == (E, K_IN, N_OUT)
+    start = int(offsets[E - 2])
+    ref = xg[start:].float().T @ dyg[start:].float()
+    got = dw[E - 1].float()
+    rel = (got - ref).abs().max() / ref.abs().max().clamp(min=1e-6)
+    assert rel.item() < 5e-2, f"dW last expert: rel={rel.item():.4e}"
+    assert torch.isfinite(dw).all()


### PR DESCRIPTION
Expert weight stacks over 2^31 elements (e.g. 512x5120x2048 = 5.4e9 at Nemotron-3-Ultra scale, 896x2048x2048 = 3.8e9 at Kimi-K3 scale) overflowed the i32 E_idx*stride pointer products: an illegal memory access in the grouped dW kernel and, worse, silent out-of-bounds dW writes that corrupt neighboring allocations. Same class of overflow in the sonicmoe NVFP4 triton codecs (row*K products in dequant/quant/fake-quant kernels).

Promote the expert index / row id to i64 at every site that multiplies it by a per-expert stride. Adds a >2^31-element regression test (fails pre-fix on the dW kernel; the forward sites are covered prophylactically since their index dtype currently arrives as int64).

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential numerical errors in large expert-model configurations by preventing integer overflow during kernel offset calculations.
  * Improved reliability for large ScatterMoE, LoRA, and NVFP4 workloads.

* **Tests**
  * Added CUDA regression coverage validating forward and gradient computations for models with very large expert stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->