### PR TITLE
fix(docs): render full attribute docstrings in API reference

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,6 +9,8 @@ quartodoc:
   package: axolotl
   title: API Reference
   parser: google
+  renderer:
+    style: docs.scripts._renderer.py
 
   sections:
     - title: Core

--- a/docs/scripts/_renderer.py
+++ b/docs/scripts/_renderer.py
@@ -1,0 +1,39 @@
+"""Custom quartodoc renderer for the Axolotl API reference."""
+
+from typing import Optional
+
+from plum import dispatch
+from quartodoc import MdRenderer, layout
+from quartodoc._griffe_compat import docstrings as ds
+
+
+class Renderer(MdRenderer):
+    """Renderer that keeps whole attribute docstrings in the summary table.
+
+    Attributes never get an expanded section of their own, so the summary table is
+    the only place their docstring appears; the default renderer truncates it to the
+    first line.
+    """
+
+    style = "axolotl"
+
+    @dispatch
+    def summarize(
+        self,
+        el: layout.DocAttribute,
+        path: Optional[str] = None,
+        shorten: bool = False,
+    ):
+        if path is None:
+            link = f"[{el.name}](#{el.anchor})"
+        else:
+            link = f"[{el.name}]({path}.qmd#{el.anchor})"
+
+        doc = el.obj.docstring
+        parts = doc.parsed if doc is not None else []
+        if parts and isinstance(parts[0], ds.DocstringSectionText):
+            description = parts[0].value
+        else:
+            description = ""
+
+        return self._summary_row(link, description)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Our docs was just rendering the first line from api docstrings, this fixes that

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated API documentation with a custom Axolotl-style layout.
  * Preserved complete attribute descriptions in documentation summary tables.
  * Added clearer navigation anchors for documented attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->