### PR TITLE
fix(sonicmoe): stop importing _sonicmoe_wrapper removed from transformers

### DIFF
--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -1,8 +1,8 @@
 """LoRA-aware sonicmoe experts forward for the transformers ExpertsInterface.
 
-Dense experts wrap upstream ``_sonicmoe_wrapper``, materializing expert LoRA via
-``MoELoRAMaterialize`` before the CUTLASS call. NVFP4 experts (which that kernel
-cannot read) take the grouped dequant path in ``nvfp4_lora`` instead.
+Dense experts call the sonic-moe CUTLASS kernel through ``_sonicmoe_call`` below,
+materializing expert LoRA via ``MoELoRAMaterialize`` first. NVFP4 experts (which that
+kernel cannot read) take the grouped dequant path in ``nvfp4_lora`` instead.
 """
 
 from __future__ import annotations
@@ -18,6 +18,79 @@ from .lora import (
     materialize_expert_lora,
     unwrap_experts_lora,
 )
+
+# Activation name (HF config ``hidden_act``) -> sonic-moe epilogue name.
+ACT_MAP = {"silu": "swiglu", "gelu": "geglu", "relu": "reglu"}
+
+
+def _load_sonicmoe():
+    """Return the loaded sonic-moe kernel bundle from ``transformers``.
+
+    ``load_sonicmoe_kernel`` is the current public entry point; before
+    huggingface/transformers#47334 (2026-07-28) only the private
+    ``_load_sonicmoe_kernel`` existed and it returned the bundle directly.
+    """
+    try:
+        from transformers.integrations.sonicmoe import load_sonicmoe_kernel
+    except ImportError:  # transformers < 2026-07-28
+        from transformers.integrations.sonicmoe import (  # type: ignore[attr-defined]
+            _load_sonicmoe_kernel as load_sonicmoe_kernel,
+        )
+
+    return load_sonicmoe_kernel()
+
+
+@torch._dynamo.allow_in_graph
+def _sonicmoe_call(
+    hidden_states: torch.Tensor,
+    router_scores: torch.Tensor,
+    expert_ids: torch.Tensor,
+    token_idx: torch.Tensor,
+    w1: torch.Tensor,
+    b1: torch.Tensor | None,
+    w2: torch.Tensor,
+    b2: torch.Tensor | None,
+    act_name: str,
+    num_experts: int,
+    concat_layout: bool,
+    is_inference_mode_enabled: bool,
+) -> torch.Tensor:
+    """Module-level shim around ``moe_general_routing_inputs`` so ``allow_in_graph`` can wrap it.
+
+    sonic-moe asserts ``not torch.compiler.is_compiling()`` internally because it dispatches
+    CuteDSL kernels, which Dynamo can't trace. ``allow_in_graph`` keeps the call in the FX
+    graph as a single opaque node (no tracing into the body, no graph break) while still
+    running the real Python at runtime — autograd through the kernel's projections flows
+    normally. The decorator must be applied at module load time, not inside the compiled
+    function — hence this shim.
+
+    This mirrors the ``_sonicmoe_wrapper`` that transformers removed in #47334; we keep our
+    own copy because we call the kernel with LoRA-materialized weights rather than through
+    upstream's ``sonicmoe_experts_forward``.
+    """
+    sonicmoe = _load_sonicmoe()
+    activation_type_enum = sonicmoe.activation_type_enum
+    activation_type = getattr(
+        activation_type_enum,
+        ACT_MAP.get(act_name, "swiglu").upper(),
+        activation_type_enum.SWIGLU,
+    )
+    output, _ = sonicmoe.moe_general_routing_inputs(
+        hidden_states,
+        router_scores,
+        token_idx,
+        expert_ids,
+        w1,
+        b1,
+        w2,
+        b2,
+        E=num_experts,
+        activation_type=activation_type,
+        is_inference_mode_enabled=is_inference_mode_enabled,
+        concat_layout=concat_layout,
+        stream_id=None,
+    )
+    return output
 
 
 def _maybe_unwrap_param_wrapper(param):
@@ -122,8 +195,6 @@ def sonicmoe_experts_forward_with_lora(
             lora_w2,
         )
 
-    from transformers.integrations.sonicmoe import _sonicmoe_wrapper
-
     device = hidden_states.device
     num_top_k = top_k_index.size(-1)
     num_tokens = hidden_states.size(0)
@@ -154,7 +225,7 @@ def sonicmoe_experts_forward_with_lora(
 
     act_name = getattr(self.config, "hidden_act", "silu").lower()
 
-    return _sonicmoe_wrapper(
+    return _sonicmoe_call(
         hidden_states=hidden_states,
         router_scores=router_scores,
         expert_ids=expert_ids,

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -235,3 +235,125 @@ class TestExpertsClassMetadata:
             sonicmoe_experts_forward_with_lora(
                 fake_self, hidden, top_k_index, top_k_weights
             )
+
+
+class TestSonicmoeKernelLoaderCompat:
+    """`_load_sonicmoe` must work against both the current transformers entry point
+    (`load_sonicmoe_kernel`) and the pre-#47334 private one (`_load_sonicmoe_kernel`),
+    without importing the `_sonicmoe_wrapper` that #47334 removed."""
+
+    @staticmethod
+    def _install_fake_sonicmoe_module(monkeypatch, *, public: bool):
+        import sys
+        from types import ModuleType
+
+        bundle = SimpleNamespace(
+            activation_type_enum=SimpleNamespace(SWIGLU="SWIGLU", GEGLU="GEGLU"),
+            moe_general_routing_inputs=lambda *a, **kw: (torch.zeros(1), None),
+        )
+        mod = ModuleType("transformers.integrations.sonicmoe")
+        name = "load_sonicmoe_kernel" if public else "_load_sonicmoe_kernel"
+        setattr(mod, name, lambda: bundle)
+        monkeypatch.setitem(sys.modules, "transformers.integrations.sonicmoe", mod)
+        return bundle
+
+    @pytest.mark.parametrize("public", [True, False])
+    def test_load_sonicmoe_resolves_either_entry_point(self, monkeypatch, public):
+        from axolotl.integrations.kernels.libs.sonicmoe.experts import _load_sonicmoe
+
+        bundle = self._install_fake_sonicmoe_module(monkeypatch, public=public)
+        assert _load_sonicmoe() is bundle
+
+    def test_no_import_of_removed_private_wrapper(self):
+        """#47334 deleted `_sonicmoe_wrapper`; importing it breaks on current transformers."""
+        from pathlib import Path
+
+        import axolotl.integrations.kernels.libs.sonicmoe.experts as experts_mod
+
+        source = Path(experts_mod.__file__).read_text(encoding="utf-8")
+        assert "import _sonicmoe_wrapper" not in source
+        assert "_sonicmoe_wrapper(" not in source
+
+    def test_call_forwards_expected_kernel_arguments(self, monkeypatch):
+        from axolotl.integrations.kernels.libs.sonicmoe.experts import _sonicmoe_call
+
+        captured = {}
+
+        def fake_kernel(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return torch.full((2, 3), 7.0), None
+
+        bundle = SimpleNamespace(
+            activation_type_enum=SimpleNamespace(SWIGLU="SWIGLU", GEGLU="GEGLU"),
+            moe_general_routing_inputs=fake_kernel,
+        )
+        monkeypatch.setattr(
+            "axolotl.integrations.kernels.libs.sonicmoe.experts._load_sonicmoe",
+            lambda: bundle,
+        )
+
+        hidden = torch.zeros(2, 3)
+        scores = torch.zeros(4)
+        expert_ids = torch.zeros(4, dtype=torch.int32)
+        token_idx = torch.zeros(4, dtype=torch.int32)
+        w1, w2 = torch.zeros(3, 3, 2), torch.zeros(3, 3, 2)
+
+        out = _sonicmoe_call(
+            hidden_states=hidden,
+            router_scores=scores,
+            expert_ids=expert_ids,
+            token_idx=token_idx,
+            w1=w1,
+            b1=None,
+            w2=w2,
+            b2=None,
+            act_name="gelu",
+            num_experts=2,
+            concat_layout=True,
+            is_inference_mode_enabled=False,
+        )
+
+        # Only the output tensor is returned; the kernel's second value is dropped.
+        assert torch.equal(out, torch.full((2, 3), 7.0))
+        # Positional order is (hidden, scores, token_idx, expert_ids, w1, b1, w2, b2) —
+        # token_idx and expert_ids are NOT in keyword order here.
+        assert captured["args"][2] is token_idx
+        assert captured["args"][3] is expert_ids
+        assert captured["kwargs"]["E"] == 2
+        assert captured["kwargs"]["activation_type"] == "GEGLU"
+        assert captured["kwargs"]["concat_layout"] is True
+        assert captured["kwargs"]["is_inference_mode_enabled"] is False
+        assert captured["kwargs"]["stream_id"] is None
+
+    def test_unknown_activation_falls_back_to_swiglu(self, monkeypatch):
+        from axolotl.integrations.kernels.libs.sonicmoe.experts import _sonicmoe_call
+
+        captured = {}
+        bundle = SimpleNamespace(
+            activation_type_enum=SimpleNamespace(SWIGLU="SWIGLU"),
+            moe_general_routing_inputs=lambda *a, **kw: (
+                captured.update(kw) or torch.zeros(1),
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "axolotl.integrations.kernels.libs.sonicmoe.experts._load_sonicmoe",
+            lambda: bundle,
+        )
+
+        _sonicmoe_call(
+            hidden_states=torch.zeros(1, 2),
+            router_scores=torch.zeros(1),
+            expert_ids=torch.zeros(1, dtype=torch.int32),
+            token_idx=torch.zeros(1, dtype=torch.int32),
+            w1=torch.zeros(2, 2, 1),
+            b1=None,
+            w2=torch.zeros(2, 2, 1),
+            b2=None,
+            act_name="not_a_real_activation",
+            num_experts=1,
+            concat_layout=False,
+            is_inference_mode_enabled=True,
+        )
+        assert captured["activation_type"] == "SWIGLU"


### PR DESCRIPTION
## Summary

`sonicmoe_experts_forward_with_lora` currently does:

```python
from transformers.integrations.sonicmoe import _sonicmoe_wrapper
```

That private shim was **deleted upstream** in huggingface/transformers#47334 (`ebea912f`, 2026-07-28, "Kernels and loaders robustification"). On any transformers newer than that commit, every dense (non-NVFP4) sonicmoe expert forward raises `ImportError` at the call site. I hit this while trying to run the real `kernels-community/sonic-moe` kernel for the benchmark in #3936 — getting it to run at all required pinning transformers to a pre-`ebea912f` commit.

## What changed

Keep our own copy of the shim (`_sonicmoe_call`) in `experts.py` rather than reaching for a private upstream symbol:

- We can't just call upstream's public `sonicmoe_experts_forward`, because our whole reason for being here is calling the kernel with **LoRA-materialized** `W_eff = W + scaling * (B @ A)` weights (and our own layout permute), not the module's raw `gate_up_proj`/`down_proj`.
- The `@torch._dynamo.allow_in_graph` decorator is preserved and still applied at module load time. sonic-moe asserts `not torch.compiler.is_compiling()` internally, so the call must stay an opaque FX node — this is exactly why the upstream shim existed, and why inlining the kernel call into the compiled function would be wrong.
- Kernel loading goes through the current public `load_sonicmoe_kernel()`, falling back to the old private `_load_sonicmoe_kernel()` so **pre-#47334 transformers keeps working**. Both are exercised in tests.
- `ACT_MAP` is now local (3 entries, unchanged semantics). The lenient `.get(act_name, "swiglu")` fallback from the old shim is preserved deliberately — upstream's rewrite made unknown activations raise, but that would be a behavior change unrelated to fixing the import, so it's left alone here.

No behavior change on a working (pinned) transformers; this only restores the dense path on current transformers.

## Test plan

- [x] Added `TestSonicmoeKernelLoaderCompat` in `tests/integrations/test_sonicmoe.py` (5 tests, CPU-only, no CUDA / DeepEP / sonic-moe needed):
  - `_load_sonicmoe` resolves against **both** entry points (parametrized over public `load_sonicmoe_kernel` and legacy private `_load_sonicmoe_kernel`)
  - a regression guard that the source no longer references the removed `_sonicmoe_wrapper`
  - argument forwarding into `moe_general_routing_inputs`, including the easy-to-get-wrong positional order (`token_idx` before `expert_ids`, which is *not* the wrapper's keyword order) and that only the first element of the kernel's `(output, _)` tuple is returned
  - unknown-activation fallback to `SWIGLU`
- [x] `pytest tests/integrations/test_sonicmoe.py` — 27 passed
- [x] `ruff check` / `ruff format --check` / `mypy` clean on both changed files (the only mypy hit on `experts.py` is a pre-existing `peft.tuners.param_wrapper` stub warning)
- [x] **Verified on a real H100 against the real `kernels-community/sonic-moe` CUTLASS kernel** (details below).

### GPU verification

Ran on an **H100 80GB HBM3** (SM90) with **unpinned, current** dependencies — `torch 2.9.0+cu128`, `transformers 5.15.1`, `nvidia-cutlass-dsl 4.7.0`, `apache-tvm-ffi 0.1.13.post3`, `kernels 0.16.1` — driving the actual downloaded sonic-moe kernel, not a stand-in:

| # | check | result |
|---|---|---|
| 1 | `transformers 5.15.1` exports | `_sonicmoe_wrapper` **absent**; `load_sonicmoe_kernel` and `_load_sonicmoe_kernel` both present; `is_sonicmoe_loadable()` → `True` |
| 2 | importing the removed symbol | `ImportError: cannot import name '_sonicmoe_wrapper'` |
| 3 | **pre-fix** code (`upstream/main`, `2f16189e`) | forward dies with `ImportError` at `experts.py:125` — the reported breakage, reproduced |
| 4 | **post-fix** `_load_sonicmoe()` | resolves the real `SonicMoE` bundle (`enum ActivationType`, `moe_general_routing_inputs`) |
| 5 | end-to-end forward vs naive fp32 per-token/per-slot reference | `max_abs_diff = 4.88e-4` **without** LoRA and **with** LoRA — bf16 rounding level ✅ |
| 6 | LoRA is genuinely applied (not silently a no-op) | `max|out_lora − out_base| = 4.03e-2` ✅ |
| 7 | `torch.compile` vs eager | `max_abs_diff = 0.0` — confirms `allow_in_graph` still holds the kernel call as one opaque FX node ✅ |
| 8 | backward through the kernel | input grads finite and non-zero ✅ |

Checks 6–8 are there because they're the parts that could silently regress: 5 alone would still pass if LoRA were dropped on the floor, and the `allow_in_graph` placement is the subtle bit of this change.

The repo's own `tests/e2e/integrations/test_sonicmoe.py` still deserves a CI run on hardware, but note that suite currently can't run *at all* against unpinned transformers — which is the point of this PR.

Follow-up to the discussion in #3936.
