### PR TITLE
SkyPilot example and docs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -513,6 +513,7 @@ website:
             - docs/multi-gpu.qmd
             - docs/multi-node.qmd
             - docs/ray-integration.qmd
+            - docs/skypilot.qmd
             - docs/amd_hpc.qmd
             - docs/mac.qmd
 

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -102,6 +102,10 @@ For providers supporting Docker:
     - [JarvisLabs.ai](https://jarvislabs.ai/templates/axolotl)
     - [Latitude.sh](https://latitude.sh/blueprint/989e0e79-3bf6-41ea-a46b-1f246e309d5c)
 
+### SkyPilot {#sec-skypilot}
+
+To launch Axolotl on your own cloud accounts (AWS, GCP, Azure, etc.) or Kubernetes cluster with a single command, see the [SkyPilot guide](skypilot.qmd).
+
 ### Google Colab {#sec-colab}
 
 [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/axolotl-ai-cloud/axolotl/blob/main/examples/colab-notebooks/colab-axolotl-example.ipynb#scrollTo=msOCO4NRmRLa)

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -102,13 +102,13 @@ For providers supporting Docker:
     - [JarvisLabs.ai](https://jarvislabs.ai/templates/axolotl)
     - [Latitude.sh](https://latitude.sh/blueprint/989e0e79-3bf6-41ea-a46b-1f246e309d5c)
 
-### SkyPilot {#sec-skypilot}
-
-To launch Axolotl on your own cloud accounts (AWS, GCP, Azure, etc.) or Kubernetes cluster with a single command, see the [SkyPilot guide](skypilot.qmd).
-
 ### Google Colab {#sec-colab}
 
 [![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/axolotl-ai-cloud/axolotl/blob/main/examples/colab-notebooks/colab-axolotl-example.ipynb#scrollTo=msOCO4NRmRLa)
+
+### SkyPilot {#sec-skypilot}
+
+To launch Axolotl on your own cloud accounts (AWS, GCP, Azure, etc.) or Kubernetes cluster with a single command, see the [SkyPilot guide](skypilot.qmd).
 
 ## Platform-Specific Instructions {#sec-platform-specific}
 

--- a/docs/installation.qmd
+++ b/docs/installation.qmd
@@ -102,13 +102,13 @@ For providers supporting Docker:
     - [JarvisLabs.ai](https://jarvislabs.ai/templates/axolotl)
     - [Latitude.sh](https://latitude.sh/blueprint/989e0e79-3bf6-41ea-a46b-1f246e309d5c)
 
-### Google Colab {#sec-colab}
-
-[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/axolotl-ai-cloud/axolotl/blob/main/examples/colab-notebooks/colab-axolotl-example.ipynb#scrollTo=msOCO4NRmRLa)
-
 ### SkyPilot {#sec-skypilot}
 
 To launch Axolotl on your own cloud accounts (AWS, GCP, Azure, etc.) or Kubernetes cluster with a single command, see the [SkyPilot guide](skypilot.qmd).
+
+### Google Colab {#sec-colab}
+
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/axolotl-ai-cloud/axolotl/blob/main/examples/colab-notebooks/colab-axolotl-example.ipynb#scrollTo=msOCO4NRmRLa)
 
 ## Platform-Specific Instructions {#sec-platform-specific}
 

--- a/docs/multi-node.qmd
+++ b/docs/multi-node.qmd
@@ -92,7 +92,3 @@ Please make sure to substitute the placeholder variables:
 The new CLI approach (Option 1) is recommended as it provides consistent argument handling and works seamlessly with other Axolotl CLI features.
 
 More info on the available configs can be found on the Pytorch docs [here](https://pytorch.org/docs/stable/elastic/run.html)
-
-::: {.callout-tip}
-[SkyPilot](skypilot.qmd) can provision the nodes on any cloud or Kubernetes and run this torchrun launcher on each of them automatically.
-:::

--- a/docs/multi-node.qmd
+++ b/docs/multi-node.qmd
@@ -92,3 +92,7 @@ Please make sure to substitute the placeholder variables:
 The new CLI approach (Option 1) is recommended as it provides consistent argument handling and works seamlessly with other Axolotl CLI features.
 
 More info on the available configs can be found on the Pytorch docs [here](https://pytorch.org/docs/stable/elastic/run.html)
+
+::: {.callout-tip}
+[SkyPilot](skypilot.qmd) can provision the nodes on any cloud or Kubernetes and run this torchrun launcher on each of them automatically.
+:::

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -41,11 +41,11 @@ sky logs axolotl
 sky down axolotl
 ```
 
-Training outputs live on the cluster and disappear with `sky down`. Without a `workdir`, the `run` block executes in `$HOME`, so copy outputs off first (`rsync -Pavz axolotl:outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
+Training outputs live on the cluster and disappear with `sky down`. The `run` block always executes in `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
 
 The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`: the value is read from your local environment and exposed to the `run` commands.
 
-To train with your own config, add `workdir: .` to the task file and drop the `axolotl fetch examples` line. Your current directory is synced to the cluster and the `run` commands then execute inside it (`~/sky_workdir`), so `axolotl train my_training.yml` works as-is and outputs land there instead of `$HOME`.
+To train with your own config, add `workdir: .` to the task file and drop the `axolotl fetch examples` line. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
 
 ## Multi-node
 
@@ -62,9 +62,13 @@ run: |
   # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
   source /workspace/axolotl/scripts/cuda13_env.sh
 
-  # NCCL tuning for Infiniband, from the multi-node guide; adjust for your fabric
+  # Pin collectives to the node's real NIC. Without this, Gloo resolves the
+  # hostname to 127.0.1.1 (the Debian/Ubuntu loopback alias in /etc/hosts) and
+  # startup fails with "Gloo connectFullMesh failed ... Connection refused".
+  IFACE=$(ls /sys/class/net | grep -vE '^(lo|docker.*|veth.*)$' | head -n1)
+  export GLOO_SOCKET_IFNAME=$IFACE
+  export NCCL_SOCKET_IFNAME=$IFACE
   export NCCL_IB_DISABLE=0
-  export NCCL_SOCKET_IFNAME="eth0,en,eth,em,bond"
   export NCCL_BUFFSIZE=2097152
 
   axolotl fetch examples

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -3,7 +3,7 @@ title: SkyPilot
 description: How to launch Axolotl on any cloud or Kubernetes with SkyPilot
 ---
 
-[SkyPilot](https://github.com/skypilot-org/skypilot) is an open-source framework for running workloads on any cloud or Kubernetes cluster. Instead of provisioning an instance and setting up Docker yourself, you describe the job in a short YAML and SkyPilot finds a GPU across your enabled infrastructure (AWS, GCP, Azure, RunPod, Vast.ai, Kubernetes, and [more](https://docs.skypilot.ai/en/latest/getting-started/installation.html)), pulls the Axolotl image, and runs training.
+[SkyPilot](https://github.com/skypilot-org/skypilot) runs workloads on any cloud or Kubernetes cluster. You describe the job in a short YAML, and SkyPilot finds a GPU across your enabled infrastructure (AWS, GCP, Azure, RunPod, Vast.ai, Kubernetes, and [more](https://docs.skypilot.ai/en/latest/getting-started/installation.html)), pulls the Axolotl image, and runs training.
 
 ## Setup
 
@@ -30,11 +30,11 @@ run: |
   axolotl train /workspace/axolotl/examples/llama-3/lora-1b.yml
 ```
 
-The image ships the example configs at `/workspace/axolotl/examples`, so there is nothing to fetch. Paths are absolute because the `run` block executes in `~/sky_workdir`, not in the image's Axolotl checkout.
+The `run` block executes in `~/sky_workdir`, not in the image's Axolotl checkout, so configs bundled in the image need absolute paths.
 
-Note the image choice: SkyPilot sources `~/.bashrc` when running `setup` and `run`, and the `-cloud` image's `.bashrc` attaches a tmux session and exits, which terminates the command. Use the plain image as above, or `axolotlai/axolotl-cloud-term:main-latest` if you want the cloud image's HuggingFace cache defaults without tmux.
+On the image choice: SkyPilot sources `~/.bashrc` for `setup` and `run`, and the `-cloud` image's `.bashrc` attaches a tmux session and exits, killing the command. Use the plain image as above, or `axolotlai/axolotl-cloud-term:main-latest` for the cloud image's HuggingFace cache defaults without tmux.
 
-Launch it, stream logs, and clean up when done:
+Launch it, then re-attach to logs or clean up when done:
 
 ```bash
 sky launch -c axolotl axolotl-skypilot.yaml
@@ -42,7 +42,7 @@ sky logs axolotl
 sky down axolotl
 ```
 
-Training outputs live on the cluster and disappear with `sky down`. The config's relative `output_dir` lands under `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
+The config's relative `output_dir` lands under `~/sky_workdir` on the cluster and disappears with `sky down`, so copy it off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown below.
 
 The example configs referenced here use ungated models. For gated models, pass your token at launch:
 
@@ -50,13 +50,13 @@ The example configs referenced here use ungated models. For gated models, pass y
 sky launch -c axolotl axolotl-skypilot.yaml --secret HF_TOKEN
 ```
 
-The bare name with no value attached is intentional: SkyPilot reads `$HF_TOKEN` from your local shell.
+The bare name is intentional: SkyPilot reads `$HF_TOKEN` from your local shell.
 
-To train with your own config, add `workdir: .` to the task file. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
+To train with your own config, add `workdir: .` to the task file. Your current directory syncs to `~/sky_workdir`, where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
 
 ## Multi-node
 
-Set `num_nodes` and pass SkyPilot's runtime environment variables to the torchrun launcher described in the [multi-node guide](multi-node.qmd). SkyPilot runs the `run` block on every node, and the image already ships Axolotl, so nothing needs installing per node. In a separate task file, e.g. `axolotl-multinode.yaml`:
+Set `num_nodes` and pass SkyPilot's runtime environment variables to the torchrun launcher described in the [multi-node guide](multi-node.qmd). SkyPilot runs the `run` block on every node. In a separate task file, e.g. `axolotl-multinode.yaml`:
 
 ```yaml
 num_nodes: 2
@@ -98,7 +98,7 @@ To scale out, launch a new cluster with more nodes: `sky launch -c axolotl-4n --
 
 ## Spot instances
 
-To run on spot (preemptible) instances, add `use_spot: true` under `resources` in your task file:
+To run on spot (preemptible) instances, add `use_spot: true` under `resources`:
 
 ```yaml
 resources:
@@ -107,7 +107,7 @@ resources:
   use_spot: true
 ```
 
-For long runs, use managed jobs instead of `sky launch`: SkyPilot then auto-recovers the job if the spot instance is preempted. If the task has a `workdir` or local `file_mounts`, managed jobs stage them through a temporary object-store bucket (or one you pick with `jobs.bucket` in `~/.sky/config.yaml`); without object store access, files are streamed through the jobs controller instead.
+For long runs, use managed jobs instead of `sky launch`: SkyPilot then auto-recovers the job if the instance is preempted. Any `workdir` or local `file_mounts` are staged through an object-store bucket, which you can pick with `jobs.bucket` in `~/.sky/config.yaml`.
 
 ```bash
 sky jobs launch -n axolotl axolotl-skypilot.yaml
@@ -122,7 +122,7 @@ file_mounts:
     mode: MOUNT_CACHED
 ```
 
-Point `output_dir` in your Axolotl config at `/checkpoints` and set `auto_resume_from_checkpoints: true` so a recovered job resumes from the newest checkpoint in the bucket. One caveat: `MOUNT_CACHED` uploads asynchronously and Axolotl resumes from the highest-numbered checkpoint without validating it, so an abrupt preemption can leave that checkpoint incomplete and the resume failing. If that happens, delete the incomplete checkpoint directory from the bucket and the job will resume from the previous one.
+Point `output_dir` at `/checkpoints` and set `auto_resume_from_checkpoints: true` so a recovered job resumes from the newest checkpoint. Caveat: `MOUNT_CACHED` uploads asynchronously and Axolotl does not validate what it resumes from, so a preemption can leave the newest checkpoint incomplete. If the resume fails, delete that directory from the bucket to fall back to the previous one.
 
 ## Further reading
 

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -1,0 +1,122 @@
+---
+title: SkyPilot
+description: How to launch Axolotl on any cloud or Kubernetes with SkyPilot
+---
+
+[SkyPilot](https://github.com/skypilot-org/skypilot) is an open-source framework for running workloads on any cloud or Kubernetes cluster. Instead of provisioning an instance and setting up Docker yourself, you describe the job in a short YAML and SkyPilot finds a GPU across your enabled infrastructure (AWS, GCP, Azure, RunPod, Vast.ai, Kubernetes, and [more](https://docs.skypilot.co/en/latest/getting-started/installation.html)), pulls the Axolotl image, and runs training.
+
+## Setup
+
+Install SkyPilot with the providers you use, then confirm your credentials work:
+
+```bash
+pip install "skypilot[aws,gcp,kubernetes]"
+sky check
+```
+
+## Single node
+
+Create a SkyPilot task file, e.g. `axolotl-skypilot.yaml`:
+
+```yaml
+resources:
+  accelerators: A100:1  # or L40S:1, H100:8, ...
+  image_id: docker:axolotlai/axolotl-uv:main-latest
+
+run: |
+  # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
+  source /workspace/axolotl/scripts/cuda13_env.sh
+
+  axolotl fetch examples
+  axolotl train examples/llama-3/lora-1b.yml
+```
+
+Note the image choice: SkyPilot sources `~/.bashrc` when running `setup` and `run`, and the `-cloud` image's `.bashrc` attaches a tmux session and exits, which terminates the command. Use the plain image as above, or `axolotlai/axolotl-cloud-term:main-latest` if you want the cloud image's HuggingFace cache defaults without tmux.
+
+Launch it, stream logs, and clean up when done:
+
+```bash
+sky launch -c axolotl axolotl-skypilot.yaml
+sky logs axolotl
+sky down axolotl
+```
+
+Training outputs live on the cluster and disappear with `sky down`. Without a `workdir`, the `run` block executes in `$HOME`, so copy outputs off first (`rsync -Pavz axolotl:outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
+
+The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`: the value is read from your local environment and exposed to the `run` commands.
+
+To train with your own config, add `workdir: .` to the task file and drop the `axolotl fetch examples` line. Your current directory is synced to the cluster and the `run` commands then execute inside it (`~/sky_workdir`), so `axolotl train my_training.yml` works as-is and outputs land there instead of `$HOME`.
+
+## Multi-node
+
+Set `num_nodes` and pass SkyPilot's runtime environment variables to the torchrun launcher described in the [multi-node guide](multi-node.qmd). SkyPilot runs the `run` block on every node, and the image already ships Axolotl, so nothing needs installing per node. In a separate task file, e.g. `axolotl-multinode.yaml`:
+
+```yaml
+num_nodes: 2
+
+resources:
+  accelerators: H100:8
+  image_id: docker:axolotlai/axolotl-uv:main-latest
+
+run: |
+  # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
+  source /workspace/axolotl/scripts/cuda13_env.sh
+
+  # NCCL tuning for Infiniband, from the multi-node guide; adjust for your fabric
+  export NCCL_IB_DISABLE=0
+  export NCCL_SOCKET_IFNAME="eth0,en,eth,em,bond"
+  export NCCL_BUFFSIZE=2097152
+
+  axolotl fetch examples
+  HEAD_IP=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  axolotl train examples/llama-3/fft-8b-liger-fsdp.yaml --launcher torchrun -- \
+    --nnodes $SKYPILOT_NUM_NODES \
+    --nproc_per_node $SKYPILOT_NUM_GPUS_PER_NODE \
+    --rdzv_id $SKYPILOT_TASK_ID \
+    --rdzv_backend c10d \
+    --rdzv_endpoint "$HEAD_IP:29400"
+```
+
+```bash
+sky launch -c axolotl-2n axolotl-multinode.yaml
+```
+
+On AWS, GCP, Nebius, and RDMA-capable Kubernetes clusters, add `network_tier: best` under `resources` to get the fastest inter-node networking available; clouds without the feature reject the option.
+
+Each node tokenizes the dataset independently on first run. For large datasets, mount a bucket with `file_mounts`, point `dataset_prepared_path` in the Axolotl config at it, and run `axolotl preprocess` once so all nodes reuse the tokenized data.
+
+To scale out, launch a new cluster with more nodes: `sky launch -c axolotl-4n --num-nodes 4 axolotl-multinode.yaml`.
+
+## Spot instances
+
+To run on spot (preemptible) instances, add `use_spot: true` under `resources` in your task file:
+
+```yaml
+resources:
+  accelerators: A100:1
+  image_id: docker:axolotlai/axolotl-uv:main-latest
+  use_spot: true
+```
+
+For long runs, use managed jobs instead of `sky launch`: SkyPilot then auto-recovers the job if the spot instance is preempted. If the task has a `workdir` or local `file_mounts`, managed jobs stage them through cloud object storage, which needs an object store (S3, GCS, etc.) enabled or `jobs.bucket` set in `~/.sky/config.yaml`.
+
+```bash
+sky jobs launch -n axolotl axolotl-skypilot.yaml
+```
+
+Mount a bucket for checkpoints so recovery resumes instead of restarting:
+
+```yaml
+file_mounts:
+  /checkpoints:
+    name: my-axolotl-checkpoints  # bucket is created if it doesn't exist
+    mode: MOUNT_CACHED
+```
+
+Point `output_dir` in your Axolotl config at `/checkpoints` and set `auto_resume_from_checkpoints: true` so a recovered job picks up where it left off. `MOUNT_CACHED` uploads asynchronously, so the newest checkpoint may be incomplete after an abrupt preemption.
+
+## Further reading
+
+- [SkyPilot docs](https://docs.skypilot.co/)
+- [Task YAML reference](https://docs.skypilot.co/en/latest/reference/yaml-spec.html)
+- [Managed jobs](https://docs.skypilot.co/en/latest/examples/managed-jobs.html)

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -98,7 +98,7 @@ resources:
   use_spot: true
 ```
 
-For long runs, use managed jobs instead of `sky launch`: SkyPilot then auto-recovers the job if the spot instance is preempted. If the task has a `workdir` or local `file_mounts`, managed jobs stage them through cloud object storage, which needs an object store (S3, GCS, etc.) enabled or `jobs.bucket` set in `~/.sky/config.yaml`.
+For long runs, use managed jobs instead of `sky launch`: SkyPilot then auto-recovers the job if the spot instance is preempted. If the task has a `workdir` or local `file_mounts`, managed jobs stage them through a temporary object-store bucket (or one you pick with `jobs.bucket` in `~/.sky/config.yaml`); without object store access, files are streamed through the jobs controller instead.
 
 ```bash
 sky jobs launch -n axolotl axolotl-skypilot.yaml
@@ -113,7 +113,7 @@ file_mounts:
     mode: MOUNT_CACHED
 ```
 
-Point `output_dir` in your Axolotl config at `/checkpoints` and set `auto_resume_from_checkpoints: true` so a recovered job picks up where it left off. `MOUNT_CACHED` uploads asynchronously, so the newest checkpoint may be incomplete after an abrupt preemption.
+Point `output_dir` in your Axolotl config at `/checkpoints` and set `auto_resume_from_checkpoints: true` so a recovered job resumes from the newest checkpoint in the bucket. One caveat: `MOUNT_CACHED` uploads asynchronously and Axolotl resumes from the highest-numbered checkpoint without validating it, so an abrupt preemption can leave that checkpoint incomplete and the resume failing. If that happens, delete the incomplete checkpoint directory from the bucket and the job will resume from the previous one.
 
 ## Further reading
 

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -44,7 +44,13 @@ sky down axolotl
 
 Training outputs live on the cluster and disappear with `sky down`. The config's relative `output_dir` lands under `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
 
-The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`, written literally like that with no value attached: the bare name tells SkyPilot to read `$HF_TOKEN` from your local shell and expose it to the `run` commands. You can also list it in the task file as an empty `secrets:` entry, but the value still has to come from `--secret` at launch. Writing `HF_TOKEN: $HF_TOKEN` there does not work: SkyPilot passes that through as the literal string rather than expanding it.
+The example configs referenced here use ungated models. For gated models, pass your token at launch:
+
+```bash
+sky launch -c axolotl axolotl-skypilot.yaml --secret HF_TOKEN
+```
+
+The bare name with no value attached is intentional: SkyPilot reads `$HF_TOKEN` from your local shell.
 
 To train with your own config, add `workdir: .` to the task file. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
 

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -21,7 +21,7 @@ Create a SkyPilot task file, e.g. `axolotl-skypilot.yaml`:
 ```yaml
 resources:
   accelerators: A100:1  # or L40S:1, H100:8, ...
-  image_id: docker:axolotlai/axolotl-uv:main-latest
+  image_id: docker:axolotlai/axolotl:main-latest
 
 run: |
   # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
@@ -43,7 +43,7 @@ sky down axolotl
 
 Training outputs live on the cluster and disappear with `sky down`. The `run` block always executes in `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
 
-The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`: the value is read from your local environment and exposed to the `run` commands.
+The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`, written literally like that with no value attached: the bare name tells SkyPilot to read `$HF_TOKEN` from your local shell and expose it to the `run` commands. You can also list it in the task file as an empty `secrets:` entry, but the value still has to come from `--secret` at launch. Writing `HF_TOKEN: $HF_TOKEN` there does not work: SkyPilot passes that through as the literal string rather than expanding it.
 
 To train with your own config, add `workdir: .` to the task file and drop the `axolotl fetch examples` line. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
 
@@ -56,7 +56,7 @@ num_nodes: 2
 
 resources:
   accelerators: H100:8
-  image_id: docker:axolotlai/axolotl-uv:main-latest
+  image_id: docker:axolotlai/axolotl:main-latest
 
 run: |
   # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
@@ -98,7 +98,7 @@ To run on spot (preemptible) instances, add `use_spot: true` under `resources` i
 ```yaml
 resources:
   accelerators: A100:1
-  image_id: docker:axolotlai/axolotl-uv:main-latest
+  image_id: docker:axolotlai/axolotl:main-latest
   use_spot: true
 ```
 

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -65,7 +65,7 @@ run: |
   # Pin collectives to the node's real NIC. Without this, Gloo resolves the
   # hostname to 127.0.1.1 (the Debian/Ubuntu loopback alias in /etc/hosts) and
   # startup fails with "Gloo connectFullMesh failed ... Connection refused".
-  IFACE=$(ls /sys/class/net | grep -vE '^(lo|docker.*|veth.*)$' | head -n1)
+  IFACE=$(awk '$2=="00000000" {print $1; exit}' /proc/net/route)
   export GLOO_SOCKET_IFNAME=$IFACE
   export NCCL_SOCKET_IFNAME=$IFACE
   export NCCL_IB_DISABLE=0

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -3,7 +3,7 @@ title: SkyPilot
 description: How to launch Axolotl on any cloud or Kubernetes with SkyPilot
 ---
 
-[SkyPilot](https://github.com/skypilot-org/skypilot) is an open-source framework for running workloads on any cloud or Kubernetes cluster. Instead of provisioning an instance and setting up Docker yourself, you describe the job in a short YAML and SkyPilot finds a GPU across your enabled infrastructure (AWS, GCP, Azure, RunPod, Vast.ai, Kubernetes, and [more](https://docs.skypilot.co/en/latest/getting-started/installation.html)), pulls the Axolotl image, and runs training.
+[SkyPilot](https://github.com/skypilot-org/skypilot) is an open-source framework for running workloads on any cloud or Kubernetes cluster. Instead of provisioning an instance and setting up Docker yourself, you describe the job in a short YAML and SkyPilot finds a GPU across your enabled infrastructure (AWS, GCP, Azure, RunPod, Vast.ai, Kubernetes, and [more](https://docs.skypilot.ai/en/latest/getting-started/installation.html)), pulls the Axolotl image, and runs training.
 
 ## Setup
 
@@ -121,6 +121,6 @@ Point `output_dir` in your Axolotl config at `/checkpoints` and set `auto_resume
 
 ## Further reading
 
-- [SkyPilot docs](https://docs.skypilot.co/)
-- [Task YAML reference](https://docs.skypilot.co/en/latest/reference/yaml-spec.html)
-- [Managed jobs](https://docs.skypilot.co/en/latest/examples/managed-jobs.html)
+- [SkyPilot docs](https://docs.skypilot.ai/)
+- [Task YAML reference](https://docs.skypilot.ai/en/latest/reference/yaml-spec.html)
+- [Managed jobs](https://docs.skypilot.ai/en/latest/examples/managed-jobs.html)

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -68,7 +68,6 @@ run: |
   IFACE=$(awk '$2=="00000000" {print $1; exit}' /proc/net/route)
   export GLOO_SOCKET_IFNAME=$IFACE
   export NCCL_SOCKET_IFNAME=$IFACE
-  export NCCL_IB_DISABLE=0
   export NCCL_BUFFSIZE=2097152
 
   axolotl fetch examples

--- a/docs/skypilot.qmd
+++ b/docs/skypilot.qmd
@@ -27,9 +27,10 @@ run: |
   # the image entrypoint normally sources this; SkyPilot bypasses the entrypoint
   source /workspace/axolotl/scripts/cuda13_env.sh
 
-  axolotl fetch examples
-  axolotl train examples/llama-3/lora-1b.yml
+  axolotl train /workspace/axolotl/examples/llama-3/lora-1b.yml
 ```
+
+The image ships the example configs at `/workspace/axolotl/examples`, so there is nothing to fetch. Paths are absolute because the `run` block executes in `~/sky_workdir`, not in the image's Axolotl checkout.
 
 Note the image choice: SkyPilot sources `~/.bashrc` when running `setup` and `run`, and the `-cloud` image's `.bashrc` attaches a tmux session and exits, which terminates the command. Use the plain image as above, or `axolotlai/axolotl-cloud-term:main-latest` if you want the cloud image's HuggingFace cache defaults without tmux.
 
@@ -41,11 +42,11 @@ sky logs axolotl
 sky down axolotl
 ```
 
-Training outputs live on the cluster and disappear with `sky down`. The `run` block always executes in `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
+Training outputs live on the cluster and disappear with `sky down`. The config's relative `output_dir` lands under `~/sky_workdir`, so copy outputs off first (`rsync -Pavz axolotl:sky_workdir/outputs/ ./outputs/`) or mount a bucket as shown in the spot section below.
 
 The example configs referenced here use ungated models. For gated models, launch with `--secret HF_TOKEN`, written literally like that with no value attached: the bare name tells SkyPilot to read `$HF_TOKEN` from your local shell and expose it to the `run` commands. You can also list it in the task file as an empty `secrets:` entry, but the value still has to come from `--secret` at launch. Writing `HF_TOKEN: $HF_TOKEN` there does not work: SkyPilot passes that through as the literal string rather than expanding it.
 
-To train with your own config, add `workdir: .` to the task file and drop the `axolotl fetch examples` line. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
+To train with your own config, add `workdir: .` to the task file. Your current directory is then synced to `~/sky_workdir`, which is where the `run` commands already execute, so `axolotl train my_training.yml` works as-is.
 
 ## Multi-node
 
@@ -70,9 +71,8 @@ run: |
   export NCCL_SOCKET_IFNAME=$IFACE
   export NCCL_BUFFSIZE=2097152
 
-  axolotl fetch examples
   HEAD_IP=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
-  axolotl train examples/llama-3/fft-8b-liger-fsdp.yaml --launcher torchrun -- \
+  axolotl train /workspace/axolotl/examples/llama-3/fft-8b-liger-fsdp.yaml --launcher torchrun -- \
     --nnodes $SKYPILOT_NUM_NODES \
     --nproc_per_node $SKYPILOT_NUM_GPUS_PER_NODE \
     --rdzv_id $SKYPILOT_TASK_ID \


### PR DESCRIPTION
Docs only. Adds `docs/skypilot.qmd` (based on in the structure of `ray-integration.qmd`) covering single-node, multi-node, and spot, plus nav entry and cross-links. 
Re-adds what was dropped from the README in #2295 (originally #862), now in the docs format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a SkyPilot guide for launching Axolotl training on cloud accounts or Kubernetes clusters.
  * Documented single-node and multi-node training, spot instances, checkpoint mounting, networking, secrets, and dataset reuse.
  * Added SkyPilot references to the installation and multi-node documentation.
  * Added the new guide to the website’s Deployments section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->