### PR TITLE
upgrade flash-linear-attention package for bugfixes, etc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ dependencies = [
     "torchao==0.17.0 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
 
     # Architecture-specific
-    "fla-core==0.4.1 ; platform_machine != 'aarch64'",
-    "flash-linear-attention==0.4.1 ; platform_machine != 'aarch64'",
+    "fla-core>=0.5.2 ; platform_machine != 'aarch64'",
+    "flash-linear-attention>=0.5.2 ; platform_machine != 'aarch64'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compatibility requirements for non-ARM64 systems.
  * Enables use of newer versions of the `fla-core` and `flash-linear-attention` packages (version 0.5.2 or later).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->