### PR TITLE
fix: ORPO numerical stability with log1p and clamping

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -636,8 +636,11 @@ class AxolotlTrainer(
         )
 
         # Calculate log odds
+        # Clamp probabilities to prevent exp(x) > 1 which causes log(1 - exp(x)) to produce NaN
+        pos_prob_clamped = torch.clamp(pos_prob, max=0.999)
+        neg_prob_clamped = torch.clamp(neg_prob, max=0.999)
         log_odds = (pos_prob - neg_prob) - (
-            torch.log(1 - torch.exp(pos_prob)) - torch.log(1 - torch.exp(neg_prob))
+            torch.log1p(-torch.exp(pos_prob_clamped)) - torch.log1p(-torch.exp(neg_prob_clamped))
         )
         sig_ratio = torch.nn.functional.sigmoid(log_odds)
         ratio = torch.log(sig_ratio)


### PR DESCRIPTION
## Description

Fix numerical instability in ORPO loss computation that causes NaN when probabilities approach 1.

## Problem

In \src/axolotl/core/trainers/base.py\ line 639-641, the ORPO loss computation uses:
\\\python
torch.log(1 - torch.exp(pos_prob)) - torch.log(1 - torch.exp(neg_prob))
\\\

When \pos_prob\ or \
eg_prob\ approach 1, \	orch.exp(prob)\ exceeds 1, causing \	orch.log(1 - exp(prob))\ to produce \-inf\ or \NaN\, leading to training crashes.

## Solution

1. Clamp probabilities to \max=0.999\ to ensure \exp(x) <= 1\
2. Use \	orch.log1p(-torch.exp(clamped_prob))\ for better numerical stability

## Changes

- File: \src/axolotl/core/trainers/base.py\
- Lines: 639-644
- Added probability clamping before log computation
- Replaced \	orch.log(1 - x)\ with \	orch.log1p(-x)\ for numerical stability

## Testing

Due to local environment limitations (GPU resources), testing relies on CI/CD. The fix follows PyTorch best practices for numerical stability.

Thank you for reviewing this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ORPO training stability by preventing invalid probability calculations during log-odds evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->