### PR TITLE
perf(quantize): pass raw ptrs/ints to bnb dequant when argtypes are set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "mistral-common==1.11.5",
 
     # Platform-specific (Linux only)
-    "bitsandbytes==0.49.1 ; sys_platform != 'darwin'",
+    "bitsandbytes==0.50.0 ; sys_platform != 'darwin'",
     "triton>=3.4.0 ; sys_platform != 'darwin'",
     "xformers>=0.0.33.post2 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
     "liger-kernel==0.8.0 ; sys_platform != 'darwin'",

--- a/src/axolotl/kernels/quantize.py
+++ b/src/axolotl/kernels/quantize.py
@@ -1,6 +1,7 @@
 """Dequantization utilities for `bitsandbytes` and FP8 integration."""
 
 import ctypes
+from collections.abc import Callable
 from typing import List
 
 import bitsandbytes as bnb
@@ -19,6 +20,24 @@ _NF4_DEQUANT_KERNELS = {
     torch.bfloat16: cdequantize_blockwise_bf16_nf4,
     torch.float32: cdequantize_blockwise_fp32_nf4,
 }
+
+# bnb >= 0.50.0 sets argtypes on the C dequant symbols, so ctypes coerces raw ints itself
+# and we skip a per-call c_void_p/c_int alloc; older bnb (no argtypes) still needs wrappers.
+_BNB_TYPED_CAPI = getattr(cdequantize_blockwise_fp32, "argtypes", None) is not None
+
+_ptr: Callable[..., object]
+_int: Callable[..., object]
+if _BNB_TYPED_CAPI:
+
+    def _ptr(tensor):
+        return None if tensor is None else tensor.data_ptr()
+
+    def _int(value):
+        return value
+
+else:
+    _ptr = get_ptr
+    _int = ctypes.c_int
 
 # Cached per-device: per-call current_stream() measurably slows this hot path.
 CUDA_STREAM: dict[torch.device, torch.cuda.Stream] = {}
@@ -50,12 +69,12 @@ def _ctypes_nf4_dequant(
         )
 
     cdequantize_blockwise_fp32(
-        get_ptr(code2),
-        get_ptr(absmax),
-        get_ptr(absmax2),
-        get_ptr(out_absmax),
-        ctypes.c_int(blocksize2),
-        ctypes.c_int(n_elements_absmax),
+        _ptr(code2),
+        _ptr(absmax),
+        _ptr(absmax2),
+        _ptr(out_absmax),
+        _int(blocksize2),
+        _int(n_elements_absmax),
         stream,
     )
     out_absmax += offset
@@ -64,12 +83,12 @@ def _ctypes_nf4_dequant(
     if fx is None:
         raise ValueError(f"NF4 dequantization unsupported for output dtype {dtype}")
     fx(
-        get_ptr(None),
-        get_ptr(W),
-        get_ptr(out_absmax),
-        get_ptr(out),
-        ctypes.c_int(blocksize),
-        ctypes.c_int(out.numel()),
+        _ptr(None),
+        _ptr(W),
+        _ptr(out_absmax),
+        _ptr(out),
+        _int(blocksize),
+        _int(out.numel()),
         stream,
     )
 

--- a/src/axolotl/utils/optimizers/qgalore.py
+++ b/src/axolotl/utils/optimizers/qgalore.py
@@ -13,17 +13,31 @@ LOG = get_logger(__name__)
 
 
 def patch_q_galore_for_modern_bnb() -> None:
-    """bnb >=0.44 inserted (beta3, alpha) into ``optimizer_update_8bit_blockwise``
-    and ``optimizer_update_32bit``; q-galore-torch==1.0 still calls the legacy
-    positional layout. Swap q_galore's bnb handle for one that re-emits the
-    modern layout. No-op on older bnb."""
+    """q-galore-torch==1.0 targets the pre-0.44 bnb optimizer API; adapt it to
+    the installed bnb:
+
+    - bnb >=0.44 inserted (beta3, alpha) into ``optimizer_update_8bit_blockwise``
+      and ``optimizer_update_32bit``: re-emit q_galore's legacy positional layout.
+    - bnb >=0.50 removed the non-blockwise 8-bit path: ``F.optimizer_update_8bit``
+      and ``F.percentile_clipping`` are gone, ``get_config()`` lost the
+      ``percentile_clipping``/``block_wise`` keys, and — silently worst —
+      ``Optimizer2State.__init__`` lost those two params so q_galore's positional
+      ``super().__init__`` call lands them on ``max_unorm``/``skip_zeros``.
+
+    No-op on bnb <0.44."""
     import bitsandbytes.functional as F
     import q_galore_torch.q_galore_adamw8bit as mod
+    from bitsandbytes.optim.optimizer import Optimizer2State
 
     if "beta3" not in inspect.signature(F.optimizer_update_8bit_blockwise).parameters:
         return
 
     bw, fp32 = F.optimizer_update_8bit_blockwise, F.optimizer_update_32bit
+    legacy = {
+        name: getattr(F, name)
+        for name in ("optimizer_update_8bit", "percentile_clipping")
+        if hasattr(F, name)
+    }
     mod.F = types.SimpleNamespace(
         optimizer_update_8bit_blockwise=(
             lambda *a, **kw: bw(
@@ -35,9 +49,60 @@ def patch_q_galore_for_modern_bnb() -> None:
                 *(a[:10] + (0.0, 0.0) + a[10:] if len(a) == 13 else a), **kw
             )
         ),
-        optimizer_update_8bit=F.optimizer_update_8bit,
-        percentile_clipping=F.percentile_clipping,
+        **legacy,
     )
+
+    ctor_params = inspect.signature(Optimizer2State.__init__).parameters
+    if "percentile_clipping" in ctor_params or getattr(
+        mod.AdamW8bit, "_axolotl_bnb050_patched", False
+    ):
+        return
+
+    def _init(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+        is_paged=False,
+    ):
+        if percentile_clipping != 100 or not block_wise:
+            raise ValueError(
+                "bnb >=0.50 removed percentile_clipping and non-blockwise 8-bit "
+                "optimizer support"
+            )
+        Optimizer2State.__init__(
+            self,
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            8,
+            args,
+            min_8bit_size,
+            is_paged=is_paged,
+        )
+
+    orig_get_config = mod.AdamW8bit.get_config
+
+    def _get_config(self, gindex, pindex, group):
+        config = orig_get_config(self, gindex, pindex, group)
+        config.setdefault("percentile_clipping", 100)
+        config.setdefault("block_wise", True)
+        return config
+
+    mod.AdamW8bit.__init__ = _init
+    mod.AdamW8bit.get_config = _get_config
+    mod.AdamW8bit._axolotl_bnb050_patched = True
 
 
 def build_qgalore_param_groups(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

A bnb dev commented on discord about our access to the low level C types and about potential optim in the 0.50.0 release. This PR checks if those new types are available and uses them, otherwise, falls back.

Ref: https://discord.com/channels/1104757954588196865/1104758010959634503/1529861378934833162

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

We do have quantize test to check it, waiting on CI.

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved NF4 quantization performance by reducing overhead during dequantization.
  * Added compatibility handling for different bitsandbytes versions while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->