### PR TITLE
fix: use safe dict access for quant_method

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -729,19 +729,19 @@ class ModelLoader:
         if (
             self.cfg.adapter in ["qlora", "lora"]
             and hasattr(self.model_config, "quantization_config")
-            and self.model_config.quantization_config["quant_method"]
+            and self.model_config.quantization_config.get("quant_method")
             in ["gptq", "awq", "bitsandbytes"]
         ):
-            if self.model_config.quantization_config["quant_method"] == "gptq":
+            if self.model_config.quantization_config.get("quant_method") == "gptq":
                 self.model_kwargs["quantization_config"] = GPTQConfig(
                     **self.model_config.quantization_config
                 )
-            elif self.model_config.quantization_config["quant_method"] == "awq":
+            elif self.model_config.quantization_config.get("quant_method") == "awq":
                 self.model_kwargs["quantization_config"] = AwqConfig(
                     **self.model_config.quantization_config
                 )
             elif (
-                self.model_config.quantization_config["quant_method"] == "bitsandbytes"
+                self.model_config.quantization_config.get("quant_method") == "bitsandbytes"
             ):
                 self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                     **self.model_config.quantization_config


### PR DESCRIPTION
Fix KeyError when quant_method key is missing from quantization_config by using .get() instead of direct dictionary access. Changes in src/axolotl/loaders/model.py lines 732, 735, 739, 744.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading adapter-based GPTQ, AWQ, and bitsandbytes models with incomplete quantization configuration data.
  * Preserved existing quantization behavior while preventing configuration lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->