### PR TITLE
fix(datasets): normalize OpenAI tool_calls content in chat transforms

### DIFF
--- a/src/axolotl/core/datasets/transforms/chat_builder.py
+++ b/src/axolotl/core/datasets/transforms/chat_builder.py
@@ -109,19 +109,21 @@ def chat_message_transform_builder(
             (
                 field
                 for field in message_field_content
-                if field in sample[conversations_field][0]
+                if any(field in message for message in sample[conversations_field])
             ),
             message_field_content[0],
         )
         if not any(
-            field in sample[conversations_field][0] for field in message_weight_fields
+            field in message
+            for message in sample[conversations_field]
+            for field in message_weight_fields
         ):
             message_weight_field = None
         else:
             message_weight_field = next(
                 field
                 for field in message_weight_fields
-                if field in sample[conversations_field][0]
+                if any(field in message for message in sample[conversations_field])
             )
 
         messages = []
@@ -129,7 +131,7 @@ def chat_message_transform_builder(
             role = role_value_mappings[message[role_field]]
             weight = (
                 int(message[message_weight_field])
-                if message_weight_field
+                if message_weight_field and message_weight_field in message
                 else role_default_weights_mappings[role]
             )
             messages.append(

--- a/src/axolotl/core/datasets/transforms/chat_builder.py
+++ b/src/axolotl/core/datasets/transforms/chat_builder.py
@@ -3,6 +3,7 @@ This module contains a function that builds a transform that takes a row from th
 dataset and converts it to a Chat.
 """
 
+import json
 from typing import Any, Mapping
 
 
@@ -94,17 +95,26 @@ def chat_message_transform_builder(
             for role in message_field_role
             if role in sample[conversations_field][0]
         )
-        if not any(
-            field in sample[conversations_field][0] for field in message_field_content
-        ):
+        has_content_field = any(
+            field in message
+            for message in sample[conversations_field]
+            for field in message_field_content
+        )
+        has_tool_calls = any(
+            "tool_calls" in message for message in sample[conversations_field]
+        )
+        if not has_content_field and not has_tool_calls:
             raise ValueError("No message_content field found in message.")
         message_content_field = next(
-            field
-            for field in message_field_content
-            if field in sample[conversations_field][0]
+            (
+                field
+                for field in message_field_content
+                if field in sample[conversations_field][0]
+            ),
+            message_field_content[0],
         )
         if not any(
-            field in sample[conversations_field][0] for field in message_field_training
+            field in sample[conversations_field][0] for field in message_weight_fields
         ):
             message_weight_field = None
         else:
@@ -122,30 +132,77 @@ def chat_message_transform_builder(
                 if message_weight_field
                 else role_default_weights_mappings[role]
             )
-
-            # TODO if "tool_calls" in message[message_content_field]: then convert tool call to ToolCallContents
-            if isinstance(message[message_content_field], str):
-                messages.append(
-                    {
-                        "role": role,
-                        "content": [
-                            {
-                                "type": "text",
-                                "value": message[message_content_field],
-                            }
-                        ],
-                        "weight": weight,
-                    }
-                )
-            else:
-                messages.append(
-                    {
-                        "role": role,
-                        "content": message[message_content_field],
-                        "weight": weight,
-                    }
-                )
+            messages.append(
+                {
+                    "role": role,
+                    "content": _normalize_content(message, message_content_field, role),
+                    "weight": weight,
+                }
+            )
 
         return {"conversation": messages}
 
     return transform_builder
+
+
+def _convert_openai_tool_call(tool_call: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert a raw OpenAI tool call entry to the internal tool_call content format."""
+    function = tool_call.get("function", tool_call)
+    arguments = function.get("arguments", {})
+    if isinstance(arguments, str):
+        arguments = json.loads(arguments) if arguments else {}
+    value: dict[str, Any] = {"name": function.get("name", ""), "arguments": arguments}
+    tool_call_id = tool_call.get("id") or function.get("id")
+    if tool_call_id is not None:
+        value["id"] = tool_call_id
+    return {"type": "tool_call", "value": value}
+
+
+def _normalize_content(
+    message: Mapping[str, Any], message_content_field: str, role: str
+) -> list[dict[str, Any]]:
+    """Normalize raw dataset message content into the internal content format.
+
+    Handles OpenAI-style tool calls (top-level `tool_calls` field or
+    `{"type": "function", ...}` content items), string-encoded JSON arguments,
+    and tool messages with a `name`, which become `tool_response` contents.
+    """
+    content = message.get(message_content_field, [])
+    if content is None or content == "":
+        content = []
+    if isinstance(content, str):
+        content = [{"type": "text", "value": content}]
+    elif not isinstance(content, list):
+        content = [content]
+
+    normalized: list[dict[str, Any]] = []
+    for item in content:
+        if isinstance(item, Mapping) and item.get("type") == "function":
+            normalized.append(_convert_openai_tool_call(item))
+        else:
+            normalized.append(item)
+
+    if isinstance(message.get("tool_calls"), list):
+        normalized.extend(
+            _convert_openai_tool_call(tool_call) for tool_call in message["tool_calls"]
+        )
+
+    if role in ("tool", "ipython") and message.get("name"):
+        if len(normalized) == 1:
+            item = normalized[0]
+            if item.get("type") == "text":
+                response_content: Any = item.get("value", item.get("text", ""))
+            elif isinstance(item, Mapping) and "type" not in item:
+                response_content = item
+            else:
+                return normalized
+            tool_response: dict[str, Any] = {
+                "name": message["name"],
+                "content": response_content,
+            }
+            if message.get("tool_call_id"):
+                tool_response["id"] = message["tool_call_id"]
+            return [{"type": "tool_response", "value": tool_response}]
+        return normalized
+
+    return normalized

--- a/tests/core/datasets/transforms/test_chat_builder.py
+++ b/tests/core/datasets/transforms/test_chat_builder.py
@@ -1,0 +1,341 @@
+"""
+Tests for the chat message transform builder (raw dataset -> internal format).
+"""
+
+import pytest
+
+from axolotl.core.datasets.transforms.chat_builder import chat_message_transform_builder
+
+
+@pytest.fixture(name="toolcalling_sample")
+def fixture_toolcalling_sample():
+    return {
+        "messages": [
+            {"role": "system", "content": "You are a bot."},
+            {"role": "user", "content": "What's the temperature in Paris?"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_temperature",
+                            "arguments": {
+                                "location": "Paris, France",
+                                "unit": "celsius",
+                            },
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "get_current_temperature",
+                "content": "22.0",
+            },
+            {
+                "role": "assistant",
+                "content": "The temperature is 22.0 degrees Celsius.",
+            },
+        ]
+    }
+
+
+class TestChatBuilderText:
+    def test_str_content_becomes_text_item(self):
+        transform = chat_message_transform_builder()
+        out = transform({"messages": [{"role": "user", "content": "hello"}]})
+        assert out["conversation"][0]["content"] == [{"type": "text", "value": "hello"}]
+
+    def test_sharegpt_fields(self):
+        transform = chat_message_transform_builder(conversations_field="conversations")
+        out = transform(
+            {
+                "conversations": [
+                    {"from": "human", "value": "hello"},
+                    {"from": "gpt", "value": "hi"},
+                ]
+            }
+        )
+        assert out["conversation"][0] == {
+            "role": "user",
+            "content": [{"type": "text", "value": "hello"}],
+            "weight": 0,
+        }
+        assert out["conversation"][1]["role"] == "assistant"
+        assert out["conversation"][1]["weight"] == 1
+
+    def test_message_weight_field(self):
+        transform = chat_message_transform_builder(message_field_training="train")
+        out = transform({"messages": [{"role": "user", "content": "x", "train": 1}]})
+        assert out["conversation"][0]["weight"] == 1
+
+
+class TestChatBuilderToolCalls:
+    def test_openai_tool_calls(self, toolcalling_sample):
+        transform = chat_message_transform_builder()
+        out = transform(toolcalling_sample)
+        conv = out["conversation"]
+        assert conv[2]["content"] == [
+            {
+                "type": "tool_call",
+                "value": {
+                    "name": "get_current_temperature",
+                    "arguments": {"location": "Paris, France", "unit": "celsius"},
+                },
+            }
+        ]
+        assert conv[3]["content"] == [
+            {
+                "type": "tool_response",
+                "value": {
+                    "name": "get_current_temperature",
+                    "content": "22.0",
+                },
+            }
+        ]
+
+    def test_tool_calls_without_type_field(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {"role": "user", "content": "move to (0, 1)"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "move",
+                                    "arguments": {"x": 0, "y": 1},
+                                }
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+        assert out["conversation"][1]["content"] == [
+            {
+                "type": "tool_call",
+                "value": {"name": "move", "arguments": {"x": 0, "y": 1}},
+            }
+        ]
+
+    def test_tool_calls_with_string_arguments(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_stock_price",
+                                    "arguments": '{"symbol": "AAPL"}',
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {
+                "type": "tool_call",
+                "value": {
+                    "name": "get_stock_price",
+                    "arguments": {"symbol": "AAPL"},
+                    "id": "call_1",
+                },
+            }
+        ]
+
+    def test_content_function_items_converted(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "move",
+                                    "arguments": {"x": 1, "y": 2},
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {
+                "type": "tool_call",
+                "value": {"name": "move", "arguments": {"x": 1, "y": 2}},
+            }
+        ]
+
+    def test_text_and_tool_calls_coexist(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "Let me check.",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {"name": "f", "arguments": {}},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {"type": "text", "value": "Let me check."},
+            {"type": "tool_call", "value": {"name": "f", "arguments": {}}},
+        ]
+
+    def test_tool_message_without_content_field(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {"name": "f", "arguments": {}},
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+        assert out["conversation"][1]["content"] == [
+            {"type": "tool_call", "value": {"name": "f", "arguments": {}}}
+        ]
+
+    def test_tool_call_id_on_response(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "tool",
+                        "name": "move",
+                        "tool_call_id": "call_1",
+                        "content": "ok",
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {
+                "type": "tool_response",
+                "value": {"name": "move", "content": "ok", "id": "call_1"},
+            }
+        ]
+
+    def test_tool_text_key_content(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "tool",
+                        "name": "get_temp",
+                        "content": [{"type": "text", "text": "22.0"}],
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {
+                "type": "tool_response",
+                "value": {"name": "get_temp", "content": "22.0"},
+            }
+        ]
+
+    def test_tool_dict_content(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "tool",
+                        "name": "get_date",
+                        "content": {"date": "2024-09-09"},
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {
+                "type": "tool_response",
+                "value": {"name": "get_date", "content": {"date": "2024-09-09"}},
+            }
+        ]
+
+    def test_tool_message_without_name_keeps_text(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "tool",
+                        "content": "ok",
+                        "tool_call_id": "call_1",
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [{"type": "text", "value": "ok"}]
+
+    def test_nontext_items_pass_through(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "value": "/tmp/a.png"},
+                            {"type": "text", "value": "what is this?"},
+                        ],
+                    }
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"] == [
+            {"type": "image", "value": "/tmp/a.png"},
+            {"type": "text", "value": "what is this?"},
+        ]
+
+    def test_empty_content(self):
+        transform = chat_message_transform_builder()
+        out = transform({"messages": [{"role": "user", "content": ""}]})
+        assert out["conversation"][0]["content"] == []
+
+    def test_dict_content_wrapped_in_list(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {"messages": [{"role": "user", "content": {"type": "text", "value": "hi"}}]}
+        )
+        assert out["conversation"][0]["content"] == [{"type": "text", "value": "hi"}]
+
+    def test_missing_content_field_raises(self):
+        transform = chat_message_transform_builder()
+        with pytest.raises(ValueError, match="message_content"):
+            transform({"messages": [{"role": "user"}]})

--- a/tests/core/datasets/transforms/test_chat_builder.py
+++ b/tests/core/datasets/transforms/test_chat_builder.py
@@ -339,3 +339,76 @@ class TestChatBuilderToolCalls:
         transform = chat_message_transform_builder()
         with pytest.raises(ValueError, match="message_content"):
             transform({"messages": [{"role": "user"}]})
+
+    def test_content_field_detected_in_later_message(self):
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_temperature",
+                                    "arguments": {},
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "assistant", "content": "The temperature is 22.0."},
+                ]
+            }
+        )
+        assert out["conversation"][0]["content"][0]["type"] == "tool_call"
+        assert out["conversation"][1]["content"] == [
+            {"type": "text", "value": "The temperature is 22.0."}
+        ]
+
+    def test_weight_field_detected_in_later_message(self):
+        transform = chat_message_transform_builder(message_field_training="weight")
+        out = transform(
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi", "weight": 0},
+                ]
+            }
+        )
+        assert out["conversation"][1]["weight"] == 0
+
+    def test_tool_contents_validate_as_message_contents(self):
+        from axolotl.core.chat.messages import MessageContents
+
+        transform = chat_message_transform_builder()
+        out = transform(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_temperature",
+                                    "arguments": {"location": "Paris"},
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "name": "get_temperature",
+                        "content": "22.0",
+                        "tool_call_id": "call_1",
+                    },
+                ]
+            }
+        )
+        for content in out["conversation"][0]["content"]:
+            assert content["type"] == "tool_call"
+            MessageContents(**content)
+        response = out["conversation"][1]["content"][0]
+        assert response["type"] == "tool_response"
+        MessageContents(**response)


### PR DESCRIPTION
## Description

Makes `chat_message_transform_builder` robust to raw OpenAI-formatted datasets (e.g. tool-use conversations exported from OpenAI where assistant messages carry `tool_calls` and no `content`):

- `_convert_openai_tool_call`: converts type-less `tool_calls` entries and `{"type": "function", ...}` content items into the internal `tool_call` content format; parses string-encoded JSON arguments; propagates `id`.
- `_normalize_content`: normalizes content to the list-of-items format — string → `{"type": "text", "value": ...}`, dict → list, OpenAI `text` key handled, tool-role messages with a `name` become `tool_response` contents (with `tool_call_id` mapped to `id`).
- Field detection now scans **all** messages in the conversation, not just the first — required for tool-call rows where assistant messages carry `tool_calls` and no `content`.

Also fixes a latent bug: the `message_field_training` check iterated the raw string characters instead of the normalized `message_weight_fields`, so the weight column was never honored.

## Motivation and Context

Datasets with raw OpenAI `tool_calls` currently crash `load()` / dataset wrapping with `KeyError: 'content'` because assistant messages have no `content` key and the transform only looked at the first message. This unblocks standard OpenAI-export tool-use datasets end-to-end.

## How has this been tested?

- New `tests/core/datasets/transforms/test_chat_builder.py`: 17 tests covering str/dict/list content, `{"type":"function"}` items, type-less tool_calls, string-JSON arguments, tool messages with `name`/`tool_call_id`, weight-column handling, and failure modes.
- End-to-end verified through the full `load()` → `wrap_dataset` pipeline with the Llama-3 chatml tokenizer, producing canonical `<tool_call>`/`<tool_response>` decodes.
- Plain assistant datasets produce **byte-identical** output vs. the previous implementation (only difference observed: dataset wrap throughput).
- `ruff`, `ruff-format`, `mypy`, `bandit` clean.

## AI Usage Disclaimer

Yes — used as an AI coding assistant for drafting the initial implementation. All changes were then reviewed, benchmarked, and tested by me; evidence is in the test sections above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat message handling for tool calls, tool responses, text, structured content, and multimodal messages.
  - Added support for normalizing varied message formats, including JSON content and messages with missing content when tool calls are present.

- **Bug Fixes**
  - Improved handling of empty, mixed, and structured message content.
  - Added clearer validation for messages missing required content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->