### PR TITLE
B200-tuned factored LoRA MLP kernel behind lora_mlp_kernel_b200 + dedicated B200 CI suite

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/*.yml"
       - "cicd/cicd.sh"
       - "cicd/cicd_cuda_kernels.sh"
+      - "cicd/cicd_b200.sh"
       - "cicd/Dockerfile-uv.jinja"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
@@ -24,6 +25,7 @@ on:
       - ".github/workflows/*.yml"
       - "cicd/cicd.sh"
       - "cicd/cicd_cuda_kernels.sh"
+      - "cicd/cicd_b200.sh"
       - "cicd/Dockerfile-uv.jinja"
   workflow_dispatch:
 
@@ -236,10 +238,61 @@ jobs:
         run: |
           modal run -m cicd.e2e_cuda_kernels
 
+  docker-e2e-b200-tests:
+    if: >
+      github.repository_owner == 'axolotl-ai-cloud' &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.gate-skip-e2e.outputs.skip != 'true'
+    runs-on: [self-hosted, modal]
+    timeout-minutes: 60
+    needs: [gate-skip-e2e, docker-e2e-tests-1st]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # B200 suite runs on cu130 images only, and only the b200-marked tests
+        # (see cicd/cicd_b200.sh) -- keep this matrix to a single entry to
+        # bound B200 spend.
+        include:
+          - cuda: 130
+            cuda_version: 13.0.0
+            python_version: "3.12"
+            pytorch: 2.12.1
+            num_gpus: 1
+            axolotl_extras:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Install Modal
+        run: |
+          python -m pip install --upgrade pip
+          pip install modal==1.3.0.post1 jinja2
+      - name: Update env vars
+        run: |
+          echo "BASE_TAG=main-base-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}" >> $GITHUB_ENV
+          echo "PYTORCH_VERSION=${{ matrix.pytorch}}" >> $GITHUB_ENV
+          echo "AXOLOTL_ARGS=${{ matrix.axolotl_args}}" >> $GITHUB_ENV
+          echo "AXOLOTL_EXTRAS=${{ matrix.axolotl_extras}}" >> $GITHUB_ENV
+          echo "CUDA=${{ matrix.cuda }}" >> $GITHUB_ENV
+          echo "MODAL_IMAGE_BUILDER_VERSION=2024.10" >> $GITHUB_ENV
+          echo "N_GPUS=${{ matrix.num_gpus }}" >> $GITHUB_ENV
+          echo "E2E_DOCKERFILE=${{ matrix.dockerfile || 'Dockerfile-uv.jinja'}}" >> $GITHUB_ENV
+      - name: Run B200 tests job on Modal
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          modal run -m cicd.e2e_b200
+
   docker-e2e-cleanup:
     runs-on: [self-hosted, modal]
     timeout-minutes: 90
-    needs: [docker-e2e-tests, docker-e2e-kernel-tests]
+    needs: [docker-e2e-tests, docker-e2e-kernel-tests, docker-e2e-b200-tests]
     if: ${{ !github.event.pull_request.draft }}
 
     strategy:

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -288,3 +288,52 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           modal run -m cicd.e2e_cuda_kernels
+
+  docker-e2e-b200-tests:
+    if: github.repository_owner == 'axolotl-ai-cloud'
+    runs-on: [self-hosted, modal]
+    timeout-minutes: 60
+    needs: [pre-commit, pytest]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # B200 suite runs on cu130 images only, and only the b200-marked tests
+        # (see cicd/cicd_b200.sh) -- keep this matrix to a single entry to
+        # bound B200 spend.
+        include:
+          - cuda: 130
+            cuda_version: 13.0.0
+            python_version: "3.12"
+            pytorch: 2.12.1
+            num_gpus: 1
+            axolotl_extras:
+            nightly_build: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+      - name: Install Modal
+        run: |
+          python -m pip install --upgrade pip
+          pip install modal==1.3.0.post1 jinja2
+      - name: Update env vars
+        run: |
+          echo "BASE_TAG=main-base-py${{ matrix.python_version }}-cu${{ matrix.cuda }}-${{ matrix.pytorch }}" >> $GITHUB_ENV
+          echo "PYTORCH_VERSION=${{ matrix.pytorch}}" >> $GITHUB_ENV
+          echo "AXOLOTL_ARGS=${{ matrix.axolotl_args}}" >> $GITHUB_ENV
+          echo "AXOLOTL_EXTRAS=${{ matrix.axolotl_extras}}" >> $GITHUB_ENV
+          echo "CUDA=${{ matrix.cuda }}" >> $GITHUB_ENV
+          echo "N_GPUS=${{ matrix.num_gpus }}" >> $GITHUB_ENV
+          echo "E2E_DOCKERFILE=${{ matrix.dockerfile || 'Dockerfile-uv.jinja'}}" >> $GITHUB_ENV
+          echo "NIGHTLY_BUILD=${{ matrix.nightly_build }}" >> $GITHUB_ENV
+      - name: Run B200 tests job on Modal
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          modal run -m cicd.e2e_b200

--- a/cicd/cicd.sh
+++ b/cicd/cicd.sh
@@ -80,11 +80,8 @@ pytest -v --durations=10 /workspace/axolotl/tests/cli \
   --cov=axolotl \
   --cov-append
 
-# Run remaining e2e tests with coverage append and final report.
-# b200-marked tests run in the dedicated B200 suite (cicd_b200.sh) only;
-# a CLI -m overrides the addopts -m, so "not slow" must be restated here.
+# Run remaining e2e tests with coverage append and final report
 pytest -v --durations=10 \
-  -m "not b200 and not slow" \
   --ignore=tests/e2e/solo/ \
   --ignore=tests/e2e/patched/ \
   --ignore=tests/e2e/multigpu/ \

--- a/cicd/cicd.sh
+++ b/cicd/cicd.sh
@@ -80,8 +80,11 @@ pytest -v --durations=10 /workspace/axolotl/tests/cli \
   --cov=axolotl \
   --cov-append
 
-# Run remaining e2e tests with coverage append and final report
+# Run remaining e2e tests with coverage append and final report.
+# b200-marked tests run in the dedicated B200 suite (cicd_b200.sh) only;
+# a CLI -m overrides the addopts -m, so "not slow" must be restated here.
 pytest -v --durations=10 \
+  -m "not b200 and not slow" \
   --ignore=tests/e2e/solo/ \
   --ignore=tests/e2e/patched/ \
   --ignore=tests/e2e/multigpu/ \

--- a/cicd/cicd_b200.sh
+++ b/cicd/cicd_b200.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+python -c "import torch; assert '$PYTORCH_VERSION' in torch.__version__, f'Expected torch $PYTORCH_VERSION but got {torch.__version__}'"
+
+# Certified launch environment for the B200 factored LoRA MLP kernel: cuBLAS
+# reads this once at handle creation, and the launch-budget goldens were
+# certified under it (workspace size influences cuBLAS algorithm selection).
+export CUBLAS_WORKSPACE_CONFIG=":4096:2"
+
+# No HF cache download: the B200 suite uses raw tensors and tiny in-memory
+# models only.
+
+pytest -v --durations=10 \
+  -m b200 \
+  /workspace/axolotl/tests/e2e/kernels/test_blackwell_lora_mlp.py \
+  --cov=axolotl \
+  --cov-report=xml:e2e-b200-coverage.xml
+
+codecov upload-process -t "$CODECOV_TOKEN" -f e2e-b200-coverage.xml -F e2e,b200,pytorch-${PYTORCH_VERSION} || true

--- a/cicd/e2e_b200.py
+++ b/cicd/e2e_b200.py
@@ -1,0 +1,22 @@
+"""Modal app to run the B200 (sm_100)-only test suite."""
+
+from .single_gpu import VOLUME_CONFIG, app, cicd_image, run_cmd
+
+
+@app.function(
+    image=cicd_image,
+    # Hardcoded on purpose: every test in this suite hard-gates on sm_100, so
+    # any other GPU type would silently skip everything and report green.
+    gpu="B200:1",
+    timeout=60 * 60,
+    cpu=8.0,
+    memory=131072,
+    volumes=VOLUME_CONFIG,
+)
+def cicd_b200():
+    run_cmd("./cicd/cicd_b200.sh", "/workspace/axolotl")
+
+
+@app.local_entrypoint()
+def main():
+    cicd_b200.remote()

--- a/docs/lora_optims.qmd
+++ b/docs/lora_optims.qmd
@@ -105,6 +105,67 @@ LoRA kernels do not support remote modeling code.
 Models with pre-existing LoRA adapters that use Dropout or have bias terms may need to
 be re-finetuned without these features in order to be useful.
 
+## B200-optimized LoRA MLP kernel (experimental)
+
+On NVIDIA B200 (sm_100, compute capability `(10, 0)`), an opt-in factored LoRA
+MLP kernel is available that replaces the standard SwiGLU MLP path with a
+B200-tuned cuBLAS + Triton implementation:
+
+```yaml
+adapter: lora
+lora_dropout: 0
+lora_mlp_kernel: true
+lora_mlp_kernel_b200: true
+```
+
+Certified (B200, bf16, Llama-3-8B MLP shape `4096x14336`, 4096
+tokens/micro-batch, ranks 8-64): 1.01-1.17x speed vs the reference factored
+implementation across grad-accumulation regimes, ~1.00-1.01x peak memory,
+29 kernel launches per fwd+bwd step (vs 38).
+
+The kernel is **hard-gated at runtime to compute capability `(10, 0)`**: on
+any other device (H100, sm_120 workstation Blackwell, etc.) the flag logs a
+warning and the standard `lora_mlp_kernel` path runs unmodified. The
+per-architecture tunings do not transfer, so no attempt is made to run it
+elsewhere.
+
+Requirements and limitations:
+
+- `adapter: lora` with bf16 base weights only. QLoRA / quantized bases are
+  unsupported and rejected at config validation.
+- SwiGLU MLPs only (`silu` activation); no LoRA dropout, no bias, no DoRA.
+- Not traceable by `torch.compile`: the kernel writes into non-contiguous
+  buffer slices, which Dynamo cannot trace. It is wrapped in
+  `torch.compiler.disable`, so a compiled model graph-breaks around the MLP
+  blocks rather than failing.
+- Untested with FSDP/DeepSpeed sharding (rejected at config validation) and
+  with sequence lengths / model shapes far outside the certified grid --
+  correctness is shape-independent, but the speed/memory wins were only
+  measured on the shapes above.
+- Numerical parity is certified at the single-block level (fp32-reference
+  Frobenius relative error < 2%). Treat full-run loss curves as your own
+  validation gate before relying on it for a production run.
+
+For the certified memory figures, set the cuBLAS workspace cap **in the
+process launch environment** (it is read once, at cuBLAS handle creation):
+
+```bash
+CUBLAS_WORKSPACE_CONFIG=":4096:2" axolotl train config.yaml
+```
+
+Axolotl also applies this value best-effort at config-validation time when
+unset, and never overrides an explicit different value. `":16:8"` is the
+bitwise-deterministic alternative (one of cuBLAS's two documented
+deterministic settings) with slightly lower memory and a narrower certified
+speed margin.
+
+Regression goldens (kernel launch counts and required/forbidden kernel names,
+keyed by compute capability) live in
+`tests/e2e/kernels/blackwell_launch_budgets.json`; the update procedure is
+documented in that file's `_meta.how_to_update` key. If a deliberate kernel
+change moves a number, re-certify and update the golden in place -- never
+widen an assertion to accept a range.
+
 ## Implementation details
 
 ### Custom autograd functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ markers = [
     "slow: marks tests as slow",
     "perf: marks tests as performance/memory regression guards (Blackwell only, large E)",
     "integration: marks tests as integration tests (real model modeling paths)",
+    "b200: marks tests that need a B200 (sm_100) GPU; run by the dedicated B200 CI suite, excluded elsewhere",
 ]
 
 # UV specific configuration

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -2363,6 +2363,12 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         "Apply custom LoRA autograd functions and activation function Triton kernels for speed and memory savings. See: https://docs.axolotl.ai/docs/lora_optims.html",
     ),
     (
+        ("--lora-mlp-kernel-b200/--no-lora-mlp-kernel-b200",),
+        None,
+        None,
+        "Opt-in B200-tuned factored LoRA MLP kernel. Requires lora_mlp_kernel, adapter: lora with bf16 base weights, a SwiGLU MLP, and lora_dropout: 0. Hard-gated to compute capability (10, 0) (B200/sm_100) at runtime; every other device falls back to the standard LoRA MLP kernel. See: https://docs.axolotl.ai/docs/lora_optims.html",
+    ),
+    (
         ("--lora-qkv-kernel/--no-lora-qkv-kernel",),
         None,
         None,

--- a/src/axolotl/kernels/blackwell/__init__.py
+++ b/src/axolotl/kernels/blackwell/__init__.py
@@ -1,0 +1,22 @@
+"""B200 (sm_100)-tuned LoRA kernels.
+
+The factored LoRA MLP kernel here is certified on B200 (compute capability
+(10, 0)) only — see `support.py` for the hard arch gate and
+`docs/lora_optims.qmd` for the certified envelope and limitations.
+"""
+
+from .support import (
+    CUBLAS_WORKSPACE_CONFIG_RECOMMENDED,
+    is_sm100,
+    lora_mlp_b200_config_eligible,
+    lora_mlp_b200_module_supported,
+    maybe_set_cublas_workspace_config,
+)
+
+__all__ = [
+    "CUBLAS_WORKSPACE_CONFIG_RECOMMENDED",
+    "is_sm100",
+    "lora_mlp_b200_config_eligible",
+    "lora_mlp_b200_module_supported",
+    "maybe_set_cublas_workspace_config",
+]

--- a/src/axolotl/kernels/blackwell/lora_mlp_factored.py
+++ b/src/axolotl/kernels/blackwell/lora_mlp_factored.py
@@ -119,6 +119,17 @@ class LoRA_MLP_B200_Factored(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dY):
+        # backward consumes its saved buffers in place (swiglu_backward_view
+        # mutates buf_eg; inplace=True writes dX into X's storage) and the
+        # Triton writes bypass autograd's version counters, so a second
+        # backward over the same graph would silently compute garbage.
+        if getattr(ctx, "_consumed", False):
+            raise RuntimeError(
+                "LoRA_MLP_B200_Factored does not support backward through the "
+                "same graph twice (saved buffers are consumed in place)"
+            )
+        ctx._consumed = True
+
         (X, buf_eg, XAg, XAu, hAd, A_gu, gate_A, gate_B, up_A, up_B, down_A, down_B) = (
             ctx.saved_tensors
         )

--- a/src/axolotl/kernels/blackwell/lora_mlp_factored.py
+++ b/src/axolotl/kernels/blackwell/lora_mlp_factored.py
@@ -1,0 +1,250 @@
+"""B200 (sm_100)-tuned factored LoRA MLP kernel.
+
+Computes the standard factored LoRA form per branch (no merged/augmented
+weight buffer, one weight copy):
+
+    e = X @ gate_W.T + gate_s * (X @ gate_A.T) @ gate_B.T
+    g = X @ up_W.T   + up_s   * (X @ up_A.T)   @ up_B.T
+    h = swiglu(e, g)
+    out = h @ down_W.T + down_s * (h @ down_A.T) @ down_B.T
+
+cuBLAS GEMMs throughout plus the stride-aware fused SwiGLU kernels in
+`swiglu_gateup`. Structural wins over the reference factored implementation:
+forward intermediates (XAg/XAu/hAd) are saved instead of re-derived in
+backward, the skinny adapter GEMMs are deduplicated and concatenated
+(X @ [gate_A.T | up_A.T] as one GEMM, and the dual on the dX accumulation),
+dX is built with 1 write + 2 read-modify-write passes instead of 1 + 3, the
+big base GEMMs are dispatched before the small adapter ops so the CPU can
+queue the small ops while the GPU is busy, and scalar multiplies are fused
+into their adjacent GEMM's addmm alpha.
+
+Certified on B200 (compute capability (10, 0)) ONLY, bf16 only, no dropout,
+no bias, no quantized base -- callers must gate on
+`support.lora_mlp_b200_config_eligible` / `lora_mlp_b200_module_supported`
+before dispatching here. Not traceable by torch.compile: the forward writes
+into non-contiguous buffer slices via `out=`, which Dynamo cannot trace, so
+the public wrapper is marked `torch.compiler.disable`.
+"""
+
+import torch
+
+from axolotl.utils.logging import get_logger
+
+from . import swiglu_gateup as sgv
+
+LOG = get_logger(__name__)
+
+
+def _scaled_matmul(A, B, scale):
+    """(A @ B) * scale as one GEMM via addmm's alpha (beta=0).
+
+    With beta=0 the input matrix is never read (standard BLAS semantics), so
+    an uninitialized dummy is safe, and torch.empty() launches no kernel --
+    this saves one elementwise-multiply launch per call vs
+    `scale * torch.matmul(A, B)`.
+    """
+    out_shape = (A.shape[0], B.shape[1])
+    dummy = torch.empty(out_shape, device=A.device, dtype=A.dtype)
+    return torch.addmm(dummy, A, B, alpha=scale, beta=0.0)
+
+
+class LoRA_MLP_B200_Factored(torch.autograd.Function):
+    """Factored LoRA SwiGLU MLP, B200-tuned. See module docstring."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        X,
+        gate_W,
+        gate_A,
+        gate_B,
+        gate_s,
+        up_W,
+        up_A,
+        up_B,
+        up_s,
+        down_W,
+        down_A,
+        down_B,
+        down_s,
+        inplace=True,
+    ):
+        reshape = X.dim() == 3
+        if reshape:
+            batch, seq_len, hd = X.shape
+            X = X.reshape(-1, hd)
+        T, HIDDEN = X.shape
+        INTER = gate_W.shape[0]
+        r = gate_A.shape[0]
+
+        # Dispatch the two big base GEMMs first: PyTorch's async dispatch needs
+        # a backlog of queued GPU work for the CPU to race ahead; starting with
+        # the small adapter ops leaves the GPU idle waiting on CPU dispatch.
+        # e/g's base terms depend only on X and the base weights, so ordering
+        # them before the adapter concat is safe.
+        buf_eg = torch.empty(T, 2 * INTER, device=X.device, dtype=X.dtype)
+        e = buf_eg[:, :INTER]
+        g = buf_eg[:, INTER:]
+        torch.matmul(X, gate_W.t(), out=e)
+        torch.matmul(X, up_W.t(), out=g)
+
+        # One skinny GEMM for both adapters: X @ [gate_A.T | up_A.T].
+        A_gu = torch.cat([gate_A, up_A], dim=0)  # [2r, HIDDEN]
+        XA_gu = torch.matmul(X, A_gu.t())  # [T, 2r]
+        XAg = XA_gu[:, :r]
+        XAu = XA_gu[:, r:]
+
+        e.addmm_(XAg, gate_B.t(), alpha=gate_s)
+        g.addmm_(XAu, up_B.t(), alpha=up_s)
+
+        h = torch.empty(T, INTER, device=X.device, dtype=X.dtype)
+        sgv.swiglu_forward_view(e, g, h)
+
+        # hAd is saved for backward -- recomputing it there would re-read all
+        # of h for a [T, r] result.
+        hAd = torch.matmul(h, down_A.t())  # [T, r]
+        out = torch.matmul(h, down_W.t())  # [T, HIDDEN]
+        out.addmm_(hAd, down_B.t(), alpha=down_s)
+
+        if reshape:
+            out = out.view(batch, seq_len, -1)
+
+        ctx.save_for_backward(
+            X, buf_eg, XAg, XAu, hAd, A_gu, gate_A, gate_B, up_A, up_B, down_A, down_B
+        )
+        ctx.mats = (gate_W, up_W, down_W, gate_s, up_s, down_s, r, HIDDEN, INTER)
+        ctx.reshape = (batch, seq_len, hd) if reshape else None
+        ctx.inplace = inplace
+        return out
+
+    @staticmethod
+    def backward(ctx, dY):
+        (X, buf_eg, XAg, XAu, hAd, A_gu, gate_A, gate_B, up_A, up_B, down_A, down_B) = (
+            ctx.saved_tensors
+        )
+        gate_W, up_W, down_W, gate_s, up_s, down_s, r, HIDDEN, INTER = ctx.mats
+
+        if ctx.reshape is not None:
+            batch, seq_len, hd = ctx.reshape
+            dY = dY.reshape(-1, hd)
+        T = dY.shape[0]
+
+        e = buf_eg[:, :INTER]
+        g = buf_eg[:, INTER:]
+
+        # Down projection: dhAd computed once, reused for d_down_A and dh.
+        dhAd = torch.matmul(dY, down_B)  # [T, r]
+        d_down_B = _scaled_matmul(dY.t(), hAd, down_s)  # [HIDDEN, r]
+
+        dh = torch.empty(T, INTER, device=X.device, dtype=X.dtype)
+        torch.matmul(dY, down_W, out=dh)
+        dh.addmm_(dhAd, down_A, alpha=down_s)
+
+        # Recomputes h (cheaper than saving it), mutates e->grad_gate,
+        # g->grad_up in place so buf_eg becomes [grad_gate|grad_up] adjacently.
+        h, grad_gate, grad_up = sgv.swiglu_backward_view(dh, e, g)
+
+        d_down_A = _scaled_matmul(dhAd.t(), h, down_s)  # [r, INTER]
+
+        # Up/gate: each dXA* computed once, reused for the adapter-A gradient
+        # and the dX accumulation.
+        dXAu = _scaled_matmul(grad_up, up_B, up_s)  # [T, r]
+        d_up_B = _scaled_matmul(grad_up.t(), XAu, up_s)  # [INTER, r]
+        d_up_A = torch.matmul(dXAu.t(), X)  # [r, HIDDEN]
+
+        dXAg = _scaled_matmul(grad_gate, gate_B, gate_s)  # [T, r]
+        d_gate_B = _scaled_matmul(grad_gate.t(), XAg, gate_s)  # [INTER, r]
+        d_gate_A = torch.matmul(dXAg.t(), X)  # [r, HIDDEN]
+
+        # dX: 1 write + 2 RMW passes. When inplace, dX reuses X's storage --
+        # safe because every read of X (d_up_A/d_gate_A above) has already
+        # happened, and it saves a full [T, HIDDEN] allocation.
+        dX = X if ctx.inplace else torch.empty_like(X)
+        torch.matmul(grad_up, up_W, out=dX)
+        dX.addmm_(grad_gate, gate_W)
+        dXA_gu = torch.cat([dXAg, dXAu], dim=1)  # [T, 2r]
+        dX.addmm_(dXA_gu, A_gu)
+
+        if ctx.reshape is not None:
+            dX = dX.view(batch, seq_len, hd)
+
+        return (
+            dX,
+            None,
+            d_gate_A,
+            d_gate_B,
+            None,
+            None,
+            d_up_A,
+            d_up_B,
+            None,
+            None,
+            d_down_A,
+            d_down_B,
+            None,
+            None,
+        )
+
+
+def _dropout_is_noop(dropout, training: bool) -> bool:
+    if dropout is None or not training:
+        return True
+    if isinstance(dropout, torch.nn.Identity):
+        return True
+    return getattr(dropout, "p", 0.0) == 0.0
+
+
+@torch.compiler.disable
+def apply_lora_mlp_swiglu_b200(self, X: torch.Tensor, inplace: bool = True):
+    """Module-swap forward for the B200 factored LoRA MLP kernel.
+
+    Patch-time gating (`support.lora_mlp_b200_config_eligible` /
+    `lora_mlp_b200_module_supported`) should make the fallback here
+    unreachable; it exists so a state change after patching (e.g. an adapter
+    toggled off) degrades to the standard kernel instead of wrong numbers.
+    """
+    from axolotl.kernels.lora import apply_lora_mlp_swiglu, get_lora_parameters
+
+    gate_W, gate_b, gate_q, gate_A, gate_B, gate_s, gate_lb, gate_drop, gate_mag = (
+        get_lora_parameters(self.gate_proj)
+    )
+    up_W, up_b, up_q, up_A, up_B, up_s, up_lb, _, up_mag = get_lora_parameters(
+        self.up_proj
+    )
+    down_W, down_b, down_q, down_A, down_B, down_s, down_lb, _, down_mag = (
+        get_lora_parameters(self.down_proj)
+    )
+
+    supported = (
+        all(t is None for t in (gate_b, up_b, down_b, gate_q, up_q, down_q))
+        and all(
+            t is None for t in (gate_lb, up_lb, down_lb, gate_mag, up_mag, down_mag)
+        )
+        and all(t is not None for t in (gate_A, gate_B, up_A, up_B, down_A, down_B))
+        and _dropout_is_noop(gate_drop, self.training)
+        and X.dtype == torch.bfloat16
+        and gate_W.dtype == torch.bfloat16
+    )
+    if not supported:
+        LOG.warning_once(
+            "lora_mlp_kernel_b200: MLP state changed after patching; using the "
+            "standard LoRA MLP kernel for this module"
+        )
+        return apply_lora_mlp_swiglu(self, X, inplace)
+
+    return LoRA_MLP_B200_Factored.apply(
+        X,
+        gate_W,
+        gate_A,
+        gate_B,
+        gate_s,
+        up_W,
+        up_A,
+        up_B,
+        up_s,
+        down_W,
+        down_A,
+        down_B,
+        down_s,
+        inplace,
+    )

--- a/src/axolotl/kernels/blackwell/support.py
+++ b/src/axolotl/kernels/blackwell/support.py
@@ -1,0 +1,115 @@
+"""Eligibility gates and environment setup for the B200 factored LoRA MLP kernel.
+
+Deliberately light on imports (torch only) so config validation can use these
+helpers without pulling in triton/bitsandbytes.
+"""
+
+import os
+import warnings
+
+import torch
+from torch import nn
+
+# The certified cuBLAS workspace cap for the B200 factored kernel: the largest
+# cap that keeps both certification axes -- speed (>1.0x vs the reference
+# factored implementation at every grad-accum K) and memory (<=1.02x).
+# ":16:8" is the bitwise-deterministic alternative with slightly lower memory
+# but a narrower speed margin.
+CUBLAS_WORKSPACE_CONFIG_RECOMMENDED = ":4096:2"
+
+
+def maybe_set_cublas_workspace_config() -> None:
+    """Best-effort application of the certified ``CUBLAS_WORKSPACE_CONFIG``.
+
+    cuBLAS reads this env var once, at handle creation (the first cuBLAS op in
+    the process), so the canonical place to set it is the process launch
+    environment. This helper applies it when unset, warns when it may be too
+    late, and never clobbers an explicit different value.
+    """
+    current = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    if current == CUBLAS_WORKSPACE_CONFIG_RECOMMENDED:
+        return
+    if current is not None:
+        warnings.warn(
+            f"CUBLAS_WORKSPACE_CONFIG is already set to {current!r} (not the "
+            f"recommended {CUBLAS_WORKSPACE_CONFIG_RECOMMENDED!r}) -- leaving "
+            "your explicit choice untouched, but the certified memory figures "
+            "for lora_mlp_kernel_b200 assume the recommended value.",
+            stacklevel=2,
+        )
+        return
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = CUBLAS_WORKSPACE_CONFIG_RECOMMENDED
+    if torch.cuda.is_initialized():
+        warnings.warn(
+            "CUBLAS_WORKSPACE_CONFIG was applied after CUDA initialization -- "
+            "cuBLAS may already have created handles, in which case the "
+            "setting has no effect. Set CUBLAS_WORKSPACE_CONFIG in the "
+            "process launch environment (before starting python) for the "
+            "certified lora_mlp_kernel_b200 memory figures to hold.",
+            stacklevel=2,
+        )
+
+
+def is_sm100() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+
+
+def lora_mlp_b200_config_eligible(lora_config, activation) -> tuple[bool, str]:
+    """Run-wide gate for the B200 factored MLP kernel, checked once at patch time.
+
+    Returns (eligible, reason-if-not). The arch gate is mandatory: every
+    certified number for this kernel is B200/sm_100-specific and tunings do
+    not transfer between compute-capability classes.
+    """
+    if not is_sm100():
+        cap = torch.cuda.get_device_capability() if torch.cuda.is_available() else None
+        return False, (
+            f"device compute capability {cap} is not (10, 0) (B200/sm_100); "
+            "the kernel is certified on B200 only"
+        )
+    if activation != "silu":
+        return False, f"activation {activation!r} is not silu/SwiGLU"
+    if lora_config.lora_dropout > 0:
+        return False, (
+            f"lora_dropout={lora_config.lora_dropout} is not implemented by "
+            "the B200 factored kernel"
+        )
+    if getattr(lora_config, "use_dora", False):
+        return False, "DoRA is not supported by the B200 factored kernel"
+    return True, ""
+
+
+def lora_mlp_b200_module_supported(
+    gate_proj: nn.Module, up_proj: nn.Module, down_proj: nn.Module
+) -> tuple[bool, str]:
+    """Per-MLP gate: bf16 dense base weights, LoRA adapters, no bias, no quant."""
+    for name, proj in (
+        ("gate_proj", gate_proj),
+        ("up_proj", up_proj),
+        ("down_proj", down_proj),
+    ):
+        if not hasattr(proj, "lora_A"):
+            return False, f"{name} has no LoRA adapter"
+        base_layer = proj.base_layer if hasattr(proj, "base_layer") else proj
+        weight = base_layer.weight
+        if getattr(weight, "quant_state", None) is not None:
+            return False, f"{name} has a quantized base weight"
+        if weight.dtype != torch.bfloat16:
+            return False, f"{name} base weight dtype {weight.dtype} is not bfloat16"
+        if base_layer.bias is not None:
+            return False, f"{name} has a base bias"
+        active_adapter = (
+            proj.active_adapters[0]
+            if hasattr(proj, "active_adapters")
+            else proj.active_adapter
+        )
+        linear_a = proj.lora_A[active_adapter]
+        linear_b = proj.lora_B[active_adapter]
+        if linear_b.bias is not None:
+            return False, f"{name} has a LoRA bias"
+        if (
+            linear_a.weight.dtype != torch.bfloat16
+            or linear_b.weight.dtype != torch.bfloat16
+        ):
+            return False, f"{name} LoRA adapter dtype is not bfloat16"
+    return True, ""

--- a/src/axolotl/kernels/blackwell/swiglu_gateup.py
+++ b/src/axolotl/kernels/blackwell/swiglu_gateup.py
@@ -108,9 +108,24 @@ def _swiglu_bwd_view_kernel(
     tl.store(up_ptr + om[:, None] * stride_um + on[None, :], grad_up, mask=mask)
 
 
+def _check_view_contract(*tensors: torch.Tensor) -> None:
+    # The kernels index ptr + row*stride_m + col: rows may be strided (column
+    # slices of a wider buffer) but the last dim must be unit-stride, and all
+    # operands must share a shape -- anything else silently corrupts.
+    shape = tensors[0].shape
+    for t in tensors:
+        if t.shape != shape or t.stride(1) != 1:
+            raise ValueError(
+                "swiglu_gateup kernels require same-shape 2D tensors with "
+                f"unit last-dim stride; got shape={tuple(t.shape)}, "
+                f"stride={t.stride()}"
+            )
+
+
 def swiglu_forward_view(
     gate: torch.Tensor, up: torch.Tensor, out: torch.Tensor
 ) -> torch.Tensor:
+    _check_view_contract(gate, up, out)
     M, N = gate.shape
     grid = lambda META: (  # noqa: E731
         triton.cdiv(M, META["BLOCK_M"]),
@@ -127,6 +142,7 @@ def swiglu_backward_view(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """In-place: returns (h, grad_gate, grad_up) as the mutated
     (grad_output, gate, up)."""
+    _check_view_contract(grad_output, gate, up)
     M, N = gate.shape
     grid = lambda META: (  # noqa: E731
         triton.cdiv(M, META["BLOCK_M"]),

--- a/src/axolotl/kernels/blackwell/swiglu_gateup.py
+++ b/src/axolotl/kernels/blackwell/swiglu_gateup.py
@@ -1,0 +1,138 @@
+"""Stride-aware fused SwiGLU forward/backward Triton kernels.
+
+Unlike the flat-indexed kernels in `axolotl.kernels.swiglu`, these take an
+explicit row stride so gate/up may be non-contiguous column slices of one
+shared ``[M, 2*INTER]`` buffer -- the adjacent-buffer layout the B200 factored
+LoRA MLP kernel relies on to make its backward concat free.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+# Small 2D tiles on purpose: large tiles (e.g. 32x1024) put far too many
+# elements in one program (register pressure / poor occupancy) and measured
+# ~16x slower than the flat baseline kernels.
+_CONFIGS = [
+    triton.Config({"BLOCK_M": bm, "BLOCK_N": bn}, num_warps=w)
+    for bm, bn in [
+        (4, 256),
+        (8, 256),
+        (4, 512),
+        (8, 512),
+        (16, 256),
+        (2, 1024),
+        (4, 1024),
+    ]
+    for w in [4, 8]
+]
+
+
+@triton.autotune(configs=_CONFIGS, key=["M", "N"])
+@triton.jit
+def _swiglu_fwd_view_kernel(
+    gate_ptr,
+    up_ptr,
+    out_ptr,
+    M,
+    N,
+    stride_gm,
+    stride_um,
+    stride_om,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    om = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    on = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (om[:, None] < M) & (on[None, :] < N)
+
+    gate = tl.load(
+        gate_ptr + om[:, None] * stride_gm + on[None, :], mask=mask, other=0.0
+    ).to(tl.float32)
+    up = tl.load(up_ptr + om[:, None] * stride_um + on[None, :], mask=mask, other=0.0)
+    f = gate * tl.sigmoid(gate)
+    f = f.to(up.dtype)
+    result = f * up
+    tl.store(out_ptr + om[:, None] * stride_om + on[None, :], result, mask=mask)
+
+
+# This kernel mutates its own inputs in place (grad_out/gate/up all become
+# outputs). Autotuning would rerun trials against progressively-mutated inputs
+# (-> NaN) without `restore_value`, which snapshots and restores the named
+# arguments around each trial.
+@triton.autotune(
+    configs=_CONFIGS,
+    key=["M", "N"],
+    restore_value=["grad_out_ptr", "gate_ptr", "up_ptr"],
+)
+@triton.jit
+def _swiglu_bwd_view_kernel(
+    grad_out_ptr,
+    gate_ptr,
+    up_ptr,
+    M,
+    N,
+    stride_dm,
+    stride_gm,
+    stride_um,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    om = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    on = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (om[:, None] < M) & (on[None, :] < N)
+
+    grad_out = tl.load(
+        grad_out_ptr + om[:, None] * stride_dm + on[None, :], mask=mask, other=0.0
+    )
+    gate = tl.load(
+        gate_ptr + om[:, None] * stride_gm + on[None, :], mask=mask, other=0.0
+    ).to(tl.float32)
+    up = tl.load(up_ptr + om[:, None] * stride_um + on[None, :], mask=mask, other=0.0)
+
+    sigmoid_gate = tl.sigmoid(gate)
+    silu_gate = sigmoid_gate * gate
+    silu_gate = silu_gate.to(grad_out.dtype)
+    h = silu_gate * up
+    grad_up = grad_out * silu_gate
+    temp = grad_out * up
+    grad_gate = temp.to(tl.float32) * sigmoid_gate * (1.0 + gate * (1.0 - sigmoid_gate))
+    grad_gate = grad_gate.to(grad_out.dtype)
+
+    tl.store(grad_out_ptr + om[:, None] * stride_dm + on[None, :], h, mask=mask)
+    tl.store(gate_ptr + om[:, None] * stride_gm + on[None, :], grad_gate, mask=mask)
+    tl.store(up_ptr + om[:, None] * stride_um + on[None, :], grad_up, mask=mask)
+
+
+def swiglu_forward_view(
+    gate: torch.Tensor, up: torch.Tensor, out: torch.Tensor
+) -> torch.Tensor:
+    M, N = gate.shape
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+    _swiglu_fwd_view_kernel[grid](
+        gate, up, out, M, N, gate.stride(0), up.stride(0), out.stride(0)
+    )
+    return out
+
+
+def swiglu_backward_view(
+    grad_output: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """In-place: returns (h, grad_gate, grad_up) as the mutated
+    (grad_output, gate, up)."""
+    M, N = gate.shape
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+    _swiglu_bwd_view_kernel[grid](
+        grad_output, gate, up, M, N, grad_output.stride(0), gate.stride(0), up.stride(0)
+    )
+    return grad_output, gate, up

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -533,8 +533,12 @@ def apply_lora_kernel_patches(
     # standard kernel path with a logged reason.
     use_b200_mlp = False
     apply_b200_mlp_fn = None
+    lora_mlp_b200_module_supported = None
     if cfg.lora_mlp_kernel and cfg.lora_mlp_kernel_b200:
-        from axolotl.kernels.blackwell import lora_mlp_b200_config_eligible
+        from axolotl.kernels.blackwell import (
+            lora_mlp_b200_config_eligible,
+            lora_mlp_b200_module_supported,
+        )
 
         use_b200_mlp, b200_reason = lora_mlp_b200_config_eligible(
             lora_config, activation
@@ -662,10 +666,6 @@ def apply_lora_kernel_patches(
                 if can_patch_mlp:
                     apply_fn = APPLY_FN_MAPPING[activation]
                     if use_b200_mlp:
-                        from axolotl.kernels.blackwell import (
-                            lora_mlp_b200_module_supported,
-                        )
-
                         supported, module_reason = lora_mlp_b200_module_supported(
                             gate_proj, up_proj, down_proj
                         )

--- a/src/axolotl/monkeypatch/lora_kernels.py
+++ b/src/axolotl/monkeypatch/lora_kernels.py
@@ -528,6 +528,32 @@ def apply_lora_kernel_patches(
 
     layers = get_layers(model)
 
+    # Opt-in B200 factored MLP kernel: hard-gated to sm_100 (and other
+    # certified-envelope conditions); anything else falls back to the
+    # standard kernel path with a logged reason.
+    use_b200_mlp = False
+    apply_b200_mlp_fn = None
+    if cfg.lora_mlp_kernel and cfg.lora_mlp_kernel_b200:
+        from axolotl.kernels.blackwell import lora_mlp_b200_config_eligible
+
+        use_b200_mlp, b200_reason = lora_mlp_b200_config_eligible(
+            lora_config, activation
+        )
+        if use_b200_mlp:
+            from axolotl.kernels.blackwell.lora_mlp_factored import (
+                apply_lora_mlp_swiglu_b200,
+            )
+
+            apply_b200_mlp_fn = apply_lora_mlp_swiglu_b200
+            LOG.info(
+                "lora_mlp_kernel_b200: using the B200 (sm_100) factored LoRA MLP kernel"
+            )
+        else:
+            LOG.warning(
+                f"lora_mlp_kernel_b200: falling back to the standard LoRA MLP "
+                f"kernel: {b200_reason}"
+            )
+
     linear_attn_patched_layers = 0
     linear_attn_patched_projs: set[str] = set()
 
@@ -635,6 +661,21 @@ def apply_lora_kernel_patches(
 
                 if can_patch_mlp:
                     apply_fn = APPLY_FN_MAPPING[activation]
+                    if use_b200_mlp:
+                        from axolotl.kernels.blackwell import (
+                            lora_mlp_b200_module_supported,
+                        )
+
+                        supported, module_reason = lora_mlp_b200_module_supported(
+                            gate_proj, up_proj, down_proj
+                        )
+                        if supported:
+                            apply_fn = apply_b200_mlp_fn
+                        else:
+                            LOG.warning_once(
+                                f"lora_mlp_kernel_b200: standard kernel for "
+                                f"unsupported MLP module(s): {module_reason}"
+                            )
                     layer.mlp.forward = types.MethodType(apply_fn, mlp)
                 else:
                     LOG.warning_once(

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -1914,6 +1914,13 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 "around the LoRA MLP blocks"
             )
 
+        if not (data.get("bf16") or data.get("bfloat16")):
+            LOG.warning(
+                "lora_mlp_kernel_b200 requires bf16 base weights; without "
+                "bf16: true the per-module checks will fall back to the "
+                "standard LoRA MLP kernel"
+            )
+
         capabilities = data.get("capabilities")
         compute_capability = (
             capabilities.get("compute_capability")
@@ -1925,15 +1932,17 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                 f"lora_mlp_kernel_b200: device is {compute_capability}, not sm_100 "
                 "(B200) - the standard LoRA MLP kernel will be used"
             )
+        else:
+            # Best-effort: cuBLAS reads this env var at handle creation, so the
+            # launch environment is the reliable place to set it (documented in
+            # docs/lora_optims.qmd); this covers the common single-process case.
+            # Skipped when the device is known not to be sm_100 -- the setting
+            # is process-wide and the B200 kernel won't run there.
+            from axolotl.kernels.blackwell.support import (
+                maybe_set_cublas_workspace_config,
+            )
 
-        # Best-effort: cuBLAS reads this env var at handle creation, so the
-        # launch environment is the reliable place to set it (documented in
-        # docs/lora_optims.qmd); this covers the common single-process case.
-        from axolotl.kernels.blackwell.support import (
-            maybe_set_cublas_workspace_config,
-        )
-
-        maybe_set_cublas_workspace_config()
+            maybe_set_cublas_workspace_config()
         return data
 
     @model_validator(mode="before")

--- a/src/axolotl/utils/schemas/config.py
+++ b/src/axolotl/utils/schemas/config.py
@@ -956,6 +956,12 @@ class AxolotlInputConfig(
             "description": "Apply custom LoRA autograd functions and activation function Triton kernels for speed and memory savings. See: https://docs.axolotl.ai/docs/lora_optims.html"
         },
     )
+    lora_mlp_kernel_b200: bool | None = Field(
+        default=None,
+        json_schema_extra={
+            "description": "Opt-in B200-tuned factored LoRA MLP kernel. Requires lora_mlp_kernel, adapter: lora with bf16 base weights, a SwiGLU MLP, and lora_dropout: 0. Hard-gated to compute capability (10, 0) (B200/sm_100) at runtime; every other device falls back to the standard LoRA MLP kernel. See: https://docs.axolotl.ai/docs/lora_optims.html"
+        },
+    )
     lora_qkv_kernel: bool | None = Field(
         default=None,
         json_schema_extra={
@@ -1869,6 +1875,65 @@ class AxolotlConfigWCapabilities(AxolotlInputConfig):
                     raise ValueError(
                         "lora_mlp_kernel, lora_qkv_kernel, and lora_o_kernel are not compatible with FSDP1."
                     )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_lora_mlp_kernel_b200(cls, data):
+        if not data.get("lora_mlp_kernel_b200"):
+            return data
+        if data.get("lora_mlp_kernel") is False:
+            raise ValueError("lora_mlp_kernel_b200 requires lora_mlp_kernel: true")
+        if data.get("adapter") != "lora":
+            raise ValueError(
+                "lora_mlp_kernel_b200 requires adapter: lora (bf16 dense base "
+                "weights; QLoRA/quantized bases are unsupported)"
+            )
+        if data.get("load_in_4bit") or data.get("load_in_8bit"):
+            raise ValueError(
+                "lora_mlp_kernel_b200 is incompatible with load_in_4bit/load_in_8bit "
+                "(bf16 dense base weights only)"
+            )
+        if data.get("lora_dropout"):
+            raise ValueError(
+                "lora_mlp_kernel_b200 does not implement LoRA dropout - set "
+                "lora_dropout: 0 or disable the kernel"
+            )
+        if data.get("peft_use_dora"):
+            raise ValueError("lora_mlp_kernel_b200 does not support DoRA")
+        if data.get("fsdp_config") or data.get("deepspeed"):
+            raise ValueError(
+                "lora_mlp_kernel_b200 has not been validated with FSDP/DeepSpeed "
+                "sharding - disable one of them"
+            )
+        if data.get("lora_mlp_kernel") is None:
+            data["lora_mlp_kernel"] = True
+        if data.get("torch_compile"):
+            LOG.warning(
+                "lora_mlp_kernel_b200 runs eager; torch.compile will graph-break "
+                "around the LoRA MLP blocks"
+            )
+
+        capabilities = data.get("capabilities")
+        compute_capability = (
+            capabilities.get("compute_capability")
+            if isinstance(capabilities, dict)
+            else getattr(capabilities, "compute_capability", None)
+        )
+        if compute_capability and compute_capability != "sm_100":
+            LOG.warning(
+                f"lora_mlp_kernel_b200: device is {compute_capability}, not sm_100 "
+                "(B200) - the standard LoRA MLP kernel will be used"
+            )
+
+        # Best-effort: cuBLAS reads this env var at handle creation, so the
+        # launch environment is the reliable place to set it (documented in
+        # docs/lora_optims.qmd); this covers the common single-process case.
+        from axolotl.kernels.blackwell.support import (
+            maybe_set_cublas_workspace_config,
+        )
+
+        maybe_set_cublas_workspace_config()
         return data
 
     @model_validator(mode="before")

--- a/tests/e2e/kernels/blackwell_launch_budgets.json
+++ b/tests/e2e/kernels/blackwell_launch_budgets.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "purpose": "Golden kernel-launch-count/name budgets for the B200 factored LoRA MLP kernel (axolotl.kernels.blackwell), keyed by compute capability. test_blackwell_lora_mlp.py asserts measured == budget for a single fully-warmed fwd+bwd step. An INCREASE fails loudly (silent launch-count creep is the exact mechanism that historically produced multi-percent speed regressions in this kernel's lineage); a DECREASE also fails, with a distinct message, so genuine improvements get locked in deliberately rather than drifting the budget without re-certifying the rest of the suite.",
+    "how_to_update": "When a deliberate kernel change moves a number: (1) run the launch-budget test on the target hardware; the failure message reports the measured launch count; (2) verify with torch.profiler that the delta is explained by your change (inspect the per-kernel-name list); (3) update 'launches' (and 'total_self_cuda_us', informational) to the NEW measured values; (4) update required/forbidden kernel substrings if the kernel-name set changed; (5) update 'locked' with the date and a one-line reason; (6) re-run the full blackwell kernel test file, not just the budget test. Never widen an assertion to accept a range.",
+    "provenance": "Ported from the B200 LoRA-kernel optimization campaign handoff (lora_kernel_experiments/b200_handoff, M15 final state, locked 2026-07-26). Certified envelope: B200 (sm_100), bf16, BATCH=8 SEQ=512 (4096 tokens), HIDDEN=4096 INTER=14336, rank 16 for the budget entry."
+  },
+  "sm_100": {
+    "lora_mlp_factored_fwdbwd_r16_M4096": {
+      "launches": 29,
+      "total_self_cuda_us": 2350.84,
+      "locked": "2026-07-26 (campaign M15 final; ported into axolotl 2026-07-28)",
+      "required_kernel_substrings": [
+        "nvjet_sm100",
+        "_swiglu_fwd_view_kernel",
+        "_swiglu_bwd_view_kernel",
+        "splitKreduce_kernel"
+      ],
+      "forbidden_kernel_substrings": [
+        "_fg_kernel",
+        "_DWf_DW_dfg_kernel",
+        "MulFunctor"
+      ],
+      "forbidden_kernel_note": "_fg_kernel/_DWf_DW_dfg_kernel are third-party fused-SwiGLU kernel names -- their appearance would indicate an import mixup. MulFunctor would mean a scalar multiply regressed out of its GEMM's addmm alpha into a separate elementwise kernel."
+    }
+  },
+  "perf_vs_axolotl_lora_mlp": {
+    "sm_100": {
+      "threshold_min_ratio": null,
+      "note": "Relative wall-clock ratio (axolotl standard LoRA_MLP time / B200 factored time) for a K=8 fwd+bwd loop at rank 16, min-of-3 interleaved trials after warmup. null = not yet certified: the campaign certified the kernel against external reference implementations and its own internal baseline, never against axolotl's LoRA_MLP. To certify: run test_perf_vs_axolotl_lora_mlp on a B200; it skips but reports the measured ratio; set threshold_min_ratio to a value safely below the observed ratio (the campaign used ~0.05-0.15 headroom below the certified minimum across ranks) and record the date here. Never an absolute-ms threshold: node-to-node clock/thermal variance is ~15%."
+    }
+  }
+}

--- a/tests/e2e/kernels/test_blackwell_lora_mlp.py
+++ b/tests/e2e/kernels/test_blackwell_lora_mlp.py
@@ -6,6 +6,10 @@ equivalence vs the standard LoRA_MLP kernel) run on any CUDA device -- the
 math is architecture-portable. Launch-budget and perf tests are keyed by
 compute capability in blackwell_launch_budgets.json and only run where a
 golden exists (sm_100).
+
+The module-level `b200` mark selects this file for the dedicated B200 CI lane
+(cicd/cicd_b200.sh, `-m b200`) so the goldens run on certified hardware; the
+file also runs in the general GPU e2e lanes, where the sm_100-only tests skip.
 """
 
 import json
@@ -166,6 +170,16 @@ def test_live_outputs_canary():
         assert g is not None, f"{name}'s gradient is None"
         assert torch.isfinite(g).all(), f"{name}'s gradient contains NaN/Inf"
         assert g.abs().sum() > 0, f"{name}'s gradient is all-zero"
+
+
+def test_second_backward_through_same_graph_raises():
+    """backward consumes its saved buffers in place; a retain_graph
+    re-backward must fail loudly instead of returning garbage."""
+    X, grad_out, p, names, ts = _make_case()
+    out = _apply_factored(X, p)
+    torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out, retain_graph=True)
+    with pytest.raises(RuntimeError, match="twice"):
+        torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out)
 
 
 def test_no_unfused_scalar_multiply_kernel():
@@ -406,12 +420,13 @@ def _patch_and_get_mlp_forward(cfg_overrides=None):
     return get_layers(model)[0].mlp.forward
 
 
-@pytest.mark.skipif(
-    torch.cuda.get_device_capability() == (10, 0), reason="requires a non-B200 device"
-)
 def test_patching_falls_back_on_non_sm100():
     """G2: with the flag on but on a non-sm_100 device, the patcher must
     select the standard kernel -- no exception, no silent wrong path."""
+    # checked in the body, not a skipif arg: decorator args evaluate at
+    # collection time and get_device_capability raises on CPU-only hosts
+    if torch.cuda.get_device_capability() == (10, 0):
+        pytest.skip("requires a non-B200 device")
     forward = _patch_and_get_mlp_forward()
     assert forward.__func__ is apply_lora_mlp_swiglu
 

--- a/tests/e2e/kernels/test_blackwell_lora_mlp.py
+++ b/tests/e2e/kernels/test_blackwell_lora_mlp.py
@@ -24,7 +24,10 @@ from axolotl.kernels.blackwell.lora_mlp_factored import (
 from axolotl.kernels.blackwell.support import lora_mlp_b200_module_supported
 from axolotl.kernels.lora import apply_lora_mlp_swiglu
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required"),
+    pytest.mark.b200,
+]
 
 _BUDGETS = json.loads(
     (pathlib.Path(__file__).parent / "blackwell_launch_budgets.json").read_text()

--- a/tests/e2e/kernels/test_blackwell_lora_mlp.py
+++ b/tests/e2e/kernels/test_blackwell_lora_mlp.py
@@ -1,0 +1,500 @@
+"""Tests for the B200 factored LoRA MLP kernel (axolotl.kernels.blackwell).
+
+Ported from the B200 optimization campaign's regression suite. Correctness
+tests (fp32-reference parity, live-gradients canary, scalar-fusion guard,
+equivalence vs the standard LoRA_MLP kernel) run on any CUDA device -- the
+math is architecture-portable. Launch-budget and perf tests are keyed by
+compute capability in blackwell_launch_budgets.json and only run where a
+golden exists (sm_100).
+"""
+
+import json
+import pathlib
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+from torch.profiler import ProfilerActivity, profile
+
+from axolotl.kernels.blackwell.lora_mlp_factored import (
+    LoRA_MLP_B200_Factored,
+    apply_lora_mlp_swiglu_b200,
+)
+from axolotl.kernels.blackwell.support import lora_mlp_b200_module_supported
+from axolotl.kernels.lora import apply_lora_mlp_swiglu
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+_BUDGETS = json.loads(
+    (pathlib.Path(__file__).parent / "blackwell_launch_budgets.json").read_text()
+)
+
+# The campaign's certified shape grid (Llama-3-8B MLP, 4096 tokens/micro-batch)
+HIDDEN, INTER = 4096, 14336
+BATCH, SEQ = 8, 512
+RANKS = [8, 16, 32, 64]
+RANK = 16
+
+
+def _device_key():
+    major, minor = torch.cuda.get_device_capability()
+    return f"sm_{major}{minor}"
+
+
+def make_params(rank, dtype=torch.bfloat16, seed=0, scale=2.0):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+
+    def rnd(*shape, req=False, std=1.0):
+        t = torch.randn(*shape, device="cuda", dtype=dtype, generator=g) * std
+        t.requires_grad_(req)
+        return t
+
+    p = {}
+    p["gate_W"] = rnd(INTER, HIDDEN, std=HIDDEN**-0.5)
+    p["up_W"] = rnd(INTER, HIDDEN, std=HIDDEN**-0.5)
+    p["down_W"] = rnd(HIDDEN, INTER, std=INTER**-0.5)
+    for proj, (fin, fout) in {
+        "gate": (HIDDEN, INTER),
+        "up": (HIDDEN, INTER),
+        "down": (INTER, HIDDEN),
+    }.items():
+        p[f"{proj}_A"] = rnd(rank, fin, req=True, std=fin**-0.5)
+        p[f"{proj}_B"] = rnd(fout, rank, req=True, std=0.5)
+        p[f"{proj}_s"] = scale / rank
+    return p
+
+
+def _grad_tensors(p):
+    names, tensors = [], []
+    for proj in ("gate", "up", "down"):
+        for suf in ("A", "B"):
+            names.append(f"{proj}_{suf}")
+            tensors.append(p[f"{proj}_{suf}"])
+    return names, tensors
+
+
+def frob(a, b):
+    return (
+        torch.linalg.norm((a.float() - b.float()).flatten())
+        / (torch.linalg.norm(b.float().flatten()) + 1e-9)
+    ).item()
+
+
+def _apply_factored(X, p):
+    return LoRA_MLP_B200_Factored.apply(
+        X,
+        p["gate_W"],
+        p["gate_A"],
+        p["gate_B"],
+        p["gate_s"],
+        p["up_W"],
+        p["up_A"],
+        p["up_B"],
+        p["up_s"],
+        p["down_W"],
+        p["down_A"],
+        p["down_B"],
+        p["down_s"],
+    )
+
+
+def _make_case(rank=RANK):
+    torch.manual_seed(0)
+    X = torch.randn(
+        BATCH, SEQ, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    grad_out = torch.randn(BATCH, SEQ, HIDDEN, device="cuda", dtype=torch.bfloat16)
+    p = make_params(rank)
+    names, ts = _grad_tensors(p)
+    return X, grad_out, p, names, ts
+
+
+@pytest.mark.parametrize("rank", RANKS)
+def test_fp32_reference_parity_factored_math(rank):
+    """Frobenius relative error vs an fp32 reference computing the same
+    factored algebraic form -- the campaign's standing correctness bar."""
+    X, grad_out, p, names, ts = _make_case(rank)
+
+    P = {
+        k: (
+            v.detach().float().requires_grad_(True)
+            if torch.is_tensor(v) and v.requires_grad
+            else (v.detach().float() if torch.is_tensor(v) else v)
+        )
+        for k, v in p.items()
+    }
+    Xf = X.detach().float().requires_grad_(True)
+
+    def factored_proj(x, W, A, B, s):
+        return x @ W.t() + s * ((x @ A.t()) @ B.t())
+
+    e = factored_proj(Xf, P["gate_W"], P["gate_A"], P["gate_B"], P["gate_s"])
+    g = factored_proj(Xf, P["up_W"], P["up_A"], P["up_B"], P["up_s"])
+    h = e * torch.sigmoid(e) * g
+    out_ref = factored_proj(h, P["down_W"], P["down_A"], P["down_B"], P["down_s"])
+    ref_ts = [P[n] for n in names]
+    grads_ref = torch.autograd.grad(
+        out_ref, [Xf] + ref_ts, grad_outputs=grad_out.float()
+    )
+
+    out = _apply_factored(X, p)
+    grads = torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out)
+
+    tol = 2e-2
+    assert frob(out, out_ref) < tol, f"rank={rank}: forward output outside tolerance"
+    assert frob(grads[0], grads_ref[0]) < tol, f"rank={rank}: dX outside tolerance"
+    for name, g_, g_ref in zip(names, grads[1:], grads_ref[1:], strict=False):
+        assert frob(g_, g_ref) < tol, f"rank={rank}: {name} gradient outside tolerance"
+
+
+def test_live_outputs_canary():
+    """Every parameter must actually receive a finite, non-zero gradient --
+    guards against dead-code-elimination making a broken kernel look fast."""
+    X, grad_out, p, names, ts = _make_case()
+    out = _apply_factored(X, p)
+    grads = torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out)
+
+    dX = grads[0]
+    assert dX is not None and torch.isfinite(dX).all() and dX.abs().sum() > 0, (
+        "dX is None/non-finite/all-zero"
+    )
+    for name, g in zip(names, grads[1:], strict=False):
+        assert g is not None, f"{name}'s gradient is None"
+        assert torch.isfinite(g).all(), f"{name}'s gradient contains NaN/Inf"
+        assert g.abs().sum() > 0, f"{name}'s gradient is all-zero"
+
+
+def test_no_unfused_scalar_multiply_kernel():
+    """The six scalar multiplies must stay fused into their GEMM's addmm
+    alpha -- a separate MulFunctor elementwise kernel means a regression."""
+    X, grad_out, p, names, ts = _make_case()
+
+    def step():
+        out = _apply_factored(X, p)
+        torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out, retain_graph=False)
+
+    for _ in range(10):
+        step()
+    torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        step()
+        torch.cuda.synchronize()
+
+    events = prof.key_averages()
+    names_seen = [
+        e.key
+        for e in events
+        if e.device_type == torch.autograd.DeviceType.CUDA and e.count > 0
+    ]
+    assert not any("MulFunctor" in name for name in names_seen), (
+        "found a separate elementwise-multiply kernel (MulFunctor) -- "
+        "scalar-multiply fusion via addmm alpha appears to have regressed"
+    )
+
+
+def test_launch_count_budget():
+    """Golden launch-count/kernel-name budget, keyed by compute capability.
+    Skips on devices without a certified golden (currently sm_100 only)."""
+    device_key = _device_key()
+    budget_key = "lora_mlp_factored_fwdbwd_r16_M4096"
+    if device_key not in _BUDGETS or budget_key not in _BUDGETS[device_key]:
+        pytest.skip(f"no launch budget recorded for {device_key}")
+    budget = _BUDGETS[device_key][budget_key]
+
+    X, grad_out, p, names, ts = _make_case()
+
+    def step():
+        out = _apply_factored(X, p)
+        torch.autograd.grad(out, [X] + ts, grad_outputs=grad_out, retain_graph=False)
+
+    for _ in range(10):
+        step()
+    torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        step()
+        torch.cuda.synchronize()
+
+    events = prof.key_averages()
+    cuda_events = [
+        e
+        for e in events
+        if e.device_type == torch.autograd.DeviceType.CUDA and e.count > 0
+    ]
+    total_launches = sum(e.count for e in cuda_events)
+    names_seen = [e.key for e in cuda_events]
+
+    if total_launches > budget["launches"]:
+        pytest.fail(
+            f"LAUNCH COUNT REGRESSION: measured {total_launches}, budget "
+            f"{budget['launches']} (locked {budget['locked']}). See "
+            f"blackwell_launch_budgets.json _meta.how_to_update."
+        )
+    if total_launches < budget["launches"]:
+        pytest.fail(
+            f"BUDGET CAN BE LOWERED: measured {total_launches}, budget "
+            f"{budget['launches']} (locked {budget['locked']}) -- re-certify "
+            f"deliberately per blackwell_launch_budgets.json _meta.how_to_update."
+        )
+    for required in budget["required_kernel_substrings"]:
+        assert any(required in name for name in names_seen), (
+            f"required kernel '{required}' not found -- kernel set may have drifted"
+        )
+    for forbidden in budget["forbidden_kernel_substrings"]:
+        assert not any(forbidden in name for name in names_seen), (
+            f"forbidden kernel '{forbidden}' found -- "
+            f"{budget.get('forbidden_kernel_note', '')}"
+        )
+
+
+class MockLoRAProj(nn.Module):
+    """Minimal PEFT-lora-shaped projection for get_lora_parameters."""
+
+    def __init__(self, in_features, out_features, rank, dtype=torch.bfloat16):
+        super().__init__()
+        self.base_layer = nn.Linear(
+            in_features, out_features, bias=False, dtype=dtype, device="cuda"
+        )
+        self.lora_A = nn.ModuleDict(
+            {
+                "default": nn.Linear(
+                    in_features, rank, bias=False, dtype=dtype, device="cuda"
+                )
+            }
+        )
+        self.lora_B = nn.ModuleDict(
+            {
+                "default": nn.Linear(
+                    rank, out_features, bias=False, dtype=dtype, device="cuda"
+                )
+            }
+        )
+        self.scaling = {"default": 2.0 / rank}
+        self.active_adapter = "default"
+        self.disable_adapters = False
+        self.merged = False
+        self.lora_dropout = nn.ModuleDict({"default": nn.Identity()})
+
+
+class MockMLP(nn.Module):
+    """gate/up/down container matching what the MLP patch binds against."""
+
+    def __init__(self, hidden=512, inter=1024, rank=8):
+        super().__init__()
+        self.gate_proj = MockLoRAProj(hidden, inter, rank)
+        self.up_proj = MockLoRAProj(hidden, inter, rank)
+        self.down_proj = MockLoRAProj(inter, hidden, rank)
+
+
+def test_matches_standard_lora_mlp_kernel():
+    """The B200 wrapper and axolotl's standard LoRA_MLP path must agree on
+    the same weights within the campaign's fp32-parity bar."""
+    torch.manual_seed(0)
+    mlp = MockMLP()
+    X1 = torch.randn(
+        2, 128, 512, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    X2 = X1.detach().clone().requires_grad_(True)
+
+    supported, reason = lora_mlp_b200_module_supported(
+        mlp.gate_proj, mlp.up_proj, mlp.down_proj
+    )
+    assert supported, reason
+
+    # inplace=False: both paths' backward would otherwise write dX into their
+    # own X storage, which is fine in training but makes comparison awkward
+    out_std = apply_lora_mlp_swiglu(mlp, X1, inplace=False)
+    out_b200 = apply_lora_mlp_swiglu_b200(mlp, X2, inplace=False)
+    assert frob(out_b200, out_std) < 2e-2
+
+    grad_out = torch.randn_like(out_std)
+    lora_params = [
+        proj.lora_A["default"].weight
+        for proj in (mlp.gate_proj, mlp.up_proj, mlp.down_proj)
+    ] + [
+        proj.lora_B["default"].weight
+        for proj in (mlp.gate_proj, mlp.up_proj, mlp.down_proj)
+    ]
+    grads_std = torch.autograd.grad(
+        out_std, [X1] + lora_params, grad_outputs=grad_out, retain_graph=False
+    )
+    grads_b200 = torch.autograd.grad(
+        out_b200, [X2] + lora_params, grad_outputs=grad_out, retain_graph=False
+    )
+    for g_std, g_b200 in zip(grads_std, grads_b200, strict=True):
+        assert frob(g_b200, g_std) < 2e-2
+
+
+def test_wrapper_falls_back_when_module_unsupported():
+    """A post-patch state change (here: active dropout) must degrade to the
+    standard kernel, not produce silently wrong numbers."""
+    torch.manual_seed(0)
+    mlp = MockMLP()
+    mlp.gate_proj.lora_dropout = nn.ModuleDict({"default": nn.Dropout(0.5)})
+    mlp.train()
+    X = torch.randn(
+        2, 128, 512, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+
+    with patch(
+        "axolotl.kernels.lora.apply_lora_mlp_swiglu",
+        wraps=apply_lora_mlp_swiglu,
+    ) as spy:
+        apply_lora_mlp_swiglu_b200(mlp, X)
+    assert spy.called, "expected fallback to the standard LoRA MLP kernel"
+
+
+def test_module_supported_rejects_non_bf16():
+    mlp = MockMLP()
+    mlp.gate_proj.base_layer.weight.data = mlp.gate_proj.base_layer.weight.data.float()
+    supported, reason = lora_mlp_b200_module_supported(
+        mlp.gate_proj, mlp.up_proj, mlp.down_proj
+    )
+    assert not supported
+    assert "bfloat16" in reason
+
+
+def _tiny_peft_llama():
+    from peft import LoraConfig, get_peft_model
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    config = LlamaConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=512,
+    )
+    model = LlamaForCausalLM(config)
+    peft_model = get_peft_model(
+        model,
+        LoraConfig(
+            r=8,
+            lora_alpha=16,
+            lora_dropout=0.0,
+            bias="none",
+            task_type="CAUSAL_LM",
+            target_modules=["gate_proj", "up_proj", "down_proj"],
+        ),
+    )
+    return peft_model.to(device="cuda", dtype=torch.bfloat16)
+
+
+def _patch_and_get_mlp_forward(cfg_overrides=None):
+    from axolotl.monkeypatch.lora_kernels import (
+        apply_lora_kernel_patches,
+        get_layers,
+    )
+    from axolotl.utils.dict import DictDefault
+
+    cfg = DictDefault(
+        {
+            "base_model": "tiny-llama",
+            "lora_mlp_kernel": True,
+            "lora_mlp_kernel_b200": True,
+            **(cfg_overrides or {}),
+        }
+    )
+    model = _tiny_peft_llama()
+    apply_lora_kernel_patches(model, cfg)
+    return get_layers(model)[0].mlp.forward
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability() == (10, 0), reason="requires a non-B200 device"
+)
+def test_patching_falls_back_on_non_sm100():
+    """G2: with the flag on but on a non-sm_100 device, the patcher must
+    select the standard kernel -- no exception, no silent wrong path."""
+    forward = _patch_and_get_mlp_forward()
+    assert forward.__func__ is apply_lora_mlp_swiglu
+
+
+def test_patching_selects_b200_on_sm100(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (10, 0))
+    forward = _patch_and_get_mlp_forward()
+    assert forward.__func__ is apply_lora_mlp_swiglu_b200
+
+
+def test_patching_respects_flag_off(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (10, 0))
+    forward = _patch_and_get_mlp_forward({"lora_mlp_kernel_b200": None})
+    assert forward.__func__ is apply_lora_mlp_swiglu
+
+
+def test_perf_vs_axolotl_lora_mlp():
+    """B200-only relative perf gate vs axolotl's standard LoRA_MLP kernel.
+
+    Skips (reporting the measured ratio) until a threshold is certified in
+    blackwell_launch_budgets.json -- the campaign never certified against
+    axolotl's own path, and fabricating a threshold would make this gate
+    flaky or toothless.
+    """
+    device_key = _device_key()
+    cert = _BUDGETS["perf_vs_axolotl_lora_mlp"].get(device_key)
+    if cert is None:
+        pytest.skip(f"no perf golden structure for {device_key}")
+
+    torch.manual_seed(0)
+    mlp = MockMLP(hidden=HIDDEN, inter=INTER, rank=RANK)
+    X = torch.randn(
+        BATCH, SEQ, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    grad_out = torch.randn(BATCH, SEQ, HIDDEN, device="cuda", dtype=torch.bfloat16)
+    lora_params = [
+        proj.lora_A["default"].weight
+        for proj in (mlp.gate_proj, mlp.up_proj, mlp.down_proj)
+    ] + [
+        proj.lora_B["default"].weight
+        for proj in (mlp.gate_proj, mlp.up_proj, mlp.down_proj)
+    ]
+
+    def std_step(K=8):
+        for _ in range(K):
+            out = apply_lora_mlp_swiglu(mlp, X, inplace=False)
+            torch.autograd.grad(out, [X] + lora_params, grad_outputs=grad_out)
+
+    def b200_step(K=8):
+        for _ in range(K):
+            out = apply_lora_mlp_swiglu_b200(mlp, X, inplace=False)
+            torch.autograd.grad(out, [X] + lora_params, grad_outputs=grad_out)
+
+    # Interleaved warmup + interleaved min-of-3: sequential measurement lets
+    # clock/thermal drift bias one side.
+    for _ in range(3):
+        std_step()
+        b200_step()
+    torch.cuda.synchronize()
+
+    std_samples, b200_samples = [], []
+    for _ in range(3):
+        e0 = torch.cuda.Event(enable_timing=True)
+        e1 = torch.cuda.Event(enable_timing=True)
+        e0.record()
+        std_step()
+        e1.record()
+        torch.cuda.synchronize()
+        std_samples.append(e0.elapsed_time(e1))
+        e2 = torch.cuda.Event(enable_timing=True)
+        e3 = torch.cuda.Event(enable_timing=True)
+        e2.record()
+        b200_step()
+        e3.record()
+        torch.cuda.synchronize()
+        b200_samples.append(e2.elapsed_time(e3))
+    ratio = min(std_samples) / min(b200_samples)
+
+    threshold = cert.get("threshold_min_ratio")
+    if threshold is None:
+        pytest.skip(
+            f"perf threshold not yet certified for {device_key}; measured "
+            f"ratio standard/b200 = {ratio:.4f} -- see "
+            f"blackwell_launch_budgets.json perf_vs_axolotl_lora_mlp.note"
+        )
+    assert ratio >= threshold, (
+        f"PERF REGRESSION vs standard LoRA_MLP: measured ratio={ratio:.4f}, "
+        f"below certified threshold {threshold:.4f}"
+    )

--- a/tests/kernels/test_blackwell_support.py
+++ b/tests/kernels/test_blackwell_support.py
@@ -1,0 +1,273 @@
+"""CPU-safe tests for the B200 factored LoRA MLP kernel's gating and env setup.
+
+Covers the hard arch gate (mocked compute capabilities), config validation,
+per-module eligibility, and the CUBLAS_WORKSPACE_CONFIG contract (applies when
+unset in a fresh process, never clobbers an explicit value).
+"""
+
+import os
+import subprocess
+import sys
+import warnings
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from axolotl.kernels.blackwell.support import (
+    CUBLAS_WORKSPACE_CONFIG_RECOMMENDED,
+    is_sm100,
+    lora_mlp_b200_config_eligible,
+    lora_mlp_b200_module_supported,
+    maybe_set_cublas_workspace_config,
+)
+from axolotl.utils.config import validate_config
+from axolotl.utils.dict import DictDefault
+
+
+def _lora_config(lora_dropout=0.0, use_dora=False):
+    return SimpleNamespace(lora_dropout=lora_dropout, use_dora=use_dora)
+
+
+def _mock_sm(monkeypatch, capability):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: capability)
+
+
+class TestArchGate:
+    def test_sm100_detected(self, monkeypatch):
+        _mock_sm(monkeypatch, (10, 0))
+        assert is_sm100()
+        eligible, reason = lora_mlp_b200_config_eligible(_lora_config(), "silu")
+        assert eligible, reason
+
+    @pytest.mark.parametrize("capability", [(12, 0), (9, 0), (8, 0), (10, 3)])
+    def test_non_sm100_falls_back(self, monkeypatch, capability):
+        _mock_sm(monkeypatch, capability)
+        assert not is_sm100()
+        eligible, reason = lora_mlp_b200_config_eligible(_lora_config(), "silu")
+        assert not eligible
+        assert str(capability) in reason
+
+    def test_no_cuda_falls_back(self, monkeypatch):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        assert not is_sm100()
+        eligible, _ = lora_mlp_b200_config_eligible(_lora_config(), "silu")
+        assert not eligible
+
+
+class TestConfigEligibility:
+    def test_dropout_rejected(self, monkeypatch):
+        _mock_sm(monkeypatch, (10, 0))
+        eligible, reason = lora_mlp_b200_config_eligible(
+            _lora_config(lora_dropout=0.05), "silu"
+        )
+        assert not eligible
+        assert "dropout" in reason
+
+    def test_dora_rejected(self, monkeypatch):
+        _mock_sm(monkeypatch, (10, 0))
+        eligible, reason = lora_mlp_b200_config_eligible(
+            _lora_config(use_dora=True), "silu"
+        )
+        assert not eligible
+        assert "DoRA" in reason
+
+    def test_non_silu_rejected(self, monkeypatch):
+        _mock_sm(monkeypatch, (10, 0))
+        eligible, reason = lora_mlp_b200_config_eligible(_lora_config(), "gelu")
+        assert not eligible
+        assert "gelu" in reason
+
+
+class _MockLoRAProj(nn.Module):
+    def __init__(self, in_features=32, out_features=64, rank=4, dtype=torch.bfloat16):
+        super().__init__()
+        self.base_layer = nn.Linear(in_features, out_features, bias=False, dtype=dtype)
+        self.lora_A = nn.ModuleDict(
+            {"default": nn.Linear(in_features, rank, bias=False, dtype=dtype)}
+        )
+        self.lora_B = nn.ModuleDict(
+            {"default": nn.Linear(rank, out_features, bias=False, dtype=dtype)}
+        )
+        self.scaling = {"default": 0.5}
+        self.active_adapter = "default"
+        self.disable_adapters = False
+        self.merged = False
+
+
+class TestModuleEligibility:
+    def _projs(self):
+        return _MockLoRAProj(), _MockLoRAProj(), _MockLoRAProj(64, 32)
+
+    def test_supported(self):
+        supported, reason = lora_mlp_b200_module_supported(*self._projs())
+        assert supported, reason
+
+    def test_missing_adapter_rejected(self):
+        gate, up, down = self._projs()
+        del gate.lora_A
+        supported, reason = lora_mlp_b200_module_supported(gate, up, down)
+        assert not supported
+        assert "no LoRA adapter" in reason
+
+    def test_fp32_weight_rejected(self):
+        gate, up, down = self._projs()
+        up.base_layer.weight.data = up.base_layer.weight.data.float()
+        supported, reason = lora_mlp_b200_module_supported(gate, up, down)
+        assert not supported
+        assert "bfloat16" in reason
+
+    def test_base_bias_rejected(self):
+        gate, up, down = self._projs()
+        down.base_layer = nn.Linear(64, 32, bias=True, dtype=torch.bfloat16)
+        supported, reason = lora_mlp_b200_module_supported(gate, up, down)
+        assert not supported
+        assert "bias" in reason
+
+    def test_quantized_base_rejected(self):
+        gate, up, down = self._projs()
+        gate.base_layer.weight.quant_state = object()
+        supported, reason = lora_mlp_b200_module_supported(gate, up, down)
+        assert not supported
+        assert "quantized" in reason
+
+
+def _cfg(**extra):
+    base = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "learning_rate": 1e-3,
+        "datasets": [{"path": "mhenrichsen/alpaca_2k_test", "type": "alpaca"}],
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "sequence_len": 2048,
+        "adapter": "lora",
+        "lora_r": 8,
+        "lora_alpha": 16,
+        "lora_dropout": 0.0,
+        "lora_target_linear": True,
+        "lora_mlp_kernel_b200": True,
+    }
+    base.update(extra)
+    return DictDefault(base)
+
+
+def _validate(cfg, compute_capability="sm_100"):
+    # The b200 validator lives on AxolotlConfigWCapabilities, the class the
+    # real CLI path always uses -- so validate with capabilities like it does.
+    return validate_config(
+        cfg,
+        capabilities={
+            "bf16": True,
+            "n_gpu": 1,
+            "n_node": 1,
+            "compute_capability": compute_capability,
+        },
+        env_capabilities={"torch_version": str(torch.__version__).split("+")[0]},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _preserve_cublas_env():
+    saved = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    yield
+    if saved is None:
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+    else:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = saved
+
+
+class TestConfigValidation:
+    def test_valid_config_enables_mlp_kernel(self):
+        cfg = _validate(_cfg())
+        assert cfg.lora_mlp_kernel is True
+        assert cfg.lora_mlp_kernel_b200 is True
+
+    def test_requires_lora_mlp_kernel(self):
+        with pytest.raises(ValueError, match="requires lora_mlp_kernel"):
+            _validate(_cfg(lora_mlp_kernel=False))
+
+    def test_qlora_rejected(self):
+        with pytest.raises(ValueError, match="adapter: lora"):
+            _validate(_cfg(adapter="qlora", load_in_4bit=True))
+
+    def test_load_in_4bit_rejected(self):
+        with pytest.raises(ValueError, match="load_in_4bit"):
+            _validate(_cfg(load_in_4bit=True))
+
+    def test_lora_dropout_rejected(self):
+        with pytest.raises(ValueError, match="dropout"):
+            _validate(_cfg(lora_dropout=0.05))
+
+    def test_dora_rejected(self):
+        with pytest.raises(ValueError, match="DoRA"):
+            _validate(_cfg(peft_use_dora=True))
+
+    def test_fsdp_rejected(self):
+        with pytest.raises(ValueError, match="FSDP"):
+            _validate(
+                _cfg(
+                    fsdp_version=2,
+                    fsdp_config={"transformer_layer_cls_to_wrap": "LlamaDecoderLayer"},
+                )
+            )
+
+    def test_non_sm100_capability_warns_but_validates(self, caplog):
+        cfg = _validate(_cfg(), compute_capability="sm_120")
+        assert cfg.lora_mlp_kernel_b200 is True
+        assert any("not sm_100" in r.message for r in caplog.records)
+
+
+class TestCublasWorkspaceConfig:
+    """The env var is read at cuBLAS handle creation, so the applies-when-unset
+    behavior must be verified in a fresh subprocess."""
+
+    def _run(self, code, env_overrides=None):
+        env = {k: v for k, v in os.environ.items() if k != "CUBLAS_WORKSPACE_CONFIG"}
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+
+    def test_applied_in_fresh_process_when_unset(self):
+        result = self._run(
+            "import os\n"
+            "from axolotl.kernels.blackwell.support import maybe_set_cublas_workspace_config\n"
+            "maybe_set_cublas_workspace_config()\n"
+            "print(os.environ.get('CUBLAS_WORKSPACE_CONFIG'))"
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == CUBLAS_WORKSPACE_CONFIG_RECOMMENDED
+
+    def test_never_clobbers_explicit_value(self):
+        result = self._run(
+            "import os, warnings\n"
+            "from axolotl.kernels.blackwell.support import maybe_set_cublas_workspace_config\n"
+            "with warnings.catch_warnings(record=True) as w:\n"
+            "    warnings.simplefilter('always')\n"
+            "    maybe_set_cublas_workspace_config()\n"
+            "    print(os.environ.get('CUBLAS_WORKSPACE_CONFIG'))\n"
+            "    print(len(w) > 0)",
+            env_overrides={"CUBLAS_WORKSPACE_CONFIG": ":9999:1"},
+        )
+        assert result.returncode == 0, result.stderr
+        lines = result.stdout.strip().splitlines()
+        assert lines[0] == ":9999:1", "explicit user choice was clobbered"
+        assert lines[1] == "True", "expected a warning for a differing explicit value"
+
+    def test_noop_when_already_recommended(self):
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = CUBLAS_WORKSPACE_CONFIG_RECOMMENDED
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            maybe_set_cublas_workspace_config()
+        assert not w
+        assert (
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] == CUBLAS_WORKSPACE_CONFIG_RECOMMENDED
+        )

--- a/tests/kernels/test_blackwell_support.py
+++ b/tests/kernels/test_blackwell_support.py
@@ -218,6 +218,27 @@ class TestConfigValidation:
         assert cfg.lora_mlp_kernel_b200 is True
         assert any("not sm_100" in r.message for r in caplog.records)
 
+    def test_non_sm100_capability_does_not_set_cublas_env(self):
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        _validate(_cfg(), compute_capability="sm_120")
+        assert "CUBLAS_WORKSPACE_CONFIG" not in os.environ
+
+    def test_sm100_capability_sets_cublas_env(self):
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        _validate(_cfg())
+        assert (
+            os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+            == CUBLAS_WORKSPACE_CONFIG_RECOMMENDED
+        )
+
+    def test_missing_bf16_warns(self, caplog):
+        _validate(_cfg())
+        assert any("bf16" in r.message for r in caplog.records)
+
+    def test_bf16_enabled_does_not_warn(self, caplog):
+        _validate(_cfg(bf16=True))
+        assert not any("requires bf16" in r.message for r in caplog.records)
+
 
 class TestCublasWorkspaceConfig:
     """The env var is read at cuBLAS handle creation, so the applies-when-unset


### PR DESCRIPTION
# Description

Integrates the B200 (sm_100)-optimized factored LoRA MLP kernel from the B200 kernel-optimization campaign, behind a new opt-in `lora_mlp_kernel_b200` flag, plus a dedicated Modal CI lane that runs the sm_100-gated tests on an actual B200.

**Kernel** (`src/axolotl/kernels/blackwell/`): factored (no-merge) LoRA SwiGLU MLP — cuBLAS GEMMs + stride-aware fused SwiGLU Triton kernels, saved forward intermediates (no X/h re-reads in backward), deduplicated/concatenated skinny adapter GEMMs, 1-write+2-RMW dX accumulation, big-GEMM-first dispatch ordering, and scalar multiplies fused into addmm alpha. Certified on B200: **1.01–1.17x speed** vs the reference factored implementation at **~1.00–1.01x peak memory**, **29 vs 38 kernel launches** per fwd+bwd step (bf16, Llama-3-8B MLP shape, ranks 8–64, grad-accum K 1–8).

**Gating** (3 layers, opt-in only — never auto-enabled):
- config validation: requires `adapter: lora` + `lora_mlp_kernel`; rejects QLoRA/4-bit/8-bit, `lora_dropout > 0`, DoRA, FSDP/DeepSpeed; warns early when the detected capability isn't sm_100
- patch time: hard runtime gate on `torch.cuda.get_device_capability() == (10, 0)` with a logged fallback to the standard `lora_mlp_kernel` path on every other device; per-module checks (bf16 dense weights, adapters on all three projections, no biases, no quant)
- runtime: the wrapper degrades to the standard kernel if module state changes post-patch, and is `torch.compiler.disable`'d (Dynamo can't trace matmul into non-contiguous `out=` slices, so compiled models graph-break around the MLP instead of failing)

`CUBLAS_WORKSPACE_CONFIG=":4096:2"` (the certified cap) is applied best-effort at config validation and never clobbers an explicit value; the launch-environment recommendation is documented in `docs/lora_optims.qmd`.

**CI**: new `b200` pytest marker + `cicd/e2e_b200.py` Modal app (hardcodes `gpu="B200:1"` so a misconfigured GPU type can't silently skip-and-pass). The docker-e2e and nightly workflows get a cu130-only, single-matrix-entry B200 job running only `-m b200` tests under the certified launch env; The arch-portable correctness tests also run in the general GPU lanes (where the sm_100-only goldens skip), which keeps the real-device fallback test covered on non-B200 hardware.

**Not included**: the campaign's two merge-family alternate kernels (need `refresh_merge()` wired into the optimizer-step lifecycle; not certified head-to-head against the shipped kernel) — possible follow-up.

## Motivation and Context

LoRA fine-tuning on B200s currently uses the generic `lora_mlp_kernel` path. The handed-off campaign kernel is measurably faster at parity memory on that hardware, with an evidence trail (launch budgets, fp32 parity, perf certifications) worth locking in as CI goldens.

## How has this been tested?

- 62 new tests: fp32-reference parity at ranks 8/16/32/64 (< 2% Frobenius vs an fp32 reference of the same factored form), live-gradients canary, addmm-alpha scalar-fusion guard, equivalence vs the standard `LoRA_MLP` kernel, patch-selection/fallback tests, CUBLAS env-var contract subprocess tests, config-validation tests, and an sm_100-keyed launch-count/kernel-name budget (`tests/e2e/kernels/blackwell_launch_budgets.json`, golden-update procedure in `_meta`)
- Verified on sm_120 hardware (RTX PRO 6000 Blackwell): all arch-portable correctness tests pass, and the arch gate falls back through the real patch path (12 passed, 2 sm_100-only skips)
- Existing suites unaffected: 36 lora-kernel-patching tests, 220 CPU kernel tests, 74 validation tests all pass; pre-commit clean
- First B200 CI run will exercise the launch-budget golden on real sm_100; the perf-vs-standard-kernel gate skips and reports its measured ratio until a threshold is certified into the budgets JSON (deliberately not fabricated)

Still pending before any default-on consideration (per the handoff's mandatory gate): a loss-curve equivalence run on a real B200 (same seed/data/optimizer, standard vs B200 kernel, few hundred steps).

## AI Usage Disclaimer

Yes — Claude Code

## Types of changes

- New feature (opt-in kernel path + config flag)
- CI (new B200 Modal suite, nightly lane)
- Docs (`docs/lora_optims.qmd`)


