### PR TITLE
feat(model_support): expand profile seams across transformers registries and the save boundary

### DIFF
--- a/docs/agents/new_model_support.md
+++ b/docs/agents/new_model_support.md
@@ -107,11 +107,11 @@ Move one concern at a time using this mapping:
 | `pre_config_load()` / `pre_tokenizer_load()` / `pre_model_load()` | `BEFORE_CONFIG_LOAD` / `BEFORE_TOKENIZER_LOAD` / `BEFORE_MODEL_BUILD` hook |
 | `post_model_load()` | `AFTER_ADAPTER_LOAD` hook |
 
-Unless a profile phase explicitly replaces its family hooks, hooks from the family, profile, and legacy method are additive. Remove a legacy method once its behavior moves into a profile hook, or the old and new implementations both run. The compatibility guard prevents a legacy method's `super()` call from re-entering the declarative hook, but it cannot identify duplicate logic implemented in both places. `AFTER_BASE_MODEL_BUILD` has no legacy-method equivalent.
+Unless a profile phase explicitly replaces its family hooks, hooks from the family, profile, and legacy method are additive. Remove a legacy method once its behavior moves into a profile hook, or the old and new implementations both run. The compatibility guard prevents a legacy method's `super()` call from re-entering the declarative hook, but it cannot identify duplicate logic implemented in both places. `AFTER_BASE_MODEL_BUILD` and `BEFORE_SAVE` have no legacy-method equivalent.
 
 ### Hook phases
 
-Hooks receive an immutable `ModelHookContext` containing the run config and the objects available at that phase. The `tokenizer` and `processor` fields are optional because early phases do not construct them and direct `ModelLoader` callers can omit a processor; hooks must handle `None` unless their phase and caller guarantee the object. Register hooks under `ModelHookPhase` rather than relying on an implied ordering.
+Hooks receive an immutable `ModelHookContext` containing the run config and the objects available at that phase. The `tokenizer` and `processor` fields are optional because early phases do not construct them and direct `ModelLoader` callers can omit a processor; hooks must handle `None` unless their phase and caller guarantee the object. Prefer consuming `context.processor` when it is set — transformers v5 is converging on the processor as the primary preprocessing object — and fall back to `context.tokenizer`; the tokenizer field remains for text-only runs and compatibility. Register hooks under `ModelHookPhase` rather than relying on an implied ordering.
 
 | Phase | Meaning |
 |-------|---------|
@@ -121,6 +121,7 @@ Hooks receive an immutable `ModelHookContext` containing the run config and the 
 | `BEFORE_MODEL_BUILD` | At the established pre-load patch slot before checkpoint construction; use only for patches that must exist while the model class is imported or instantiated. |
 | `AFTER_BASE_MODEL_BUILD` | Immediately after the raw base model is built and before adapters are applied. |
 | `AFTER_ADAPTER_LOAD` | After adapters and final load setup, before the remaining generic and plugin post-load hooks. |
+| `BEFORE_SAVE` | Right before the trained model is saved (`save_trained_model`) or a legacy-merged model is written (`merge-lora`); use to undo or finalize model state for serialization. The memory-efficient merge path never materializes a model instance and does not dispatch this phase. |
 
 The context fields available at each phase are:
 
@@ -132,6 +133,7 @@ The context fields available at each phase are:
 | `BEFORE_MODEL_BUILD` | Available | Available | Optional | - | Available |
 | `AFTER_BASE_MODEL_BUILD` | Available | Available | Optional | Raw base model | Available |
 | `AFTER_ADAPTER_LOAD` | Available | Available | Optional | Final loaded model | Available |
+| `BEFORE_SAVE` | - | Optional | Optional | Trained/merged model | - |
 
 `cfg` is always available. Although the context dataclass prevents assigning different field values, the contained config and model objects remain mutable so hooks can apply their intended configuration or patch. At `BEFORE_TOKENIZER_LOAD`, the exact type may already be available as `cfg.model_config_type`, but the `model_config` object itself is not included in the context. The standard loading helper supplies a processor for multimodal runs; direct `ModelLoader` callers must pass one explicitly if their hooks require it.
 
@@ -172,13 +174,20 @@ profile = ModelProfile(
 ```
 
 - `weight_conversions` maps a `model_type` or model class name to `WeightTransform` entries (`WeightConverter`, `WeightRenaming`, ...) passed to `transformers.conversion_mapping.register_checkpoint_conversion_mapping`. Class-name keys take priority over `model_type` keys inside transformers. Remote-code models receive only conversion mappings registered this way; transformers skips its built-in table for custom code.
-- `patch_mappings` maps class names (or regex patterns) to replacement `nn.Module` subclasses passed to `transformers.monkey_patching.register_patch_mapping`; transformers swaps the classes during `from_pretrained`/`from_config` module construction. Prefer exact class names: the registry is process-global, and a broad pattern such as `.*Attention` also patches every other architecture loaded later in the same process.
+- `patch_mappings` maps class names (or regex patterns) to replacement `nn.Module` subclasses passed to `transformers.monkey_patching.register_patch_mapping`; transformers swaps the classes during `from_pretrained`/`from_config` module construction. This is the sanctioned way to replace a single module class within one architecture; an exact class name such as `"MyModelExperts"` swaps only that module. Prefer exact class names: the registry is process-global, and a broad pattern such as `.*Attention` also patches every other architecture loaded later in the same process.
+- `attention_functions` / `attention_mask_functions` map implementation names to callables registered into `ALL_ATTENTION_FUNCTIONS` / `ALL_MASK_ATTENTION_FUNCTIONS`. Every attention implementation needs a matching mask entry, or mask construction falls through to defaults that may not fit the implementation.
+- `experts_functions` maps implementation names to callables registered into `ALL_EXPERTS_FUNCTIONS`; the run selects one via `config._experts_implementation`.
+- `quantizers` maps quantization-method names to `QuantizerRegistration(quantizer_cls, config_cls)`. Registration is idempotent (re-applying the same classes is a no-op); a different existing registration is overwritten with a warning. A custom quantizer can hook the weight-conversion pipeline via `HfQuantizer.update_weight_conversions`.
+- `auto_classes` takes `AutoClassRegistration` entries wiring a config class plus its model / tokenizer / processor classes into the transformers auto registries (`AutoConfig.register`, `AutoModelFor*.register`, ...), with `exist_ok` so repeated application is a no-op. Note transformers silently refuses to re-point a *native* transformers config class at a custom model class through this path; use `patch_mappings` for that.
+- `model_class_attrs` maps classes to attribute overrides applied with plain `setattr` before model build, for class-level knobs with no registration API: `_no_split_modules`, `_keep_in_fp32_modules(_strict)`, `_tied_weights_keys`, `supports_gradient_checkpointing`, and config-side `base_model_tp_plan` / `base_model_ep_plan` / `base_model_fsdp_plan` class vars.
 
-These registries are two halves of one operation: a patch mapping that changes a module's checkpoint layout must ship matching `weight_conversions`, or loading breaks; transformers' own kernel-fusion machinery always registers them as a pair.
+`weight_conversions` and `patch_mappings` are two halves of one operation: a patch mapping that changes a module's checkpoint layout must ship matching `weight_conversions`, or loading breaks; transformers' own kernel-fusion machinery always registers them as a pair. The same pairing applies to `attention_functions`/`attention_mask_functions`.
 
 Saving reverses conversions. `save_pretrained(save_original_format=True)` (the default) applies each registered transform's reverse to emit the original checkpoint layout, so every `ConversionOps` in a registered `WeightConverter` must implement `reverse_op`. Axolotl warns at registration for any op missing a `reverse_op`; a transform carrying a quantization operation also cannot round-trip, though that only surfaces at save time. The reverse pass is skipped while a PEFT config is loaded, so merged and full-parameter saves are the affected path.
 
 Registrations resolve family → profile like strategies (an omitted field inherits, explicit `None` clears); there is no legacy-method equivalent.
+
+A per-architecture loss goes through `ModelStrategyOverrides(loss_function=provider)` instead: the provider's callable is set per model instance (`model.loss_function`, honored by transformers' loss dispatch) right after the base model is built, so no global `LOSS_MAPPING` mutation is needed.
 
 ### Registration and fallback
 

--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -9,6 +9,12 @@ import torch
 from axolotl.cli.config import load_cfg
 from axolotl.cli.utils import load_model_and_tokenizer
 from axolotl.cli.utils.lora_merge import merge_lora_sharded_efficient
+from axolotl.model_support import (
+    ModelHookContext,
+    ModelHookPhase,
+    get_model_support,
+    run_model_support_hooks,
+)
 from axolotl.telemetry.errors import send_errors
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.logging import get_logger
@@ -52,6 +58,14 @@ def _do_merge_lora_legacy(*, cfg: DictDefault) -> None:
 
     model.generation_config.do_sample = True
     model.config.use_cache = True
+
+    run_model_support_hooks(
+        get_model_support(cfg.model_config_type),
+        ModelHookPhase.BEFORE_SAVE,
+        ModelHookContext(
+            cfg=cfg, model=model, tokenizer=tokenizer, processor=processor
+        ),
+    )
 
     if cfg.local_rank == 0:
         LOG.info(f"Saving merged model to: {str(Path(cfg.output_dir) / 'merged')}...")

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -183,6 +183,7 @@ class PatchManager:
             ModelHookPhase.AFTER_BASE_MODEL_BUILD,
             self._hook_context(model),
         )
+        self._apply_model_support_loss_function(model)
 
         if self.cfg.model_config_type == "nemotron_h":
             # Must run after model build because NemotronHForCausalLM.__init__
@@ -229,6 +230,11 @@ class PatchManager:
 
             register_patch_mapping(dict(patch_mapping), overwrite=True)
 
+        self._register_interface_functions(registrations)
+        self._register_quantizers(registrations)
+        self._register_auto_classes(registrations)
+        self._apply_model_class_attrs(registrations)
+
     @staticmethod
     def _warn_irreversible_weight_transforms(key: str, transforms: list) -> None:
         """``save_pretrained(save_original_format=True)`` reverses registered
@@ -251,6 +257,103 @@ class PatchManager:
                     key,
                     "; ".join(problems),
                 )
+
+    @staticmethod
+    def _register_interface_functions(registrations):
+        def interface_entries(provider):
+            mapping = provider() if provider is not None else None
+            return mapping.items() if mapping else ()
+
+        for key, function in interface_entries(registrations.attention_functions):
+            from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+            ALL_ATTENTION_FUNCTIONS.register(key, function)
+        for key, function in interface_entries(registrations.attention_mask_functions):
+            from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+
+            ALL_MASK_ATTENTION_FUNCTIONS.register(key, function)
+        for key, function in interface_entries(registrations.experts_functions):
+            from transformers.integrations.moe import ALL_EXPERTS_FUNCTIONS
+
+            ALL_EXPERTS_FUNCTIONS.register(key, function)
+
+    @staticmethod
+    def _register_quantizers(registrations):
+        provider = registrations.quantizers
+        quantizers = provider() if provider is not None else None
+        if not quantizers:
+            return
+        from transformers.quantizers.auto import (
+            AUTO_QUANTIZATION_CONFIG_MAPPING,
+            AUTO_QUANTIZER_MAPPING,
+        )
+
+        # register_quantizer() raises on any existing key, so write the
+        # mappings directly: same class is an idempotent no-op, a different
+        # class is a deliberate profile override.
+        for name, registration in quantizers.items():
+            existing = AUTO_QUANTIZER_MAPPING.get(name)
+            if existing is not None and existing is not registration.quantizer_cls:
+                LOG.warning(
+                    "Overriding quantizer %s: %s -> %s",
+                    name,
+                    existing.__name__,
+                    registration.quantizer_cls.__name__,
+                )
+            AUTO_QUANTIZER_MAPPING[name] = registration.quantizer_cls
+            if registration.config_cls is not None:
+                AUTO_QUANTIZATION_CONFIG_MAPPING[name] = registration.config_cls
+
+    @staticmethod
+    def _register_auto_classes(registrations):
+        provider = registrations.auto_classes
+        auto_classes = provider() if provider is not None else None
+        if not auto_classes:
+            return
+        import transformers
+        from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+
+        for registration in auto_classes:
+            config_cls = registration.config_cls
+            AutoConfig.register(config_cls.model_type, config_cls, exist_ok=True)
+            for auto_name, model_cls in registration.model_classes.items():
+                auto_cls = getattr(transformers, auto_name, None)
+                if auto_cls is None or not hasattr(auto_cls, "register"):
+                    raise ValueError(
+                        f"Unknown transformers auto class {auto_name!r} in "
+                        f"auto_classes registration for {config_cls.__name__}"
+                    )
+                auto_cls.register(config_cls, model_cls, exist_ok=True)
+            if registration.slow_tokenizer_cls or registration.fast_tokenizer_cls:
+                AutoTokenizer.register(
+                    config_cls,
+                    slow_tokenizer_class=registration.slow_tokenizer_cls,
+                    fast_tokenizer_class=registration.fast_tokenizer_cls,
+                    exist_ok=True,
+                )
+            if registration.processor_cls is not None:
+                AutoProcessor.register(
+                    config_cls, registration.processor_cls, exist_ok=True
+                )
+
+    @staticmethod
+    def _apply_model_class_attrs(registrations):
+        provider = registrations.model_class_attrs
+        class_attrs = provider() if provider is not None else None
+        if not class_attrs:
+            return
+        for target_cls, attrs in class_attrs.items():
+            for attr_name, value in attrs.items():
+                setattr(target_cls, attr_name, value)
+
+    def _apply_model_support_loss_function(self, model: PreTrainedModel):
+        support = get_model_support(self.cfg.model_config_type)
+        if support is None:
+            return
+        provider = resolve_model_support(support).strategies.loss_function
+        loss_function = provider() if provider is not None else None
+        if loss_function is not None:
+            model.loss_function = loss_function
 
     def _apply_model_support_pre_load_hook(self):
         support = get_model_support(self.cfg.model_config_type)

--- a/src/axolotl/model_support/__init__.py
+++ b/src/axolotl/model_support/__init__.py
@@ -15,8 +15,13 @@ from .base import (
     check_capability,
 )
 from .profile import (
+    AutoClassesProvider,
+    AutoClassRegistration,
     AutoModelClassProvider,
     ConfigMatcher,
+    InterfaceFunctionsProvider,
+    LossFunctionProvider,
+    ModelClassAttrsProvider,
     ModelFamilyTemplate,
     ModelHook,
     ModelHookContext,
@@ -31,6 +36,8 @@ from .profile import (
     PatchMappingsProvider,
     ProcessingStrategyClassProvider,
     ProcessorMatcher,
+    QuantizerRegistration,
+    QuantizersProvider,
     ResolvedModelProfile,
     WeightConversionsProvider,
     resolve_model_support,
@@ -45,10 +52,15 @@ from .registry import (
 from .templates import IMAGE_TEXT_TO_TEXT, VANILLA_CAUSAL_LM
 
 __all__ = [
+    "AutoClassRegistration",
+    "AutoClassesProvider",
     "AutoModelClassProvider",
     "Capability",
     "ConfigMatcher",
     "Experimental",
+    "InterfaceFunctionsProvider",
+    "LossFunctionProvider",
+    "ModelClassAttrsProvider",
     "ModelSupport",
     "ModelFamilyTemplate",
     "ModelHook",
@@ -64,6 +76,8 @@ __all__ = [
     "PatchMappingsProvider",
     "ProcessingStrategyClassProvider",
     "ProcessorMatcher",
+    "QuantizerRegistration",
+    "QuantizersProvider",
     "ResolvedModelProfile",
     "WeightConversionsProvider",
     "Supported",

--- a/src/axolotl/model_support/profile.py
+++ b/src/axolotl/model_support/profile.py
@@ -164,11 +164,11 @@ class ModelStrategyOverrides:
     inherited provider and restores the downstream generic fallback.
     """
 
-    auto_model_cls: AutoModelClassProvider | None | _InheritStrategy = _INHERIT_STRATEGY
+    auto_model_cls: AutoModelClassProvider | _InheritStrategy | None = _INHERIT_STRATEGY
     processing_strategy_cls: (
-        ProcessingStrategyClassProvider | None | _InheritStrategy
+        ProcessingStrategyClassProvider | _InheritStrategy | None
     ) = _INHERIT_STRATEGY
-    loss_function: LossFunctionProvider | None | _InheritStrategy = _INHERIT_STRATEGY
+    loss_function: LossFunctionProvider | _InheritStrategy | None = _INHERIT_STRATEGY
 
 
 @dataclass(frozen=True)
@@ -233,22 +233,22 @@ class ModelRegistrationOverrides:
     the inherited provider. Field names mirror `ModelRegistrations`.
     """
 
-    weight_conversions: WeightConversionsProvider | None | _InheritStrategy = (
+    weight_conversions: WeightConversionsProvider | _InheritStrategy | None = (
         _INHERIT_STRATEGY
     )
-    patch_mappings: PatchMappingsProvider | None | _InheritStrategy = _INHERIT_STRATEGY
-    attention_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+    patch_mappings: PatchMappingsProvider | _InheritStrategy | None = _INHERIT_STRATEGY
+    attention_functions: InterfaceFunctionsProvider | _InheritStrategy | None = (
         _INHERIT_STRATEGY
     )
-    attention_mask_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+    attention_mask_functions: InterfaceFunctionsProvider | _InheritStrategy | None = (
         _INHERIT_STRATEGY
     )
-    experts_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+    experts_functions: InterfaceFunctionsProvider | _InheritStrategy | None = (
         _INHERIT_STRATEGY
     )
-    quantizers: QuantizersProvider | None | _InheritStrategy = _INHERIT_STRATEGY
-    auto_classes: AutoClassesProvider | None | _InheritStrategy = _INHERIT_STRATEGY
-    model_class_attrs: ModelClassAttrsProvider | None | _InheritStrategy = (
+    quantizers: QuantizersProvider | _InheritStrategy | None = _INHERIT_STRATEGY
+    auto_classes: AutoClassesProvider | _InheritStrategy | None = _INHERIT_STRATEGY
+    model_class_attrs: ModelClassAttrsProvider | _InheritStrategy | None = (
         _INHERIT_STRATEGY
     )
 

--- a/src/axolotl/model_support/profile.py
+++ b/src/axolotl/model_support/profile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, overload
@@ -35,6 +35,7 @@ class ModelHookPhase(str, Enum):
     BEFORE_MODEL_BUILD = "before_model_build"
     AFTER_BASE_MODEL_BUILD = "after_base_model_build"
     AFTER_ADAPTER_LOAD = "after_adapter_load"
+    BEFORE_SAVE = "before_save"
 
 
 @dataclass(frozen=True)
@@ -66,6 +67,48 @@ WeightConversionsProvider = Callable[
     [], "Mapping[str, Sequence[WeightTransform]] | None"
 ]
 PatchMappingsProvider = Callable[[], "Mapping[str, type[nn.Module]] | None"]
+InterfaceFunctionsProvider = Callable[[], "Mapping[str, Callable[..., Any]] | None"]
+QuantizersProvider = Callable[[], "Mapping[str, QuantizerRegistration] | None"]
+AutoClassesProvider = Callable[[], "Sequence[AutoClassRegistration] | None"]
+ModelClassAttrsProvider = Callable[[], "Mapping[type, Mapping[str, Any]] | None"]
+LossFunctionProvider = Callable[[], "Callable[..., Any] | None"]
+
+
+@dataclass(frozen=True)
+class QuantizerRegistration:
+    """One entry for transformers' quantizer registries.
+
+    Registered under its mapping key in ``AUTO_QUANTIZER_MAPPING`` (and
+    ``AUTO_QUANTIZATION_CONFIG_MAPPING`` when ``config_cls`` is set). An
+    existing different registration is overwritten with a warning; re-applying
+    the same classes is a no-op.
+    """
+
+    quantizer_cls: type
+    config_cls: type | None = None
+
+
+@dataclass(frozen=True)
+class AutoClassRegistration:
+    """One config class and its auto-class wiring.
+
+    ``model_classes`` maps auto-class names (``"AutoModelForCausalLM"``,
+    ``"AutoModelForImageTextToText"``, ...) to model classes; each must declare
+    ``config_class = config_cls``. Tokenizer and processor classes register
+    into their respective auto classes. All registrations use ``exist_ok`` so
+    repeated application is a no-op.
+    """
+
+    config_cls: type
+    model_classes: Mapping[str, type] = field(default_factory=dict)
+    slow_tokenizer_cls: type | None = None
+    fast_tokenizer_cls: type | None = None
+    processor_cls: type | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "model_classes", MappingProxyType(dict(self.model_classes))
+        )
 
 
 class _InheritStrategy:
@@ -89,23 +132,27 @@ class ModelStrategies:
 
     Each field is a zero-argument callable that returns a component class or ``None``.
     Providers should import optional or heavyweight implementations only when called.
+    ``loss_function`` instead returns a loss callable, set per model instance
+    (``model.loss_function``) right after the base model is built — no global
+    ``LOSS_MAPPING`` mutation.
     """
 
     auto_model_cls: AutoModelClassProvider | None = None
     processing_strategy_cls: ProcessingStrategyClassProvider | None = None
+    loss_function: LossFunctionProvider | None = None
 
     def with_overrides(self, overrides: ModelStrategyOverrides) -> ModelStrategies:
         return ModelStrategies(
-            auto_model_cls=(
-                self.auto_model_cls
-                if isinstance(overrides.auto_model_cls, _InheritStrategy)
-                else overrides.auto_model_cls
-            ),
-            processing_strategy_cls=(
-                self.processing_strategy_cls
-                if isinstance(overrides.processing_strategy_cls, _InheritStrategy)
-                else overrides.processing_strategy_cls
-            ),
+            **{
+                strategy_field.name: (
+                    getattr(self, strategy_field.name)
+                    if isinstance(
+                        getattr(overrides, strategy_field.name), _InheritStrategy
+                    )
+                    else getattr(overrides, strategy_field.name)
+                )
+                for strategy_field in fields(self)
+            }
         )
 
 
@@ -121,40 +168,60 @@ class ModelStrategyOverrides:
     processing_strategy_cls: (
         ProcessingStrategyClassProvider | None | _InheritStrategy
     ) = _INHERIT_STRATEGY
+    loss_function: LossFunctionProvider | None | _InheritStrategy = _INHERIT_STRATEGY
 
 
 @dataclass(frozen=True)
 class ModelRegistrations:
     """Lazy payloads for transformers' own extension registries.
 
-    ``weight_conversions`` maps a ``model_type`` or model class name to
-    ``WeightTransform`` entries registered via
-    ``transformers.conversion_mapping.register_checkpoint_conversion_mapping``;
-    ``patch_mappings`` maps class names (or regex patterns) to replacement
-    modules registered via
-    ``transformers.monkey_patching.register_patch_mapping``. Both are applied
-    idempotently before model build. A patch mapping that changes a module's
-    checkpoint layout must ship matching weight conversions, or loading and
-    saving break.
+    Every field is a zero-argument provider returning that registry's payload
+    (or ``None``); all are applied idempotently before model build:
+
+    - ``weight_conversions``: ``model_type`` or model class name to
+      ``WeightTransform`` entries, via
+      ``transformers.conversion_mapping.register_checkpoint_conversion_mapping``.
+    - ``patch_mappings``: class names (or regex patterns) to replacement
+      modules, via ``transformers.monkey_patching.register_patch_mapping``.
+      A patch mapping that changes a module's checkpoint layout must ship
+      matching weight conversions, or loading and saving break.
+    - ``attention_functions`` / ``attention_mask_functions``: implementation
+      name to callable, via ``ALL_ATTENTION_FUNCTIONS`` /
+      ``ALL_MASK_ATTENTION_FUNCTIONS``. Every attention implementation needs a
+      matching mask entry.
+    - ``experts_functions``: implementation name to callable, via
+      ``ALL_EXPERTS_FUNCTIONS`` (selected by ``config._experts_implementation``).
+    - ``quantizers``: quantization-method name to `QuantizerRegistration`.
+    - ``auto_classes``: `AutoClassRegistration` entries wiring config, model,
+      tokenizer, and processor classes into the transformers auto registries.
+    - ``model_class_attrs``: class to attribute overrides applied with
+      ``setattr`` (``_no_split_modules``, ``_keep_in_fp32_modules``,
+      config-side ``base_model_tp_plan``-style class vars, ...).
     """
 
     weight_conversions: WeightConversionsProvider | None = None
     patch_mappings: PatchMappingsProvider | None = None
+    attention_functions: InterfaceFunctionsProvider | None = None
+    attention_mask_functions: InterfaceFunctionsProvider | None = None
+    experts_functions: InterfaceFunctionsProvider | None = None
+    quantizers: QuantizersProvider | None = None
+    auto_classes: AutoClassesProvider | None = None
+    model_class_attrs: ModelClassAttrsProvider | None = None
 
     def with_overrides(
         self, overrides: ModelRegistrationOverrides
     ) -> ModelRegistrations:
         return ModelRegistrations(
-            weight_conversions=(
-                self.weight_conversions
-                if isinstance(overrides.weight_conversions, _InheritStrategy)
-                else overrides.weight_conversions
-            ),
-            patch_mappings=(
-                self.patch_mappings
-                if isinstance(overrides.patch_mappings, _InheritStrategy)
-                else overrides.patch_mappings
-            ),
+            **{
+                registry_field.name: (
+                    getattr(self, registry_field.name)
+                    if isinstance(
+                        getattr(overrides, registry_field.name), _InheritStrategy
+                    )
+                    else getattr(overrides, registry_field.name)
+                )
+                for registry_field in fields(self)
+            }
         )
 
 
@@ -163,13 +230,27 @@ class ModelRegistrationOverrides:
     """Per-model registration overrides layered over family registrations.
 
     An omitted field inherits its family provider. Explicit ``None`` removes
-    the inherited provider.
+    the inherited provider. Field names mirror `ModelRegistrations`.
     """
 
     weight_conversions: WeightConversionsProvider | None | _InheritStrategy = (
         _INHERIT_STRATEGY
     )
     patch_mappings: PatchMappingsProvider | None | _InheritStrategy = _INHERIT_STRATEGY
+    attention_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+        _INHERIT_STRATEGY
+    )
+    attention_mask_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+        _INHERIT_STRATEGY
+    )
+    experts_functions: InterfaceFunctionsProvider | None | _InheritStrategy = (
+        _INHERIT_STRATEGY
+    )
+    quantizers: QuantizersProvider | None | _InheritStrategy = _INHERIT_STRATEGY
+    auto_classes: AutoClassesProvider | None | _InheritStrategy = _INHERIT_STRATEGY
+    model_class_attrs: ModelClassAttrsProvider | None | _InheritStrategy = (
+        _INHERIT_STRATEGY
+    )
 
 
 @dataclass(frozen=True)

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -31,6 +31,12 @@ from axolotl.contribs.lgpl import (  # pylint: disable = no-name-in-module
 )
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders import ModelLoader, load_processor, load_tokenizer
+from axolotl.model_support import (
+    ModelHookContext,
+    ModelHookPhase,
+    get_model_support,
+    run_model_support_hooks,
+)
 from axolotl.telemetry.errors import send_errors
 from axolotl.telemetry.manager import TelemetryManager
 from axolotl.utils.ctx_managers.sequence_parallel import SequenceParallelContextManager
@@ -263,6 +269,8 @@ def save_trained_model(
     cfg: DictDefault,
     trainer: Any,
     model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer | None = None,
+    processor: ProcessorMixin | None = None,
 ):
     """
     Save the trained model according to configuration and training setup.
@@ -271,8 +279,18 @@ def save_trained_model(
         cfg: Dictionary mapping `axolotl` config keys to values.
         trainer: The trainer object.
         model: The trained model to save.
+        tokenizer: The tokenizer, for model-support save hooks.
+        processor: The processor, for model-support save hooks.
     """
     LOG.info(f"Training completed! Saving trained model to {cfg.output_dir}.")
+
+    run_model_support_hooks(
+        get_model_support(cfg.model_config_type),
+        ModelHookPhase.BEFORE_SAVE,
+        ModelHookContext(
+            cfg=cfg, model=model, tokenizer=tokenizer, processor=processor
+        ),
+    )
 
     # Post training module hooks
     for name, module in model.named_modules():
@@ -664,7 +682,7 @@ def train(
         torch.cuda.empty_cache()
 
     # Save the trained model and cleanup
-    save_trained_model(cfg, trainer, model)
+    save_trained_model(cfg, trainer, model, tokenizer=tokenizer, processor=processor)
     tokenizer.save_pretrained(
         str(Path(cfg.output_dir)), save_jinja_files=cfg.tokenizer_save_jinja_files
     )

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -284,14 +284,6 @@ def save_trained_model(
     """
     LOG.info(f"Training completed! Saving trained model to {cfg.output_dir}.")
 
-    run_model_support_hooks(
-        get_model_support(cfg.model_config_type),
-        ModelHookPhase.BEFORE_SAVE,
-        ModelHookContext(
-            cfg=cfg, model=model, tokenizer=tokenizer, processor=processor
-        ),
-    )
-
     # Post training module hooks
     for name, module in model.named_modules():
         if hasattr(module, "_post_training"):
@@ -318,6 +310,16 @@ def save_trained_model(
         else:
             # final model weights have already been saved by `ReLoRACallback.on_train_end`
             return
+
+    # After QAT conversion and any ReLoRA merge: save hooks get the model
+    # object the save paths below will actually serialize.
+    run_model_support_hooks(
+        get_model_support(cfg.model_config_type),
+        ModelHookPhase.BEFORE_SAVE,
+        ModelHookContext(
+            cfg=cfg, model=model, tokenizer=tokenizer, processor=processor
+        ),
+    )
 
     # EP-sharded expert LoRA: the adapter is split across the EP axis, so the normal
     # FSDP/PEFT save would persist only the local rank's experts. Gather across EP and

--- a/tests/test_model_support_registrations.py
+++ b/tests/test_model_support_registrations.py
@@ -430,7 +430,9 @@ def test_loss_function_strategy_sets_per_instance_loss(monkeypatch):
     assert not hasattr(plain_model, "loss_function")
 
 
-def test_before_save_hooks_dispatch_from_save_trained_model():
+def test_before_save_hooks_dispatch_with_the_finalized_model():
+    from types import SimpleNamespace
+
     from axolotl.model_support import ModelHookContext, ModelHookPhase
     from axolotl.train import save_trained_model
 
@@ -446,7 +448,19 @@ def test_before_save_hooks_dispatch_from_save_trained_model():
             hooks=ModelHooks({ModelHookPhase.BEFORE_SAVE: (_on_save,)}),
         )
 
-    class _FakeTrainedModel:
+    class _MergedModel:
+        pass
+
+    merged = _MergedModel()
+
+    class _ReloraModel:
+        def named_modules(self):
+            return []
+
+        def merge_and_unload(self):
+            return merged
+
+    class _AlreadySavedReloraModel:
         def named_modules(self):
             return []
 
@@ -457,17 +471,25 @@ def test_before_save_hooks_dispatch_from_save_trained_model():
     train_module.get_model_support = lambda model_type: (
         support if model_type == "registrations_save_test" else None
     )
-    model = _FakeTrainedModel()
+    trainer = SimpleNamespace(is_fsdp_enabled=False)
     processor = object()
     try:
-        # relora with no merge_and_unload returns right after the save hooks
+        # hooks run after the ReLoRA merge, with the model the save paths use
         save_trained_model(
             DictDefault(model_config_type="registrations_save_test", relora=True),
-            trainer=None,
-            model=model,
+            trainer=trainer,
+            model=_ReloraModel(),
             processor=processor,
         )
+        assert events == [(merged, processor)]
+
+        # the already-saved ReLoRA path returns before any save: no dispatch
+        save_trained_model(
+            DictDefault(model_config_type="registrations_save_test", relora=True),
+            trainer=trainer,
+            model=_AlreadySavedReloraModel(),
+            processor=processor,
+        )
+        assert events == [(merged, processor)]
     finally:
         train_module.get_model_support = original
-
-    assert events == [(model, processor)]

--- a/tests/test_model_support_registrations.py
+++ b/tests/test_model_support_registrations.py
@@ -1,5 +1,6 @@
 """Offline contracts for declarative transformers-registry payloads."""
 
+import pytest
 from torch import nn
 from transformers.conversion_mapping import get_checkpoint_conversion_mapping
 from transformers.core_model_loading import (
@@ -12,11 +13,15 @@ from transformers.monkey_patching import get_patch_mapping, unregister_patch_map
 import axolotl.loaders.patch_manager as patch_manager_module
 from axolotl.model_support import (
     VANILLA_CAUSAL_LM,
+    AutoClassRegistration,
     ModelFamilyTemplate,
+    ModelHooks,
     ModelProfile,
     ModelRegistrationOverrides,
     ModelRegistrations,
+    ModelStrategyOverrides,
     ModelSupport,
+    QuantizerRegistration,
     resolve_model_support,
 )
 from axolotl.utils.dict import DictDefault
@@ -176,3 +181,293 @@ def test_registration_free_profiles_do_not_touch_transformers(monkeypatch):
     unregistered = _patch_manager_for(monkeypatch, None, "registrations_absent_test")
     unregistered._apply_model_support_registrations()
     assert get_checkpoint_conversion_mapping("registrations_absent_test") is None
+
+
+def _fake_attention_fn(*args, **kwargs):
+    return None
+
+
+def _fake_mask_fn(*args, **kwargs):
+    return None
+
+
+def _fake_experts_fn(*args, **kwargs):
+    return None
+
+
+def test_interface_functions_register_into_transformers_interfaces(monkeypatch):
+    from transformers.integrations.moe import ALL_EXPERTS_FUNCTIONS
+    from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    class InterfaceSupport(ModelSupport):
+        model_types = ("registrations_interface_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            registrations=ModelRegistrationOverrides(
+                attention_functions=lambda: {
+                    "registrations_test_attn": _fake_attention_fn
+                },
+                attention_mask_functions=lambda: {
+                    "registrations_test_attn": _fake_mask_fn
+                },
+                experts_functions=lambda: {
+                    "registrations_test_experts": _fake_experts_fn
+                },
+            ),
+        )
+
+    manager = _patch_manager_for(
+        monkeypatch, InterfaceSupport(), "registrations_interface_test"
+    )
+    try:
+        manager._apply_model_support_registrations()
+        manager._apply_model_support_registrations()
+
+        assert ALL_ATTENTION_FUNCTIONS["registrations_test_attn"] is _fake_attention_fn
+        assert ALL_MASK_ATTENTION_FUNCTIONS["registrations_test_attn"] is _fake_mask_fn
+        assert ALL_EXPERTS_FUNCTIONS["registrations_test_experts"] is _fake_experts_fn
+    finally:
+        ALL_ATTENTION_FUNCTIONS._global_mapping.pop("registrations_test_attn", None)
+        ALL_MASK_ATTENTION_FUNCTIONS._global_mapping.pop(
+            "registrations_test_attn", None
+        )
+        ALL_EXPERTS_FUNCTIONS._global_mapping.pop("registrations_test_experts", None)
+
+
+def test_quantizer_registration_is_idempotent_and_overrides_with_warning(
+    monkeypatch, caplog
+):
+    from transformers.quantizers.auto import (
+        AUTO_QUANTIZATION_CONFIG_MAPPING,
+        AUTO_QUANTIZER_MAPPING,
+    )
+    from transformers.quantizers.base import HfQuantizer
+    from transformers.utils.quantization_config import QuantizationConfigMixin
+
+    class _FakeQuantizer(HfQuantizer):
+        def _process_model_before_weight_loading(self, model, **kwargs):
+            return model
+
+        def _process_model_after_weight_loading(self, model, **kwargs):
+            return model
+
+        def is_serializable(self, safe_serialization=None):
+            return True
+
+        @property
+        def is_trainable(self):
+            return True
+
+    class _OtherQuantizer(_FakeQuantizer):
+        pass
+
+    class _FakeQuantConfig(QuantizationConfigMixin):
+        pass
+
+    class QuantizerSupport(ModelSupport):
+        model_types = ("registrations_quantizer_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            registrations=ModelRegistrationOverrides(
+                quantizers=lambda: {
+                    "registrations_test_method": QuantizerRegistration(
+                        quantizer_cls=_FakeQuantizer,
+                        config_cls=_FakeQuantConfig,
+                    )
+                },
+            ),
+        )
+
+    manager = _patch_manager_for(
+        monkeypatch, QuantizerSupport(), "registrations_quantizer_test"
+    )
+    try:
+        manager._apply_model_support_registrations()
+        assert AUTO_QUANTIZER_MAPPING["registrations_test_method"] is _FakeQuantizer
+        assert (
+            AUTO_QUANTIZATION_CONFIG_MAPPING["registrations_test_method"]
+            is _FakeQuantConfig
+        )
+
+        with capture_axolotl_warnings(caplog):
+            manager._apply_model_support_registrations()
+        assert "Overriding quantizer" not in caplog.text
+
+        AUTO_QUANTIZER_MAPPING["registrations_test_method"] = _OtherQuantizer
+        with capture_axolotl_warnings(caplog):
+            manager._apply_model_support_registrations()
+        assert "Overriding quantizer" in caplog.text
+        assert AUTO_QUANTIZER_MAPPING["registrations_test_method"] is _FakeQuantizer
+    finally:
+        AUTO_QUANTIZER_MAPPING.pop("registrations_test_method", None)
+        AUTO_QUANTIZATION_CONFIG_MAPPING.pop("registrations_test_method", None)
+
+
+def test_auto_class_registration_wires_config_model_and_processor(monkeypatch):
+    from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedConfig
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+    from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
+
+    class _FakeAutoConfig(PreTrainedConfig):
+        model_type = "registrations_auto_test"
+
+    class _FakeAutoModel:
+        config_class = _FakeAutoConfig
+
+    class AutoClassSupport(ModelSupport):
+        model_types = ("registrations_auto_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            registrations=ModelRegistrationOverrides(
+                auto_classes=lambda: [
+                    AutoClassRegistration(
+                        config_cls=_FakeAutoConfig,
+                        model_classes={"AutoModelForCausalLM": _FakeAutoModel},
+                    )
+                ],
+            ),
+        )
+
+    manager = _patch_manager_for(
+        monkeypatch, AutoClassSupport(), "registrations_auto_test"
+    )
+    try:
+        manager._apply_model_support_registrations()
+        manager._apply_model_support_registrations()
+
+        assert AutoConfig.for_model("registrations_auto_test").__class__ is (
+            _FakeAutoConfig
+        )
+        assert AutoModelForCausalLM._model_mapping[_FakeAutoConfig] is _FakeAutoModel
+    finally:
+        CONFIG_MAPPING._extra_content.pop("registrations_auto_test", None)
+        MODEL_FOR_CAUSAL_LM_MAPPING._extra_content.pop(_FakeAutoConfig, None)
+
+
+def test_unknown_auto_class_name_raises(monkeypatch):
+    from transformers import PreTrainedConfig
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    class _BadAutoConfig(PreTrainedConfig):
+        model_type = "registrations_bad_auto_test"
+
+    class BadAutoClassSupport(ModelSupport):
+        model_types = ("registrations_bad_auto_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            registrations=ModelRegistrationOverrides(
+                auto_classes=lambda: [
+                    AutoClassRegistration(
+                        config_cls=_BadAutoConfig,
+                        model_classes={"AutoModelForNoSuchTask": object},
+                    )
+                ],
+            ),
+        )
+
+    manager = _patch_manager_for(
+        monkeypatch, BadAutoClassSupport(), "registrations_bad_auto_test"
+    )
+    try:
+        with pytest.raises(ValueError, match="AutoModelForNoSuchTask"):
+            manager._apply_model_support_registrations()
+    finally:
+        CONFIG_MAPPING._extra_content.pop("registrations_bad_auto_test", None)
+
+
+def test_model_class_attrs_are_applied_with_setattr(monkeypatch):
+    class _PatchTarget:
+        _no_split_modules = None
+
+    class ClassAttrSupport(ModelSupport):
+        model_types = ("registrations_class_attrs_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            registrations=ModelRegistrationOverrides(
+                model_class_attrs=lambda: {
+                    _PatchTarget: {
+                        "_no_split_modules": ["FakeDecoderLayer"],
+                        "supports_gradient_checkpointing": True,
+                    }
+                },
+            ),
+        )
+
+    manager = _patch_manager_for(
+        monkeypatch, ClassAttrSupport(), "registrations_class_attrs_test"
+    )
+    manager._apply_model_support_registrations()
+
+    assert _PatchTarget._no_split_modules == ["FakeDecoderLayer"]
+    assert _PatchTarget.supports_gradient_checkpointing is True
+
+
+def test_loss_function_strategy_sets_per_instance_loss(monkeypatch):
+    def _custom_loss(*args, **kwargs):
+        return None
+
+    class LossSupport(ModelSupport):
+        model_types = ("registrations_loss_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            strategies=ModelStrategyOverrides(loss_function=lambda: _custom_loss),
+        )
+
+    class _FakeModel:
+        pass
+
+    manager = _patch_manager_for(monkeypatch, LossSupport(), "registrations_loss_test")
+    model = _FakeModel()
+    manager._apply_model_support_loss_function(model)
+    assert model.loss_function is _custom_loss
+
+    plain_manager = _patch_manager_for(
+        monkeypatch, None, "registrations_loss_absent_test"
+    )
+    plain_model = _FakeModel()
+    plain_manager._apply_model_support_loss_function(plain_model)
+    assert not hasattr(plain_model, "loss_function")
+
+
+def test_before_save_hooks_dispatch_from_save_trained_model():
+    from axolotl.model_support import ModelHookContext, ModelHookPhase
+    from axolotl.train import save_trained_model
+
+    events = []
+
+    def _on_save(context: ModelHookContext) -> None:
+        events.append((context.model, context.processor))
+
+    class SaveHookSupport(ModelSupport):
+        model_types = ("registrations_save_test",)
+        profile = ModelProfile(
+            family=VANILLA_CAUSAL_LM,
+            hooks=ModelHooks({ModelHookPhase.BEFORE_SAVE: (_on_save,)}),
+        )
+
+    class _FakeTrainedModel:
+        def named_modules(self):
+            return []
+
+    import axolotl.train as train_module
+
+    support = SaveHookSupport()
+    original = train_module.get_model_support
+    train_module.get_model_support = lambda model_type: (
+        support if model_type == "registrations_save_test" else None
+    )
+    model = _FakeTrainedModel()
+    processor = object()
+    try:
+        # relora with no merge_and_unload returns right after the save hooks
+        save_trained_model(
+            DictDefault(model_config_type="registrations_save_test", relora=True),
+            trainer=None,
+            model=model,
+            processor=processor,
+        )
+    finally:
+        train_module.get_model_support = original
+
+    assert events == [(model, processor)]


### PR DESCRIPTION
# Description

Follow-up to #3884 completing the deferred transformers-seam list, so the model-support surface stabilizes before any model migrations.

## `ModelRegistrations`: six new registry seams

Same contract as the existing fields (lazy zero-argument providers; family → profile resolution; omitted inherits, explicit `None` clears; applied idempotently at the `BEFORE_MODEL_BUILD` boundary). `with_overrides` is now field-generic so future registries are one-line additions.

- `attention_functions` / `attention_mask_functions` → `ALL_ATTENTION_FUNCTIONS` / `ALL_MASK_ATTENTION_FUNCTIONS`. Declared as a pair for the same reason `weight_conversions`/`patch_mappings` are: every attention implementation needs a matching mask entry.
- `experts_functions` → `ALL_EXPERTS_FUNCTIONS` (selected via `config._experts_implementation`).
- `quantizers` → `QuantizerRegistration(quantizer_cls, config_cls)` written to `AUTO_QUANTIZER_MAPPING` / `AUTO_QUANTIZATION_CONFIG_MAPPING`. Written directly because `register_quantizer()` raises on any existing key: re-applying the same classes is a no-op, a different existing registration is overwritten with a warning. (The in-tree NVFP4 quantizer's `AUTO_QUANTIZER_MAPPING["fp8"]` dict-swap can migrate onto this.)
- `auto_classes` → `AutoClassRegistration` entries wiring a config class plus model / tokenizer / processor classes through `AutoConfig.register`, `AutoModelFor*.register`, `AutoTokenizer.register`, `AutoProcessor.register` with `exist_ok`. Unknown auto-class names raise. (Gives kimi-style in-tree modeling code a sanctioned registration path instead of dynamic-module interception.)
- `model_class_attrs` → plain `setattr` overrides for the class-level knobs that have no registration API: `_no_split_modules`, `_keep_in_fp32_modules(_strict)`, `_tied_weights_keys`, `supports_gradient_checkpointing`, and config-side `base_model_tp_plan` / `base_model_ep_plan` / `base_model_fsdp_plan` class vars.

## Per-instance loss strategy

`ModelStrategyOverrides(loss_function=provider)` sets `model.loss_function` (transformers' per-instance override, honored by its loss dispatch) right after base-model build — a per-architecture loss no longer requires mutating the global `LOSS_MAPPING`.

## `BEFORE_SAVE` hook phase

New lifecycle phase dispatched right before the trained model is saved (`save_trained_model`, which now receives tokenizer/processor) and before the legacy merge-lora path writes the merged model. Use it to undo or finalize model state for serialization. The memory-efficient merge never materializes a model instance and does not dispatch it (documented). No legacy-method equivalent.

## Processor-first hooks

Per the review discussion on #3869: hook docs now steer consumers to `context.processor` (transformers v5 direction), with `context.tokenizer` retained for text-only runs and compatibility; processor is threaded through every dispatch site including the new save phase.

Model migrations (kimi_linear, paddleocr_vl, nemotron_h branch, NVFP4 converters) are deliberately deferred until this API settles.

## How has this been tested?

- `tests/test_model_support_registrations.py` grown to cover every new seam: interface registration (idempotent re-apply), quantizer no-op/override-with-warning semantics, auto-class wiring incl. unknown-name error, `model_class_attrs` application, per-instance loss strategy, and `BEFORE_SAVE` dispatch from `save_trained_model`.
- Full model-support suite (84 tests) plus the loader/normalize-config/processing-strategy CPU tests, rebased on `main` at the #3884 merge (including its review tweaks: staticmethod warn helper, `capture_axolotl_warnings`).
- Pinned pre-commit suite (ruff, ruff-format, mypy, bandit) passing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-save lifecycle hook for trained and merged models.
  * Expanded model support to configure attention, masking, expert functions, quantizers, automatic class mappings, model attributes, and per-model loss functions.
  * Added public APIs for declaring these model integrations.
* **Documentation**
  * Clarified hook inheritance, save lifecycle behavior, registry integrations, and loss-function configuration.
* **Bug Fixes**
  * Ensured pre-save hooks receive the finalized model and are not dispatched redundantly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->