### PR TITLE
chore(deps): bump peft to 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "torch>=2.11.0,<=2.12.1",
     "packaging==26.0",
     "huggingface_hub==1.17.0",
-    "peft==0.19.1",
+    "peft==0.20.0",
     "tokenizers==0.22.2",
     "transformers==5.14.1",
     "accelerate==1.13.0",

--- a/tests/utils/lora/test_modules_to_save_kwargs.py
+++ b/tests/utils/lora/test_modules_to_save_kwargs.py
@@ -19,8 +19,6 @@ HIDDEN_SIZE = 16
 
 
 class KwargsOnlyVisionTower(torch.nn.Module):
-    """Submodule that only accepts keyword arguments, like Gemma's vision tower."""
-
     def __init__(self):
         super().__init__()
         self.proj = torch.nn.Linear(HIDDEN_SIZE, HIDDEN_SIZE)
@@ -30,8 +28,6 @@ class KwargsOnlyVisionTower(torch.nn.Module):
 
 
 class TinyVlmForCausalLM(torch.nn.Module):
-    """Minimal VLM-shaped model: kwargs-only vision tower feeding LoRA-targeted projections."""
-
     def __init__(self):
         super().__init__()
         self.config = PretrainedConfig()

--- a/tests/utils/lora/test_modules_to_save_kwargs.py
+++ b/tests/utils/lora/test_modules_to_save_kwargs.py
@@ -1,0 +1,86 @@
+"""Kwargs-only forward through modules wrapped by lora_modules_to_save.
+
+PEFT < 0.20.0 required a positional first argument in
+``ModulesToSaveWrapper.forward``, so any ``lora_modules_to_save`` entry the
+model invokes with keyword arguments only (e.g. a VLM's
+``vision_tower(pixel_values=...)``) crashed with a TypeError at the first
+forward pass. Fixed upstream in huggingface/peft#3199 (peft 0.20.0).
+"""
+
+import torch
+from peft import get_peft_model
+from peft.utils import ModulesToSaveWrapper
+from transformers import PretrainedConfig
+
+from axolotl.loaders.adapter import _build_peft_lora_config
+from axolotl.utils.dict import DictDefault
+
+HIDDEN_SIZE = 16
+
+
+class KwargsOnlyVisionTower(torch.nn.Module):
+    """Submodule that only accepts keyword arguments, like Gemma's vision tower."""
+
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(HIDDEN_SIZE, HIDDEN_SIZE)
+
+    def forward(self, *, pixel_values: torch.Tensor) -> torch.Tensor:
+        return self.proj(pixel_values)
+
+
+class TinyVlmForCausalLM(torch.nn.Module):
+    """Minimal VLM-shaped model: kwargs-only vision tower feeding LoRA-targeted projections."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = PretrainedConfig()
+        self.vision_tower = KwargsOnlyVisionTower()
+        self.q_proj = torch.nn.Linear(HIDDEN_SIZE, HIDDEN_SIZE)
+        self.v_proj = torch.nn.Linear(HIDDEN_SIZE, HIDDEN_SIZE)
+
+    def forward(self, pixel_values: torch.Tensor = None, **kwargs) -> torch.Tensor:
+        hidden = self.vision_tower(pixel_values=pixel_values)
+        return self.q_proj(hidden) + self.v_proj(hidden)
+
+    def prepare_inputs_for_generation(self, *args, **kwargs):
+        return {}
+
+
+def build_peft_model():
+    cfg = DictDefault(
+        {
+            "adapter": "lora",
+            "lora_r": 4,
+            "lora_alpha": 8,
+            "lora_dropout": 0.0,
+            "lora_target_modules": ["q_proj", "v_proj"],
+            "lora_modules_to_save": ["vision_tower"],
+        }
+    )
+    model = TinyVlmForCausalLM()
+    lora_config = _build_peft_lora_config(model, cfg)
+    return get_peft_model(model, lora_config)
+
+
+class TestModulesToSaveKwargsForward:
+    def test_kwargs_only_forward_through_wrapper(self):
+        peft_model = build_peft_model()
+
+        vision_tower = peft_model.base_model.model.vision_tower
+        assert isinstance(vision_tower, ModulesToSaveWrapper)
+
+        out = vision_tower(pixel_values=torch.randn(2, HIDDEN_SIZE))
+        assert out.shape == (2, HIDDEN_SIZE)
+
+    def test_full_forward_backward_trains_saved_module(self):
+        peft_model = build_peft_model()
+
+        out = peft_model(pixel_values=torch.randn(2, HIDDEN_SIZE))
+        out.sum().backward()
+
+        vision_tower = peft_model.base_model.model.vision_tower
+        saved_params = list(vision_tower.modules_to_save["default"].parameters())
+        assert saved_params
+        assert all(p.requires_grad for p in saved_params)
+        assert all(p.grad is not None for p in saved_params)

--- a/tests/utils/lora/test_modules_to_save_kwargs.py
+++ b/tests/utils/lora/test_modules_to_save_kwargs.py
@@ -1,10 +1,7 @@
 """Kwargs-only forward through modules wrapped by lora_modules_to_save.
 
-PEFT < 0.20.0 required a positional first argument in
-``ModulesToSaveWrapper.forward``, so any ``lora_modules_to_save`` entry the
-model invokes with keyword arguments only (e.g. a VLM's
-``vision_tower(pixel_values=...)``) crashed with a TypeError at the first
-forward pass. Fixed upstream in huggingface/peft#3199 (peft 0.20.0).
+Guards the peft pin: peft < 0.20.0 required a positional first argument in
+``ModulesToSaveWrapper.forward``, crashing wrapped modules invoked kwargs-only.
 """
 
 import torch


### PR DESCRIPTION
# Description

Bumps `peft` from `0.19.1` to `0.20.0` (released to PyPI yesterday) and adds the `lora_modules_to_save` test discussed in #3801.

0.20.0 picks up huggingface/peft#3199, which makes `ModulesToSaveWrapper.forward` accept kwargs-only calls. On 0.19.1, any `lora_modules_to_save` module the model invokes with keyword args only (e.g. a VLM's `vision_tower(pixel_values=...)`) crashed at the first forward pass with `TypeError: AuxiliaryTrainingWrapper.forward() missing 1 required positional argument: 'x'`. The new test builds a tiny VLM-shaped model with a kwargs-only vision tower and runs it through axolotl's LoRA config path — it fails with that exact error on 0.19.1 and passes on 0.20.0, so it guards the pin going forward.

`pyproject.toml` is the only place a peft release is pinned; nightly CI and the uv Dockerfile already track peft@main.

## Motivation and Context

Closes #3801.

I also went through the peft `v0.19.1..v0.20.0` diff against everything axolotl touches — nothing to worry about: all imported symbols and `LoraConfig` kwargs are intact, the `prepare_model_for_kbit_training` source-patch still applies (upstream only added a backward-compatible `auto_clear_cache` arg), `_LoraParameterProxy.forward` and `Linear.merge` are byte-identical (so the FSDP2 DTensor patch and merge paths are unaffected), and the remaining dtype-related changes all live in the nine newly added PEFT methods axolotl doesn't use.

## How has this been tested?

- New test verified both ways: passes on 0.20.0, fails with the original `TypeError` on 0.19.1.
- Full CPU suite (`pytest -m 'not slow' --ignore=tests/e2e tests/`) against peft 0.20.0 on latest main: 3206 passed. The only reds were environmental on my machine (a timing-sensitive kernel test under `-n 8` contention, and two `test_expert_parallel` setup errors from a rendezvous port held by an unrelated training run).
- Env: Python 3.12, torch 2.12.0+cu130, transformers 5.14.1, trl 1.8.0.

## AI Usage Disclaimer

Yes — Fable/Opus throughout

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test coverage added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA module compatibility with components that require keyword-only inputs.
  * Ensured wrapped modules correctly receive inputs during inference and training.
  * Preserved gradient flow for saved modules during forward and backward passes.

* **Compatibility**
  * Updated the underlying PEFT integration to support the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->