### PR TITLE
fix(trainers): feature-detect is_main_process for save_pretrained

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -934,8 +934,6 @@ class AxolotlTrainer(
 
         return result
 
-    # TODO(wing): drop the is_main_process forwarding below once
-    # https://github.com/huggingface/transformers/pull/39866/files is merged
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import gc
+import inspect
 import json
 import math
 import os
@@ -67,6 +68,19 @@ REDUCTION_FNS = {
     "max": torch.max,
     "sum": torch.sum,
 }
+
+_SAVE_PRETRAINED_IS_MAIN_PROCESS_SUPPORTED: bool | None = None
+
+
+def _save_pretrained_supports_is_main_process() -> bool:
+    """True when the installed transformers save_pretrained accepts is_main_process."""
+    global _SAVE_PRETRAINED_IS_MAIN_PROCESS_SUPPORTED
+    if _SAVE_PRETRAINED_IS_MAIN_PROCESS_SUPPORTED is None:
+        _SAVE_PRETRAINED_IS_MAIN_PROCESS_SUPPORTED = (
+            "is_main_process"
+            in inspect.signature(PreTrainedModel.save_pretrained).parameters
+        )
+    return _SAVE_PRETRAINED_IS_MAIN_PROCESS_SUPPORTED
 
 
 class AxolotlTrainer(
@@ -920,12 +934,17 @@ class AxolotlTrainer(
 
         return result
 
-    # TODO(wing): remove once https://github.com/huggingface/transformers/pull/39866/files is merged
+    # TODO(wing): drop the is_main_process forwarding below once
+    # https://github.com/huggingface/transformers/pull/39866/files is merged
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)
         LOG.info(f"Saving model checkpoint to {output_dir}")
+
+        save_pretrained_kwargs = {}
+        if _save_pretrained_supports_is_main_process():
+            save_pretrained_kwargs["is_main_process"] = self.accelerator.is_main_process
 
         # fix for Context Parallel save: CP eval invalidates tensor storage
         # pointers, so clone to CPU to get fresh valid storage for safetensors
@@ -960,7 +979,7 @@ class AxolotlTrainer(
                 ).save_pretrained(
                     output_dir,
                     state_dict=state_dict,
-                    is_main_process=self.accelerator.is_main_process,
+                    **save_pretrained_kwargs,
                 )
             else:
                 LOG.info(
@@ -975,7 +994,7 @@ class AxolotlTrainer(
             self.model.save_pretrained(
                 output_dir,
                 state_dict=state_dict,
-                is_main_process=self.accelerator.is_main_process,
+                **save_pretrained_kwargs,
             )
 
         if self.processing_class is not None:

--- a/tests/core/test_trainer_save_pretrained.py
+++ b/tests/core/test_trainer_save_pretrained.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from axolotl.core.trainers.base import (
+    AxolotlTrainer,
+    _save_pretrained_supports_is_main_process,
+)
+
+
+def _make_trainer(tmp_path, is_main_process=True):
+    config = LlamaConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+    )
+    trainer = AxolotlTrainer.__new__(AxolotlTrainer)
+    trainer.args = SimpleNamespace(output_dir=str(tmp_path))
+    trainer.axolotl_cfg = None
+    trainer.model = LlamaForCausalLM(config)
+    trainer.accelerator = SimpleNamespace(is_main_process=is_main_process)
+    trainer.processing_class = None
+    trainer.data_collator = None
+    return trainer
+
+
+def test_save_pretrained_supports_is_main_process():
+    assert _save_pretrained_supports_is_main_process() is True
+
+
+def test_save_forwards_is_main_process(tmp_path):
+    trainer = _make_trainer(tmp_path)
+    with patch.object(LlamaForCausalLM, "save_pretrained", new=MagicMock()) as m:
+        trainer._save()
+    m.assert_called_once_with(str(tmp_path), state_dict=None, is_main_process=True)
+
+
+def test_save_forwards_is_main_process_false(tmp_path):
+    trainer = _make_trainer(tmp_path, is_main_process=False)
+    with patch.object(LlamaForCausalLM, "save_pretrained", new=MagicMock()) as m:
+        trainer._save()
+    m.assert_called_once_with(str(tmp_path), state_dict=None, is_main_process=False)
+
+
+def test_save_skips_is_main_process_when_unsupported(tmp_path):
+    trainer = _make_trainer(tmp_path)
+    with (
+        patch(
+            "axolotl.core.trainers.base._save_pretrained_supports_is_main_process",
+            return_value=False,
+        ),
+        patch.object(LlamaForCausalLM, "save_pretrained", new=MagicMock()) as m,
+    ):
+        trainer._save()
+    m.assert_called_once_with(str(tmp_path), state_dict=None)


### PR DESCRIPTION
## Description

The `_save` override forwards `is_main_process` to `save_pretrained` so non-main ranks skip config writes and stale-shard cleanup (the race fixed by huggingface/transformers#39866). That forwarding is currently **unconditional**; this PR makes it conditional on the installed transformers actually accepting the parameter, detected once via `inspect.signature` and cached module-wide.

## Motivation and Context

`save_pretrained` only gained `is_main_process` in a recent transformers release (it gates the config/generation-config writes and the stale-`.safetensors` `os.remove` cleanup that races across ranks — verified in the installed 5.14.1 source; the upstream `Trainer._save` still does not forward it, so the override remains required while #39866 is open). If the dependency pin ever moves below that release, the unconditional forwarding raises `TypeError: save_pretrained() got an unexpected keyword argument 'is_main_process'` in every checkpoint save. Feature-detection makes the override correct on any transformers version, and lets the `TODO(wing)` be resolved by simply deleting the forwarding once upstream merges — with no intermediate breakage.

## How has this been tested?

- New `tests/core/test_trainer_save_pretrained.py` (4 tests) drives `_save` with a real `LlamaForCausalLM` and asserts:
  - the detection helper is `True` on the installed transformers;
  - `is_main_process=True` / `False` are forwarded when supported;
  - the kwarg is omitted entirely when support is simulated absent (old-transformers path).
- `ruff`, `ruff-format`, `mypy`, `bandit` clean; full offline suite 450 tests pass.

## AI Usage Disclaimer

Yes — used as an AI coding assistant for drafting the initial implementation. All changes were then reviewed, benchmarked, and tested by me; evidence is in the test sections above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model checkpoint saving across supported Transformers versions.
  * Preserved process-aware saving when available while avoiding compatibility errors with older versions.

* **Tests**
  * Added coverage for supported and unsupported saving behaviors, including different accelerator process states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->