### PR TITLE
perf: Apply numpy optimization for label masking

### DIFF
--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -132,8 +132,8 @@ class InstructionPromptTokenizingStrategy(PromptTokenizingStrategy):
         tokenized_prompt = self._tokenize(user_prompt, add_eos_token=False)
         if not self.train_on_inputs:
             user_prompt_len = len(tokenized_prompt["input_ids"])
-            # TODO this could be sped up using numpy array slicing
-            tokenized_prompt["labels"] = [IGNORE_INDEX] * user_prompt_len
+            import numpy as np
+            tokenized_prompt["labels"] = np.full(user_prompt_len, IGNORE_INDEX, dtype=np.int32).tolist()
         tokenized_res_prompt = self._tokenize(
             response, strip_bos_token=True, add_eos_token=True
         )


### PR DESCRIPTION
Replace list multiplication with `np.full` for faster label masking during tokenization.

**Changes:**
- Use `np.full` instead of `[IGNORE_INDEX] * user_prompt_len` for constructing label arrays
- Removes TODO comment about potential numpy optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated internal prompt-label preparation to use a NumPy-based operation while preserving existing output behavior.
* **Compatibility**
  * No changes to exported interfaces or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->