### PR TITLE
fix: restore bf16 default dtype outside FSDP2/torchao optimizers

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -56,8 +56,14 @@ _TORCHAO_LOW_BIT_OPTIMIZERS = frozenset(
 
 
 def _bf16_default_dtype_safe(cfg: DictDefault) -> bool:
-    """False for FSDP2 and torchao low-bit optimizers: they allocate state via
-    torch.empty, which silently picks up a bf16 default dtype."""
+    """False for FSDP2 and torchao low-bit optimizers.
+
+    The torchao low-bit optimizers (AdamW4Bit/8Bit/Fp8, and sinkgd, which
+    subclasses torchao's ``_AdamBase``) allocate the quantized-state ``scale``
+    tensor via ``torch.zeros(..., device=device)`` without an explicit dtype,
+    so it silently picks up a bf16 default dtype. ``fsdp_version: 2`` with an
+    empty or absent ``fsdp_config`` is not FSDP2 (FSDP is enabled by providing
+    a config), so it does not block the default dtype either."""
     is_fsdp2 = bool(
         str(getattr(cfg, "fsdp_version", "")) == "2"
         and (getattr(cfg, "fsdp_config", None) or getattr(cfg, "fsdp", None))

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -243,11 +243,17 @@ def execute_training(
                 )
             )
 
+        prev_default_dtype = None
         if cfg.bf16 and _bf16_default_dtype_safe(cfg):
+            prev_default_dtype = torch.get_default_dtype()
             torch.set_default_dtype(torch.bfloat16)
 
-        LOG.info("Starting trainer...")
-        trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+        try:
+            LOG.info("Starting trainer...")
+            trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+        finally:
+            if prev_default_dtype is not None:
+                torch.set_default_dtype(prev_default_dtype)
 
         PLUGIN_MANAGER.post_train(cfg, trainer.model)
 

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -50,6 +50,22 @@ LOG = get_logger(__name__)
 TELEMETRY_MANAGER = TelemetryManager.get_instance()
 PLUGIN_MANAGER = PluginManager.get_instance()
 
+_TORCHAO_LOW_BIT_OPTIMIZERS = frozenset(
+    {"ao_adamw_4bit", "ao_adamw_8bit", "ao_adamw_fp8", "sinkgd"}
+)
+
+
+def _bf16_default_dtype_safe(cfg: DictDefault) -> bool:
+    """False for FSDP2 and torchao low-bit optimizers: they allocate state via
+    torch.empty, which silently picks up a bf16 default dtype."""
+    is_fsdp2 = bool(
+        str(getattr(cfg, "fsdp_version", "")) == "2"
+        and (getattr(cfg, "fsdp_config", None) or getattr(cfg, "fsdp", None))
+    )
+    if is_fsdp2:
+        return False
+    return str(getattr(cfg, "optimizer", "")) not in _TORCHAO_LOW_BIT_OPTIMIZERS
+
 
 def setup_model_and_tokenizer(
     cfg: DictDefault,
@@ -227,9 +243,8 @@ def execute_training(
                 )
             )
 
-        # TODO: disabling for now as not compatible with FSDP2 + torchao low bit optimizers
-        # if cfg.bf16:
-        #     torch.set_default_dtype(torch.bfloat16)
+        if cfg.bf16 and _bf16_default_dtype_safe(cfg):
+            torch.set_default_dtype(torch.bfloat16)
 
         LOG.info("Starting trainer...")
         trainer.train(resume_from_checkpoint=resume_from_checkpoint)

--- a/tests/core/test_bf16_default_dtype.py
+++ b/tests/core/test_bf16_default_dtype.py
@@ -1,0 +1,40 @@
+import pytest
+
+from axolotl.train import _bf16_default_dtype_safe
+from axolotl.utils.dict import DictDefault
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {},
+        {"bf16": True},
+        {"fsdp_version": 1, "fsdp_config": {"activation_checkpointing": True}},
+        {"fsdp_version": 2},
+        {"fsdp_version": "2", "fsdp_config": {}},
+        {"optimizer": "adamw_torch"},
+    ],
+)
+def test_bf16_default_dtype_safe(cfg):
+    assert _bf16_default_dtype_safe(DictDefault(cfg)) is True
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {"fsdp_version": 2, "fsdp_config": {"activation_checkpointing": True}},
+        {"fsdp_version": "2", "fsdp_config": {"sync_module_state": True}},
+        {
+            "fsdp_version": 2,
+            "fsdp_config": {"activation_checkpointing": True},
+            "optimizer": "adamw_torch",
+        },
+        {"fsdp_version": 2, "fsdp": "full_shard"},
+        {"optimizer": "ao_adamw_4bit"},
+        {"optimizer": "ao_adamw_8bit"},
+        {"optimizer": "ao_adamw_fp8"},
+        {"optimizer": "sinkgd"},
+    ],
+)
+def test_bf16_default_dtype_unsafe(cfg):
+    assert _bf16_default_dtype_safe(DictDefault(cfg)) is False


### PR DESCRIPTION
## Description

Re-enables `torch.set_default_dtype(torch.bfloat16)` for bf16 runs, guarded by a `_bf16_default_dtype_safe(cfg)` check that excludes the configurations the setting was disabled for: **FSDP2** (detected with the same `fsdp_version == 2` + fsdp-config pattern used elsewhere in the codebase) and **torchao low-bit optimizers** (`ao_adamw_4bit`, `ao_adamw_8bit`, `ao_adamw_fp8`, `sinkgd`). These allocate optimizer/buffer state via `torch.empty`, which silently picks up the bf16 default dtype.

## Motivation and Context

The block was disabled wholesale with "not compatible with FSDP2 + torchao low bit optimizers", which also removed the memory benefit (bf16-default intermediate buffers — roughly half the footprint of fp32) for every other bf16 configuration: single-GPU, DDP, DeepSpeed, and FSDP1 runs. The guard restores the benefit where safe while keeping the known-incompatible configurations off.

## How has this been tested?

- New `tests/core/test_bf16_default_dtype.py`: 14 parametrized cases covering plain bf16, FSDP1, FSDP2 (int and string versions, with/without fsdp config), legacy `fsdp` field, standard optimizers, and all four torchao low-bit optimizers.
- `ruff`, `ruff-format`, `mypy`, `bandit` clean; full offline suite passes.

## AI Usage Disclaimer

Yes — used as an AI coding assistant for drafting the initial implementation. All changes were then reviewed, benchmarked, and tested by me; evidence is in the test sections above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bfloat16 training is now enabled automatically when configured and compatible with the selected training setup.
  * Training avoids enabling bfloat16 in configurations that may not support it safely, improving compatibility with advanced sharding and low-bit optimization options.

* **Bug Fixes**
  * Improved handling of bfloat16 defaults across different training configurations.

* **Tests**
  * Added coverage for supported and unsupported bfloat16 configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->