### PR TITLE
fix: qwen patch broken after transformers update

### DIFF
--- a/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
@@ -80,7 +80,7 @@ def _patched_decoder_forward(
     residual = hidden_states
     hidden_states = self.input_layernorm(hidden_states)
 
-    if self.layer_type == "linear_attention":
+    if self.block_type == "linear_attention":
         hidden_states = self.linear_attn(
             hidden_states=hidden_states,
             cache_params=past_key_values,
@@ -88,7 +88,7 @@ def _patched_decoder_forward(
             attention_mask=attention_mask,
             position_ids=position_ids,
         )
-    elif self.layer_type == "full_attention":
+    elif self.block_type == "full_attention":
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,

--- a/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_5/modeling.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from transformers.integrations.accelerate import force_accelerate_hooks
 
 from axolotl.monkeypatch.lora_kernels import LINEAR_ATTN_IN_PROJS
 from axolotl.utils.logging import get_logger
@@ -20,6 +21,13 @@ except ImportError:
         from fla.modules.conv import causal_conv1d as fla_causal_conv1d  # FLA < 0.4.1
     except ImportError:
         fla_causal_conv1d = None
+
+try:
+    from fla.ops.gated_delta_rule import (
+        chunk_gated_delta_rule as fla_chunk_gated_delta_rule,
+    )
+except ImportError:
+    fla_chunk_gated_delta_rule = None
 
 
 def get_cu_seqlens(position_ids):
@@ -45,25 +53,6 @@ def get_cu_seqlens(position_ids):
             torch.tensor(position_ids.size(), **tensor_kwargs),
         )
     )
-
-
-def _inject_fla_kernels(module) -> None:
-    """Inject FLA kernels into a modeling module, bypassing is_flash_linear_attention_available."""
-    try:
-        from fla.modules import FusedRMSNormGated
-        from fla.ops.gated_delta_rule import (
-            chunk_gated_delta_rule,
-            fused_recurrent_gated_delta_rule,
-        )
-
-        module.FusedRMSNormGated = FusedRMSNormGated
-        module.chunk_gated_delta_rule = chunk_gated_delta_rule
-        module.fused_recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule
-        module.is_fast_path_available = True
-    except ImportError:
-        module.chunk_gated_delta_rule = None
-        module.fused_recurrent_gated_delta_rule = None
-        module.FusedRMSNormGated = None
 
 
 def _patched_decoder_forward(
@@ -126,9 +115,10 @@ def _la_in_proj_fwd(module, x):
     return {name: getattr(module, name)(x) for name in LINEAR_ATTN_IN_PROJS}
 
 
-def _make_qwen3_5_gated_delta_forward(apply_mask_fn):
+def _make_qwen3_5_gated_delta_forward(module):
     """Factory for patched Qwen3_5/Qwen3_5Moe GatedDeltaNet forward with packing support."""
 
+    @force_accelerate_hooks("conv1d")
     def patched_forward(
         self,
         hidden_states: torch.Tensor,
@@ -136,25 +126,32 @@ def _make_qwen3_5_gated_delta_forward(apply_mask_fn):
         cache_position: Optional[torch.LongTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        **kwargs,
     ):
-        hidden_states = apply_mask_fn(hidden_states, attention_mask)
+        hidden_states = module.apply_mask_to_padding_states(
+            hidden_states, attention_mask
+        )
 
         batch_size, seq_len, _ = hidden_states.shape
 
         use_precomputed_states = (
-            cache_params is not None
-            and cache_params.has_previous_state
-            and seq_len == 1
-            and cache_position is not None
+            cache_params is not None and cache_params.has_previous_state(self.layer_idx)
         )
 
         cu_seqlens = None
         if not use_precomputed_states and position_ids is not None:
             cu_seqlens = get_cu_seqlens(position_ids=position_ids)
 
-        if cache_params is not None:
-            conv_state = cache_params.conv_states[self.layer_idx]
-            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+        if cu_seqlens is not None and (
+            fla_causal_conv1d is None or fla_chunk_gated_delta_rule is None
+        ):
+            # the transformers fallbacks accept cu_seqlens but ignore it, which would
+            # silently mix tokens across packed samples
+            raise RuntimeError(
+                "Packed sequences require flash-linear-attention (cu_seqlens support "
+                "in causal_conv1d and chunk_gated_delta_rule). Install "
+                "flash-linear-attention or disable packing."
+            )
 
         # All in-projections share hidden_states; fuse into one autograd node.
         # mixed_qkv stays [B, T, D]; only transposed inside paths that require [B, D, T]
@@ -167,40 +164,49 @@ def _make_qwen3_5_gated_delta_forward(apply_mask_fn):
         b = in_proj["in_proj_b"]
         a = in_proj["in_proj_a"]
 
-        if use_precomputed_states:
-            mixed_qkv = self.causal_conv1d_update(
+        if (
+            use_precomputed_states
+            and seq_len == 1
+            and not cache_params.layers[self.layer_idx].record_past
+        ):
+            conv_state = cache_params.layers[self.layer_idx].conv_states[0]
+            mixed_qkv = module.causal_conv1d_update(
                 mixed_qkv.transpose(1, 2),
                 conv_state,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
                 self.activation,
             ).transpose(1, 2)
-        else:
+        elif cu_seqlens is not None:
             if cache_params is not None:
-                mixed_qkv_t = mixed_qkv.transpose(1, 2)
-                cache_params.conv_states[self.layer_idx] = F.pad(
-                    mixed_qkv_t,
-                    (self.conv_kernel_size - mixed_qkv_t.shape[-1], 0),
+                cache_params.update_conv_state(
+                    mixed_qkv.transpose(1, 2),
+                    self.layer_idx,
+                    conv_kernel_size=self.conv_kernel_size,
                 )
-
-            if fla_causal_conv1d is not None and cu_seqlens is not None:
-                # FLA varlen kernel for packed sequences; input must be contiguous [B, T, D]
-                mixed_qkv, _ = fla_causal_conv1d(
-                    x=mixed_qkv,
-                    weight=self.conv1d.weight.squeeze(1),
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                    cu_seqlens=cu_seqlens,
+            # FLA varlen kernel for packed sequences; input must be contiguous [B, T, D]
+            mixed_qkv, _ = fla_causal_conv1d(
+                x=mixed_qkv,
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            mixed_qkv = mixed_qkv.transpose(1, 2)
+            if cache_params is not None:
+                mixed_qkv = cache_params.update_conv_state(
+                    mixed_qkv, self.layer_idx, conv_kernel_size=self.conv_kernel_size
                 )
-            else:
-                if cu_seqlens is not None and fla_causal_conv1d is None:
-                    raise RuntimeError(
-                        "Packed sequences require fla.modules.convolution.causal_conv1d "
-                        "(cu_seqlens support). Install flash-linear-attention or disable packing."
-                    )
-                mixed_qkv = F.silu(
-                    self.conv1d(mixed_qkv.transpose(1, 2))[:, :, :seq_len]
-                ).transpose(1, 2)
+            mixed_qkv = module.causal_conv1d_fn(
+                mixed_qkv,
+                self.conv1d.weight.squeeze(1),
+                self.conv1d.bias,
+                activation=self.activation,
+            )
+            if cache_params is not None:
+                mixed_qkv = mixed_qkv[:, :, -seq_len:]
+            mixed_qkv = mixed_qkv.transpose(1, 2)
 
         query, key, value = torch.split(
             mixed_qkv,
@@ -217,21 +223,26 @@ def _make_qwen3_5_gated_delta_forward(apply_mask_fn):
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-        if not use_precomputed_states:
-            core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
-                query,
-                key,
-                value,
-                g=g.to(dtype=query.dtype),
-                beta=beta,
-                initial_state=None,
-                output_final_state=cache_params is not None,
-                use_qk_l2norm_in_kernel=True,
-                # torch_chunk_gated_delta_rule fallback does not accept cu_seqlens
-                **({"cu_seqlens": cu_seqlens} if cu_seqlens is not None else {}),
+        recurrent_state = (
+            cache_params.layers[self.layer_idx].recurrent_states[0]
+            if use_precomputed_states
+            else None
+        )
+        if use_precomputed_states and seq_len == 1:
+            core_attn_out, last_recurrent_state = (
+                module.torch_recurrent_gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    g=g,
+                    beta=beta,
+                    initial_state=recurrent_state,
+                    output_final_state=cache_params is not None,
+                    use_qk_l2norm_in_kernel=True,
+                )
             )
-        else:
-            core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+        elif cu_seqlens is not None:
+            core_attn_out, last_recurrent_state = fla_chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -240,10 +251,22 @@ def _make_qwen3_5_gated_delta_forward(apply_mask_fn):
                 initial_state=recurrent_state,
                 output_final_state=cache_params is not None,
                 use_qk_l2norm_in_kernel=True,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            core_attn_out, last_recurrent_state = module.torch_chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
             )
 
         if cache_params is not None:
-            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
 
         core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
         z = z.reshape(-1, self.head_v_dim)
@@ -264,10 +287,9 @@ def _apply_packing_patches(model_type: str, cls_prefix: str, forward_factory) ->
         LOG.warning(f"{model_type} not found in transformers, skipping packing patches")
         return
 
-    _inject_fla_kernels(module)
     getattr(module, f"{cls_prefix}DecoderLayer").forward = _patched_decoder_forward
     gated_cls = getattr(module, f"{cls_prefix}GatedDeltaNet")
-    gated_cls.forward = forward_factory(module.apply_mask_to_padding_states)
+    gated_cls.forward = forward_factory(module)
 
     LOG.info(
         f"Applied {cls_prefix} packing patch "

--- a/src/axolotl/monkeypatch/models/qwen3_next/modeling.py
+++ b/src/axolotl/monkeypatch/models/qwen3_next/modeling.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from transformers.integrations.accelerate import force_accelerate_hooks
 
 from axolotl.utils.logging import get_logger
 
@@ -13,6 +14,13 @@ try:
     from fla.modules.convolution import causal_conv1d as fla_causal_conv1d
 except ImportError:
     fla_causal_conv1d = None
+
+try:
+    from fla.ops.gated_delta_rule import (
+        chunk_gated_delta_rule as fla_chunk_gated_delta_rule,
+    )
+except ImportError:
+    fla_chunk_gated_delta_rule = None
 
 
 def get_cu_seqlens(position_ids):
@@ -64,7 +72,7 @@ def patch_qwen3_next_decoder_layer():
         hidden_states = self.input_layernorm(hidden_states)
 
         # Token Mixer
-        if self.layer_type == "linear_attention":
+        if self.block_type == "linear_attention":
             hidden_states = self.linear_attn(
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
@@ -72,7 +80,7 @@ def patch_qwen3_next_decoder_layer():
                 attention_mask=attention_mask,
                 position_ids=position_ids,
             )
-        elif self.layer_type == "full_attention":
+        elif self.block_type == "full_attention":
             # Self Attention
             hidden_states, _ = self.self_attn(
                 hidden_states=hidden_states,
@@ -110,17 +118,15 @@ def patch_qwen3_next_decoder_layer():
 def patch_qwen3_next_gateddelta_layer():
     """Patch Qwen3NextGatedDeltaNet to parse cu_seqlens and pass to chunk_gated_delta_rule"""
     try:
-        from transformers.models.qwen3_next.modeling_qwen3_next import (
-            Qwen3NextGatedDeltaNet,
-            apply_mask_to_padding_states,
-        )
+        from transformers.models.qwen3_next import modeling_qwen3_next as modeling
     except ImportError:
         LOG.warning("Qwen3Next model not found, skipping patch")
-        return
+        return None
 
     # Store original forward method
-    original_gated_delta_net_forward = Qwen3NextGatedDeltaNet.forward
+    original_gated_delta_net_forward = modeling.Qwen3NextGatedDeltaNet.forward
 
+    @force_accelerate_hooks("conv1d")
     def patched_gated_delta_net_forward(
         self,
         hidden_states: torch.Tensor,
@@ -130,16 +136,17 @@ def patch_qwen3_next_gateddelta_layer():
         cache_position: Optional[
             torch.LongTensor
         ] = None,  # unused: no cache in packed training
+        **kwargs,
     ):
-        hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+        hidden_states = modeling.apply_mask_to_padding_states(
+            hidden_states, attention_mask
+        )
 
         # Set up dimensions for reshapes later
-        batch_size, seq_len, _ = hidden_states.shape
+        seq_len = hidden_states.shape[1]
 
         use_precomputed_states = (
-            cache_params is not None
-            and cache_params.has_previous_state(self.layer_idx)
-            and seq_len == 1
+            cache_params is not None and cache_params.has_previous_state(self.layer_idx)
         )
 
         # Compute cu_seqlens early for use by both causal_conv1d and chunk_gated_delta_rule
@@ -147,10 +154,16 @@ def patch_qwen3_next_gateddelta_layer():
         if not use_precomputed_states and position_ids is not None:
             cu_seqlens = get_cu_seqlens(position_ids=position_ids)
 
-        # getting projected states from cache if it exists
-        if use_precomputed_states:
-            conv_state = cache_params.layers[self.layer_idx].conv_states
-            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
+        if cu_seqlens is not None and (
+            fla_causal_conv1d is None or fla_chunk_gated_delta_rule is None
+        ):
+            # the transformers fallbacks accept cu_seqlens but ignore it, which would
+            # silently mix tokens across packed samples
+            raise RuntimeError(
+                "Packed sequences require flash-linear-attention (cu_seqlens support "
+                "in causal_conv1d and chunk_gated_delta_rule). Install "
+                "flash-linear-attention or disable packing."
+            )
 
         projected_states_qkvz = self.in_proj_qkvz(hidden_states)
         projected_states_ba = self.in_proj_ba(hidden_states)
@@ -164,52 +177,50 @@ def patch_qwen3_next_gateddelta_layer():
         mixed_qkv = torch.cat((query, key, value), dim=-1)  # [B, T, D]
         mixed_qkv = mixed_qkv.transpose(1, 2)  # [B, D, T]
 
-        if use_precomputed_states:
-            mixed_qkv = self.causal_conv1d_update(
+        if (
+            use_precomputed_states
+            and seq_len == 1
+            and not cache_params.layers[self.layer_idx].record_past
+        ):
+            conv_state = cache_params.layers[self.layer_idx].conv_states[0]
+            mixed_qkv = modeling.causal_conv1d_update(
                 mixed_qkv,
                 conv_state,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
                 self.activation,
             )
+        elif cu_seqlens is not None:
+            if cache_params is not None:
+                cache_params.update_conv_state(
+                    mixed_qkv, self.layer_idx, conv_kernel_size=self.conv_kernel_size
+                )
+            # FLA Triton causal_conv1d: [B, T, D] in/out, with cu_seqlens support
+            mixed_qkv = mixed_qkv.transpose(1, 2)
+            mixed_qkv, _ = fla_causal_conv1d(
+                x=mixed_qkv,
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                cu_seqlens=cu_seqlens,
+            )
+            mixed_qkv = mixed_qkv.transpose(1, 2)  # back to [B, D, T]
         else:
             if cache_params is not None:
-                conv_state = F.pad(
-                    mixed_qkv,
-                    (self.conv_kernel_size - mixed_qkv.shape[-1], 0),
+                mixed_qkv = cache_params.update_conv_state(
+                    mixed_qkv, self.layer_idx, conv_kernel_size=self.conv_kernel_size
                 )
-                cache_params.update_conv_state(conv_state, self.layer_idx)
 
-            if fla_causal_conv1d is not None:
-                # FLA Triton causal_conv1d: [B, T, D] in/out, with cu_seqlens support
-                mixed_qkv = mixed_qkv.transpose(1, 2)  # [B, T, D] for FLA
-                mixed_qkv, _ = fla_causal_conv1d(
-                    x=mixed_qkv,
-                    weight=self.conv1d.weight.squeeze(1),
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                    cu_seqlens=cu_seqlens,
-                )
-                mixed_qkv = mixed_qkv.transpose(1, 2)  # back to [B, D, T]
-            elif self.causal_conv1d_fn is not None:
-                mixed_qkv = self.causal_conv1d_fn(
-                    x=mixed_qkv,
-                    weight=self.conv1d.weight.squeeze(1),
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                    seq_idx=None,
-                )
-            else:
-                # PyTorch fallback (no cu_seqlens support)
-                if cu_seqlens is not None and cu_seqlens.shape[0] > batch_size + 1:
-                    raise RuntimeError(
-                        "Packed sequences require fla.modules.convolution.causal_conv1d "
-                        "(cu_seqlens support). Install flash-linear-attention or disable packing."
-                    )
-                LOG.warning_once(
-                    "FLA causal_conv1d not available. Falling back to PyTorch conv1d."
-                )
-                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+            mixed_qkv = modeling.causal_conv1d_fn(
+                mixed_qkv,
+                self.conv1d.weight.squeeze(1),
+                self.conv1d.bias,
+                activation=self.activation,
+            )
+
+            # Drop the additional previous states
+            if cache_params is not None:
+                mixed_qkv = mixed_qkv[:, :, -seq_len:]
 
         mixed_qkv = mixed_qkv.transpose(1, 2)  # [B, T, D]
         query, key, value = torch.split(
@@ -232,21 +243,38 @@ def patch_qwen3_next_gateddelta_layer():
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-        if not use_precomputed_states:
-            core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+        recurrent_state = (
+            cache_params.layers[self.layer_idx].recurrent_states[0]
+            if use_precomputed_states
+            else None
+        )
+        if use_precomputed_states and seq_len == 1:
+            core_attn_out, last_recurrent_state = (
+                modeling.torch_recurrent_gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    g=g,
+                    beta=beta,
+                    initial_state=recurrent_state,
+                    output_final_state=cache_params is not None,
+                    use_qk_l2norm_in_kernel=True,
+                )
+            )
+        elif cu_seqlens is not None:
+            core_attn_out, last_recurrent_state = fla_chunk_gated_delta_rule(
                 query,
                 key,
                 value,
                 g=g,
                 beta=beta,
-                initial_state=None,
+                initial_state=recurrent_state,
                 output_final_state=cache_params is not None,
                 use_qk_l2norm_in_kernel=True,
                 cu_seqlens=cu_seqlens,
             )
-
         else:
-            core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+            core_attn_out, last_recurrent_state = modeling.torch_chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -275,71 +303,17 @@ def patch_qwen3_next_gateddelta_layer():
         return output
 
     # Apply the patches
-    Qwen3NextGatedDeltaNet.forward = patched_gated_delta_net_forward
+    modeling.Qwen3NextGatedDeltaNet.forward = patched_gated_delta_net_forward
 
     def unpatch():
         """Restore the original forward method"""
-        Qwen3NextGatedDeltaNet.forward = original_gated_delta_net_forward
-
-    return unpatch
-
-
-def patch_qwen3_next_imports():
-    """Patch Qwen3Next imports to use try/except instead of is_flash_linear_attention_available."""
-    try:
-        import transformers.models.qwen3_next.modeling_qwen3_next as qwen3_modeling
-    except ImportError:
-        LOG.warning("Qwen3Next model not found, skipping import patch")
-        return
-
-    # Save original values for unpatch
-    original_FusedRMSNormGated = getattr(qwen3_modeling, "FusedRMSNormGated", None)
-    original_chunk_gated_delta_rule = getattr(
-        qwen3_modeling, "chunk_gated_delta_rule", None
-    )
-    original_fused_recurrent_gated_delta_rule = getattr(
-        qwen3_modeling, "fused_recurrent_gated_delta_rule", None
-    )
-    original_is_fast_path_available = getattr(
-        qwen3_modeling, "is_fast_path_available", False
-    )
-
-    try:
-        from fla.modules import FusedRMSNormGated
-        from fla.ops.gated_delta_rule import (
-            chunk_gated_delta_rule,
-            fused_recurrent_gated_delta_rule,
-        )
-
-        qwen3_modeling.FusedRMSNormGated = FusedRMSNormGated
-        qwen3_modeling.chunk_gated_delta_rule = chunk_gated_delta_rule
-        qwen3_modeling.fused_recurrent_gated_delta_rule = (
-            fused_recurrent_gated_delta_rule
-        )
-
-        # Force is_fast_path_available to be True
-        # fla has triton kernels for causal_conv1d
-        qwen3_modeling.is_fast_path_available = True
-    except ImportError:
-        qwen3_modeling.chunk_gated_delta_rule = None
-        qwen3_modeling.fused_recurrent_gated_delta_rule = None
-        qwen3_modeling.FusedRMSNormGated = None
-
-    def unpatch():
-        """Restore the original import values"""
-        qwen3_modeling.FusedRMSNormGated = original_FusedRMSNormGated
-        qwen3_modeling.chunk_gated_delta_rule = original_chunk_gated_delta_rule
-        qwen3_modeling.fused_recurrent_gated_delta_rule = (
-            original_fused_recurrent_gated_delta_rule
-        )
-        qwen3_modeling.is_fast_path_available = original_is_fast_path_available
+        modeling.Qwen3NextGatedDeltaNet.forward = original_gated_delta_net_forward
 
     return unpatch
 
 
 def patch_qwen3_next_modeling_packing():
     """Apply all Qwen3Next model patches."""
-    patch_qwen3_next_imports()
     patch_qwen3_next_decoder_layer()
     patch_qwen3_next_gateddelta_layer()
 

--- a/tests/monkeypatch/test_qwen3_5_packing_patch.py
+++ b/tests/monkeypatch/test_qwen3_5_packing_patch.py
@@ -1,0 +1,110 @@
+"""Tests for the Qwen3.5 packing monkeypatch (decoder-layer dispatch)."""
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("transformers.models.qwen3_5")
+
+
+@pytest.fixture
+def patched_modeling():
+    """Apply the packing patch and restore the stock forwards after."""
+    from transformers.models.qwen3_5 import modeling_qwen3_5 as modeling
+
+    from axolotl.monkeypatch.models.qwen3_5.modeling import (
+        patch_qwen3_5_modeling_packing,
+    )
+
+    saved = (
+        modeling.Qwen3_5DecoderLayer.forward,
+        modeling.Qwen3_5GatedDeltaNet.forward,
+    )
+    patch_qwen3_5_modeling_packing()
+    yield modeling
+    (
+        modeling.Qwen3_5DecoderLayer.forward,
+        modeling.Qwen3_5GatedDeltaNet.forward,
+    ) = saved
+
+
+class _Recorder(nn.Module):
+    """Stands in for linear_attn / self_attn so dispatch is tested without FLA kernels."""
+
+    def __init__(self, returns_tuple=False):
+        super().__init__()
+        self.returns_tuple = returns_tuple
+        self.calls = []
+
+    def forward(self, **kwargs):
+        self.calls.append(kwargs)
+        out = torch.ones_like(kwargs["hidden_states"])
+        return (out, None) if self.returns_tuple else out
+
+
+def _build_layer(modeling, block_type):
+    """A single decoder layer with its token mixer replaced by a recorder."""
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+
+    cfg = Qwen3_5TextConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=4,
+        layer_types=[block_type],
+    )
+    torch.manual_seed(0)
+    layer = modeling.Qwen3_5DecoderLayer(cfg, 0).eval()
+
+    mixer = _Recorder(returns_tuple=block_type == "full_attention")
+    attr = "linear_attn" if block_type == "linear_attention" else "self_attn"
+    setattr(layer, attr, mixer)
+    return layer, mixer
+
+
+def _inputs(batch=2, seq_len=6, hidden_size=32):
+    hidden_states = torch.randn(batch, seq_len, hidden_size)
+    # MRoPE: transformers hands the decoder layer [axes, B, T] position_ids
+    position_ids = torch.arange(seq_len).expand(3, batch, seq_len).contiguous()
+    cos = torch.ones(batch, seq_len, 8)
+    return hidden_states, position_ids, (cos, cos.clone())
+
+
+def test_linear_attention_receives_position_ids(patched_modeling):
+    layer, mixer = _build_layer(patched_modeling, "linear_attention")
+    hidden_states, position_ids, position_embeddings = _inputs()
+
+    out = layer(
+        hidden_states,
+        position_embeddings=position_embeddings,
+        attention_mask=None,
+        position_ids=position_ids,
+    )
+
+    assert len(mixer.calls) == 1
+    assert torch.equal(mixer.calls[0]["position_ids"], position_ids)
+    assert out.shape == hidden_states.shape
+
+
+def test_full_attention_receives_position_embeddings(patched_modeling):
+    layer, mixer = _build_layer(patched_modeling, "full_attention")
+    hidden_states, position_ids, position_embeddings = _inputs()
+
+    out = layer(
+        hidden_states,
+        position_embeddings=position_embeddings,
+        attention_mask=None,
+        position_ids=position_ids,
+    )
+
+    assert len(mixer.calls) == 1
+    assert mixer.calls[0]["position_embeddings"] is position_embeddings
+    assert out.shape == hidden_states.shape

--- a/tests/monkeypatch/test_qwen3_next_modeling_patch.py
+++ b/tests/monkeypatch/test_qwen3_next_modeling_patch.py
@@ -71,21 +71,6 @@ class TestQwen3NextModelingPatchIntegration:
             )
 
     @pytest.mark.integration
-    def test_qwen3_next_imports_patch(self):
-        """Test that Qwen3Next imports patch can be applied without errors."""
-        from axolotl.monkeypatch.models.qwen3_next.modeling import (
-            patch_qwen3_next_imports,
-        )
-
-        # Apply patch - should not raise any exceptions even if modules unavailable
-        unpatch_fn = patch_qwen3_next_imports()
-
-        # Test that unpatch function is returned (or None if skipped)
-        assert unpatch_fn is None or callable(unpatch_fn), (
-            "patch_qwen3_next_imports should return None or callable unpatch function"
-        )
-
-    @pytest.mark.integration
     def test_qwen3_next_modeling_packing_patch(self):
         """Test that all Qwen3Next modeling patches can be applied together."""
         from axolotl.monkeypatch.models.qwen3_next.modeling import (
@@ -94,6 +79,75 @@ class TestQwen3NextModelingPatchIntegration:
 
         # This should not raise any exceptions
         patch_qwen3_next_modeling_packing()
+
+    @pytest.mark.integration
+    def test_linear_attention_receives_position_ids(self):
+        """The patched decoder layer must route linear-attention layers with position_ids."""
+        from torch import nn
+        from transformers.models.qwen3_next.configuration_qwen3_next import (
+            Qwen3NextConfig,
+        )
+
+        from axolotl.monkeypatch.models.qwen3_next.modeling import (
+            patch_qwen3_next_decoder_layer,
+        )
+
+        class Recorder(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def forward(self, **kwargs):
+                self.calls.append(kwargs)
+                return torch.ones_like(kwargs["hidden_states"])
+
+        class StubMLP(nn.Module):
+            def forward(self, hidden_states):
+                return torch.ones_like(hidden_states)
+
+        cfg = Qwen3NextConfig(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            linear_num_value_heads=4,
+            linear_num_key_heads=2,
+            linear_key_head_dim=8,
+            linear_value_head_dim=8,
+            linear_conv_kernel_dim=4,
+            layer_types=["linear_attention"],
+            num_experts=2,
+            num_experts_per_tok=1,
+            moe_intermediate_size=32,
+            shared_expert_intermediate_size=32,
+        )
+        torch.manual_seed(0)
+        layer = qwen3_next.Qwen3NextDecoderLayer(cfg, 0).eval()
+        mixer = Recorder()
+        layer.linear_attn = mixer
+        layer.mlp = StubMLP()
+
+        unpatch_fn = patch_qwen3_next_decoder_layer()
+        try:
+            hidden_states = torch.randn(2, 6, cfg.hidden_size)
+            position_ids = torch.arange(6).expand(2, 6).contiguous()
+            cos = torch.ones(2, 6, 8)
+            out = layer(
+                hidden_states,
+                position_embeddings=(cos, cos.clone()),
+                attention_mask=None,
+                position_ids=position_ids,
+            )
+        finally:
+            if unpatch_fn:
+                unpatch_fn()
+
+        assert len(mixer.calls) == 1
+        assert torch.equal(mixer.calls[0]["position_ids"], position_ids)
+        assert out.shape == hidden_states.shape
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Latest transformers bump seems to have broken our optimized patches
- self.layer_type renamed
- fla became module level

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Added CI

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3.5 and Qwen3 Next attention handling across cached decoding, packed sequences, and standard execution.
  * Added validation and fallback behavior for supported sequence formats and kernel availability.
  * Improved compatibility with updated cache structures and Accelerate hooks.
  * Preserved positional information when processing linear-attention layers.

* **Tests**
  * Added coverage for Qwen3.5 decoder dispatch, packed-sequence behavior, output shapes, and patch restoration.
  * Expanded Qwen3 Next modeling tests for positional arguments and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->