### PR TITLE
fix(moe_quant): cache-gate hooks leak the parametrize cache under checkpointing

### DIFF
--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -42,9 +42,17 @@ def _enable_parametrization_cache(module, inputs):
 
 
 def _disable_parametrization_cache(module, inputs, output):
-    P._cache_enabled -= 1
+    # always_call can fire without a matching pre-hook; a negative counter is truthy.
+    P._cache_enabled = max(0, P._cache_enabled - 1)
     if not P._cache_enabled:
         P._cache = {}
+
+
+def _register_parametrization_cache_hooks(module):
+    """Gate torch's parametrization cache to this module's forward."""
+    module.register_forward_pre_hook(_enable_parametrization_cache)
+    # Without always_call, an aborted checkpoint recompute skips this and pins experts.
+    module.register_forward_hook(_disable_parametrization_cache, always_call=True)
 
 
 def replace_parameter_8bit(module, param_name):
@@ -63,8 +71,7 @@ def replace_parameter_8bit(module, param_name):
 
     # Cache dequantized values during forward to avoid redundant dequantization.
     if not getattr(module, "_axolotl_8bit_hooks_registered", False):
-        module.register_forward_pre_hook(_enable_parametrization_cache)
-        module.register_forward_hook(_disable_parametrization_cache)
+        _register_parametrization_cache_hooks(module)
         module._axolotl_8bit_hooks_registered = True
 
 

--- a/tests/monkeypatch/test_moe_quant_cache_hooks.py
+++ b/tests/monkeypatch/test_moe_quant_cache_hooks.py
@@ -1,0 +1,74 @@
+"""Tests for the MoE 8-bit parametrization cache-gate hooks."""
+
+import torch
+import torch.nn.utils.parametrize as P
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from axolotl.monkeypatch.moe_quant import (
+    _disable_parametrization_cache,
+    _register_parametrization_cache_hooks,
+)
+
+
+class _ResidualBlock(nn.Module):
+    """Minimal stand-in for a MoE decoder layer: experts, then a residual add.
+
+    Under ``use_reentrant=False``, early stop fires once the last tensor saved for
+    backward has been rematerialized. A residual add saves nothing, so the last save
+    lands inside the expert module's forward and its forward hook is skipped. A
+    trailing op that does save (another ``Linear``) hides this.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.norm = nn.Linear(8, 8)
+        self.experts = nn.Linear(8, 8)
+
+    def forward(self, x):
+        residual = self.norm(x)
+        return residual + self.experts(residual)
+
+
+def _reset_cache():
+    P._cache_enabled = 0
+    P._cache = {}
+
+
+class TestParametrizationCacheHooks:
+    """The cache-gate hook pair must stay balanced under activation checkpointing.
+
+    The pre-hook increments the global ``parametrize._cache_enabled`` counter and the
+    post-hook decrements it, clearing the cache at zero. When the post-hook is skipped
+    the counter leaks upward once per checkpointed layer per step, the cache is never
+    cleared again, and every dequantized expert stays resident for the rest of training.
+    """
+
+    def test_counter_balanced_under_checkpoint_early_stop(self):
+        _reset_cache()
+        try:
+            model = _ResidualBlock()
+            _register_parametrization_cache_hooks(model.experts)
+
+            for _ in range(3):
+                inputs = torch.randn(2, 8, requires_grad=True)
+                checkpoint(model, inputs, use_reentrant=False).sum().backward()
+
+            assert P._cache_enabled == 0, (
+                f"parametrize cache counter leaked to {P._cache_enabled}; dequantized "
+                "expert weights would be retained for the rest of training"
+            )
+            assert P._cache == {}
+        finally:
+            _reset_cache()
+
+    def test_counter_never_goes_negative(self):
+        _reset_cache()
+        try:
+            P._cache[("k",)] = torch.zeros(1)
+            _disable_parametrization_cache(nn.Identity(), (), None)
+
+            assert P._cache_enabled == 0
+            assert P._cache == {}
+        finally:
+            _reset_cache()


### PR DESCRIPTION
# Description

`replace_parameter_8bit` in `src/axolotl/monkeypatch/moe_quant.py` registers a `forward_pre_hook`/`forward_hook` pair that gates torch's global parametrization cache by counter: pre-hook does `parametrize._cache_enabled += 1`, post-hook decrements and clears `parametrize._cache` at zero.

Checkpointing with `use_reentrant=False` aborts its backward recompute mid-forward **by design**—early stop raises an internal exception once the last tensor *saved for backward* has been rematerialized. A plain `forward_hook` is skipped when the forward is interrupted.

Whether that bites depends on what follows the hooked module, and in a MoE decoder layer it does: **a residual add saves nothing for backward**, so the last save lands inside the experts forward and early stop fires there. The pair runs pre-only, the counter leaks +1 per checkpointed layer per step, and from then on the cache is permanently enabled and never cleared—every dequantized expert stays resident for the rest of training.

Two changes:

- register the disable hook with `always_call=True`, so it also runs when the recompute is aborted
- clamp the decrement at zero. With `always_call=True` the hook can also fire when an earlier pre-hook raised before `_enable` ran; a negative counter is truthy, so `if not P._cache_enabled` would never clear the cache again

Same defect and same fix as [bitsandbytes#1999](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1999), which I filed against `bitsandbytes/nn/parametrize.py`—`moe_quant.py` carries its own copy of the pair for the 8-bit path. `always_call=True` is already the convention here for hooks on checkpointed modules: `monkeypatch/selective_checkpointing.py:157`, `core/trainers/mixins/activation_checkpointing.py`.

## Motivation and Context

Measured on an A2000 12 GB: a 4-layer, 32-expert `GptOss` (fused 3D expert stacks, the layout `_patched_set_param_for_module` selects), every 3D expert param quantized through the real `replace_parameter_8bit`, `model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})`, 5 steps:

| | counter after 5 steps | dequantized experts pinned | allocated |
|---|---|---|---|
| main | 20 (+4/step, i.e. every layer) | 384.0 of 384.0 MiB | 511.3 MiB |
| this PR | 0 | 0.0 MiB | 127.3 MiB |

All four layers leak, and the retained set is the *entire* dequantized expert weight—`int8_vectorwise_dequant` returns fp32, so 4x the packed int8 bytes. On real models the same mechanism cost 12.9 GiB retained on OLMoE-1B-7B and ~53 GiB on Qwen3-30B-A3B (measured on the `bitsandbytes` side, where the 4-bit path had the identical bug).

Worth distinguishing from #3638: this is a **step, not a ramp**. The counter climbs without bound but the memory does not—it jumps once to the full dequantized expert set and stays flat there (511.3 MiB on every step above). So it presents as a fixed unexplained baseline and a step-1 OOM, not as linear growth.

**Scope: this fires whenever `use_reentrant: false`, and several common paths select that for you.**

- `rl` is set—the `use_reentrant: true` default at `utils/config/__init__.py:401` is skipped, so `builders/base.py:609` falls back to `{"use_reentrant": False}`. Nothing forbids `quantize_moe_experts` with `rl`, so **MoE LoRA + DPO/GRPO leaks with no opt-in at all**
- `model_config_type` is `gemma4`/`gemma4_unified`—forced to `false`
- `unfrozen_parameters` is set—same fallback, and `use_reentrant: true` is rejected outright by `check_use_reentrant_mismatch`
- `activation_offloading: hidden_states`—only offloads when it is `false`
- set explicitly, which `check_rl_config_gradient_checkpointing` tells users to do in as many words

Plain SFT with defaults resolves to `use_reentrant: true` and is not affected.

**The 4-bit path is affected too, at the currently pinned version.** `load_in_4bit` delegates to `bitsandbytes.nn.parametrize.replace_parameter_4bit`, whose hook pair had the same bug; the fix shipped in `bitsandbytes` **0.50.0** and `pyproject.toml` pins `bitsandbytes==0.49.1`. Bumping that pin closes the 4-bit half. I left it out of this PR since a minor bump touches everyone—add it here, send it separately, or leave it, your call.

## How has this been tested?

New `tests/monkeypatch/test_moe_quant_cache_hooks.py`, CPU-only, no quantization kernels, ~7 s:

1. `test_counter_balanced_under_checkpoint_early_stop` — the real hook pair on the experts module of a checkpointed block shaped like a decoder layer (experts, then a residual add), 3 fwd/bwd steps, asserts counter == 0 and cache empty
2. `test_counter_never_goes_negative` — pins the clamp

Both **fail on main and pass with the fix**, verified by mutation (reverting the two lines in place): `counter leaked to 3`, and `-1 == 0`.

The residual shape in that test is load-bearing, not decoration. Same block with a trailing `Linear` instead of the residual add does *not* leak—the `Linear` saves its input, so early stop fires inside it and the experts hook completes. That is why this went unnoticed, and why a naive minimal repro can miss it.

Ran on torch 2.8.0+cu128 / bitsandbytes 0.50.0 / transformers 4.57.6—older than the pinned 5.14.1, that's the CUDA box I have. `GptOss` is just the carrier for a fused 3D expert stack; the mechanism is torch-level and the unit test pins it with no transformers involved. `ruff@0.15.8 check` and `format --check` clean on both files.

One refactor: the two `register_*` calls moved into `_register_parametrization_cache_hooks(module)` so the test exercises the real registration rather than a copy of it. Mirrors `bitsandbytes`' `_register_parametrization_hooks`.

## AI Usage Disclaimer

Yes—Claude Code (Anthropic). The diagnosis, fix, and regression tests were produced with AI assistance and validated by me as described above.

## Types of changes

Bug fix (non-breaking change which fixes an issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during activation checkpointing by preventing parameter cache leaks.
  * Ensured cache tracking remains balanced and never drops below zero.
  * Improved cleanup when checkpoint recomputation stops early.

* **Tests**
  * Added coverage for cache behavior during checkpoint recomputation and cache-disabled scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->