### PR TITLE
fix: merge builtin checkpoint conversions

### DIFF
--- a/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
+++ b/src/axolotl/integrations/kernels/libs/scattermoe_lora/nvfp4_weight_converter.py
@@ -485,18 +485,16 @@ def register_nvfp4_expert_converters(
     detected index layout). The only per-model knob is which ``model_type`` the loader looks the
     mapping up under. Safe to call repeatedly (idempotent via overwrite on re-entry).
     """
-    from transformers.conversion_mapping import register_checkpoint_conversion_mapping
+    from axolotl.utils.weight_conversions import register_weight_conversions
 
     converters = (nvfp4_experts_weight_converters() if include_routed else []) + list(
         extra or []
     )
     if not converters:
         return
-    try:
-        register_checkpoint_conversion_mapping(model_type, converters)
-    except ValueError:
-        # Already registered; overwrite to keep converters fresh.
-        register_checkpoint_conversion_mapping(model_type, converters, overwrite=True)
+    # replace_existing: the direct-expert-load fast path (include_routed=False) relies on
+    # the stock fp16 fusion converters being absent, so these must be the only converters.
+    register_weight_conversions(model_type, converters, replace_existing=True)
 
     LOG.info(
         "Registered %s NVFP4 WeightConverters (%d) in transformers conversion_mapping",

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -213,13 +213,11 @@ class PatchManager:
             conversions_provider() if conversions_provider is not None else None
         )
         if conversions:
-            from transformers.conversion_mapping import (
-                register_checkpoint_conversion_mapping,
-            )
+            from axolotl.utils.weight_conversions import register_weight_conversions
 
             for key, entries in conversions.items():
                 entries = list(entries)
-                register_checkpoint_conversion_mapping(key, entries, overwrite=True)
+                register_weight_conversions(key, entries)
                 self._warn_irreversible_weight_transforms(key, entries)
 
         patch_provider = registrations.patch_mappings

--- a/src/axolotl/utils/weight_conversions.py
+++ b/src/axolotl/utils/weight_conversions.py
@@ -1,0 +1,75 @@
+"""Shared helper for registering transformers checkpoint weight conversions.
+
+``register_checkpoint_conversion_mapping`` replaces the entire converter list for a
+``model_type`` rather than merging, and ``rename_source_key`` picks the FIRST converter
+whose (unanchored) source pattern matches a key. Registering under a stock ``model_type``
+therefore has to be deliberate about whether to keep the built-ins transformers ships and
+about ordering, since an earlier converter shadows a later one for the same key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def _source_key(entry) -> tuple:
+    return tuple(getattr(entry, "source_patterns", ()) or ())
+
+
+def merge_weight_conversions(model_type: str, entries: Sequence) -> list:
+    """``entries`` first, then the existing converters they don't supersede.
+
+    New entries lead so they win ``rename_source_key``'s first-match; the remaining
+    built-ins act as fallbacks for keys the new entries don't claim. An existing entry
+    with the same source-pattern set as an incoming one is dropped, which also makes
+    re-registration idempotent.
+
+    Caveat: first-match ordering is what ``WeightConverter``s need, but ``WeightRenaming``s
+    all fire and chain in list order (and the save-side reverse depends on that order), so a
+    profile renaming placed ahead of a stock type's built-in renamings could chain into the
+    wrong keys. No shipped profile registers renamings under a stock model_type today.
+    """
+    from transformers.conversion_mapping import get_checkpoint_conversion_mapping
+
+    entries = list(entries)
+    existing = get_checkpoint_conversion_mapping(model_type) or []
+    incoming = {_source_key(entry) for entry in entries}
+    fallback = [entry for entry in existing if _source_key(entry) not in incoming]
+    return entries + fallback
+
+
+_MERGE_REGISTERED_MODEL_TYPES: set[str] = set()
+
+
+def register_weight_conversions(
+    model_type: str, entries: Sequence, *, replace_existing: bool = False
+) -> None:
+    """Register ``entries`` for ``model_type`` (always with ``overwrite=True``).
+
+    ``replace_existing=False`` merges with whatever is already registered
+    (:func:`merge_weight_conversions`), keeping built-ins as fallbacks. Set
+    ``replace_existing=True`` when the new converters must be the ONLY ones able to claim
+    their keys, e.g. a quantized-expert loader whose fast path relies on the stock fusion
+    converters being absent.
+
+    A ``replace_existing`` call raises ``NotImplementedError`` if a merge-mode registration
+    already ran for the same ``model_type``: stacking a model-support profile's conversions
+    with a replace-mode consumer (e.g. the NVFP4 expert converters) would silently drop the
+    profile's, which is not supported yet.
+    """
+    from transformers.conversion_mapping import register_checkpoint_conversion_mapping
+
+    if replace_existing:
+        if model_type in _MERGE_REGISTERED_MODEL_TYPES:
+            raise NotImplementedError(
+                f"Cannot register replace-mode weight conversions for model_type "
+                f"'{model_type}': a model-support profile already registered conversions for it, "
+                f"and replacing would silently drop them. Stacking a profile with a replace-mode "
+                f"consumer (e.g. NVFP4 expert converters) under one model_type is not supported "
+                f"yet; please open an issue at https://github.com/axolotl-ai-cloud/axolotl/issues."
+            )
+        payload = list(entries)
+    else:
+        _MERGE_REGISTERED_MODEL_TYPES.add(model_type)
+        payload = merge_weight_conversions(model_type, entries)
+    register_checkpoint_conversion_mapping(model_type, payload, overwrite=True)

--- a/tests/test_weight_conversions.py
+++ b/tests/test_weight_conversions.py
@@ -1,0 +1,93 @@
+"""Unit tests for the shared checkpoint weight-conversion registration helper."""
+
+import pytest
+from transformers.conversion_mapping import (
+    get_checkpoint_conversion_mapping,
+    register_checkpoint_conversion_mapping,
+)
+from transformers.core_model_loading import WeightRenaming
+
+import axolotl.utils.weight_conversions as wc
+from axolotl.utils.weight_conversions import register_weight_conversions
+
+
+def _sources(mapping):
+    return [tuple(entry.source_patterns) for entry in mapping]
+
+
+@pytest.fixture
+def key(request):
+    """A unique model_type per test, cleaned out of both registries afterwards."""
+    model_type = f"wc_test_{request.node.name}"
+    yield model_type
+    register_checkpoint_conversion_mapping(model_type, [], overwrite=True)
+    wc._MERGE_REGISTERED_MODEL_TYPES.discard(model_type)
+
+
+def _seed_builtin(key):
+    builtin = WeightRenaming(["stock.weight"], ["stock.renamed"])
+    register_checkpoint_conversion_mapping(key, [builtin], overwrite=True)
+    return builtin
+
+
+def test_merge_keeps_builtins_and_orders_new_first(key):
+    _seed_builtin(key)
+    new = WeightRenaming(["experts.new.weight"], ["experts.new.renamed"])
+
+    register_weight_conversions(key, [new])
+
+    # new entry leads (wins first-match), the stock built-in is preserved as a fallback
+    assert _sources(get_checkpoint_conversion_mapping(key)) == [
+        ("experts.new.weight",),
+        ("stock.weight",),
+    ]
+
+
+def test_merge_is_idempotent(key):
+    _seed_builtin(key)
+    new = WeightRenaming(["experts.new.weight"], ["experts.new.renamed"])
+
+    register_weight_conversions(key, [new])
+    register_weight_conversions(key, [new])
+
+    assert _sources(get_checkpoint_conversion_mapping(key)) == [
+        ("experts.new.weight",),
+        ("stock.weight",),
+    ]
+
+
+def test_merge_same_source_overrides_builtin(key):
+    _seed_builtin(key)
+    override = WeightRenaming(["stock.weight"], ["stock.override"])
+
+    register_weight_conversions(key, [override])
+
+    mapping = get_checkpoint_conversion_mapping(key)
+    assert _sources(mapping) == [("stock.weight",)]
+    assert mapping[0].target_patterns == ["stock.override"]
+
+
+def test_replace_drops_existing(key):
+    _seed_builtin(key)
+    new = WeightRenaming(["experts.new.weight"], ["experts.new.renamed"])
+
+    register_weight_conversions(key, [new], replace_existing=True)
+
+    assert _sources(get_checkpoint_conversion_mapping(key)) == [("experts.new.weight",)]
+
+
+def test_replace_without_prior_merge_is_allowed(key):
+    new = WeightRenaming(["experts.new.weight"], ["experts.new.renamed"])
+
+    register_weight_conversions(key, [new], replace_existing=True)
+
+    assert _sources(get_checkpoint_conversion_mapping(key)) == [("experts.new.weight",)]
+
+
+def test_replace_after_merge_raises_not_implemented(key):
+    register_weight_conversions(key, [WeightRenaming(["a.weight"], ["a.renamed"])])
+
+    with pytest.raises(NotImplementedError, match="not supported yet"):
+        register_weight_conversions(
+            key, [WeightRenaming(["b.weight"], ["b.renamed"])], replace_existing=True
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Followup to #3889 , this ensures that conversions are not overrode when we add a future model_type conversion. It does read-merge-write now.

Also, this puts a future notice for potential conflict between (nvfp4 conversion <=> custom model_type conversion), which we should fix when it happens / user reported.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model weight-conversion registration for more reliable checkpoint loading.
  * Preserved fallback conversion rules while allowing specialized model conversions to take precedence.
  * Prevented conflicting conversion registrations from silently replacing previously merged rules.

* **Compatibility**
  * Improved support for NVFP4 expert and other model-specific weight conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->