### PR TITLE
fix(sequence_parallel): reject batch_ring with pre-packed multi-doc sequences

### DIFF
--- a/src/axolotl/utils/ctx_managers/sequence_parallel.py
+++ b/src/axolotl/utils/ctx_managers/sequence_parallel.py
@@ -19,6 +19,24 @@ from axolotl.monkeypatch.ring_attn import (
 from axolotl.utils.schemas.enums import RingAttnFunc
 
 
+def _has_multiple_documents(position_ids: torch.Tensor) -> bool:
+    """Whether any row packs more than one document.
+
+    A document boundary shows up as ``position_ids`` resetting to 0 mid-sequence.
+    Mirrors the boundary detection in ``get_cu_seqlens_from_pos_ids`` (reset to 0
+    starts a new document) after stripping right-side zero padding, so single
+    padded documents are not mistaken for packs.
+    """
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+    for row in position_ids:
+        padding_length = (row == 0).int().flip(dims=[0]).cumprod(dim=0).sum().item()
+        adjusted_row = row[:-padding_length] if padding_length else row
+        if adjusted_row.numel() > 1 and bool((adjusted_row[1:] == 0).any()):
+            return True
+    return False
+
+
 # TODO(djsaunde): implement zigzag, stripe patterns here (and elsewhere) in this
 # module. Currently, we just focus on batch ring and varlen llama3 for simplicity.
 def apply_sequence_parallelism(
@@ -39,8 +57,9 @@ def apply_sequence_parallelism(
         local_rank: Local rank in the sequence parallel group.
         local_world_size: World size of the sequence parallel group.
         gradient_accumulation_steps: Number of steps to accumulate gradients over.
-        ring_attn_func: Which ring attention function to use. Currently unused, but
-            related to above TODO.
+        ring_attn_func: Which ring attention function to use. ``batch_ring`` does not
+            respect document boundaries and is rejected for pre-packed multi-document
+            sequences.
 
     Returns:
         tuple of:
@@ -52,6 +71,18 @@ def apply_sequence_parallelism(
 
     # Update ring attention params if needed
     if batch.get("position_ids") is not None and batch_size == 1:
+        # batch_ring ignores cu_seqlens: it rotates K/V across position_id resets, so
+        # tokens attend across documents and the loss is silently wrong. Only varlen
+        # respects boundaries within a packed sequence.
+        if ring_attn_func is RingAttnFunc.BATCH_RING and _has_multiple_documents(
+            batch["position_ids"]
+        ):
+            raise ValueError(
+                "ring_attn_func='batch_ring' does not respect document boundaries in a "
+                "packed sequence: it rotates K/V across position_id resets, so queries "
+                "attend across documents and the training loss is silently wrong. Set "
+                "ring_attn_func: varlen_llama3 for pre-packed multi-document data."
+            )
         update_ring_attn_params(position_ids=batch["position_ids"])
     else:
         # If position_ids aren't already in the batch, create them

--- a/tests/utils/ctx_managers/test_sequence_parallel_doc_boundaries.py
+++ b/tests/utils/ctx_managers/test_sequence_parallel_doc_boundaries.py
@@ -1,0 +1,83 @@
+"""Guard against ``batch_ring`` corrupting pre-packed multi-document sequences.
+
+``batch_ring`` uses the ring-flash-attn *batch* API, which has no ``cu_seqlens``
+channel, so it rotates K/V across document boundaries inside a packed sequence and
+silently inflates the loss (axolotl-ai-cloud/axolotl#3608). ``varlen_llama3`` derives
+``cu_seqlens`` from ``position_ids`` and is unaffected. These tests pin the config
+that reproduces the bug to a loud error rather than a wrong number.
+"""
+
+import sys
+import types
+
+import pytest
+import torch
+
+from axolotl.utils.ctx_managers.sequence_parallel import (
+    _has_multiple_documents,
+    apply_sequence_parallelism,
+)
+from axolotl.utils.schemas.enums import RingAttnFunc
+
+
+def _batch(position_ids: list[int]) -> dict[str, torch.Tensor]:
+    pos = torch.tensor([position_ids], dtype=torch.long)
+    seq_len = pos.size(1)
+    return {
+        "input_ids": torch.ones(1, seq_len, dtype=torch.long),
+        "labels": torch.ones(1, seq_len, dtype=torch.long),
+        "position_ids": pos,
+    }
+
+
+class TestHasMultipleDocuments:
+    """``_has_multiple_documents`` mirrors get_cu_seqlens boundary semantics."""
+
+    @pytest.mark.parametrize(
+        "position_ids, expected",
+        [
+            ([0, 1, 2, 3, 4, 5, 6, 7], False),  # single contiguous document
+            ([0, 1, 2, 3, 0, 1, 2, 3], True),  # two packed documents
+            ([0, 1, 2, 0, 1, 0, 1, 2], True),  # three packed documents
+            ([0, 1, 2, 3, 0, 0, 0, 0], False),  # single doc + right zero-padding
+            ([0, 1, 0, 1, 0, 0, 0, 0], True),  # two docs + right zero-padding
+        ],
+    )
+    def test_detects_resets(self, position_ids, expected):
+        assert _has_multiple_documents(_batch(position_ids)["position_ids"]) is expected
+
+
+class TestBatchRingRejectsPackedDocuments:
+    """apply_sequence_parallelism must reject batch_ring on multi-doc sequences."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_ring_flash_attn(self, monkeypatch):
+        # Present so the varlen control can reach update_ring_attn_params on CPU;
+        # the batch_ring guard raises before ever importing it.
+        if "ring_flash_attn" not in sys.modules:
+            monkeypatch.setitem(
+                sys.modules, "ring_flash_attn", types.ModuleType("ring_flash_attn")
+            )
+
+    def test_batch_ring_multi_doc_raises(self):
+        with pytest.raises(ValueError, match="varlen_llama3"):
+            apply_sequence_parallelism(
+                batch=_batch([0, 1, 2, 3, 0, 1, 2, 3]),
+                local_rank=0,
+                local_world_size=1,
+                gradient_accumulation_steps=1,
+                ring_attn_func=RingAttnFunc.BATCH_RING,
+            )
+
+    def test_batch_ring_single_doc_ok(self):
+        # A single document per sequence is the legitimate batch_ring case; it must
+        # not trip the guard (the bug's own single-doc control is bitwise-clean).
+        batch, orig_len, _ = apply_sequence_parallelism(
+            batch=_batch([0, 1, 2, 3, 4, 5, 6, 7]),
+            local_rank=0,
+            local_world_size=1,
+            gradient_accumulation_steps=1,
+            ring_attn_func=RingAttnFunc.BATCH_RING,
+        )
+        assert orig_len == 8
+        assert batch["input_ids"].shape[1] == 8


### PR DESCRIPTION
## Summary

Fixes #3608. `ring_attn_func: batch_ring` silently inflates training loss (~1.8×) on pre-packed multi-document sequences under context parallelism. This turns that silent corruption into a loud, immediate error.

Full diagnosis and reproduction in [the issue thread](https://github.com/axolotl-ai-cloud/axolotl/issues/3608#issuecomment-5040210074) — reproduced on `main` (v0.18.0), 2× GPU, SmolLM2-135M:

| config | step-0 loss | ratio |
|---|---|---|
| multi-doc `cp=1` baseline | 3.171875 | 1.000× |
| multi-doc `cp=2, batch_ring` | 5.812500 | **1.833×** |
| multi-doc `cp=2, varlen_llama3` | 3.171875 | 1.000× |
| single-doc control (all three configs) | 3.031250 | 1.000× (bitwise-identical) |

## Root cause

`batch_ring`'s adapter (`monkeypatch/ring_attn/adapters/batch.py`) calls the ring-flash-attn **batch** API, which has no `cu_seqlens` channel — it accepts `position_ids`/`cu_seq_lens_*` and discards them (each is documented `"Not used in this implementation."`). So it treats a packed sequence as one contiguous document and rotates K/V across every internal boundary; queries in document B attend to keys in document A, inflating the loss. `varlen_llama3` derives `cu_seqlens` and is unaffected — hence it lands exactly on baseline.

The selector in `validation.py` only routes to `varlen_llama3` when the **`sample_packing` flag** is set:

```python
self.ring_attn_func = RingAttnFunc.VARLEN_LLAMA3 if sample_packing else RingAttnFunc.BATCH_RING
```

Externally pre-packed data (`position_ids` reset per document, `sample_packing: false`) falls through to `batch_ring`. The existing decontamination check (`validation.py`) keys on `attn_implementation`, not `ring_attn_func`, so nothing catches it.

## The change

Document boundaries can't be seen at config-validation time (they live in the data), so the guard goes where `position_ids` are available — `apply_sequence_parallelism`, which already receives both the batch and `ring_attn_func` (previously unused there). When `batch_ring` meets `position_ids` containing resets, it raises with a message pointing to `varlen_llama3`. Boundary detection mirrors `get_cu_seqlens_from_pos_ids` (reset-to-0 after stripping right-side padding), so a single padded document is **not** mistaken for a pack — the legitimate `batch_ring` case is untouched.

This is the **safety-net** direction: it converts silently-wrong training into a config error and can't regress any working setup. An alternative is to **auto-route** to `varlen_llama3` when `position_ids` contain resets — more convenient but more opinionated (behavior change for existing configs, detection semantics). Happy to switch to that or add it on top — deferring to maintainers on scope.

## Test

`tests/utils/ctx_managers/test_sequence_parallel_doc_boundaries.py` (CPU-only):
- `_has_multiple_documents` across single-doc, multi-doc, and padded variants.
- `apply_sequence_parallelism` **raises** for `batch_ring` + multi-doc, and **does not** for the single-doc case.

Verified against a `git worktree` on unfixed `main`: the multi-doc test fails there with `DID NOT RAISE ValueError` (the function returns normally — the silent path), and passes on this branch. Pinned `ruff`/`ruff-format`/`bandit` clean; `mypy` scope unchanged.

## Draft

Opening as draft to confirm the direction (guard vs. auto-route) before finalizing. The second, separate observation from the investigation — that `batch_ring`'s adapter doesn't import against the pinned `transformers==5.14.1` (two flash-attn helpers moved modules upstream) — I'll file as its own issue rather than fold in here.
