### PR TITLE
fix(grpo): seed dataloader workers by SP group

### DIFF
--- a/src/axolotl/core/trainers/grpo/trainer.py
+++ b/src/axolotl/core/trainers/grpo/trainer.py
@@ -236,10 +236,18 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
                 dataloader_params["drop_last"] = self.args.dataloader_drop_last
 
             if not is_eval:
+                # Seed workers by SP group so every rank in a group gets identical
+                # worker RNG and therefore identical batches (required by ring
+                # attention, which splits the sequence at forward time).
+                worker_seed_rank = (
+                    self.args.process_index // self.args.context_parallel_size
+                    if self.args.context_parallel_size > 1
+                    else self.args.process_index
+                )
                 dataloader_params["worker_init_fn"] = partial(
                     seed_worker,
                     num_workers=self.args.dataloader_num_workers,
-                    rank=self.args.process_index,
+                    rank=worker_seed_rank,
                 )
 
         # Create the dataloader
@@ -251,10 +259,10 @@ class AxolotlGRPOSequenceParallelTrainer(AxolotlGRPOTrainer):
         ):
             self.accelerator.even_batches = False
 
-        # Return unprepared dataloader if using sequence parallelism
-        # TODO(djsaunde): We might be able to use `accelerate`'s dataloader preparation
-        # if we use `dispatch_batches` and `slice_fn_for_dispatch` properly (i.e.,
-        # slice each batch along the sequence dimension).
+        # SP groups must all receive identical full batches: the sequence is split
+        # at attention time by ring attention. Accelerate's prepare_data_loader
+        # broadcasts from process 0 and slices by global rank, which would collapse
+        # every SP group onto group 0's data, so the raw dataloader is returned.
         if self.args.context_parallel_size > 1:
             return dataloader
 

--- a/tests/core/test_grpo_dataloader.py
+++ b/tests/core/test_grpo_dataloader.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+from datasets import Dataset
+from torch.utils.data import DataLoader
+
+from axolotl.core.trainers.grpo.trainer import AxolotlGRPOSequenceParallelTrainer
+
+
+def _make_trainer(context_parallel_size, process_index, is_eval=False):
+    trainer = AxolotlGRPOSequenceParallelTrainer.__new__(
+        AxolotlGRPOSequenceParallelTrainer
+    )
+    trainer._train_batch_size = 2
+    trainer.args = SimpleNamespace(
+        eval_batch_size=2,
+        dataloader_num_workers=0,
+        dataloader_pin_memory=False,
+        dataloader_persistent_workers=False,
+        dataloader_prefetch_factor=None,
+        sample_packing=False,
+        pretraining=False,
+        eval_sample_packing=None,
+        dataloader_drop_last=False,
+        process_index=process_index,
+        context_parallel_size=context_parallel_size,
+    )
+    trainer.data_collator = lambda batch: {
+        "input_ids": torch.tensor([[1, 2, 3] for _ in batch])
+    }
+    trainer.accelerator = SimpleNamespace(
+        even_batches=True,
+        prepare_data_loader=MagicMock(side_effect=lambda dl: dl),
+    )
+    return trainer
+
+
+def test_cp_dataloader_not_prepared():
+    trainer = _make_trainer(context_parallel_size=2, process_index=0)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dataloader = trainer._prepare_dataloader(dataset, None, is_eval=False)
+
+    assert isinstance(dataloader, DataLoader)
+    trainer.accelerator.prepare_data_loader.assert_not_called()
+
+
+def test_cp1_dataloader_prepared():
+    trainer = _make_trainer(context_parallel_size=1, process_index=0)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dataloader = trainer._prepare_dataloader(dataset, None, is_eval=False)
+
+    trainer.accelerator.prepare_data_loader.assert_called_once_with(dataloader)
+
+
+def test_cp_worker_seed_rank_is_sp_group():
+    trainer = _make_trainer(context_parallel_size=2, process_index=3)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dataloader = trainer._prepare_dataloader(dataset, None, is_eval=False)
+
+    assert dataloader.worker_init_fn.keywords["rank"] == 1
+
+
+def test_cp1_worker_seed_rank_is_process_index():
+    trainer = _make_trainer(context_parallel_size=1, process_index=3)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dataloader = trainer._prepare_dataloader(dataset, None, is_eval=False)
+
+    assert dataloader.worker_init_fn.keywords["rank"] == 3
+
+
+def test_cp_same_group_identical_worker_seed():
+    group_rank0 = _make_trainer(context_parallel_size=4, process_index=0)
+    group_rank3 = _make_trainer(context_parallel_size=4, process_index=3)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dl_rank0 = group_rank0._prepare_dataloader(dataset, None, is_eval=False)
+    dl_rank3 = group_rank3._prepare_dataloader(dataset, None, is_eval=False)
+
+    assert (
+        dl_rank0.worker_init_fn.keywords["rank"]
+        == dl_rank3.worker_init_fn.keywords["rank"]
+        == 0
+    )
+
+
+def test_cp_eval_has_no_worker_init_fn():
+    trainer = _make_trainer(context_parallel_size=2, process_index=3)
+    dataset = Dataset.from_dict({"a": [1, 2, 3, 4]})
+
+    dataloader = trainer._prepare_dataloader(dataset, None, is_eval=True)
+
+    assert dataloader.worker_init_fn is None


### PR DESCRIPTION
## Description

In `_prepare_dataloader`, worker RNG is now seeded by **SP group** (`process_index // context_parallel_size`) when `context_parallel_size > 1`, instead of by global `process_index`. Also replaces the speculative `TODO(djsaunde)` about using accelerate's dataloader preparation with the verified invariant that documents why the raw dataloader must be returned.

## Motivation and Context

Sequence parallelism requires every rank in an SP group to receive **identical** full batches — the sequence dimension is split at attention time by ring attention, not by the dataloader (confirmed against transformers' own `_prepare_context_parallel_inputs`, which also splits at forward time). The old worker seeding used the global rank, so ranks within a group had different worker RNG; any collate that draws randomness (shuffling, random packing, augmentation) would produce different batches across the group, and ring attention would exchange KV shards across mismatched sequences — silently corrupting training. Seeding by SP group makes collate behavior deterministic and identical within a group (distinct across groups).

The `TODO` proposed `dispatch_batches` + `slice_fn_for_dispatch` for the dataloader; this cannot work: accelerate's dispatcher broadcasts from process 0 only and slices by global rank, which collapses every SP group onto group 0's data. The comment now states this invariant so the bypass is not "simplified away" later.

## How has this been tested?

- New `tests/core/test_grpo_dataloader.py` (6 tests): raw dataloader returned (prepare not called) when `context_parallel_size > 1`; prepared otherwise; worker seed rank equals SP group for CP runs, equals process index otherwise; identical seeds across ranks in the same group; eval has no worker init fn.
- `ruff`, `ruff-format`, `mypy`, `bandit` clean; full offline suite passes.

## AI Usage Disclaimer

Yes — used as an AI coding assistant for drafting the initial implementation. All changes were then reviewed, benchmarked, and tested by me; evidence is in the test sections above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequence-parallel data loading so workers within the same parallel group receive consistent random seeds.
  * Preserved complete, identical batches across sequence-parallel workers by avoiding incompatible data distribution.
  * Ensured evaluation data loaders do not apply training-only worker initialization.

* **Tests**
  * Added coverage for parallel and non-parallel data-loader preparation, worker seed consistency, and evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->