### PR TITLE
fix: set up tracking env vars on Ray Train worker

### DIFF
--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -23,6 +23,10 @@ _LAZY_IMPORTS = {
     "prepare_optim_env": "axolotl.utils.trainer",
     "prepare_plugins": "axolotl.cli.config",
     "resolve_dtype": "axolotl.utils.config",
+    "setup_comet_env_vars": "axolotl.utils.comet_",
+    "setup_mlflow_env_vars": "axolotl.utils.mlflow_",
+    "setup_trackio_env_vars": "axolotl.utils.trackio_",
+    "setup_wandb_env_vars": "axolotl.utils.wandb_",
     "train": "axolotl.train",
     "validate_config": "axolotl.utils.config",
 }
@@ -184,6 +188,19 @@ def ray_train_func(kwargs: dict):
     prepare_optim_env_fn(cfg)
     normalize_config_fn(cfg)
     resolve_dtype_fn(cfg)
+
+    # Tracking env vars must be set on the worker process — the HuggingFace
+    # MLflowCallback / WandbCallback read tracking URIs and experiment names
+    # from env vars, not TrainingArguments.  The driver sets these in load_cfg
+    # but that runs in a separate process; Ray Train workers do not inherit them.
+    setup_wandb_env_vars_fn: Any = _lazy_attr("setup_wandb_env_vars")
+    setup_mlflow_env_vars_fn: Any = _lazy_attr("setup_mlflow_env_vars")
+    setup_comet_env_vars_fn: Any = _lazy_attr("setup_comet_env_vars")
+    setup_trackio_env_vars_fn: Any = _lazy_attr("setup_trackio_env_vars")
+    setup_wandb_env_vars_fn(cfg)
+    setup_mlflow_env_vars_fn(cfg)
+    setup_comet_env_vars_fn(cfg)
+    setup_trackio_env_vars_fn(cfg)
 
     # ray serializing objects gets rid of frozen attribute - HF expects dict not DefaultDict
     if cfg.deepspeed and hasattr(cfg.deepspeed, "to_dict"):

--- a/src/axolotl/cli/train.py
+++ b/src/axolotl/cli/train.py
@@ -189,10 +189,7 @@ def ray_train_func(kwargs: dict):
     normalize_config_fn(cfg)
     resolve_dtype_fn(cfg)
 
-    # Tracking env vars must be set on the worker process — the HuggingFace
-    # MLflowCallback / WandbCallback read tracking URIs and experiment names
-    # from env vars, not TrainingArguments.  The driver sets these in load_cfg
-    # but that runs in a separate process; Ray Train workers do not inherit them.
+    # Tracking env vars must be set on the worker — HF callbacks read them from os.environ, not TrainingArguments.
     setup_wandb_env_vars_fn: Any = _lazy_attr("setup_wandb_env_vars")
     setup_mlflow_env_vars_fn: Any = _lazy_attr("setup_mlflow_env_vars")
     setup_comet_env_vars_fn: Any = _lazy_attr("setup_comet_env_vars")

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -106,6 +106,10 @@ def test_ray_train_func_validates_with_worker_capabilities(monkeypatch):
     monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.Accelerator", accelerator_mock)
+    monkeypatch.setattr("axolotl.cli.train.setup_wandb_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_mlflow_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_comet_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_trackio_env_vars", lambda *_: None)
 
     with patch("axolotl.cli.train.gpu_capabilities") as mock_caps:
         mock_caps.return_value = (
@@ -161,6 +165,10 @@ def test_ray_train_func_registers_plugins_before_validate_config(monkeypatch):
     monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.Accelerator", MagicMock())
+    monkeypatch.setattr("axolotl.cli.train.setup_wandb_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_mlflow_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_comet_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_trackio_env_vars", lambda *_: None)
 
     ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
 
@@ -198,8 +206,55 @@ def test_ray_train_func_skips_plugin_registration_when_no_plugins(monkeypatch):
     monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
     monkeypatch.setattr("axolotl.cli.train.Accelerator", MagicMock())
+    monkeypatch.setattr("axolotl.cli.train.setup_wandb_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_mlflow_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_comet_env_vars", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.setup_trackio_env_vars", lambda *_: None)
 
     ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
 
     prepare_plugins_mock.assert_not_called()
     plugin_set_cfg_mock.assert_not_called()
+
+
+def test_ray_train_func_sets_up_tracking_env_vars(monkeypatch):
+    """Regression: tracking env-var setup functions must be called on the Ray
+    Train worker.  The driver sets these in ``load_cfg``, but that runs in a
+    separate process; the HuggingFace callbacks (MLflowCallback, WandbCallback,
+    etc.) read tracking URIs from env vars, not TrainingArguments.
+    """
+    cfg_dict = {
+        "base_model": "HuggingFaceTB/SmolLM2-135M",
+        "micro_batch_size": 1,
+        "gradient_accumulation_steps": 1,
+    }
+
+    parent = MagicMock()
+    parent.validate_config.side_effect = lambda cfg, **_: cfg
+
+    monkeypatch.setattr("axolotl.cli.train.validate_config", parent.validate_config)
+    monkeypatch.setattr("axolotl.cli.train.gpu_capabilities", lambda: ({}, {}))
+    monkeypatch.setattr("axolotl.cli.train.do_train", MagicMock())
+    monkeypatch.setattr("axolotl.cli.train.prepare_optim_env", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.normalize_config", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.resolve_dtype", lambda *_: None)
+    monkeypatch.setattr("axolotl.cli.train.Accelerator", MagicMock())
+    monkeypatch.setattr(
+        "axolotl.cli.train.setup_wandb_env_vars", parent.setup_wandb_env_vars
+    )
+    monkeypatch.setattr(
+        "axolotl.cli.train.setup_mlflow_env_vars", parent.setup_mlflow_env_vars
+    )
+    monkeypatch.setattr(
+        "axolotl.cli.train.setup_comet_env_vars", parent.setup_comet_env_vars
+    )
+    monkeypatch.setattr(
+        "axolotl.cli.train.setup_trackio_env_vars", parent.setup_trackio_env_vars
+    )
+
+    ray_train_func({"cfg": cfg_dict, "cli_args": MagicMock()})
+
+    parent.setup_wandb_env_vars.assert_called_once()
+    parent.setup_mlflow_env_vars.assert_called_once()
+    parent.setup_comet_env_vars.assert_called_once()
+    parent.setup_trackio_env_vars.assert_called_once()

--- a/tests/cli/test_load_cfg_capabilities.py
+++ b/tests/cli/test_load_cfg_capabilities.py
@@ -218,11 +218,7 @@ def test_ray_train_func_skips_plugin_registration_when_no_plugins(monkeypatch):
 
 
 def test_ray_train_func_sets_up_tracking_env_vars(monkeypatch):
-    """Regression: tracking env-var setup functions must be called on the Ray
-    Train worker.  The driver sets these in ``load_cfg``, but that runs in a
-    separate process; the HuggingFace callbacks (MLflowCallback, WandbCallback,
-    etc.) read tracking URIs from env vars, not TrainingArguments.
-    """
+    """Tracking env-var setup must run on the worker, not just the driver."""
     cfg_dict = {
         "base_model": "HuggingFaceTB/SmolLM2-135M",
         "micro_batch_size": 1,


### PR DESCRIPTION
## Summary

- Fixes #3908

When `use_ray: true`, tracking integrations (MLflow, WandB, Comet, Trackio) silently fail because their env-var setup functions are called only in `load_cfg()` (driver process), not in `ray_train_func()` (worker process). The HuggingFace callbacks read tracking URIs/experiment names from env vars, not TrainingArguments.

## Root cause

`load_cfg()` in `cli/config.py:324-327` calls:
```python
setup_wandb_env_vars(cfg)
setup_mlflow_env_vars(cfg)
setup_comet_env_vars(cfg)
setup_trackio_env_vars(cfg)
```

These convert YAML fields (`mlflow_tracking_uri`, `mlflow_experiment_name`, etc.) into env vars. But `load_cfg` runs on the driver — the Ray Train worker is a separate process that doesn't inherit them.

This was flagged during review of #3130 but not addressed:
https://github.com/axolotl-ai-cloud/axolotl/pull/3130#discussion_r2329564517

## Changes

- Add `setup_wandb_env_vars`, `setup_mlflow_env_vars`, `setup_comet_env_vars`, `setup_trackio_env_vars` to `_LAZY_IMPORTS` in `cli/train.py`
- Call them in `ray_train_func()` after `resolve_dtype(cfg)`, mirroring the order in `load_cfg()`
- Update existing tests to mock the new calls
- Add regression test `test_ray_train_func_sets_up_tracking_env_vars`

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] New regression test passes (verified locally — existing tests require HF model downloads that fail offline)
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracking integrations now initialize their environment settings correctly when training runs on Ray workers.
  * Improved consistency for Weights & Biases, MLflow, Comet, and Trackio during distributed training.

* **Tests**
  * Added coverage to verify that all supported tracking environments are configured before training begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->