### PR TITLE
fix: kto argilla chat followups

### DIFF
--- a/src/axolotl/prompt_strategies/kto/chatml.py
+++ b/src/axolotl/prompt_strategies/kto/chatml.py
@@ -32,10 +32,15 @@ def argilla_chat(
     """
 
     def transform_fn(sample):
+        history, response = sample["completion"][:-1], sample["completion"][-1]
         sample["prompt"] = (
-            f"<|im_start|>user\n{sample['completion'][0]['content']}<|im_end|>\n<|im_start|>assistant\n"
+            "".join(
+                f"<|im_start|>{turn['role']}\n{turn['content']}<|im_end|>\n"
+                for turn in history
+            )
+            + "<|im_start|>assistant\n"
         )
-        sample["completion"] = f"{sample['completion'][1]['content']}<|im_end|>"
+        sample["completion"] = f"{response['content']}<|im_end|>"
         return sample
 
     return transform_fn

--- a/src/axolotl/prompt_strategies/kto/llama3.py
+++ b/src/axolotl/prompt_strategies/kto/llama3.py
@@ -32,10 +32,15 @@ def argilla_chat(
     """
 
     def transform_fn(sample):
+        history, response = sample["completion"][:-1], sample["completion"][-1]
         sample["prompt"] = (
-            f"<|start_header_id|>user<|end_header_id|>\n\n{sample['completion'][0]['content']}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+            "".join(
+                f"<|start_header_id|>{turn['role']}<|end_header_id|>\n\n{turn['content']}<|eot_id|>"
+                for turn in history
+            )
+            + "<|start_header_id|>assistant<|end_header_id|>\n\n"
         )
-        sample["completion"] = f"{sample['completion'][1]['content']}<|eot_id|>"
+        sample["completion"] = f"{response['content']}<|eot_id|>"
         return sample
 
     return transform_fn

--- a/tests/e2e/test_dpo.py
+++ b/tests/e2e/test_dpo.py
@@ -324,7 +324,7 @@ class TestDPOLlamaLora(unittest.TestCase):
         cfg = DictDefault(
             {
                 "base_model": "HuggingFaceTB/SmolLM2-135M",
-                "tokenizer_type": "LlamaTokenizer",
+                "tokenizer_type": "AutoTokenizer",
                 "sequence_len": 1024,
                 "load_in_8bit": True,
                 "adapter": "lora",
@@ -341,21 +341,24 @@ class TestDPOLlamaLora(unittest.TestCase):
                 "kto_undesirable_weight": 1.0,
                 "remove_unused_columns": False,
                 "datasets": [
-                    # {
-                    #     "path": "argilla/kto-mix-15k",
-                    #     "type": "chatml.argilla_chat",
-                    #     "split": "train",
-                    # },
+                    {
+                        # this repo's test split carries a DPO schema that fails to cast
+                        "path": "argilla/kto-mix-15k",
+                        "data_files": ["data/train-*.parquet"],
+                        "type": "chatml.argilla_chat",
+                        "split": "train",
+                    },
                     {
                         "path": "argilla/ultrafeedback-binarized-preferences-cleaned-kto",
                         "type": "chatml.ultra",
                         "split": "train",
                     },
-                    # {
-                    #     "path": "argilla/kto-mix-15k",
-                    #     "type": "llama3.argilla_chat",
-                    #     "split": "train",
-                    # },
+                    {
+                        "path": "argilla/kto-mix-15k",
+                        "data_files": ["data/train-*.parquet"],
+                        "type": "llama3.argilla_chat",
+                        "split": "train",
+                    },
                     {
                         "path": "argilla/ultrafeedback-binarized-preferences-cleaned-kto",
                         "type": "llama3.ultra",

--- a/tests/prompt_strategies/test_kto_llama3.py
+++ b/tests/prompt_strategies/test_kto_llama3.py
@@ -1,20 +1,16 @@
 """
-Tests for KTO dataset transform strategies with chatml formatting
+Tests for KTO dataset transform strategies with llama-3 formatting
 """
 
-from axolotl.prompt_strategies.kto.chatml import argilla_chat
+from axolotl.prompt_strategies.kto.llama3 import argilla_chat
 
 
-class TestKTOChatml:
+class TestKTOLlama3:
     """
-    Test kto.chatml transforms
+    Test kto.llama3 transforms
     """
 
-    def test_argilla_chat_reads_completion_messages(self):
-        """argilla_chat builds the prompt from the conversation stored in the
-        `completion` column. argilla/kto-mix-15k has no `chosen` column, so
-        reading one raised KeyError during preprocessing; the llama-3 sibling
-        already reads `completion`."""
+    def test_argilla_chat_single_turn(self):
         transform_fn = argilla_chat(cfg=None)
         sample = transform_fn(
             {
@@ -26,11 +22,11 @@ class TestKTOChatml:
                 "label": True,
             }
         )
-        assert (
-            sample["prompt"]
-            == "<|im_start|>user\nWhat is 2 + 2?<|im_end|>\n<|im_start|>assistant\n"
+        assert sample["prompt"] == (
+            "<|start_header_id|>user<|end_header_id|>\n\nWhat is 2 + 2?<|eot_id|>"
+            "<|start_header_id|>assistant<|end_header_id|>\n\n"
         )
-        assert sample["completion"] == "4<|im_end|>"
+        assert sample["completion"] == "4<|eot_id|>"
 
     def test_argilla_chat_keeps_multi_turn_history(self):
         """argilla/kto-mix-15k is not uniformly single-turn, so earlier turns
@@ -49,9 +45,9 @@ class TestKTOChatml:
             }
         )
         assert sample["prompt"] == (
-            "<|im_start|>user\nWhat is 2 + 2?<|im_end|>\n"
-            "<|im_start|>assistant\n4<|im_end|>\n"
-            "<|im_start|>user\nAnd times 3?<|im_end|>\n"
-            "<|im_start|>assistant\n"
+            "<|start_header_id|>user<|end_header_id|>\n\nWhat is 2 + 2?<|eot_id|>"
+            "<|start_header_id|>assistant<|end_header_id|>\n\n4<|eot_id|>"
+            "<|start_header_id|>user<|end_header_id|>\n\nAnd times 3?<|eot_id|>"
+            "<|start_header_id|>assistant<|end_header_id|>\n\n"
         )
-        assert sample["completion"] == "12<|im_end|>"
+        assert sample["completion"] == "12<|eot_id|>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Continues https://github.com/axolotl-ai-cloud/axolotl/pull/3838#issuecomment-5085964301

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

CI tested locally

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KTO chat formatting to preserve complete multi-turn conversation history.
  * Correctly separates prior messages from the final assistant response.
  * Applies the appropriate ChatML and Llama 3 end-of-turn markers.

* **Tests**
  * Added coverage for single-turn and multi-turn prompt formatting.
  * Updated end-to-end KTO testing configurations and datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->