### PR TITLE
fix(attention): don't route fp32/CPU QKV into the sdpa varlen flash kernel

### DIFF
--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -748,6 +748,16 @@ class PatchManager:
         if not varlen_available():
             return  # torch < 2.10; block-diagonal packing path is correct
 
+        # Every call would fall back anyway, and patching drops the shared 4D mask.
+        half = self.cfg.torch_dtype in (torch.float16, torch.bfloat16)
+        if not (half and torch.cuda.is_available()):
+            if explicit:
+                LOG.info(
+                    "sdpa_varlen: varlen_attn needs CUDA fp16/bf16; keeping stock SDPA "
+                    "(packing still isolated via the block-diagonal mask)."
+                )
+            return
+
         def _attr(name):
             mc = self.model_config
             return mc.get(name) if isinstance(mc, dict) else getattr(mc, name, None)

--- a/src/axolotl/monkeypatch/attention/sdpa_varlen.py
+++ b/src/axolotl/monkeypatch/attention/sdpa_varlen.py
@@ -109,6 +109,7 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
         # - dropout unsupported by varlen_attn.
         # - head_dim within the Flash limit.
         # - scaling: varlen_attn only applies 1/sqrt(head_dim); a custom scale can't be honored.
+        # - CUDA fp16/bf16 only: the flash kernel backing varlen_attn has no CPU or fp32 support.
         standard_scale = scaling is None or abs(scaling - head_dim**-0.5) < 1e-9
         use_varlen = (
             attention_mask is None
@@ -116,6 +117,8 @@ def _build_varlen_forward(original_sdpa: Callable) -> Callable:
             and head_dim <= _VARLEN_MAX_HEAD_DIM
             and position_ids is not None
             and standard_scale
+            and query.is_cuda
+            and query.dtype in (torch.float16, torch.bfloat16)
         )
         packed = position_ids is not None and _is_packed(position_ids)
         use_varlen = use_varlen and packed  # single-doc rows -> stock SDPA

--- a/tests/e2e/integrations/test_kd.py
+++ b/tests/e2e/integrations/test_kd.py
@@ -63,7 +63,7 @@ def min_cfg(temp_dir):
             "pad_token": "<|end_of_text|>",
             "eos_token": "<|eot_id|>",
         },
-        "max_steps": 5,
+        "max_steps": 10,
         "output_dir": temp_dir,
         "use_tensorboard": True,
         "save_first_step": False,

--- a/tests/monkeypatch/test_sdpa_varlen.py
+++ b/tests/monkeypatch/test_sdpa_varlen.py
@@ -10,14 +10,17 @@ from axolotl.monkeypatch.attention.sdpa_varlen import (
     varlen_available,
 )
 
-pytestmark = [
-    pytest.mark.skipif(not torch.cuda.is_available(), reason="varlen_attn needs CUDA"),
-    pytest.mark.skipif(
-        not varlen_available(), reason="torch.nn.attention.varlen needs torch >= 2.10"
-    ),
-]
+pytestmark = pytest.mark.skipif(
+    not varlen_available(), reason="torch.nn.attention.varlen needs torch >= 2.10"
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="varlen_attn needs CUDA"
+)
 
 DEV = "cuda"
+# The fallback path never reaches varlen_attn, so it runs on CPU too.
+FALLBACK_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
 def _varlen_supports_window() -> bool:
@@ -46,11 +49,11 @@ def _block_mask(position_ids, dtype, sliding=None):
     B, S = position_ids.shape
     doc = (position_ids == 0).cumsum(-1)
     same = doc[:, :, None] == doc[:, None, :]
-    idx = torch.arange(S, device=DEV)
+    idx = torch.arange(S, device=position_ids.device)
     allow = same & (idx[:, None] >= idx[None, :])[None]
     if sliding:
         allow = allow & ((idx[:, None] - idx[None, :]) < sliding)[None]
-    m = torch.zeros(B, 1, S, S, device=DEV, dtype=dtype)
+    m = torch.zeros(B, 1, S, S, device=position_ids.device, dtype=dtype)
     m.masked_fill_(~allow[:, None], torch.finfo(dtype).min)
     return m
 
@@ -65,10 +68,10 @@ def _ref(q, k, v, scaling, position_ids, sliding=None):
     return o.transpose(1, 2)  # [B,S,H,D]
 
 
-def _pos(doclens_per_row):
+def _pos(doclens_per_row, device=DEV):
     rows = [torch.cat([torch.arange(ln) for ln in dl]) for dl in doclens_per_row]
     S = max(len(r) for r in rows)
-    return torch.stack([F.pad(r, (0, S - len(r))) for r in rows]).to(DEV)
+    return torch.stack([F.pad(r, (0, S - len(r))) for r in rows]).to(device)
 
 
 @pytest.fixture
@@ -78,6 +81,7 @@ def patched():
     unpatch_sdpa_varlen()
 
 
+@requires_cuda
 @pytest.mark.parametrize(
     "doclens,sliding,label",
     [
@@ -136,6 +140,7 @@ def _assert_defers_to_stock(mod, q, k, v, pos):
     assert torch.equal(out_w, out_o)
 
 
+@requires_cuda
 def test_varlen_matches_flash_attention_2_e2e():
     """The varlen path matches FA2 (the canonical varlen-packing impl) on a real packed forward."""
     from transformers import LlamaConfig, LlamaModel
@@ -176,30 +181,32 @@ def test_varlen_matches_flash_attention_2_e2e():
     )
 
 
-def test_falls_back_when_not_packed(patched):
+@pytest.mark.parametrize("device", FALLBACK_DEVICES)
+def test_falls_back_when_not_packed(patched, device):
     """Single-document rows must defer to stock SDPA (no varlen path)."""
     S, Hq, Hkv, D = 512, 16, 4, 256
-    pos = torch.arange(S, device=DEV)[None]  # one document -> no packing
+    pos = torch.arange(S, device=device)[None]  # one document -> no packing
     torch.manual_seed(0)
-    q = torch.randn(1, Hq, S, D, device=DEV, dtype=torch.bfloat16)
-    k = torch.randn(1, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
-    v = torch.randn(1, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
+    q = torch.randn(1, Hq, S, D, device=device, dtype=torch.bfloat16)
+    k = torch.randn(1, Hkv, S, D, device=device, dtype=torch.bfloat16)
+    v = torch.randn(1, Hkv, S, D, device=device, dtype=torch.bfloat16)
     _assert_defers_to_stock(_Mod(num_key_value_groups=Hq // Hkv), q, k, v, pos)
 
 
-def test_falls_back_on_large_head_dim(patched):
+@pytest.mark.parametrize("device", FALLBACK_DEVICES)
+def test_falls_back_on_large_head_dim(patched, device):
     """head_dim > 256 can't use Flash varlen, but a packed row whose padding mask was
     dropped (attention_mask=None) must still be isolated: the wrapper rebuilds the
     block-diagonal mask rather than running pure-causal (which would leak)."""
     from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
-    pos = _pos([[256, 256]])
+    pos = _pos([[256, 256]], device)
     B, S = pos.shape
     Hq, Hkv, D = 8, 2, 512  # head_dim 512
     torch.manual_seed(0)
-    q = torch.randn(B, Hq, S, D, device=DEV, dtype=torch.bfloat16)
-    k = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
-    v = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.bfloat16)
+    q = torch.randn(B, Hq, S, D, device=device, dtype=torch.bfloat16)
+    k = torch.randn(B, Hkv, S, D, device=device, dtype=torch.bfloat16)
+    v = torch.randn(B, Hkv, S, D, device=device, dtype=torch.bfloat16)
     mod = _Mod(num_key_value_groups=Hq // Hkv)
     scaling = D**-0.5
 
@@ -215,27 +222,34 @@ def test_falls_back_on_large_head_dim(patched):
     assert not torch.allclose(out, leak, atol=1e-2)
 
 
-def test_falls_back_on_fp32(patched):
-    """Regression: fp32 QKV must not reach varlen_attn (the Flash kernel rejects fp32
-    with a RuntimeError); a packed fp32 row falls back to block-diagonal stock SDPA."""
+@pytest.mark.parametrize(
+    "device,dtype",
+    # cpu/bf16 isolates the device guard, cuda/fp32 the dtype guard, cpu/fp32 hits both.
+    [("cpu", torch.bfloat16), ("cpu", torch.float32)]
+    + ([("cuda", torch.float32)] if torch.cuda.is_available() else []),
+)
+def test_falls_back_on_unsupported_dtype_or_device(patched, device, dtype):
+    """Regression: only CUDA fp16/bf16 QKV may reach varlen_attn — its Flash kernel raises on
+    fp32 and has no CPU dispatch. Everything else falls back to block-diagonal stock SDPA."""
     from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
-    pos = _pos([[256, 256]])
+    pos = _pos([[256, 256]], device)
     B, S = pos.shape
     Hq, Hkv, D = 8, 2, 64
     torch.manual_seed(0)
-    q = torch.randn(B, Hq, S, D, device=DEV, dtype=torch.float32)
-    k = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.float32)
-    v = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.float32)
+    q = torch.randn(B, Hq, S, D, device=device, dtype=dtype)
+    k = torch.randn(B, Hkv, S, D, device=device, dtype=dtype)
+    v = torch.randn(B, Hkv, S, D, device=device, dtype=dtype)
     mod = _Mod(num_key_value_groups=Hq // Hkv)
     scaling = D**-0.5
 
     wrapper = ALL_ATTENTION_FUNCTIONS["sdpa"]
     out, _ = wrapper(mod, q, k, v, None, scaling=scaling, position_ids=pos)
     ref = _ref(q, k, v, scaling, pos)
-    assert torch.allclose(out, ref, atol=1e-4)
+    assert torch.allclose(out, ref, atol=1e-4 if dtype == torch.float32 else 1e-2)
 
 
+@requires_cuda
 def test_varlen_engages_in_training_forward():
     """Regression: in a real training forward (use_cache=False) transformers builds a 4D
     packed mask from position_ids, which used to bypass the varlen path entirely. The mask

--- a/tests/monkeypatch/test_sdpa_varlen.py
+++ b/tests/monkeypatch/test_sdpa_varlen.py
@@ -215,6 +215,27 @@ def test_falls_back_on_large_head_dim(patched):
     assert not torch.allclose(out, leak, atol=1e-2)
 
 
+def test_falls_back_on_fp32(patched):
+    """Regression: fp32 QKV must not reach varlen_attn (the Flash kernel rejects fp32
+    with a RuntimeError); a packed fp32 row falls back to block-diagonal stock SDPA."""
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    pos = _pos([[256, 256]])
+    B, S = pos.shape
+    Hq, Hkv, D = 8, 2, 64
+    torch.manual_seed(0)
+    q = torch.randn(B, Hq, S, D, device=DEV, dtype=torch.float32)
+    k = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.float32)
+    v = torch.randn(B, Hkv, S, D, device=DEV, dtype=torch.float32)
+    mod = _Mod(num_key_value_groups=Hq // Hkv)
+    scaling = D**-0.5
+
+    wrapper = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    out, _ = wrapper(mod, q, k, v, None, scaling=scaling, position_ids=pos)
+    ref = _ref(q, k, v, scaling, pos)
+    assert torch.allclose(out, ref, atol=1e-4)
+
+
 def test_varlen_engages_in_training_forward():
     """Regression: in a real training forward (use_cache=False) transformers builds a 4D
     packed mask from position_ids, which used to bypass the varlen path entirely. The mask


### PR DESCRIPTION
The sdpa_varlen fast path guarded on mask/dropout/head_dim/scaling but not on dtype or device, so sdpa + sample_packing with fp32 (or CPU) tensors fed torch.nn.attention.varlen.varlen_attn, whose backing flash kernel only supports CUDA fp16/bf16 — crashing with 'FlashAttention only support fp16 and bf16 data type' on torch 2.12.1. Such rows now fall back to stock SDPA with the rebuilt block-diagonal mask (documents stay isolated).

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention compatibility by limiting the optimized variable-length path to supported CUDA half-precision formats.
  * Ensured float32 attention uses the standard implementation for correct results.

* **Tests**
  * Added regression coverage validating accurate float32 attention behavior in packed, multi-document inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->