### PR TITLE
Fix SAC compatibility with saved tensor hooks

### DIFF
--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -329,6 +329,8 @@ def apply_selective_checkpointing(
         gc_kwargs["context_fn"] = context_fn
         if _SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS:
             gc_kwargs["respect_saved_tensors_hooks"] = False
+        else:
+            gc_kwargs.pop("respect_saved_tensors_hooks", None)
         return orig_enable(gradient_checkpointing_kwargs=gc_kwargs, **kwargs)
 
     enable_with_sac._axolotl_sac = True

--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -24,7 +24,7 @@ LOG = get_logger(__name__)
 
 ATTENTION_GROUP = "attention"
 
-# Older supported PyTorch releases reject this keyword.
+# PyTorch releases before 2.14 reject this keyword.
 _SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS = (
     "respect_saved_tensors_hooks" in inspect.signature(_torch_checkpoint).parameters
 )
@@ -328,7 +328,7 @@ def apply_selective_checkpointing(
         gc_kwargs["use_reentrant"] = False
         gc_kwargs["context_fn"] = context_fn
         if _SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS:
-            gc_kwargs["respect_saved_tensors_hooks"] = False
+            gc_kwargs.setdefault("respect_saved_tensors_hooks", False)
         else:
             gc_kwargs.pop("respect_saved_tensors_hooks", None)
         return orig_enable(gradient_checkpointing_kwargs=gc_kwargs, **kwargs)

--- a/src/axolotl/monkeypatch/selective_checkpointing.py
+++ b/src/axolotl/monkeypatch/selective_checkpointing.py
@@ -8,11 +8,13 @@ dispatcher-visible.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Callable
 
 import torch
 from torch.utils.checkpoint import (
     CheckpointPolicy,
+    checkpoint as _torch_checkpoint,
     create_selective_checkpoint_contexts,
 )
 
@@ -21,6 +23,11 @@ from axolotl.utils.logging import get_logger
 LOG = get_logger(__name__)
 
 ATTENTION_GROUP = "attention"
+
+# Older supported PyTorch releases reject this keyword.
+_SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS = (
+    "respect_saved_tensors_hooks" in inspect.signature(_torch_checkpoint).parameters
+)
 
 _ATEN_ATTENTION_PACKETS = (
     "_scaled_dot_product_flash_attention",
@@ -320,6 +327,8 @@ def apply_selective_checkpointing(
         gc_kwargs = dict(gradient_checkpointing_kwargs or {})
         gc_kwargs["use_reentrant"] = False
         gc_kwargs["context_fn"] = context_fn
+        if _SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS:
+            gc_kwargs["respect_saved_tensors_hooks"] = False
         return orig_enable(gradient_checkpointing_kwargs=gc_kwargs, **kwargs)
 
     enable_with_sac._axolotl_sac = True

--- a/tests/monkeypatch/test_selective_checkpointing.py
+++ b/tests/monkeypatch/test_selective_checkpointing.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.checkpoint import CheckpointPolicy, checkpoint
 
+import axolotl.monkeypatch.selective_checkpointing as selective_checkpointing
 from axolotl.monkeypatch.selective_checkpointing import (
     SacPolicyState,
     apply_selective_checkpointing,
@@ -167,6 +168,46 @@ class TestEnableWrap:
         model.gradient_checkpointing_enable()
         assert model.seen_kwargs["use_reentrant"] is False
         assert callable(model.seen_kwargs["context_fn"])
+
+    @pytest.mark.parametrize("supports_kwarg", [False, True])
+    def test_respect_saved_tensors_hooks_is_feature_gated(
+        self, monkeypatch, supports_kwarg
+    ):
+        monkeypatch.setattr(
+            selective_checkpointing,
+            "_SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS",
+            supports_kwarg,
+        )
+        model = self._FakeModel()
+        original_kwargs = {"preserve_rng_state": False}
+        apply_selective_checkpointing(model)
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs=original_kwargs
+        )
+
+        assert original_kwargs == {"preserve_rng_state": False}
+        if supports_kwarg:
+            assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
+        else:
+            assert "respect_saved_tensors_hooks" not in model.seen_kwargs
+
+    def test_overrides_respect_saved_tensors_hooks_to_preserve_sac_behavior(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            selective_checkpointing,
+            "_SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS",
+            True,
+        )
+        model = self._FakeModel()
+        original_kwargs = {"respect_saved_tensors_hooks": True}
+        apply_selective_checkpointing(model)
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs=original_kwargs
+        )
+
+        assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
+        assert original_kwargs["respect_saved_tensors_hooks"] is True
 
     def test_idempotent(self):
         model = self._FakeModel()

--- a/tests/monkeypatch/test_selective_checkpointing.py
+++ b/tests/monkeypatch/test_selective_checkpointing.py
@@ -170,8 +170,15 @@ class TestEnableWrap:
         assert callable(model.seen_kwargs["context_fn"])
 
     @pytest.mark.parametrize("supports_kwarg", [False, True])
+    @pytest.mark.parametrize(
+        "caller_kwargs",
+        [
+            {"preserve_rng_state": False},
+            {"respect_saved_tensors_hooks": True},
+        ],
+    )
     def test_respect_saved_tensors_hooks_is_feature_gated(
-        self, monkeypatch, supports_kwarg
+        self, monkeypatch, supports_kwarg, caller_kwargs
     ):
         monkeypatch.setattr(
             selective_checkpointing,
@@ -179,39 +186,16 @@ class TestEnableWrap:
             supports_kwarg,
         )
         model = self._FakeModel()
-        original_kwargs = {"preserve_rng_state": False}
+        original_kwargs = dict(caller_kwargs)
         apply_selective_checkpointing(model)
-        model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs=original_kwargs
-        )
+        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=caller_kwargs)
 
-        assert original_kwargs == {"preserve_rng_state": False}
+        assert caller_kwargs == original_kwargs
         if supports_kwarg:
-            assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
+            expected = caller_kwargs.get("respect_saved_tensors_hooks", False)
+            assert model.seen_kwargs["respect_saved_tensors_hooks"] is expected
         else:
             assert "respect_saved_tensors_hooks" not in model.seen_kwargs
-
-    @pytest.mark.parametrize("supports_kwarg", [False, True])
-    def test_handles_caller_provided_respect_saved_tensors_hooks(
-        self, monkeypatch, supports_kwarg
-    ):
-        monkeypatch.setattr(
-            selective_checkpointing,
-            "_SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS",
-            supports_kwarg,
-        )
-        model = self._FakeModel()
-        original_kwargs = {"respect_saved_tensors_hooks": True}
-        apply_selective_checkpointing(model)
-        model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs=original_kwargs
-        )
-
-        if supports_kwarg:
-            assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
-        else:
-            assert "respect_saved_tensors_hooks" not in model.seen_kwargs
-        assert original_kwargs["respect_saved_tensors_hooks"] is True
 
     def test_idempotent(self):
         model = self._FakeModel()

--- a/tests/monkeypatch/test_selective_checkpointing.py
+++ b/tests/monkeypatch/test_selective_checkpointing.py
@@ -191,13 +191,14 @@ class TestEnableWrap:
         else:
             assert "respect_saved_tensors_hooks" not in model.seen_kwargs
 
-    def test_overrides_respect_saved_tensors_hooks_to_preserve_sac_behavior(
-        self, monkeypatch
+    @pytest.mark.parametrize("supports_kwarg", [False, True])
+    def test_handles_caller_provided_respect_saved_tensors_hooks(
+        self, monkeypatch, supports_kwarg
     ):
         monkeypatch.setattr(
             selective_checkpointing,
             "_SUPPORTS_RESPECT_SAVED_TENSORS_HOOKS",
-            True,
+            supports_kwarg,
         )
         model = self._FakeModel()
         original_kwargs = {"respect_saved_tensors_hooks": True}
@@ -206,7 +207,10 @@ class TestEnableWrap:
             gradient_checkpointing_kwargs=original_kwargs
         )
 
-        assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
+        if supports_kwarg:
+            assert model.seen_kwargs["respect_saved_tensors_hooks"] is False
+        else:
+            assert "respect_saved_tensors_hooks" not in model.seen_kwargs
         assert original_kwargs["respect_saved_tensors_hooks"] is True
 
     def test_idempotent(self):


### PR DESCRIPTION
# Description

Feature-detect PyTorch's `respect_saved_tensors_hooks` checkpoint
argument and explicitly disable it for Axolotl's selective activation
checkpointing wrapper.

Add regression tests for both supported and unsupported PyTorch APIs,
caller argument immutability, and conflicting caller input.

## Motivation and Context

PyTorch is introducing a staged behavior change for selective activation
checkpointing under ambient `saved_tensors_hooks`. Leaving the new argument
unspecified will first warn and later become an error.

Axolotl's hidden-state activation offloader is intentionally boundary-only,
while SAC-region offloading is handled separately. Passing
`respect_saved_tensors_hooks=False` preserves the current behavior and avoids
double-processing SAC-cached tensors.

The argument is feature-detected so currently supported PyTorch releases
continue to work.

Fixes #3883.

## How has this been tested?

- `pytest` on the three directly related SAC and activation-offload test files:
  25 passed, 3 CUDA-only tests skipped
- PyTorch 2.13 compatibility and argument-forwarding smoke test
- Repository pre-commit hooks on both changed files
- `python -m compileall`
- `git diff --check`

## AI Usage Disclaimer

Yes. OpenAI Codex assisted with issue analysis, implementation, and test
drafting. I reviewed the proposed diff and local verification results before
submission.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix
- [x] Tests
