### PR TITLE
fix(offload): resolve compute stream per use; fix sliced-view restore

### DIFF
--- a/src/axolotl/monkeypatch/checkpoint_activation_offload.py
+++ b/src/axolotl/monkeypatch/checkpoint_activation_offload.py
@@ -92,7 +92,6 @@ class CheckpointHiddenStatesOffload(saved_tensors_hooks):
             tuple[
                 torch.Tensor,
                 torch.device,
-                int,
                 torch.Size,
                 tuple[int, ...],
                 _BufferKey,
@@ -111,7 +110,6 @@ class CheckpointHiddenStatesOffload(saved_tensors_hooks):
             self.accelerator_type = "cuda"
         else:
             self.accelerator_type = "cpu"
-        self.s0 = self._current_stream()
         self.s1 = self._new_stream() if use_streams else None
 
         super().__init__(self._pack_tensor, self._unpack_tensor)
@@ -124,6 +122,11 @@ class CheckpointHiddenStatesOffload(saved_tensors_hooks):
         if self.accelerator_type == "npu":
             return torch.npu.current_stream()
         return torch.cuda.current_stream()
+
+    @property
+    def s0(self):
+        # resolved per use: the compute stream may differ from the construction-time one
+        return self._current_stream()
 
     def _new_stream(self):
         if self.accelerator_type == "cpu":
@@ -246,7 +249,6 @@ class CheckpointHiddenStatesOffload(saved_tensors_hooks):
         self._tracker[tensor_id] = (
             cpu_tensor,
             tensor.device,
-            tensor.storage_offset(),
             tensor.size(),
             tensor.stride(),
             buffer_key,
@@ -268,22 +270,15 @@ class CheckpointHiddenStatesOffload(saved_tensors_hooks):
             self.stats.restored_bytes += self._num_bytes(tensor)
             return tensor
 
-        cpu_tensor, device, storage_offset, shape, stride, buffer_key = (
-            self._tracker.pop(tensor_id)
-        )
+        cpu_tensor, device, shape, stride, buffer_key = self._tracker.pop(tensor_id)
         stream = self.s1 if self.use_streams else self.s0
         with self._stream_context(stream):
-            gpu_tensor = cpu_tensor.to(device, non_blocking=self.use_streams)
-            if (
-                gpu_tensor.storage_offset() != storage_offset
-                or gpu_tensor.stride() != stride
-            ):
-                gpu_tensor = torch.as_strided(
-                    gpu_tensor,
-                    size=shape,
-                    stride=stride,
-                    storage_offset=storage_offset,
-                )
+            # restore into fresh offset-0 storage; reapplying the source
+            # storage_offset would index past the pool buffer's storage
+            gpu_tensor = torch.empty_strided(
+                shape, stride, dtype=cpu_tensor.dtype, device=device
+            )
+            gpu_tensor.copy_(cpu_tensor, non_blocking=self.use_streams)
         if self.use_streams:
             event = self.s1.record_event()
             self.s0.wait_event(event)

--- a/src/axolotl/monkeypatch/selective_checkpointing_offload.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing_offload.py
@@ -60,7 +60,6 @@ class _OffloadRef:
     device: torch.device
     size: torch.Size
     stride: tuple[int, ...]
-    storage_offset: int
     buffer_key: _BufferKey
     cpu_tensor: torch.Tensor | None = None
     gpu_tensor: torch.Tensor | None = None
@@ -181,7 +180,6 @@ class SacOffloadEngine:
             device=tensor.device,
             size=tensor.size(),
             stride=tuple(tensor.stride()),
-            storage_offset=tensor.storage_offset(),
             buffer_key=key,
             cpu_tensor=cpu_tensor,
         )
@@ -194,14 +192,11 @@ class SacOffloadEngine:
         if ref.gpu_tensor is not None or ref.cpu_tensor is None:
             return
         with torch.cuda.stream(self.s1):
-            gpu_tensor = ref.cpu_tensor.to(ref.device, non_blocking=True)
-            if (
-                gpu_tensor.storage_offset() != ref.storage_offset
-                or gpu_tensor.stride() != ref.stride
-            ):
-                gpu_tensor = torch.as_strided(
-                    gpu_tensor, ref.size, ref.stride, ref.storage_offset
-                )
+            # fresh offset-0 storage; the source offset would overrun the pooled buffer
+            gpu_tensor = torch.empty_strided(
+                ref.size, ref.stride, dtype=ref.cpu_tensor.dtype, device=ref.device
+            )
+            gpu_tensor.copy_(ref.cpu_tensor, non_blocking=True)
         ref.gpu_tensor = gpu_tensor
         ref.restore_event = self.s1.record_event()
 

--- a/src/axolotl/monkeypatch/selective_checkpointing_offload.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing_offload.py
@@ -88,7 +88,6 @@ class SacOffloadEngine:
         self.max_cpu_buffer_pool_size = max_cpu_buffer_pool_size
         self.stats = SacOffloadStats()
 
-        self.s0 = torch.cuda.current_stream() if torch.cuda.is_available() else None
         self.s1 = torch.cuda.Stream() if torch.cuda.is_available() else None
 
         self._pack_seq = 0

--- a/tests/monkeypatch/test_checkpoint_activation_offload.py
+++ b/tests/monkeypatch/test_checkpoint_activation_offload.py
@@ -53,3 +53,28 @@ def test_checkpoint_offload_ignores_unmarked_saved_tensors():
     assert offload.stats.saved_tensors_seen > 0
     assert offload.stats.marked_tensors == 0
     assert offload.stats.offloaded_tensors == 0
+
+
+def test_checkpoint_offload_restores_view_with_storage_offset():
+    def fn(x):
+        return x.sin().square()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    base = torch.randn(6, 8, device=device)
+    x_base = base[2:].detach().clone().requires_grad_(True)
+    fn(checkpoint(fn, x_base, use_reentrant=False)).sum().backward()
+
+    x = base[2:].detach().requires_grad_(True)
+    assert x.storage_offset() > 0
+    offload = CheckpointHiddenStatesOffload(use_streams=False, min_offload_size=0)
+    with offload:
+        offload.mark(x)
+        loss = fn(checkpoint(fn, x, use_reentrant=False)).sum()
+        loss.backward()
+
+    if device == "cuda":
+        assert offload.stats.offloaded_tensors == 1
+        assert offload.stats.restored_tensors == 1
+    else:
+        assert offload.stats.skipped_marked_tensors == 1
+    assert torch.allclose(x.grad, x_base.grad)

--- a/tests/monkeypatch/test_checkpoint_activation_offload.py
+++ b/tests/monkeypatch/test_checkpoint_activation_offload.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import pytest
 import torch
 from torch import nn
 from torch.utils.checkpoint import checkpoint
@@ -55,26 +56,36 @@ def test_checkpoint_offload_ignores_unmarked_saved_tensors():
     assert offload.stats.offloaded_tensors == 0
 
 
-def test_checkpoint_offload_restores_view_with_storage_offset():
-    def fn(x):
-        return x.sin().square()
+@pytest.mark.parametrize(
+    "make_view",
+    [
+        pytest.param(lambda base: base[2:], id="offset-dense"),
+        pytest.param(lambda base: base[:, 2:], id="offset-gapped-stride"),
+    ],
+)
+def test_checkpoint_offload_restores_view_with_storage_offset(make_view):
+    # _pack_tensor skips non-accelerator tensors, so an end-to-end run no-ops on CPU
+    offload = CheckpointHiddenStatesOffload(
+        use_streams=False, min_offload_size=0, use_pin_memory=False
+    )
+    if not torch.cuda.is_available():
+        # _current_stream() routes any non-cpu accelerator (mps included) to torch.cuda
+        offload.accelerator_type = "cpu"
+    source = make_view(torch.randn(6, 8))
+    assert source.storage_offset() > 0
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    base = torch.randn(6, 8, device=device)
-    x_base = base[2:].detach().clone().requires_grad_(True)
-    fn(checkpoint(fn, x_base, use_reentrant=False)).sum().backward()
+    cpu_tensor, buffer_key = offload._empty_cpu_like(source)
+    cpu_tensor.copy_(source)
+    offload._tracker[1] = (
+        cpu_tensor,
+        source.device,
+        source.size(),
+        source.stride(),
+        buffer_key,
+    )
 
-    x = base[2:].detach().requires_grad_(True)
-    assert x.storage_offset() > 0
-    offload = CheckpointHiddenStatesOffload(use_streams=False, min_offload_size=0)
-    with offload:
-        offload.mark(x)
-        loss = fn(checkpoint(fn, x, use_reentrant=False)).sum()
-        loss.backward()
+    restored = offload._restore_tensor(1)
 
-    if device == "cuda":
-        assert offload.stats.offloaded_tensors == 1
-        assert offload.stats.restored_tensors == 1
-    else:
-        assert offload.stats.skipped_marked_tensors == 1
-    assert torch.allclose(x.grad, x_base.grad)
+    assert restored.storage_offset() == 0
+    assert restored.stride() == source.stride()
+    assert torch.equal(restored, source)

--- a/tests/monkeypatch/test_selective_checkpointing_offload.py
+++ b/tests/monkeypatch/test_selective_checkpointing_offload.py
@@ -1,5 +1,8 @@
 """Tests for phase-2 SAC CPU offload."""
 
+import contextlib
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -7,6 +10,7 @@ from torch.utils.checkpoint import checkpoint
 
 from axolotl.monkeypatch.selective_checkpointing_offload import (
     SacOffloadEngine,
+    _OffloadRef,
     build_sac_offload_context_fn,
 )
 
@@ -97,3 +101,43 @@ class TestSacOffloadFunctional:
         assert engine.stats.restored_tensors == engine.stats.offloaded_tensors
         for g0, g1 in zip(baseline, grads, strict=True):
             torch.testing.assert_close(g0, g1)
+
+
+class TestSacOffloadRestore:
+    @pytest.mark.parametrize(
+        "make_view",
+        [lambda base: base[2:], lambda base: base[:, 2:]],
+        ids=["dense_offset", "gapped_stride_offset"],
+    )
+    def test_restore_rebases_offset_view(self, monkeypatch, make_view):
+        engine = SacOffloadEngine()
+        if not torch.cuda.is_available():
+            # the engine is CUDA-only; stub its stream plumbing to reach the restore body
+            monkeypatch.setattr(
+                torch.cuda, "stream", lambda _: contextlib.nullcontext()
+            )
+            monkeypatch.setattr(
+                engine, "s1", SimpleNamespace(record_event=lambda: None)
+            )
+
+        source = make_view(torch.arange(32, dtype=torch.float32).reshape(4, 8))
+        assert source.storage_offset() != 0
+
+        cpu_tensor = torch.empty_strided(
+            source.size(), source.stride(), dtype=source.dtype, device="cpu"
+        )
+        cpu_tensor.copy_(source)
+
+        ref = _OffloadRef(
+            region_id=0,
+            device=source.device,
+            size=source.size(),
+            stride=tuple(source.stride()),
+            buffer_key=engine._buffer_key(source),
+            cpu_tensor=cpu_tensor,
+        )
+        engine._start_restore(ref)
+
+        assert ref.gpu_tensor.storage_offset() == 0
+        assert ref.gpu_tensor.stride() == source.stride()
+        assert torch.equal(ref.gpu_tensor, source)


### PR DESCRIPTION
checkpoint hs offload cached s0 at construction, mis-syncing when compute runs on a non-default stream (same fix as the trl patch in #3759); restore also reapplied the source storage_offset onto offset-0 pool storage.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of offloaded tensor views, including tensors with non-zero storage offsets.
  * Preserved tensor shapes, strides, and gradients more reliably during checkpoint offloading.

* **Tests**
  * Added coverage to verify correct restoration and gradient results for offset tensor views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->