### PR TITLE
fix(kernels): resolve the NF4 dequant stream per call

### DIFF
--- a/src/axolotl/kernels/quantize.py
+++ b/src/axolotl/kernels/quantize.py
@@ -5,7 +5,7 @@ from typing import List
 
 import bitsandbytes as bnb
 import torch
-from bitsandbytes.functional import QuantState, _get_tensor_stream, get_ptr
+from bitsandbytes.functional import QuantState, get_ptr
 
 cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
 cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
@@ -40,8 +40,8 @@ def _ctypes_nf4_dequant(
         n_elements_absmax, dtype=torch.float32, device=target_device
     )
 
-    # raw pointer: the live stream without building a Python Stream on this hot path
-    stream = _get_tensor_stream(W)
+    # c_void_p is required: bnb sets no argtypes, so a bare int truncates to a C int.
+    stream = ctypes.c_void_p(torch._C._cuda_getCurrentRawStream(W.device.index))
 
     cdequantize_blockwise_fp32(
         get_ptr(code2),

--- a/src/axolotl/kernels/quantize.py
+++ b/src/axolotl/kernels/quantize.py
@@ -5,7 +5,7 @@ from typing import List
 
 import bitsandbytes as bnb
 import torch
-from bitsandbytes.functional import QuantState, get_ptr
+from bitsandbytes.functional import QuantState, _get_tensor_stream, get_ptr
 
 cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
 cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
@@ -19,9 +19,6 @@ _NF4_DEQUANT_KERNELS = {
     torch.bfloat16: cdequantize_blockwise_bf16_nf4,
     torch.float32: cdequantize_blockwise_fp32_nf4,
 }
-
-# Cached per-device: per-call current_stream() measurably slows this hot path.
-CUDA_STREAM: dict[torch.device, torch.cuda.Stream] = {}
 
 
 def _ctypes_nf4_dequant(
@@ -43,11 +40,8 @@ def _ctypes_nf4_dequant(
         n_elements_absmax, dtype=torch.float32, device=target_device
     )
 
-    stream = CUDA_STREAM.get(target_device)
-    if stream is None:
-        stream = CUDA_STREAM.setdefault(
-            target_device, torch.cuda.current_stream(target_device)
-        )
+    # raw pointer: the live stream without building a Python Stream on this hot path
+    stream = _get_tensor_stream(W)
 
     cdequantize_blockwise_fp32(
         get_ptr(code2),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Followup to #3878 . Applies the same optimization to the `quantize.py`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NF4 dequantization stream handling for more reliable CUDA execution.
  * Reduced potential issues caused by stale or incorrectly selected device streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->