### PR TITLE
docs: fix delinearize-llama4 CLI invocation to use positional args

### DIFF
--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -237,7 +237,7 @@ See [LM Eval Harness integration docs](https://docs.axolotl.ai/docs/custom_integ
 Delinearizes a Llama 4 linearized model into a regular HuggingFace Llama 4 model. This only works with the non-quantized linearized model.
 
 ```bash
-axolotl delinearize-llama4 --model path/to/model_dir --output path/to/output_dir
+axolotl delinearize-llama4 path/to/model_dir path/to/output_dir
 ```
 
 This would be necessary to use with other frameworks. If you have an adapter, merge it with the non-quantized linearized model before delinearizing.


### PR DESCRIPTION
The `delinearize-llama4` example in `docs/cli.qmd` passes `--model` and `--output` flags:

```
axolotl delinearize-llama4 --model path/to/model_dir --output path/to/output_dir
```

But the command defines both as **positional** `click.argument`s, not options (`src/axolotl/cli/main.py`):

```python
@click.argument("model", type=click.Path(exists=True, path_type=str))
@click.argument("output", type=click.Path(exists=False, path_type=str))
def delinearize_llama4(model: str, output: str):
```

There is no `--model`/`--output` option, so the documented command fails with `Error: No such option: --model`. This updates the example to pass the two paths positionally.

Docs-only, no functional change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `delinearize-llama4` command example to use positional arguments for the model and output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->