### PR TITLE
Upgrade TRL to 1.9.0 and surface new GRPO config knobs

### DIFF
--- a/docs/grpo.qmd
+++ b/docs/grpo.qmd
@@ -534,8 +534,22 @@ All GRPO-specific options live under the `trl:` key in your config. Standard tra
 | `epsilon` | float | `null` | PPO clipping lower bound |
 | `epsilon_high` | float | `null` | PPO clipping upper bound |
 | `loss_type` | str | `null` | Loss formulation: `grpo`, `bnpo`, or `dr_grpo` |
-| `scale_rewards` | bool | `true` | Normalize rewards by standard deviation |
+| `scale_rewards` | bool or str | `true` | Reward std scaling: `group`, `batch`, or `none` (bool accepted: `true`->`group`, `false`->`none`) |
 | `mask_truncated_completions` | bool | `false` | Exclude truncated completions from loss |
+| `log_multimodal` | bool | `null` | Log multimodal content (images/videos) alongside completions (TRL >= 1.9) |
+
+### Entropy regularization
+
+Available in TRL >= 1.8. Adds an entropy bonus to encourage exploration.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `entropy_coef` | float | `null` | Static entropy regularization coefficient |
+| `use_adaptive_entropy` | bool | `null` | Adaptively tune `entropy_coef` toward `entropy_target` (Skywork-OR1 style) |
+| `entropy_target` | float | `null` | Target entropy when `use_adaptive_entropy` is enabled |
+| `entropy_coef_delta` | float | `null` | Step size for adjusting `entropy_coef` |
+| `entropy_coef_min` | float | `null` | Lower bound for adaptive `entropy_coef` |
+| `entropy_coef_max` | float | `null` | Upper bound for adaptive `entropy_coef` |
 
 ### Reward functions
 
@@ -557,7 +571,7 @@ All GRPO-specific options live under the `trl:` key in your config. Standard tra
 | `repetition_penalty` | float | `null` | Penalty for repeated tokens |
 | `generation_kwargs` | dict | `null` | Additional vLLM SamplingParams (e.g., `stop_token_ids`) |
 | `chat_template_kwargs` | dict | `null` | Chat template kwargs (e.g., `{enable_thinking: false}`) |
-| `vllm_guided_decoding_regex` | str | `null` | Regex constraint for guided decoding |
+| `vllm_guided_decoding_regex` | str | `null` | Regex constraint for structured/guided decoding (mapped to TRL's `vllm_structured_outputs_regex` on TRL >= 1.7) |
 
 ### Async pipeline
 
@@ -582,6 +596,8 @@ All GRPO-specific options live under the `trl:` key in your config. Standard tra
 | `importance_sampling_level` | `"token"` or `"sequence"` | `null` | Granularity of IS ratios. Use `token` with Liger |
 | `vllm_importance_sampling_mode` | str | `null` | `token_mask`, `token_truncate`, `sequence_mask`, or `sequence_truncate` |
 | `vllm_importance_sampling_cap` | float | `null` | Cap C for IS ratio clipping/masking |
+| `vllm_importance_sampling_clip_min` | float | `null` | Lower clip bound for the IS ratio (TRL >= 1.6) |
+| `vllm_importance_sampling_clip_max` | float | `null` | Upper clip bound for the IS ratio (TRL >= 1.6) |
 | `off_policy_mask_threshold` | float | `null` | KL threshold for off-policy sequence masking (OPSM) |
 | `use_bias_correction_kl` | bool | `null` | Apply IS correction to KL divergence term |
 

--- a/docs/vllm_serving.qmd
+++ b/docs/vllm_serving.qmd
@@ -286,7 +286,7 @@ These control how the trainer interacts with vLLM.
 | `vllm_lora_sync` | bool | `false` | Sync LoRA adapters via filesystem instead of NCCL merge |
 | `vllm_sync_interval` | int | `None` | Sync weights every N optimizer steps |
 | `vllm_enable_sleep_mode` | bool | `None` | Offload vLLM VRAM when idle (colocate mode) |
-| `vllm_guided_decoding_regex` | str | `None` | Regex constraint for guided decoding |
+| `vllm_guided_decoding_regex` | str | `None` | Regex constraint for structured/guided decoding (mapped to TRL's `vllm_structured_outputs_regex` on TRL >= 1.7) |
 
 For async pipeline and off-policy correction options, see the [GRPO Configuration Reference](grpo.qmd#configuration-reference).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "transformers==5.14.1",
     "accelerate==1.13.0",
     "datasets==4.8.4",
-    "trl==1.8.0",
+    "trl==1.9.0",
     "hf_xet==1.4.3",
     "kernels==0.15.2",
     "trackio==0.19.0",
@@ -127,7 +127,7 @@ ray = [
     "ray[train]>=2.52.1",
 ]
 vllm = [
-    "vllm>=0.15.0",
+    "vllm>=0.24.0",
 ]
 llmcompressor = [
     "llmcompressor>=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ ray = [
     "ray[train]>=2.52.1",
 ]
 vllm = [
-    "vllm>=0.24.0",
+    "vllm>=0.17.0",
 ]
 llmcompressor = [
     "llmcompressor>=0.10.0",

--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -82,7 +82,8 @@ class GRPOStrategy:
             if trl.vllm_server_timeout:
                 grpo_args_kwargs["vllm_server_timeout"] = trl.vllm_server_timeout
             if trl.vllm_guided_decoding_regex:
-                grpo_args_kwargs["vllm_guided_decoding_regex"] = (
+                # TRL >=1.7 renamed guided decoding to structured outputs.
+                grpo_args_kwargs["vllm_structured_outputs_regex"] = (
                     trl.vllm_guided_decoding_regex
                 )
 
@@ -150,6 +151,33 @@ class GRPOStrategy:
             grpo_args_kwargs["multi_objective_aggregation"] = (
                 trl.multi_objective_aggregation
             )
+
+        # Entropy regularization (TRL >= 1.8)
+        if trl.entropy_coef is not None:
+            grpo_args_kwargs["entropy_coef"] = trl.entropy_coef
+        if trl.use_adaptive_entropy is not None:
+            grpo_args_kwargs["use_adaptive_entropy"] = trl.use_adaptive_entropy
+        if trl.entropy_target is not None:
+            grpo_args_kwargs["entropy_target"] = trl.entropy_target
+        if trl.entropy_coef_delta is not None:
+            grpo_args_kwargs["entropy_coef_delta"] = trl.entropy_coef_delta
+        if trl.entropy_coef_min is not None:
+            grpo_args_kwargs["entropy_coef_min"] = trl.entropy_coef_min
+        if trl.entropy_coef_max is not None:
+            grpo_args_kwargs["entropy_coef_max"] = trl.entropy_coef_max
+
+        # Bidirectional vLLM importance-sampling clip (TRL >= 1.6)
+        if trl.vllm_importance_sampling_clip_min is not None:
+            grpo_args_kwargs["vllm_importance_sampling_clip_min"] = (
+                trl.vllm_importance_sampling_clip_min
+            )
+        if trl.vllm_importance_sampling_clip_max is not None:
+            grpo_args_kwargs["vllm_importance_sampling_clip_max"] = (
+                trl.vllm_importance_sampling_clip_max
+            )
+
+        if trl.log_multimodal is not None:
+            grpo_args_kwargs["log_multimodal"] = trl.log_multimodal
 
         # Async GRPO fields
         if getattr(trl, "use_data_producer", None) is not None:

--- a/src/axolotl/core/trainers/grpo/trainer.py
+++ b/src/axolotl/core/trainers/grpo/trainer.py
@@ -605,7 +605,9 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
             self.num_generations, dim=0
         )
         advantages = rewards - mean_grouped_rewards
-        if self.args.scale_rewards:
+        # scale_rewards may be a string ("group"/"batch"/"none") or bool; only skip
+        # normalization when explicitly disabled.
+        if self.args.scale_rewards not in (False, "none"):
             advantages = advantages / (std_grouped_rewards + 1e-4)
 
         # Slice to keep only the local part of the data

--- a/src/axolotl/monkeypatch/trainer/trl_vllm.py
+++ b/src/axolotl/monkeypatch/trainer/trl_vllm.py
@@ -221,7 +221,9 @@ def _make_batched_sync_weights(original_sync_weights):
         # Check if we're in a non-PEFT, non-FSDP, non-ZeRO scenario where batching helps
         accelerator = self.accelerator
         model = self.model
-        is_fsdp_enabled = self.is_fsdp_enabled
+        # TRL >=1.6 moved the FSDP flag onto the distributed helper (_dist.is_fsdp);
+        # VLLMGeneration no longer exposes is_fsdp_enabled directly.
+        is_fsdp_enabled = self._dist.is_fsdp
 
         deepspeed_plugin = accelerator.state.deepspeed_plugin
         zero_stage_3 = deepspeed_plugin is not None and deepspeed_plugin.zero_stage == 3

--- a/src/axolotl/utils/schemas/trl.py
+++ b/src/axolotl/utils/schemas/trl.py
@@ -106,10 +106,12 @@ class TRLConfig(BaseModel):
         default=64,
         json_schema_extra={"description": "Sync steps for the reference model."},
     )
-    scale_rewards: bool = Field(
+    scale_rewards: bool | Literal["group", "batch", "none"] = Field(
         default=True,
         json_schema_extra={
-            "description": "Whether to scale rewards by their standard deviation."
+            "description": "How to scale rewards by their standard deviation. One of "
+            "'group' (per prompt-group, GRPO default), 'batch' (whole batch), or 'none'. "
+            "Booleans are accepted for back-compat (True->'group', False->'none')."
         },
     )
 
@@ -187,6 +189,65 @@ class TRLConfig(BaseModel):
             "description": "Whether to exclude truncated completions from loss calculation."
         },
     )
+
+    # Entropy regularization (TRL >= 1.8)
+    entropy_coef: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Static entropy regularization coefficient for GRPO, adding an "
+            "entropy bonus to encourage exploration."
+        },
+    )
+    use_adaptive_entropy: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Enable adaptive entropy regularization (Skywork-OR1 style), "
+            "adjusting entropy_coef toward entropy_target."
+        },
+    )
+    entropy_target: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Target entropy when use_adaptive_entropy is enabled."
+        },
+    )
+    entropy_coef_delta: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Step size for adjusting entropy_coef toward entropy_target."
+        },
+    )
+    entropy_coef_min: float | None = Field(
+        default=None,
+        json_schema_extra={"description": "Lower bound for the adaptive entropy_coef."},
+    )
+    entropy_coef_max: float | None = Field(
+        default=None,
+        json_schema_extra={"description": "Upper bound for the adaptive entropy_coef."},
+    )
+
+    # Bidirectional vLLM importance-sampling clip (TRL >= 1.6)
+    vllm_importance_sampling_clip_min: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Lower clip bound for the vLLM/training importance-sampling ratio."
+        },
+    )
+    vllm_importance_sampling_clip_max: float | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Upper clip bound for the vLLM/training importance-sampling ratio."
+        },
+    )
+
+    log_multimodal: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Whether to log multimodal content (images, videos) alongside "
+            "completions. Disable to reduce log size."
+        },
+    )
+
     vllm_enable_sleep_mode: bool | None = Field(
         default=None,
         json_schema_extra={


### PR DESCRIPTION
Bump trl 1.8.0 -> 1.9.0 and the vLLM extra floor to >=0.24.0 (TRL 1.8/1.9 dropped vLLM 0.14-0.16 support).

Fix compat breaks introduced across TRL 1.6-1.9:
- monkeypatch/trainer/trl_vllm.py: the batched sync_weights patch read self.is_fsdp_enabled, which TRL moved onto self._dist.is_fsdp.
- core/trainers/grpo: GRPOConfig renamed vllm_guided_decoding_regex to vllm_structured_outputs_regex (TRL >=1.7); remap the forwarded kwarg while keeping the user-facing config key.

Surface new opt-in GRPOConfig options in cfg.trl:
- entropy regularization (entropy_coef, use_adaptive_entropy, entropy_target, entropy_coef_delta/min/max)
- bidirectional importance-sampling clip (vllm_importance_sampling_clip_min/max)
- log_multimodal
- widen scale_rewards to accept group/batch/none (bool still supported)



Docs updated in docs/grpo.qmd and docs/vllm_serving.qmd.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GRPO configuration options for entropy regularization, adaptive entropy controls, multimodal logging, and vLLM importance-sampling clipping.
  * Expanded reward scaling to support group, batch, or disabled modes while retaining boolean compatibility.
  * Added support for structured/guided decoding configuration with updated TRL naming.

* **Bug Fixes**
  * Improved vLLM weight synchronization compatibility with newer TRL releases.

* **Documentation**
  * Updated configuration references with the new GRPO and vLLM options.

* **Chores**
  * Updated supported TRL and vLLM versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->