### PR TITLE
feat: add polora optimizer

### DIFF
--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -302,15 +302,18 @@ honor.
 
 Use `sample_packing` and `gradient_accumulation_steps` with it. The step adds a fixed cost
 regardless of batch size, so a large batch is what keeps that cost small: on 1B at 32k
-tokens per optimizer step it added 1.6% at `lora_r: 32` and 4.0% at `lora_r: 256`. Memory is
-about the same as AdamW.
+tokens per optimizer step it added 1.6% at `lora_r: 32` and 4.0% at `lora_r: 256`.
+
+`learning_rate` is the usual key and schedulers/warmup apply as normal, but the value sets a
+target spectral norm rather than an Adam step size, so useful values sit 1-2 orders of
+magnitude higher. Sweep it instead of carrying one over from an AdamW config.
 
 ```yaml
 optimizer: polora
 adapter: lora
-# spectral-norm target, not an Adam step size. Paper uses 1e-2 (math) and 3e-3 (code);
-# 3e-3 was best on a short 1B/r32 SFT run. Sweep it, the optimum is task-dependent.
-learning_rate: 0.003
+# sets a target spectral norm, not an Adam step size, so it runs 1-2 orders of
+# magnitude higher. Sweep it; we measured optima from 3e-3 to 3e-2.
+learning_rate: 0.01
 
 # optional, defaults shown
 optim_args:
@@ -328,9 +331,11 @@ optim_args:
 **Batch size.** The step cost is fixed per optimizer step, so overhead is that cost divided
 by the work in one step. A small unpacked debug run will look far slower than a real one.
 
-**Rank.** The update stacks same-shape pairs into fp32 temporaries that peak near 6x the
-size of the LoRA factors, scaling with `lora_r` times model width. At high rank on a wide
-model, budget for them.
+**Memory.** PoLoRA carries one momentum where Adam carries two, but stacks same-shape pairs
+into fp32 temporaries peaking near 6x the size of the LoRA factors. At 1B those transients
+fit under the activation peak and it came out slightly cheaper than AdamW at both `lora_r:
+32` and `256`. They scale with `lora_r` times model width, so on a wide model at high rank,
+budget for them.
 
 **Gradients.** Every LoRA factor needs a gradient every step. Exclude layers that skip
 batches (vision towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE,

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -278,3 +278,50 @@ qgalore_cos_threshold: 0.4         # skip SVD if P_t is this similar to P_{t-1}
 qgalore_gamma_proj: 2              # grow update_proj_gap by this factor when stable
 qgalore_queue_size: 5
 ```
+
+### polora
+
+PoLoRA (Preconditioned Orthogonalized LoRA) is a **LoRA-only** optimizer. It extends
+Muon-style spectral descent to the LoRA setting: each adapter pair `(A, B)` is whitened
+in a diagonal-Kronecker curvature metric, passed through the matrix sign, unwhitened, and
+rescaled to spectral norm `rho = lr / (sigma_max(A) + sigma_max(B))`. State per pair is a
+first moment plus two diagonal preconditioners, roughly half of Adam's optimizer state.
+
+GitHub: [https://github.com/nikhilgsh/polora](https://github.com/nikhilgsh/polora)
+Docs: [https://nikhilgsh.github.io/polora/](https://nikhilgsh.github.io/polora/)
+
+Install from source:
+
+```bash
+pip install git+https://github.com/nikhilgsh/polora.git
+```
+
+Requires `adapter: lora` or `adapter: qlora`. Single-GPU and DDP only for now; DeepSpeed,
+FSDP, and tensor parallelism are not supported. Config options that PoLoRA cannot honor
+are rejected at validation time.
+
+Every LoRA factor must receive a gradient on every step, so exclude layers that do not run
+on every batch (a vision tower, unrouted MoE experts) via `lora_exclude_modules`.
+
+With `lora_target_parameters` on an MoE model, PEFT builds each factor at rank
+`lora_r * num_experts`, so PoLoRA's per-pair spectral work grows with the expert count and
+the update is one joint step across block-concatenated experts rather than per-expert. Keep
+`lora_r` small there.
+
+```yaml
+optimizer: polora
+adapter: lora
+# lr is a spectral-norm target, not an Adam step size. The paper uses 1e-2 (math) and
+# 3e-3 (code), and reports that the best lr transfers across lora_r.
+learning_rate: 0.01
+
+# optional, defaults shown
+optim_args:
+  beta1: 0.9             # momentum coefficient
+  curvature_beta: 0.99   # EMA coefficient for the diagonal preconditioners
+  epsilon: 1.0e-12       # numerical floor
+  delta: 1.0e-4          # relative damping of the inverse square roots
+  ns_steps: 8            # PolarExpress matrix-sign iterations
+  higham_iters: 8        # Newton-Schulz iterations for the inverse square roots
+  compile: false         # torch.compile the two spectral kernels
+```

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -309,6 +309,11 @@ Every LoRA factor needs a gradient every step, so exclude layers that skip batch
 towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE, `lora_target_parameters`
 builds factors at `lora_r * num_experts`, so keep `lora_r` small there.
 
+Cost scales with `lora_r`: the update batches same-shape pairs into fp32 temporaries and
+does `r x r` Newton-Schulz work per pair. Measured on 7B against `adamw_torch`, at `lora_r:
+32` it was 16% slower and saved 0.4 GiB peak, but at `lora_r: 256` it was 46% slower and
+used 6.8 GiB *more*. Prefer low rank, and budget memory before raising it.
+
 ```yaml
 optimizer: polora
 adapter: lora

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -301,9 +301,9 @@ tensor parallelism are rejected at validation (ZeRO partitions the optimizer ste
 shards the LoRA rank dim), along with any other option PoLoRA cannot honor.
 
 Upstream PoLoRA is single-device only, so under FSDP2 axolotl gathers each factor, runs the
-dense update on every rank, and scatters the local shard back. The result matches single-GPU
-exactly, at the cost of one all-gather per step; FSDP2 saves memory on the frozen base, not
-on the adapter.
+dense update on every rank, and scatters the local shard back. Loss matches DDP, at the cost
+of one all-gather per step. Use FSDP2 only when the frozen base does not fit: it saves
+memory on the base, not the adapter, and on a 1B model it measured 2.2x slower than DDP.
 
 Every LoRA factor needs a gradient every step, so exclude layers that skip batches (vision
 towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE, `lora_target_parameters`

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -312,8 +312,9 @@ builds factors at `lora_r * num_experts`, so keep `lora_r` small there.
 ```yaml
 optimizer: polora
 adapter: lora
-# spectral-norm target, not an Adam step size (paper: 1e-2 math, 3e-3 code)
-learning_rate: 0.01
+# spectral-norm target, not an Adam step size. Paper uses 1e-2 (math) and 3e-3 (code);
+# 3e-3 was best on a short 1B/r32 SFT run. Sweep it, the optimum is task-dependent.
+learning_rate: 0.003
 
 # optional, defaults shown
 optim_args:

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -297,22 +297,13 @@ pip install git+https://github.com/nikhilgsh/polora.git
 ```
 
 Requires `adapter: lora` or `adapter: qlora`, and single-GPU, DDP, or FSDP2. DeepSpeed and
-tensor parallelism are rejected at validation (ZeRO partitions the optimizer step itself, TP
-shards the LoRA rank dim), along with any other option PoLoRA cannot honor.
+tensor parallelism are rejected at validation, along with any other option PoLoRA cannot
+honor.
 
-Upstream PoLoRA is single-device only, so under FSDP2 axolotl gathers each factor, runs the
-dense update on every rank, and scatters the local shard back. Loss matches DDP, at the cost
-of one all-gather per step. Use FSDP2 only when the frozen base does not fit: it saves
-memory on the base, not the adapter, and on a 1B model it measured 2.2x slower than DDP.
-
-Every LoRA factor needs a gradient every step, so exclude layers that skip batches (vision
-towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE, `lora_target_parameters`
-builds factors at `lora_r * num_experts`, so keep `lora_r` small there.
-
-Cost scales with `lora_r`: the update batches same-shape pairs into fp32 temporaries and
-does `r x r` Newton-Schulz work per pair. Measured on 7B against `adamw_torch`, at `lora_r:
-32` it was 16% slower and saved 0.4 GiB peak, but at `lora_r: 256` it was 46% slower and
-used 6.8 GiB *more*. Prefer low rank, and budget memory before raising it.
+Use `sample_packing` and `gradient_accumulation_steps` with it. The step adds a fixed cost
+regardless of batch size, so a large batch is what keeps that cost small: on 1B at 32k
+tokens per optimizer step it added 1.6% at `lora_r: 32` and 4.0% at `lora_r: 256`. Memory is
+about the same as AdamW.
 
 ```yaml
 optimizer: polora
@@ -329,5 +320,25 @@ optim_args:
   delta: 1.0e-4          # relative damping of the inverse square roots
   ns_steps: 8            # PolarExpress matrix-sign iterations
   higham_iters: 8        # Newton-Schulz iterations for the inverse square roots
-  compile: false         # torch.compile the spectral kernels
+  compile: false         # torch.compile the spectral kernels; measured worth ~0.3pp
 ```
+
+::: {.callout-note}
+
+**Batch size.** The step cost is fixed per optimizer step, so overhead is that cost divided
+by the work in one step. A small unpacked debug run will look far slower than a real one.
+
+**Rank.** The update stacks same-shape pairs into fp32 temporaries that peak near 6x the
+size of the LoRA factors, scaling with `lora_r` times model width. At high rank on a wide
+model, budget for them.
+
+**Gradients.** Every LoRA factor needs a gradient every step. Exclude layers that skip
+batches (vision towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE,
+`lora_target_parameters` builds factors at `lora_r * num_experts`, so keep `lora_r` small.
+
+**FSDP2.** Upstream PoLoRA is single-device only, so axolotl gathers each factor, updates on
+every rank, and scatters the local shard back. Loss matches DDP, at one all-gather per step.
+Use it only when the frozen base does not fit: on a 1B model it measured 2.2x slower than
+DDP.
+
+:::

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -296,24 +296,14 @@ Install from source:
 pip install git+https://github.com/nikhilgsh/polora.git
 ```
 
-Requires `adapter: lora` or `adapter: qlora`, and single-GPU, DDP, or FSDP2. DeepSpeed and
-tensor parallelism are rejected at validation, along with any other option PoLoRA cannot
-honor.
-
-Use `sample_packing` and `gradient_accumulation_steps` with it. The step adds a fixed cost
-regardless of batch size, so a large batch is what keeps that cost small: on 1B at 32k
-tokens per optimizer step it added 1.6% at `lora_r: 32` and 4.0% at `lora_r: 256`.
-
-`learning_rate` is the usual key and schedulers/warmup apply as normal, but the value sets a
-target spectral norm rather than an Adam step size, so useful values sit 1-2 orders of
-magnitude higher. Sweep it instead of carrying one over from an AdamW config.
+- Requires `adapter: lora` or `adapter: qlora`, and single-GPU, DDP, or FSDP2.
+- We recommend enabling `sample_packing` and higher batch sizes to minimize optim step overhead.
+- We find that `learning_rate` should be set 1-2 orders of magnitude higher than AdamW: 3e-4 -> 3e-2.
 
 ```yaml
 optimizer: polora
 adapter: lora
-# sets a target spectral norm, not an Adam step size, so it runs 1-2 orders of
-# magnitude higher. Sweep it; we measured optima from 3e-3 to 3e-2.
-learning_rate: 0.01
+learning_rate: 0.01      # make sure to sweep
 
 # optional, defaults shown
 optim_args:
@@ -323,27 +313,22 @@ optim_args:
   delta: 1.0e-4          # relative damping of the inverse square roots
   ns_steps: 8            # PolarExpress matrix-sign iterations
   higham_iters: 8        # Newton-Schulz iterations for the inverse square roots
-  compile: false         # torch.compile the spectral kernels; measured worth ~0.3pp
+  compile: false         # torch.compile the spectral kernels
 ```
 
 ::: {.callout-note}
 
-**Batch size.** The step cost is fixed per optimizer step, so overhead is that cost divided
-by the work in one step. A small unpacked debug run will look far slower than a real one.
-
 **Memory.** PoLoRA carries one momentum where Adam carries two, but stacks same-shape pairs
 into fp32 temporaries peaking near 6x the size of the LoRA factors. At 1B those transients
-fit under the activation peak and it came out slightly cheaper than AdamW at both `lora_r:
-32` and `256`. They scale with `lora_r` times model width, so on a wide model at high rank,
-budget for them.
+fit under the activation peak, and it came out slightly cheaper than AdamW at both `lora_r:
+32` and `256`. They scale with `lora_r` times model width, so on a wide model at high rank
+will be more costly.
 
 **Gradients.** Every LoRA factor needs a gradient every step. Exclude layers that skip
 batches (vision towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE,
 `lora_target_parameters` builds factors at `lora_r * num_experts`, so keep `lora_r` small.
 
-**FSDP2.** Upstream PoLoRA is single-device only, so axolotl gathers each factor, updates on
-every rank, and scatters the local shard back. Loss matches DDP, at one all-gather per step.
-Use it only when the frozen base does not fit: on a 1B model it measured 2.2x slower than
-DDP.
+**FSDP2.** Axolotl adds FSDP2 support, however, we recommend only using it when frozen base
+does not fit due to noticeable slowdowns.
 
 :::

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -282,10 +282,10 @@ qgalore_queue_size: 5
 ### polora
 
 PoLoRA (Preconditioned Orthogonalized LoRA) is a **LoRA-only** optimizer. It extends
-Muon-style spectral descent to the LoRA setting: each adapter pair `(A, B)` is whitened
-in a diagonal-Kronecker curvature metric, passed through the matrix sign, unwhitened, and
-rescaled to spectral norm `rho = lr / (sigma_max(A) + sigma_max(B))`. State per pair is a
-first moment plus two diagonal preconditioners, roughly half of Adam's optimizer state.
+Muon-style spectral descent to the `(A, B)` product structure: each pair is whitened in a
+diagonal-Kronecker curvature metric, passed through the matrix sign, then rescaled to
+spectral norm `rho = lr / (sigma_max(A) + sigma_max(B))`. Optimizer state is a first moment
+plus two diagonal preconditioners, roughly half of Adam's.
 
 GitHub: [https://github.com/nikhilgsh/polora](https://github.com/nikhilgsh/polora)
 Docs: [https://nikhilgsh.github.io/polora/](https://nikhilgsh.github.io/polora/)
@@ -296,32 +296,32 @@ Install from source:
 pip install git+https://github.com/nikhilgsh/polora.git
 ```
 
-Requires `adapter: lora` or `adapter: qlora`. Single-GPU and DDP only for now; DeepSpeed,
-FSDP, and tensor parallelism are not supported. Config options that PoLoRA cannot honor
-are rejected at validation time.
+Requires `adapter: lora` or `adapter: qlora`, and single-GPU, DDP, or FSDP2. DeepSpeed and
+tensor parallelism are rejected at validation (ZeRO partitions the optimizer step itself, TP
+shards the LoRA rank dim), along with any other option PoLoRA cannot honor.
 
-Every LoRA factor must receive a gradient on every step, so exclude layers that do not run
-on every batch (a vision tower, unrouted MoE experts) via `lora_exclude_modules`.
+Upstream PoLoRA is single-device only, so under FSDP2 axolotl gathers each factor, runs the
+dense update on every rank, and scatters the local shard back. The result matches single-GPU
+exactly, at the cost of one all-gather per step; FSDP2 saves memory on the frozen base, not
+on the adapter.
 
-With `lora_target_parameters` on an MoE model, PEFT builds each factor at rank
-`lora_r * num_experts`, so PoLoRA's per-pair spectral work grows with the expert count and
-the update is one joint step across block-concatenated experts rather than per-expert. Keep
-`lora_r` small there.
+Every LoRA factor needs a gradient every step, so exclude layers that skip batches (vision
+towers, unrouted MoE experts) via `lora_exclude_modules`. On MoE, `lora_target_parameters`
+builds factors at `lora_r * num_experts`, so keep `lora_r` small there.
 
 ```yaml
 optimizer: polora
 adapter: lora
-# lr is a spectral-norm target, not an Adam step size. The paper uses 1e-2 (math) and
-# 3e-3 (code), and reports that the best lr transfers across lora_r.
+# spectral-norm target, not an Adam step size (paper: 1e-2 math, 3e-3 code)
 learning_rate: 0.01
 
 # optional, defaults shown
 optim_args:
-  beta1: 0.9             # momentum coefficient
-  curvature_beta: 0.99   # EMA coefficient for the diagonal preconditioners
+  beta1: 0.9             # momentum
+  curvature_beta: 0.99   # EMA for the diagonal preconditioners
   epsilon: 1.0e-12       # numerical floor
   delta: 1.0e-4          # relative damping of the inverse square roots
   ns_steps: 8            # PolarExpress matrix-sign iterations
   higham_iters: 8        # Newton-Schulz iterations for the inverse square roots
-  compile: false         # torch.compile the two spectral kernels
+  compile: false         # torch.compile the spectral kernels
 ```

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -190,7 +190,7 @@ Generic HuggingFace support is universal. This table lists **added acceleration/
 
 ## Optimizers & schedulers
 
-**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon, Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore, PoLoRA. (Muon / Flash / Q-GaLore require FSDP2, not DeepSpeed; PoLoRA is LoRA-only and single-GPU/DDP-only.)
+**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon, Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore, PoLoRA. (Muon / Flash / Q-GaLore / PoLoRA require FSDP2, not DeepSpeed; PoLoRA is additionally LoRA-only.)
 
 **Schedulers:** cosine (+min-lr, +constant-ratio, +quadratic warmup), REX, one-cycle, linear warmup, jagged-restart (ReLoRA).
 
@@ -246,7 +246,7 @@ The dense corner. This is why, for example, DeepSeek-V4 (which ships in NVFP4) c
 | ReLoRA | `jagged_restart_steps` (and *not* FSDP/DeepSpeed/one_cycle) |
 | Sample packing | varlen backend (FA2/3, flex, xformers, sage) |
 | Muon / Flash / Q-GaLore optimizers | FSDP2 (not DeepSpeed) |
-| PoLoRA optimizer | LoRA/QLoRA + single-GPU or DDP (not FSDP/DeepSpeed/TP) |
+| PoLoRA optimizer | LoRA/QLoRA + single-GPU, DDP, or FSDP2 (not DeepSpeed/TP) |
 | EBFT (`rl: ebft`) | `ebft:` config block |
 
 ### Incompatible {#incompatible}

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -190,7 +190,7 @@ Generic HuggingFace support is universal. This table lists **added acceleration/
 
 ## Optimizers & schedulers
 
-**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon, Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore. (Muon / Flash / Q-GaLore require FSDP2, not DeepSpeed.)
+**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon, Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore, PoLoRA. (Muon / Flash / Q-GaLore require FSDP2, not DeepSpeed; PoLoRA is LoRA-only and single-GPU/DDP-only.)
 
 **Schedulers:** cosine (+min-lr, +constant-ratio, +quadratic warmup), REX, one-cycle, linear warmup, jagged-restart (ReLoRA).
 
@@ -246,6 +246,7 @@ The dense corner. This is why, for example, DeepSeek-V4 (which ships in NVFP4) c
 | ReLoRA | `jagged_restart_steps` (and *not* FSDP/DeepSpeed/one_cycle) |
 | Sample packing | varlen backend (FA2/3, flex, xformers, sage) |
 | Muon / Flash / Q-GaLore optimizers | FSDP2 (not DeepSpeed) |
+| PoLoRA optimizer | LoRA/QLoRA + single-GPU or DDP (not FSDP/DeepSpeed/TP) |
 | EBFT (`rl: ebft`) | `ebft:` config block |
 
 ### Incompatible {#incompatible}

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -356,6 +356,10 @@ class TrainerBuilderBase(abc.ABC):
 
                     optimizer_cls = SinkGDOptimizerFactory
                 optimizer_kwargs.update(adam_kwargs)
+            elif self.cfg.optimizer == "polora":
+                from axolotl.utils.optimizers.polora import PoloraOptimizerFactory
+
+                optimizer_cls = PoloraOptimizerFactory
             elif self.cfg.optimizer == "optimi_adamw":
                 from optimi import AdamW
 

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -47,11 +47,20 @@ class _PoloraCompat:
     saves nothing and a resumed run silently restarts from zero. It also raises a bare
     ``ValueError`` when a factor has no gradient, which the Trainer triggers whenever a
     LoRA layer sits out a step.
+
+    Under FSDP2 the factors arrive as DTensors sharded on dim 0, which for ``A`` is the
+    LoRA rank itself. The algorithm is built on ``r x r`` Gram matrices and global
+    spectral norms, so ``_sharded_pairs`` holds the real params and the optimizer runs
+    over gathered stand-ins instead; see :func:`_gathered_pairs`.
     """
 
+    _sharded_pairs: list | None = None
+
     def step(self, closure=None):
+        if self._sharded_pairs is not None:
+            _gather_into(self._sharded_pairs, self.pairs)  # type: ignore[attr-defined]
         try:
-            return super().step(closure)  # type: ignore[misc]
+            loss = super().step(closure)  # type: ignore[misc]
         except ValueError as exc:
             if "Gradients are required" not in str(exc):
                 raise
@@ -61,6 +70,9 @@ class _PoloraCompat:
                 "this: a vision tower under lora_target_linear on a multimodal model, "
                 "or an unrouted MoE expert. Exclude those with lora_exclude_modules."
             ) from exc
+        if self._sharded_pairs is not None:
+            _scatter_from(self.pairs, self._sharded_pairs)  # type: ignore[attr-defined]
+        return loss
 
     def state_dict(self) -> dict:
         state_dict = super().state_dict()  # type: ignore[misc]
@@ -105,6 +117,57 @@ def _pair_state_matches(saved_pairs: dict, current: dict) -> bool:
         )
         for idx, saved in saved_pairs.items()
     )
+
+
+def _is_sharded(tensor) -> bool:
+    from torch.distributed.tensor import DTensor
+
+    return isinstance(tensor, DTensor) and any(
+        placement.is_shard() for placement in tensor.placements
+    )
+
+
+def _gathered_pairs(pairs: list) -> list:
+    """Dense full-shape stand-ins for sharded factors, sharing storage when replicated."""
+    import torch
+
+    gathered = []
+    for pair in pairs:
+        stand_ins = []
+        for param in pair:
+            if _is_sharded(param):
+                stand_ins.append(
+                    torch.nn.Parameter(param.full_tensor().detach().clone())
+                )
+            else:
+                stand_ins.append(param)
+        gathered.append(tuple(stand_ins))
+    return gathered
+
+
+def _gather_into(real_pairs: list, stand_ins: list) -> None:
+    for real_pair, stand_in_pair in zip(real_pairs, stand_ins, strict=True):
+        for real, stand_in in zip(real_pair, stand_in_pair, strict=True):
+            if real is stand_in:
+                continue
+            stand_in.data.copy_(real.full_tensor().detach())
+            grad = real.grad
+            stand_in.grad = grad.full_tensor().detach() if _is_sharded(grad) else grad
+
+
+def _scatter_from(stand_ins: list, real_pairs: list) -> None:
+    from torch.distributed.tensor import distribute_tensor
+
+    for stand_in_pair, real_pair in zip(stand_ins, real_pairs, strict=True):
+        for stand_in, real in zip(stand_in_pair, real_pair, strict=True):
+            if real is stand_in:
+                continue
+            # Every rank ran the same update on the same gathered inputs, so each can
+            # slice its own shard out without a further collective.
+            sharded = distribute_tensor(
+                stand_in.data, real.device_mesh, real.placements
+            )
+            real.data.to_local().copy_(sharded.to_local())
 
 
 @lru_cache(maxsize=1)
@@ -172,5 +235,14 @@ class PoloraOptimizerFactory(BaseOptimizerFactory):
                 f"Supported: {sorted(_POLORA_ARGS)}."
             )
 
-        LOG.info(f"polora: optimizing {len(pairs)} LoRA (A, B) pairs.")
-        return _polora_cls()(pairs=pairs, lr=lr, **kwargs)
+        sharded = any(_is_sharded(param) for pair in pairs for param in pair)
+        step_pairs = _gathered_pairs(pairs) if sharded else pairs
+        LOG.info(
+            f"polora: optimizing {len(pairs)} LoRA (A, B) pairs"
+            f"{' (FSDP2-sharded, gathered per step)' if sharded else ''}."
+        )
+
+        optimizer = _polora_cls()(pairs=step_pairs, lr=lr, **kwargs)
+        if sharded:
+            optimizer._sharded_pairs = pairs  # pylint: disable=protected-access
+        return optimizer

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from contextlib import contextmanager
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -112,7 +113,8 @@ class _PoloraCompat:
         if self._sharded_pairs is not None:
             _gather_into(self._sharded_pairs, self.pairs)
         try:
-            loss = super().step(closure)  # type: ignore[misc]
+            with _no_tf32():
+                loss = super().step(closure)  # type: ignore[misc]
         except ValueError as exc:
             if "Gradients are required" not in str(exc):
                 raise
@@ -150,6 +152,25 @@ class _PoloraCompat:
         for idx, saved in saved_pairs.items():
             device = self.pairs[int(idx)][0].device
             current[int(idx)] = {key: val.to(device) for key, val in saved.items()}
+
+
+@contextmanager
+def _no_tf32():
+    """Keeps polora's spectral iterations in true fp32.
+
+    Upstream guards them by writing ``allow_tf32 = False`` inside the kernels, but that is a
+    Python side effect ``torch.compile`` does not replay, so with ``compile=true`` the
+    Newton-Schulz iteration silently runs in TF32 and diverges to NaN within a step or two.
+    Hoisting the guard outside the compiled region restores it.
+    """
+    import torch
+
+    prev = torch.backends.cuda.matmul.allow_tf32
+    torch.backends.cuda.matmul.allow_tf32 = False
+    try:
+        yield
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = prev
 
 
 def _pair_state_matches(saved_pairs: dict, current: dict) -> bool:

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -1,0 +1,176 @@
+"""Factory for the PoLoRA optimizer (optional third-party dependency)."""
+
+from __future__ import annotations
+
+import importlib.util
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from axolotl.integrations.base import BaseOptimizerFactory
+from axolotl.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from torch.optim import Optimizer
+
+LOG = get_logger(__name__)
+
+_INSTALL_HINT = (
+    "optimizer: polora requires the `polora` package, which is not installed. "
+    "It is not published on PyPI, so install it from source:\n"
+    "    pip install git+https://github.com/nikhilgsh/polora.git"
+)
+
+
+def _as_bool(value) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+# optim_args may arrive as strings from the "key=value" form.
+_POLORA_ARGS: dict[str, Any] = {
+    "beta1": float,
+    "epsilon": float,
+    "delta": float,
+    "curvature_beta": float,
+    "ns_steps": int,
+    "higham_iters": int,
+    "compile": _as_bool,
+}
+
+
+class _PoloraCompat:
+    """Adapts upstream polora to the Trainer loop.
+
+    Upstream keeps momentum and preconditioners in a plain ``pair_state`` dict keyed
+    by pair index rather than in ``Optimizer.state``, so the inherited ``state_dict()``
+    saves nothing and a resumed run silently restarts from zero. It also raises a bare
+    ``ValueError`` when a factor has no gradient, which the Trainer triggers whenever a
+    LoRA layer sits out a step.
+    """
+
+    def step(self, closure=None):
+        try:
+            return super().step(closure)  # type: ignore[misc]
+        except ValueError as exc:
+            if "Gradients are required" not in str(exc):
+                raise
+            raise RuntimeError(
+                "polora requires a gradient on every LoRA factor at every step, but "
+                "some had none. A LoRA layer that does not run on every batch causes "
+                "this: a vision tower under lora_target_linear on a multimodal model, "
+                "or an unrouted MoE expert. Exclude those with lora_exclude_modules."
+            ) from exc
+
+    def state_dict(self) -> dict:
+        state_dict = super().state_dict()  # type: ignore[misc]
+        state_dict["pair_state"] = {
+            idx: dict(state)
+            for idx, state in self.pair_state.items()  # type: ignore[attr-defined]
+        }
+        return state_dict
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        current = self.pair_state  # type: ignore[attr-defined]
+        saved_pairs = state_dict.get("pair_state")
+        # Checked before super(), which raises on a param-count change of its own.
+        if not isinstance(saved_pairs, dict) or not _pair_state_matches(
+            saved_pairs, current
+        ):
+            LOG.warning(
+                "polora: checkpoint pair state does not match this model's LoRA layout; "
+                "resuming with fresh momentum and preconditioners."
+            )
+            return
+
+        super().load_state_dict(state_dict)  # type: ignore[misc]
+        for idx, saved in saved_pairs.items():
+            device = self.pairs[int(idx)][0].device  # type: ignore[attr-defined]
+            current[int(idx)] = {key: val.to(device) for key, val in saved.items()}
+
+
+def _pair_state_matches(saved_pairs: dict, current: dict) -> bool:
+    """Whether a checkpoint's pair state lines up with the freshly built one.
+
+    Pairs are matched by discovery order, so a changed LoRA config invalidates them.
+    """
+    if len(saved_pairs) != len(current):
+        return False
+    return all(
+        int(idx) in current
+        and isinstance(saved, dict)
+        and all(
+            key in saved and saved[key].shape == current[int(idx)][key].shape
+            for key in ("M_A", "M_B")
+        )
+        for idx, saved in saved_pairs.items()
+    )
+
+
+@lru_cache(maxsize=1)
+def _polora_cls() -> type:
+    from polora import Polora
+
+    return type("Polora", (_PoloraCompat, Polora), {})
+
+
+class PoloraOptimizerFactory(BaseOptimizerFactory):
+    """Builds a :class:`polora.Polora` over the model's trainable LoRA ``(A, B)`` pairs."""
+
+    def __call__(
+        self, opt_model, training_args=None, **optimizer_kwargs
+    ) -> "Optimizer":
+        if importlib.util.find_spec("polora") is None:
+            raise ImportError(_INSTALL_HINT)
+        from polora.optim import collect_lora_pairs
+
+        lr = optimizer_kwargs.pop("lr")
+        optimizer_kwargs.pop("weight_decay", None)  # polora has no decay term
+
+        pairs = collect_lora_pairs(opt_model)
+        if not pairs:
+            raise ValueError(
+                "optimizer: polora found no trainable LoRA (A, B) pairs on the model. "
+                "It only optimizes LoRA factors, so it requires adapter: lora or qlora."
+            )
+
+        names = {
+            id(param): name
+            for name, param in opt_model.named_parameters()
+            if param.requires_grad
+        }
+        covered = {id(param) for pair in pairs for param in pair}
+        unhandled = [name for pid, name in names.items() if pid not in covered]
+        if unhandled:
+            raise ValueError(
+                "optimizer: polora only updates LoRA (A, B) factors, but the model has "
+                f"{len(unhandled)} other trainable parameter(s) that would never be "
+                f"trained, e.g. {unhandled[:5]}. Freeze them or pick a different optimizer."
+            )
+
+        # polora unpacks every factor as (r, d_in) / (d_out, r); conv LoRA weights are 4D.
+        non_2d = [
+            names.get(id(param), "?")
+            for pair in pairs
+            for param in pair
+            if param.ndim != 2
+        ]
+        if non_2d:
+            raise ValueError(
+                "optimizer: polora only supports 2D LoRA factors, but "
+                f"{non_2d[:5]} are not. Drop convolutional targets from "
+                "lora_target_modules or pick a different optimizer."
+            )
+
+        kwargs = {}
+        for key, cast in _POLORA_ARGS.items():
+            if key in optimizer_kwargs:
+                kwargs[key] = cast(optimizer_kwargs.pop(key))
+        if optimizer_kwargs:
+            raise ValueError(
+                f"Unsupported optim_args for polora: {sorted(optimizer_kwargs)}. "
+                f"Supported: {sorted(_POLORA_ARGS)}."
+            )
+
+        LOG.info(f"polora: optimizing {len(pairs)} LoRA (A, B) pairs.")
+        return _polora_cls()(pairs=pairs, lr=lr, **kwargs)

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -1,4 +1,4 @@
-"""Factory for the PoLoRA optimizer (optional third-party dependency)."""
+"""Factory for the PoLoRA optimizer."""
 
 from __future__ import annotations
 

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -16,7 +16,7 @@ LOG = get_logger(__name__)
 
 _INSTALL_HINT = (
     "optimizer: polora requires the `polora` package, which is not installed. "
-    "It is not published on PyPI, so install it from source:\n"
+    "Install via:\n"
     "    pip install git+https://github.com/nikhilgsh/polora.git"
 )
 

--- a/src/axolotl/utils/optimizers/polora.py
+++ b/src/axolotl/utils/optimizers/polora.py
@@ -54,11 +54,63 @@ class _PoloraCompat:
     over gathered stand-ins instead; see :func:`_gathered_pairs`.
     """
 
+    # set by polora.Polora.__init__ / torch.optim.Optimizer
+    pairs: list
+    pair_state: dict
+    param_groups: list
+
+    _model = None
     _sharded_pairs: list | None = None
+    _bound = False
+
+    def _bind_live_pairs(self) -> None:
+        """Rebind onto the model's current parameters.
+
+        FSDP2 replaces module parameters with DTensors *after* the optimizer is built, so
+        the pairs captured at construction go stale and never receive gradients. Global
+        shapes are unchanged, so the already-allocated ``pair_state`` stays valid.
+        """
+        self._bound = True
+        if self._model is None:
+            return
+        from polora.optim import collect_lora_pairs
+
+        live = collect_lora_pairs(self._model)
+        current = self.pairs
+        if len(live) != len(current):
+            return
+        if all(
+            new is old
+            for live_pair, cur_pair in zip(live, current, strict=True)
+            for new, old in zip(live_pair, cur_pair, strict=True)
+        ):
+            return
+        if any(
+            new.shape != old.shape
+            for live_pair, cur_pair in zip(live, current, strict=True)
+            for new, old in zip(live_pair, cur_pair, strict=True)
+        ):
+            return
+
+        if any(_is_sharded(param) for pair in live for param in pair):
+            self._sharded_pairs = live
+            self.pairs = _gathered_pairs(live)
+        else:
+            self.pairs = live
+        self.param_groups[0]["params"] = [
+            param for pair in self.pairs for param in pair
+        ]
+        # State was allocated against the pre-shard params, which sit on CPU.
+        for idx, pair in enumerate(self.pairs):
+            self.pair_state[idx] = {
+                key: val.to(pair[0].device) for key, val in self.pair_state[idx].items()
+            }
 
     def step(self, closure=None):
+        if not self._bound:
+            self._bind_live_pairs()
         if self._sharded_pairs is not None:
-            _gather_into(self._sharded_pairs, self.pairs)  # type: ignore[attr-defined]
+            _gather_into(self._sharded_pairs, self.pairs)
         try:
             loss = super().step(closure)  # type: ignore[misc]
         except ValueError as exc:
@@ -71,19 +123,18 @@ class _PoloraCompat:
                 "or an unrouted MoE expert. Exclude those with lora_exclude_modules."
             ) from exc
         if self._sharded_pairs is not None:
-            _scatter_from(self.pairs, self._sharded_pairs)  # type: ignore[attr-defined]
+            _scatter_from(self.pairs, self._sharded_pairs)
         return loss
 
     def state_dict(self) -> dict:
         state_dict = super().state_dict()  # type: ignore[misc]
         state_dict["pair_state"] = {
-            idx: dict(state)
-            for idx, state in self.pair_state.items()  # type: ignore[attr-defined]
+            idx: dict(state) for idx, state in self.pair_state.items()
         }
         return state_dict
 
     def load_state_dict(self, state_dict: dict) -> None:
-        current = self.pair_state  # type: ignore[attr-defined]
+        current = self.pair_state
         saved_pairs = state_dict.get("pair_state")
         # Checked before super(), which raises on a param-count change of its own.
         if not isinstance(saved_pairs, dict) or not _pair_state_matches(
@@ -97,7 +148,7 @@ class _PoloraCompat:
 
         super().load_state_dict(state_dict)  # type: ignore[misc]
         for idx, saved in saved_pairs.items():
-            device = self.pairs[int(idx)][0].device  # type: ignore[attr-defined]
+            device = self.pairs[int(idx)][0].device
             current[int(idx)] = {key: val.to(device) for key, val in saved.items()}
 
 
@@ -235,14 +286,9 @@ class PoloraOptimizerFactory(BaseOptimizerFactory):
                 f"Supported: {sorted(_POLORA_ARGS)}."
             )
 
-        sharded = any(_is_sharded(param) for pair in pairs for param in pair)
-        step_pairs = _gathered_pairs(pairs) if sharded else pairs
-        LOG.info(
-            f"polora: optimizing {len(pairs)} LoRA (A, B) pairs"
-            f"{' (FSDP2-sharded, gathered per step)' if sharded else ''}."
-        )
-
-        optimizer = _polora_cls()(pairs=step_pairs, lr=lr, **kwargs)
-        if sharded:
-            optimizer._sharded_pairs = pairs  # pylint: disable=protected-access
+        LOG.info(f"polora: optimizing {len(pairs)} LoRA (A, B) pairs.")
+        optimizer = _polora_cls()(pairs=pairs, lr=lr, **kwargs)
+        # Sharding is resolved on the first step, not here: under FSDP2 the params are
+        # still unsharded at this point.
+        optimizer._model = opt_model  # pylint: disable=protected-access
         return optimizer

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -92,6 +92,7 @@ class CustomSupportedOptimizers(str, Enum):
     muon = "muon"
     dion = "dion"
     sinkgd = "sinkgd"
+    polora = "polora"
     flash_adamw = "flash_adamw"
     flash_adam = "flash_adam"
     flash_sgd = "flash_sgd"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -904,6 +904,74 @@ class OptimizationValidationMixin:
 
     @model_validator(mode="before")
     @classmethod
+    def check_polora(cls, data):
+        if data.get("optimizer") != "polora":
+            return data
+        if data.get("adapter") not in ("lora", "qlora"):
+            raise ValueError(
+                "polora only updates LoRA (A, B) factors and requires "
+                "adapter: lora or qlora."
+            )
+        if (
+            data.get("deepspeed")
+            or data.get("fsdp")
+            or data.get("fsdp_config")
+            or (data.get("tensor_parallel_size") or 1) > 1
+        ):
+            # The update stacks pairs by shape and rebuilds curvature from whole weights.
+            raise ValueError(
+                "polora is not compatible with DeepSpeed, FSDP, or tensor parallelism. "
+                "Use single-GPU or DDP."
+            )
+
+        untrained = [
+            key
+            for key in (
+                "lora_modules_to_save",
+                "unfrozen_parameters",
+                "peft_use_dora",
+                "peft_trainable_token_indices",
+                "lisa_step_interval",
+                "reward_model",
+                "process_reward_model",
+            )
+            if data.get(key)
+        ]
+        if untrained:
+            raise ValueError(
+                f"polora has no fallback optimizer, so the parameters added by {untrained} "
+                "would never be trained. Remove them or pick a different optimizer."
+            )
+
+        # The factory builds the optimizer straight from the model, bypassing axolotl's
+        # parameter grouping, so per-group learning rates never take effect.
+        ignored_lrs = [
+            key
+            for key in (
+                "loraplus_lr_ratio",
+                "lr_groups",
+                "embedding_lr",
+                "embedding_lr_scale",
+            )
+            if data.get(key)
+        ]
+        if ignored_lrs:
+            raise ValueError(
+                f"polora sets its own per-factor step size, so {ignored_lrs} would be "
+                "silently ignored. Remove them or pick a different optimizer."
+            )
+
+        if data.get("relora_steps"):
+            raise ValueError(
+                "relora resets optimizer state through Optimizer.state, which polora "
+                "does not use, so its momentum would survive every merge."
+            )
+        if data.get("weight_decay"):
+            LOG.warning("polora has no weight decay term; weight_decay is ignored.")
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_qgalore(cls, data):
         if data.get("optimizer") != "q_galore_adamw8bit":
             return data

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -912,17 +912,18 @@ class OptimizationValidationMixin:
                 "polora only updates LoRA (A, B) factors and requires "
                 "adapter: lora or qlora."
             )
-        if (
-            data.get("deepspeed")
-            or data.get("fsdp")
-            or data.get("fsdp_config")
-            or (data.get("tensor_parallel_size") or 1) > 1
-        ):
-            # The update stacks pairs by shape and rebuilds curvature from whole weights.
+        if data.get("deepspeed") or (data.get("tensor_parallel_size") or 1) > 1:
+            # ZeRO partitions the optimizer step itself, and TP shards the rank dim;
+            # polora needs whole factors to build its r x r curvature matrices.
             raise ValueError(
-                "polora is not compatible with DeepSpeed, FSDP, or tensor parallelism. "
-                "Use single-GPU or DDP."
+                "polora is not compatible with DeepSpeed or tensor parallelism. "
+                "Use single-GPU, DDP, or FSDP2."
             )
+        if data.get("fsdp") or data.get("fsdp_config"):
+            if str(cls._resolve_fsdp_version(data)) != "2":
+                raise ValueError(
+                    "polora requires FSDP2. Set fsdp_version: 2 to use polora with FSDP."
+                )
 
         untrained = [
             key

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -146,6 +146,25 @@ class TestHFCausalTrainerBuilder:
         optim = trainer.create_optimizer()
         assert isinstance(optim, Muon)
 
+    def test_polora_optimizer(self, sft_cfg, model, tokenizer):
+        cfg = sft_cfg.copy()
+        cfg["optimizer"] = "polora"
+        cfg["optim_args"] = {"beta1": 0.95, "ns_steps": 4}
+
+        builder = HFCausalTrainerBuilder(cfg, model, tokenizer)
+        trainer = builder.build(100)
+
+        from axolotl.utils.optimizers.polora import PoloraOptimizerFactory
+
+        optimizer_cls, optimizer_kwargs = trainer.optimizer_cls_and_kwargs
+        assert optimizer_cls is PoloraOptimizerFactory
+        assert optimizer_kwargs["lr"] == 0.00005
+        assert optimizer_kwargs["beta1"] == 0.95
+        assert optimizer_kwargs["ns_steps"] == 4
+        # polora takes no Adam betas/eps; the builder branch must not merge them in
+        assert "betas" not in optimizer_kwargs
+        assert "eps" not in optimizer_kwargs
+
     def test_sinkgd_optimizer(self, sft_cfg, model, tokenizer):
         cfg = sft_cfg.copy()
         cfg["optimizer"] = "sinkgd"

--- a/tests/e2e/multigpu/test_polora_fsdp2.py
+++ b/tests/e2e/multigpu/test_polora_fsdp2.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Axolotl AI
+# Licensed under the Apache License, Version 2.0
+"""PoLoRA gather-compute-scatter correctness under a 2-rank device mesh.
+
+Upstream polora is single-device only: it builds ``r x r`` Gram matrices and global
+spectral norms from whole factors. Under FSDP2 the factors arrive as DTensors sharded
+on dim 0, which for ``A`` is the LoRA rank itself, so the factory gathers them, runs the
+dense update redundantly on every rank, and scatters the local shard back.
+
+These tests verify that the sharded path reproduces the single-device update exactly,
+for both the rank-sharded ``A`` and the output-sharded ``B``, and that ranks stay in
+lockstep (the update must be bit-identical across ranks, since each writes its own
+shard of a value every rank computed independently).
+
+Run with::
+
+    torchrun --nproc-per-node=2 -m pytest tests/e2e/multigpu/test_polora_fsdp2.py
+
+On a 1-GPU executor the tests skip with a clear reason.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard, distribute_tensor
+
+polora = pytest.importorskip("polora", reason="polora is an optional dependency")
+
+from axolotl.utils.optimizers.polora import (  # noqa: E402
+    _gather_into,
+    _gathered_pairs,
+    _polora_cls,
+    _scatter_from,
+)
+
+_TORCHRUN_LOCAL_RANK = os.environ.get("LOCAL_RANK")
+_TORCHRUN_WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "1"))
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+    pytest.mark.skipif(
+        torch.cuda.device_count() < 2, reason="Need >=2 GPUs for FSDP2 multi-rank tests"
+    ),
+    pytest.mark.skipif(
+        _TORCHRUN_LOCAL_RANK is None or _TORCHRUN_WORLD_SIZE < 2,
+        reason="Launch via `torchrun --nproc-per-node=2 -m pytest <file>`",
+    ),
+]
+
+R, D_IN, D_OUT = 16, 64, 32
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    rank = int(os.environ["RANK"])
+    torch.cuda.set_device(rank % torch.cuda.device_count())
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    dm = init_device_mesh(
+        "cuda", (dist.get_world_size(),), mesh_dim_names=("dp_shard",)
+    )
+    yield dm
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def _factors(n_pairs=2):
+    """Identical-across-ranks full factors and grads, seeded so every rank agrees."""
+    torch.manual_seed(0)
+    pairs, grads = [], []
+    for _ in range(n_pairs):
+        A = torch.randn(R, D_IN, device="cuda")
+        B = torch.randn(D_OUT, R, device="cuda")
+        pairs.append((A, B))
+        grads.append((torch.randn_like(A), torch.randn_like(B)))
+    return pairs, grads
+
+
+def _single_device_reference(pairs, grads, steps, lr):
+    dense = [
+        (torch.nn.Parameter(A.clone()), torch.nn.Parameter(B.clone())) for A, B in pairs
+    ]
+    opt = _polora_cls()(pairs=dense, lr=lr)
+    for _ in range(steps):
+        for (A, B), (gA, gB) in zip(dense, grads, strict=True):
+            A.grad = gA.clone()
+            B.grad = gB.clone()
+        opt.step()
+    return dense
+
+
+def _sharded_run(mesh, pairs, grads, steps, lr):
+    """Same update, with A rank-sharded and B output-sharded across the mesh."""
+    real = [
+        (
+            torch.nn.Parameter(distribute_tensor(A.clone(), mesh, [Shard(0)])),
+            torch.nn.Parameter(distribute_tensor(B.clone(), mesh, [Shard(0)])),
+        )
+        for A, B in pairs
+    ]
+    stand_ins = _gathered_pairs(real)
+    opt = _polora_cls()(pairs=stand_ins, lr=lr)
+    opt._sharded_pairs = real  # pylint: disable=protected-access
+
+    for _ in range(steps):
+        for (A, B), (gA, gB) in zip(real, grads, strict=True):
+            A.grad = distribute_tensor(gA.clone(), mesh, [Shard(0)])
+            B.grad = distribute_tensor(gB.clone(), mesh, [Shard(0)])
+        opt.step()
+    return real
+
+
+@pytest.mark.parametrize("steps", [1, 3])
+def test_sharded_matches_single_device(mesh, steps):
+    """The gathered update must reproduce the dense one bit-for-bit after scatter."""
+    pairs, grads = _factors()
+    expected = _single_device_reference(pairs, grads, steps, lr=1e-2)
+    got = _sharded_run(mesh, pairs, grads, steps, lr=1e-2)
+
+    for idx, ((eA, eB), (gA, gB)) in enumerate(zip(expected, got, strict=True)):
+        torch.testing.assert_close(
+            gA.full_tensor(), eA.data, msg=f"pair {idx} factor A diverged"
+        )
+        torch.testing.assert_close(
+            gB.full_tensor(), eB.data, msg=f"pair {idx} factor B diverged"
+        )
+
+
+def test_ranks_stay_in_lockstep(mesh):
+    """Each rank writes its own shard of an update every rank computed independently,
+    so any cross-rank drift silently corrupts the weights rather than erroring."""
+    pairs, grads = _factors()
+    real = _sharded_run(mesh, pairs, grads, steps=3, lr=1e-2)
+
+    for idx, (A, B) in enumerate(real):
+        for name, param in (("A", A), ("B", B)):
+            full = param.full_tensor()
+            broadcast = full.clone()
+            dist.broadcast(broadcast, src=0)
+            torch.testing.assert_close(
+                full, broadcast, msg=f"pair {idx} factor {name} differs across ranks"
+            )
+
+
+def test_gather_scatter_round_trip_is_lossless(mesh):
+    """Scatter-then-gather must be the identity, independent of the optimizer math."""
+    pairs, _ = _factors(n_pairs=1)
+    real = [
+        (
+            torch.nn.Parameter(distribute_tensor(A.clone(), mesh, [Shard(0)])),
+            torch.nn.Parameter(distribute_tensor(B.clone(), mesh, [Shard(0)])),
+        )
+        for A, B in pairs
+    ]
+    stand_ins = _gathered_pairs(real)
+    for (A, B), (gA, gB) in zip(real, [(pairs[0][0], pairs[0][1])], strict=True):
+        A.grad = distribute_tensor(torch.randn_like(gA), mesh, [Shard(0)])
+        B.grad = distribute_tensor(torch.randn_like(gB), mesh, [Shard(0)])
+
+    _gather_into(real, stand_ins)
+    torch.testing.assert_close(stand_ins[0][0].data, pairs[0][0])
+    torch.testing.assert_close(stand_ins[0][1].data, pairs[0][1])
+
+    stand_ins[0][0].data.mul_(2.0)
+    _scatter_from(stand_ins, real)
+    torch.testing.assert_close(real[0][0].full_tensor(), pairs[0][0] * 2.0)

--- a/tests/utils/schemas/validation/test_polora.py
+++ b/tests/utils/schemas/validation/test_polora.py
@@ -36,13 +36,29 @@ class TestPoloraValidation:
         "overrides",
         [
             {"deepspeed": "deepspeed_configs/zero2.json"},
-            {"fsdp_version": 2, "fsdp_config": {"reshard_after_forward": True}},
             {"tensor_parallel_size": 2},
         ],
     )
     def test_sharded_backends_rejected(self, min_base_cfg, overrides):
         with pytest.raises(ValueError, match="not compatible with DeepSpeed"):
             validate_config(_polora_cfg(min_base_cfg, **overrides))
+
+    def test_fsdp2_accepted(self, min_base_cfg):
+        cfg = _polora_cfg(
+            min_base_cfg,
+            fsdp_version=2,
+            fsdp_config={"reshard_after_forward": True},
+        )
+        assert validate_config(cfg).optimizer == "polora"
+
+    def test_fsdp1_rejected(self, min_base_cfg):
+        cfg = _polora_cfg(
+            min_base_cfg,
+            fsdp_version=1,
+            fsdp_config={"reshard_after_forward": True},
+        )
+        with pytest.raises(ValueError, match="requires FSDP2"):
+            validate_config(cfg)
 
     @pytest.mark.parametrize(
         "overrides",

--- a/tests/utils/schemas/validation/test_polora.py
+++ b/tests/utils/schemas/validation/test_polora.py
@@ -1,0 +1,76 @@
+"""Validation tests for the PoLoRA optimizer config gates."""
+
+import pytest
+
+from axolotl.utils.config import validate_config
+from axolotl.utils.dict import DictDefault
+
+
+def _polora_cfg(min_base_cfg, **overrides):
+    return (
+        min_base_cfg
+        | DictDefault(
+            optimizer="polora",
+            adapter="lora",
+            lora_r=8,
+            lora_alpha=16,
+            lora_target_linear=True,
+        )
+        | DictDefault(**overrides)
+    )
+
+
+class TestPoloraValidation:
+    """Pydantic-level checks for polora."""
+
+    def test_lora_adapter_accepted(self, min_base_cfg):
+        cfg = validate_config(_polora_cfg(min_base_cfg))
+        assert cfg.optimizer == "polora"
+
+    def test_missing_adapter_rejected(self, min_base_cfg):
+        cfg = min_base_cfg | DictDefault(optimizer="polora")
+        with pytest.raises(ValueError, match="requires adapter: lora or qlora"):
+            validate_config(cfg)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"deepspeed": "deepspeed_configs/zero2.json"},
+            {"fsdp_version": 2, "fsdp_config": {"reshard_after_forward": True}},
+            {"tensor_parallel_size": 2},
+        ],
+    )
+    def test_sharded_backends_rejected(self, min_base_cfg, overrides):
+        with pytest.raises(ValueError, match="not compatible with DeepSpeed"):
+            validate_config(_polora_cfg(min_base_cfg, **overrides))
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"lora_modules_to_save": ["embed_tokens", "lm_head"]},
+            {"unfrozen_parameters": ["lm_head"]},
+            {"peft_use_dora": True},
+            {"peft_trainable_token_indices": [128000]},
+            {"lisa_step_interval": 20, "lisa_n_layers": 4},
+        ],
+    )
+    def test_untrainable_params_rejected(self, min_base_cfg, overrides):
+        with pytest.raises(ValueError, match="would never be trained"):
+            validate_config(_polora_cfg(min_base_cfg, **overrides))
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"loraplus_lr_ratio": 8},
+            {"embedding_lr": 1e-6},
+            {"embedding_lr_scale": 0.5},
+        ],
+    )
+    def test_ignored_learning_rates_rejected(self, min_base_cfg, overrides):
+        with pytest.raises(ValueError, match="silently ignored"):
+            validate_config(_polora_cfg(min_base_cfg, **overrides))
+
+    def test_relora_rejected(self, min_base_cfg):
+        cfg = _polora_cfg(min_base_cfg, relora_steps=100, relora_warmup_steps=10)
+        with pytest.raises(ValueError, match="relora resets optimizer state"):
+            validate_config(cfg)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

https://nikhilgsh.github.io/polora/

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

2x A40, Llama-3.2-1B, LoRA all-linear, `nvidia/OpenMathInstruct-2`, packed seq 2048,
**32768 tokens per optimizer step** (the paper's batch), bf16, constant LR, no warmup.

**Per-step overhead** (paper claims "at most 3%"):

| `lora_r` | overhead |
|---|---|
| 32 | **+1.6%** |
| 256 | +4.0% |

**Steps to loss**, both optimizers LR-swept with interior (bracketed) optima, 1500-step
horizon:

| AdamW | final eval | | PoLoRA | final eval |
|---|---|---|---|---|
| 1e-4 | 0.4960 | | 1e-2 | 0.4621 |
| **3e-4** | **0.4686** | | **3e-2** | **0.4556** |
| 1e-3 | 0.5087 | | 1e-1 | 0.4788 |

PoLoRA reaches AdamW's best-LR final loss at step 1076 of 1500, i.e. **1.39x fewer steps**,
inside the paper's claimed 1.20-1.74x (they report 1.48x for math at r=32). Net **~1.37x
wall-clock**.

**Memory**, same runs (peak over 60 steps, single A40):

| `lora_r` | optimizer | peak reserved | peak active |
|---|---|---|---|
| 32 | adamw_torch | 26.20 GiB | 24.05 GiB |
| 32 | polora | **26.10 GiB** | **23.97 GiB** |
| 256 | adamw_torch | 28.79 GiB | 26.70 GiB |
| 256 | polora | **28.17 GiB** | **26.03 GiB** |

## AI Usage Disclaimer

Claude

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the PoLoRA optimizer for LoRA and QLoRA training.
  * Added configuration validation, supported hyperparameters, and compatibility with single-GPU, DDP, and FSDP2 setups.
  * Added checkpointing and sharded-training support for PoLoRA.

* **Documentation**
  * Added PoLoRA usage guidance, installation requirements, configuration details, and support-matrix entries.

* **Bug Fixes**
  * Added clear validation errors for unsupported training configurations and missing gradient requirements.

* **Tests**
  * Added coverage for optimizer configuration, validation rules, and multi-GPU FSDP2 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->