### PR TITLE
docs: Document upstream dependency blocker for transformers PR 39866

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -921,6 +921,9 @@ class AxolotlTrainer(
         return result
 
     # TODO(wing): remove once https://github.com/huggingface/transformers/pull/39866/files is merged
+    # Status (checked 2026-07-29): upstream PR 39866 accessible (HTTP 200); workaround preserved
+    # because installed transformers version does not include the merged change.
+    # Blocker: upstream release verification needed before safe removal.
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir


### PR DESCRIPTION
Add inline documentation for an upstream transformers PR (#39866) that blocks a planned refactor in the trainer base, making the dependency visible to future contributors.

**Changes:**
- Add comment referencing transformers PR 39866 with context on the blocker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal documentation noting the status of an upstream fix and the conditions for removing the existing workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->