### PR TITLE
fix(callbacks): resolve the resume checkpoint after auto-resume runs (#3940)

### DIFF
--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -87,12 +87,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             callbacks.append(QATCallback(self.cfg.qat))
 
         if self.cfg.include_tkps:
-            callbacks.append(
-                TokensPerSecondCallback(
-                    resume_from_checkpoint=self.cfg.resume_from_checkpoint,
-                    cfg=self.cfg,
-                )
-            )
+            callbacks.append(TokensPerSecondCallback(cfg=self.cfg))
         return callbacks
 
     def get_post_trainer_create_callbacks(self, trainer):

--- a/src/axolotl/core/builders/causal.py
+++ b/src/axolotl/core/builders/causal.py
@@ -90,6 +90,7 @@ class HFCausalTrainerBuilder(TrainerBuilderBase):
             callbacks.append(
                 TokensPerSecondCallback(
                     resume_from_checkpoint=self.cfg.resume_from_checkpoint,
+                    cfg=self.cfg,
                 )
             )
         return callbacks

--- a/src/axolotl/utils/callbacks/tokens_per_second.py
+++ b/src/axolotl/utils/callbacks/tokens_per_second.py
@@ -25,9 +25,19 @@ class TokensPerSecondCallback(TrainerCallback):
     gradient_accumulation_steps and logging_steps.
     """
 
-    def __init__(self, resume_from_checkpoint=None):
+    def __init__(self, resume_from_checkpoint=None, cfg=None):
         super().__init__()
         self.resume_from_checkpoint = resume_from_checkpoint
+        self.cfg = cfg
+
+    def _resolve_resume_from_checkpoint(self):
+        # auto-resume fills in cfg.resume_from_checkpoint only after the callbacks
+        # are built, so the config has to be re-read here rather than snapshotted
+        if isinstance(self.resume_from_checkpoint, str):
+            return self.resume_from_checkpoint
+        if self.cfg is not None:
+            return self.cfg.resume_from_checkpoint
+        return None
 
     def on_train_begin(
         self,
@@ -37,9 +47,10 @@ class TokensPerSecondCallback(TrainerCallback):
         **kwargs,
     ):  # pylint: disable=unused-argument
         """Restore total_tokens state when resuming from checkpoint."""
-        if not isinstance(self.resume_from_checkpoint, str):
+        resume_from_checkpoint = self._resolve_resume_from_checkpoint()
+        if not isinstance(resume_from_checkpoint, str):
             return
-        tokens_state_path = os.path.join(self.resume_from_checkpoint, TOKENS_STATE_FILE)
+        tokens_state_path = os.path.join(resume_from_checkpoint, TOKENS_STATE_FILE)
         if os.path.isfile(tokens_state_path):
             with open(tokens_state_path, "r", encoding="utf-8") as f:
                 tokens_state = json.load(f)

--- a/src/axolotl/utils/callbacks/tokens_per_second.py
+++ b/src/axolotl/utils/callbacks/tokens_per_second.py
@@ -52,8 +52,12 @@ class TokensPerSecondCallback(TrainerCallback):
             return
         tokens_state_path = os.path.join(resume_from_checkpoint, TOKENS_STATE_FILE)
         if os.path.isfile(tokens_state_path):
-            with open(tokens_state_path, "r", encoding="utf-8") as f:
-                tokens_state = json.load(f)
+            try:
+                with open(tokens_state_path, "r", encoding="utf-8") as f:
+                    tokens_state = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                LOG.warning(f"Ignoring unreadable token state at {tokens_state_path}")
+                return
             state.tokens = {
                 "total": torch.tensor(tokens_state.get("total", 0)),
                 "trainable": torch.tensor(tokens_state.get("trainable", 0)),

--- a/tests/utils/callbacks/test_tokens_per_second.py
+++ b/tests/utils/callbacks/test_tokens_per_second.py
@@ -1,6 +1,16 @@
 """Tests for trainable-token throughput accounting."""
 
+import json
+import os
+from unittest.mock import MagicMock
+
+from transformers import TrainerState
+
+from axolotl.core.trainers.constants import TOKENS_STATE_FILE
 from axolotl.core.trainers.utils import trainable_tokens_per_sec_per_gpu
+from axolotl.utils.callbacks.tokens_per_second import TokensPerSecondCallback
+from axolotl.utils.dict import DictDefault
+from axolotl.utils.train import determine_last_checkpoint
 
 
 def _cumulative_after_window(microbatch_token_counts, world_size, start=0.0):
@@ -48,3 +58,84 @@ class TestTrainableTokensPerSec:
         fast = trainable_tokens_per_sec_per_gpu(0.0, 800.0, 1, 10.0)
         slow = trainable_tokens_per_sec_per_gpu(0.0, 800.0, 1, 20.0)
         assert slow < fast
+
+
+def _write_checkpoint(output_dir, step, total, trainable):
+    checkpoint = os.path.join(output_dir, f"checkpoint-{step}")
+    os.makedirs(checkpoint, exist_ok=True)
+    with open(
+        os.path.join(checkpoint, TOKENS_STATE_FILE), "w", encoding="utf-8"
+    ) as fout:
+        json.dump({"total": total, "trainable": trainable}, fout)
+    return checkpoint
+
+
+def _restored_tokens(callback):
+    """Run on_train_begin and report the counters the trainer would see.
+
+    The trainer gates on ``hasattr(state, "tokens")``, so an untouched state
+    must not grow the attribute at all.
+    """
+    state = TrainerState()
+    callback.on_train_begin(MagicMock(), state, MagicMock())
+    return getattr(state, "tokens", None)
+
+
+class TestTokensPerSecondResume:
+    """Counter restore must survive auto-resume, which resolves the path late."""
+
+    def test_restores_on_auto_resume(self, tmp_path):
+        output_dir = str(tmp_path)
+        _write_checkpoint(output_dir, 10, total=1234, trainable=567)
+        cfg = DictDefault(
+            {
+                "output_dir": output_dir,
+                "auto_resume_from_checkpoints": True,
+                "resume_from_checkpoint": None,
+            }
+        )
+
+        # the builder runs first, while the path is still unresolved
+        callback = TokensPerSecondCallback(
+            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
+        )
+        determine_last_checkpoint(cfg)
+
+        tokens = _restored_tokens(callback)
+        assert tokens is not None
+        assert tokens["total"].item() == 1234
+        assert tokens["trainable"].item() == 567
+
+    def test_explicit_checkpoint_still_restores(self, tmp_path):
+        output_dir = str(tmp_path)
+        checkpoint = _write_checkpoint(output_dir, 5, total=42, trainable=7)
+        cfg = DictDefault(
+            {"output_dir": output_dir, "resume_from_checkpoint": checkpoint}
+        )
+
+        callback = TokensPerSecondCallback(
+            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
+        )
+        assert _restored_tokens(callback)["total"].item() == 42
+
+    def test_fresh_run_leaves_counters_alone(self, tmp_path):
+        cfg = DictDefault(
+            {
+                "output_dir": str(tmp_path),
+                "auto_resume_from_checkpoints": True,
+                "resume_from_checkpoint": None,
+            }
+        )
+
+        callback = TokensPerSecondCallback(
+            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
+        )
+        determine_last_checkpoint(cfg)
+
+        assert _restored_tokens(callback) is None
+
+    def test_no_cfg_falls_back_to_constructor_value(self, tmp_path):
+        checkpoint = _write_checkpoint(str(tmp_path), 3, total=99, trainable=9)
+
+        callback = TokensPerSecondCallback(resume_from_checkpoint=checkpoint)
+        assert _restored_tokens(callback)["total"].item() == 99

--- a/tests/utils/callbacks/test_tokens_per_second.py
+++ b/tests/utils/callbacks/test_tokens_per_second.py
@@ -2,10 +2,11 @@
 
 import json
 import os
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from transformers import TrainerState
 
+from axolotl.core.builders import HFCausalTrainerBuilder
 from axolotl.core.trainers.constants import TOKENS_STATE_FILE
 from axolotl.core.trainers.utils import trainable_tokens_per_sec_per_gpu
 from axolotl.utils.callbacks.tokens_per_second import TokensPerSecondCallback
@@ -81,6 +82,26 @@ def _restored_tokens(callback):
     return getattr(state, "tokens", None)
 
 
+def _builder_tkps_callback(cfg):
+    """Build the callback the way training actually does.
+
+    Going through ``HFCausalTrainerBuilder.get_callbacks()`` is what pins the
+    ordering this fix is about: the callback is constructed here, while
+    ``cfg.resume_from_checkpoint`` is still unresolved.
+    """
+    builder = HFCausalTrainerBuilder.__new__(HFCausalTrainerBuilder)
+    builder.cfg = cfg
+    builder.model = MagicMock()
+    with (
+        patch("axolotl.core.builders.base.PluginManager") as pm,
+        patch("axolotl.core.builders.base.TelemetryManager") as tm,
+    ):
+        pm.get_instance.return_value.add_callbacks_pre_trainer.return_value = []
+        tm.get_instance.return_value.enabled = False
+        callbacks = builder.get_callbacks()
+    return next(c for c in callbacks if isinstance(c, TokensPerSecondCallback))
+
+
 class TestTokensPerSecondResume:
     """Counter restore must survive auto-resume, which resolves the path late."""
 
@@ -92,13 +113,12 @@ class TestTokensPerSecondResume:
                 "output_dir": output_dir,
                 "auto_resume_from_checkpoints": True,
                 "resume_from_checkpoint": None,
+                "include_tkps": True,
             }
         )
 
         # the builder runs first, while the path is still unresolved
-        callback = TokensPerSecondCallback(
-            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
-        )
+        callback = _builder_tkps_callback(cfg)
         determine_last_checkpoint(cfg)
 
         tokens = _restored_tokens(callback)
@@ -110,12 +130,14 @@ class TestTokensPerSecondResume:
         output_dir = str(tmp_path)
         checkpoint = _write_checkpoint(output_dir, 5, total=42, trainable=7)
         cfg = DictDefault(
-            {"output_dir": output_dir, "resume_from_checkpoint": checkpoint}
+            {
+                "output_dir": output_dir,
+                "resume_from_checkpoint": checkpoint,
+                "include_tkps": True,
+            }
         )
 
-        callback = TokensPerSecondCallback(
-            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
-        )
+        callback = _builder_tkps_callback(cfg)
         assert _restored_tokens(callback)["total"].item() == 42
 
     def test_fresh_run_leaves_counters_alone(self, tmp_path):
@@ -124,12 +146,11 @@ class TestTokensPerSecondResume:
                 "output_dir": str(tmp_path),
                 "auto_resume_from_checkpoints": True,
                 "resume_from_checkpoint": None,
+                "include_tkps": True,
             }
         )
 
-        callback = TokensPerSecondCallback(
-            resume_from_checkpoint=cfg.resume_from_checkpoint, cfg=cfg
-        )
+        callback = _builder_tkps_callback(cfg)
         determine_last_checkpoint(cfg)
 
         assert _restored_tokens(callback) is None
@@ -139,3 +160,15 @@ class TestTokensPerSecondResume:
 
         callback = TokensPerSecondCallback(resume_from_checkpoint=checkpoint)
         assert _restored_tokens(callback)["total"].item() == 99
+
+    def test_unreadable_token_state_is_ignored(self, tmp_path):
+        """A truncated state file must not take the whole run down."""
+        checkpoint = os.path.join(str(tmp_path), "checkpoint-1")
+        os.makedirs(checkpoint, exist_ok=True)
+        with open(
+            os.path.join(checkpoint, TOKENS_STATE_FILE), "w", encoding="utf-8"
+        ) as fout:
+            fout.write("{not json")
+
+        callback = TokensPerSecondCallback(resume_from_checkpoint=checkpoint)
+        assert _restored_tokens(callback) is None


### PR DESCRIPTION
# Description

`TokensPerSecondCallback` snapshots `resume_from_checkpoint` at construction time. On an auto-resumed run that value is still `None`, so the saved token counters are never restored.

The ordering in `train.py` is:

```python
(trainer, ...) = setup_model_and_trainer(cfg, dataset_meta)  # L647 -> builds the callbacks
...
resume_from_checkpoint = determine_last_checkpoint(cfg)      # L659 -> sets cfg.resume_from_checkpoint
execute_training(cfg, trainer, resume_from_checkpoint)
```

`get_callbacks()` (`core/builders/causal.py:91`) passes `self.cfg.resume_from_checkpoint` into the callback, but `determine_last_checkpoint()` — the only thing that resolves the auto-resume path (`utils/train.py:42`) — runs twelve lines later. So with

```yaml
include_tkps: true
auto_resume_from_checkpoints: true
# no explicit resume_from_checkpoint
```

`on_train_begin()`'s `isinstance(self.resume_from_checkpoint, str)` guard is `False`, the `tokens_state.json` restore is skipped, and `tokens/total`, `tokens/trainable` and `tokens/train_per_sec_per_gpu` silently restart from zero. No warning is emitted. Setting `resume_from_checkpoint` explicitly in the YAML works, because it is already a string by the time the builder runs.

The fix holds the config and re-reads it in `on_train_begin()` rather than snapshotting at construction. `cfg` is the same object throughout (`setup_trainer(cfg=cfg, ...)` → `HFCausalTrainerBuilder(cfg, ...)` → `self.cfg = cfg`), and `determine_last_checkpoint()` mutates it in place, so the late read sees the resolved path. An explicitly configured `resume_from_checkpoint` still takes precedence, and the constructor keeps working without a `cfg`.

## Motivation and Context

Fixes #3940.

Throughput accounting is the reason `include_tkps` exists; on a resumed run the cumulative counters are the part that has to survive. Today they only survive for users who spell the checkpoint out by hand, which is the opposite of what `auto_resume_from_checkpoints` is for — and the failure is silent, so the numbers just look wrong rather than reporting an error.

## How has this been tested?

Four tests added to `tests/utils/callbacks/test_tokens_per_second.py`, driving the **real** `determine_last_checkpoint()` in the same order `train.py` calls it (build the callback first, resolve the checkpoint second):

| case | expectation |
|---|---|
| auto-resume, no explicit path | counters restored from `tokens_state.json` |
| explicit `resume_from_checkpoint` | still restored (unchanged behaviour) |
| fresh run, nothing to resume | `state` never grows a `tokens` attribute |
| no `cfg` passed | falls back to the constructor value |

The third case asserts absence of the attribute rather than `None`, matching how the trainer gates on it (`core/trainers/base.py:401`, `if not hasattr(self.state, "tokens")`).

**Environment caveat, stated plainly:** I could not run the repo's pytest suite locally. This is a Windows box with torch 2.5.1, and the current `trl` needs `torch.distributed.fsdp.FSDPModule` (torch >= 2.6); separately, `pyarrow` hard-crashes the interpreter under pytest here. So instead of the suite I ran an equivalent old-vs-new harness that `exec`s the **actual shipped source files** — `utils/callbacks/tokens_per_second.py` and `utils/train.py`, not transcriptions of them — with only `axolotl.utils.logging` stubbed, and replicates the `causal.py` construction call verbatim:

```
########## BEFORE (unpatched main) ##########
FAIL  auto-resume restores counters                    (state.tokens['total']=None)
PASS  explicit resume_from_checkpoint still restores   (state.tokens['total']=42)
PASS  fresh run leaves counters untouched              (state.tokens['total']=None)

########## AFTER (patched) ##########
PASS  auto-resume restores counters                    (state.tokens['total']=1234)
PASS  explicit resume_from_checkpoint still restores   (state.tokens['total']=42)
PASS  fresh run leaves counters untouched              (state.tokens['total']=None)
```

Exactly one scenario changes state; the other two are byte-identical before and after. CI will be the first run of the pytest file itself — please flag anything it turns up and I'll fix it promptly.

`ruff check` and `ruff format --diff` pass at the pinned `v0.15.8` from `.pre-commit-config.yaml`, against the repo's own config.

Note this branch is based on an older `main`: syncing my fork trips GitHub's `workflow` scope guard on `.github/workflows/base.yml`, so I based on the fork tip and wrote `causal.py` from that same tree to keep unrelated upstream drift out of the diff. Happy to rebase if you'd prefer.

## AI Usage Disclaimer

Yes — AI-assisted (Claude). The diagnosis, patch, tests and the old-vs-new harness above were produced with AI assistance and reviewed by me before submitting; the before/after output quoted above is from an actual run, not generated text.

## Types of changes

Bug fix (non-breaking change which fixes an issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training resume behavior by correctly restoring token-counting state from configured or explicitly selected checkpoints.
  * Preserved expected behavior for fresh training runs and configurations without a resume checkpoint.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->