### PR TITLE
chore(prompt): remove stale numpy slicing TODOs

### DIFF
--- a/src/axolotl/prompt_strategies/alpaca_w_system.py
+++ b/src/axolotl/prompt_strategies/alpaca_w_system.py
@@ -40,7 +40,6 @@ class InstructionWSystemPromptTokenizingStrategy(PromptTokenizingStrategy):
         tokenized_prompt = self._tokenize(user_prompt, add_eos_token=False)
         if not self.train_on_inputs:
             user_prompt_len = len(tokenized_prompt["input_ids"])
-            # TODO this could be sped up using numpy array slicing
             tokenized_prompt["labels"] = [-100] * user_prompt_len
         tokenized_res_prompt = self._tokenize(
             response, strip_bos_token=True, add_eos_token=True

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -132,7 +132,6 @@ class InstructionPromptTokenizingStrategy(PromptTokenizingStrategy):
         tokenized_prompt = self._tokenize(user_prompt, add_eos_token=False)
         if not self.train_on_inputs:
             user_prompt_len = len(tokenized_prompt["input_ids"])
-            # TODO this could be sped up using numpy array slicing
             tokenized_prompt["labels"] = [IGNORE_INDEX] * user_prompt_len
         tokenized_res_prompt = self._tokenize(
             response, strip_bos_token=True, add_eos_token=True
@@ -282,7 +281,6 @@ class ReflectionPromptTokenizingStrategy(PromptTokenizingStrategy):
             )
             tokenized_user_prompt = self._tokenize(user_prompt, add_eos_token=False)
             user_prompt_len = len(tokenized_user_prompt["input_ids"])
-            # TODO this could be sped up using numpy array slicing
             tokenized_full_prompt["labels"] = [
                 IGNORE_INDEX
             ] * user_prompt_len + tokenized_full_prompt["labels"][user_prompt_len:]


### PR DESCRIPTION
## Description

Removes three stale `# TODO this could be sped up using numpy array slicing` comments in the prompt tokenizers.

## Motivation and Context

Benchmarked before removing: `np.full(...).tolist()` is **6-9x slower** than the existing `[IGNORE_INDEX] * n` list multiplication at all sizes, and a profile of the tokenizing strategies shows ~86% of runtime is the tokenizer's `encode_batch` while the Python list operations account for ~3%. The TODOs suggest an optimization that would measurably regress performance, so they are removed to avoid misleading future contributors. No behavior change.

## How has this been tested?

- Existing prompt-tokenizer tests pass unchanged (3 tests, llama-7b tokenizer).
- `ruff`, `ruff-format`, `mypy`, `bandit` clean.

## AI Usage Disclaimer

Yes — used as an AI coding assistant for drafting the initial implementation. All changes were then reviewed, benchmarked, and tested by me; evidence is in the test sections above.

## Types of changes

- [x] Chore/cleanup (no behavior change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete internal TODO comments.
  * No user-visible functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->