### PR TITLE
fix(loaders): keep out_proj out of 4-bit for nemotron_h (#3951)

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -68,10 +68,8 @@ from axolotl.utils.schemas.enums import RLType
 LOG = get_logger(__name__)
 PLUGIN_MANAGER = PluginManager.get_instance()
 
-# Architectures whose Mamba2 mixer calls the fused kernel with
-# ``outproj_weight=self.out_proj.weight`` (see ``modeling_falcon_h1.py`` /
-# ``modeling_nemotron_h.py`` in transformers) rather than going through the
-# module, so ``out_proj`` must stay in its original dtype under bitsandbytes.
+# Mamba2 mixers in these architectures pass ``outproj_weight=self.out_proj.weight``
+# to the fused kernel instead of calling the module, so ``out_proj`` cannot be 4-bit.
 MAMBA2_FUSED_OUT_PROJ_MODEL_TYPES = ("falcon_h1", "nemotron_h")
 
 
@@ -691,14 +689,8 @@ class ModelLoader:
                 # but deepspeed needs this still in bfloat16
                 bnb_config["bnb_4bit_quant_storage"] = torch.float32
             if self.cfg.model_config_type in MAMBA2_FUSED_OUT_PROJ_MODEL_TYPES:
-                # The Mamba2 fused kernels read ``out_proj.weight`` directly
-                # instead of calling the module, so the output projection cannot
-                # be packed to 4-bit. ``lm_head`` is listed explicitly because
-                # setting ``llm_int8_skip_modules`` at all makes transformers
-                # skip the automatic default it would otherwise compute
-                # (``HfQuantizer.get_modules_to_not_convert`` only falls back to
-                # ``get_keys_to_not_convert`` when the list is ``None``), which
-                # is what keeps the output head out of 4-bit.
+                # lm_head is listed too: passing llm_int8_skip_modules at all
+                # suppresses the default transformers would otherwise compute.
                 bnb_config["llm_int8_skip_modules"] = ["out_proj", "lm_head"]
 
             if self.cfg.bnb_config_kwargs:

--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -68,6 +68,12 @@ from axolotl.utils.schemas.enums import RLType
 LOG = get_logger(__name__)
 PLUGIN_MANAGER = PluginManager.get_instance()
 
+# Architectures whose Mamba2 mixer calls the fused kernel with
+# ``outproj_weight=self.out_proj.weight`` (see ``modeling_falcon_h1.py`` /
+# ``modeling_nemotron_h.py`` in transformers) rather than going through the
+# module, so ``out_proj`` must stay in its original dtype under bitsandbytes.
+MAMBA2_FUSED_OUT_PROJ_MODEL_TYPES = ("falcon_h1", "nemotron_h")
+
 
 class ModelLoader:
     """Manages model configuration, initialization and application of patches during
@@ -684,9 +690,16 @@ class ModelLoader:
                 # for some reason, this causes the loss to be off by an order of magnitude
                 # but deepspeed needs this still in bfloat16
                 bnb_config["bnb_4bit_quant_storage"] = torch.float32
-            if self.cfg.model_config_type == "falcon_h1":
-                # output projection cannot be quantized for Falcon-H1 models
-                bnb_config["llm_int8_skip_modules"] = ["out_proj"]
+            if self.cfg.model_config_type in MAMBA2_FUSED_OUT_PROJ_MODEL_TYPES:
+                # The Mamba2 fused kernels read ``out_proj.weight`` directly
+                # instead of calling the module, so the output projection cannot
+                # be packed to 4-bit. ``lm_head`` is listed explicitly because
+                # setting ``llm_int8_skip_modules`` at all makes transformers
+                # skip the automatic default it would otherwise compute
+                # (``HfQuantizer.get_modules_to_not_convert`` only falls back to
+                # ``get_keys_to_not_convert`` when the list is ``None``), which
+                # is what keeps the output head out of 4-bit.
+                bnb_config["llm_int8_skip_modules"] = ["out_proj", "lm_head"]
 
             if self.cfg.bnb_config_kwargs:
                 bnb_config.update(self.cfg.bnb_config_kwargs)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -102,6 +102,53 @@ class TestModelsUtils:
                 is True
             )
 
+    @pytest.mark.parametrize("model_config_type", ["falcon_h1", "nemotron_h"])
+    def test_qlora_skips_out_proj_for_mamba2_fused_architectures(
+        self, model_config_type
+    ):
+        """The Mamba2 fused kernels read ``out_proj.weight`` directly, so it must
+        not be packed to 4-bit. ``lm_head`` rides along because passing
+        ``llm_int8_skip_modules`` suppresses the default transformers computes."""
+        self.cfg.load_in_8bit = False
+        self.cfg.load_in_4bit = True
+        self.cfg.adapter = "qlora"
+        self.cfg.model_config_type = model_config_type
+
+        self.model_loader._set_quantization_config()
+
+        assert self.model_loader.model_kwargs[
+            "quantization_config"
+        ].llm_int8_skip_modules == ["out_proj", "lm_head"]
+
+    def test_qlora_leaves_skip_modules_unset_for_other_architectures(self):
+        """Architectures without the fused-kernel constraint keep transformers'
+        own default, which is computed from the model at load time."""
+        self.cfg.load_in_8bit = False
+        self.cfg.load_in_4bit = True
+        self.cfg.adapter = "qlora"
+        self.cfg.model_config_type = "llama"
+
+        self.model_loader._set_quantization_config()
+
+        assert (
+            self.model_loader.model_kwargs["quantization_config"].llm_int8_skip_modules
+            is None
+        )
+
+    def test_bnb_config_kwargs_still_overrides_the_skip_modules(self):
+        """``bnb_config_kwargs`` is applied last and stays authoritative."""
+        self.cfg.load_in_8bit = False
+        self.cfg.load_in_4bit = True
+        self.cfg.adapter = "qlora"
+        self.cfg.model_config_type = "nemotron_h"
+        self.cfg.bnb_config_kwargs = {"llm_int8_skip_modules": ["out_proj"]}
+
+        self.model_loader._set_quantization_config()
+
+        assert self.model_loader.model_kwargs[
+            "quantization_config"
+        ].llm_int8_skip_modules == ["out_proj"]
+
     def test_message_property_mapping(self):
         """Test message property mapping configuration validation"""
         from axolotl.utils.schemas.datasets import SFTDataset

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -106,9 +106,7 @@ class TestModelsUtils:
     def test_qlora_skips_out_proj_for_mamba2_fused_architectures(
         self, model_config_type
     ):
-        """The Mamba2 fused kernels read ``out_proj.weight`` directly, so it must
-        not be packed to 4-bit. ``lm_head`` rides along because passing
-        ``llm_int8_skip_modules`` suppresses the default transformers computes."""
+        """out_proj must stay out of 4-bit for the Mamba2 fused kernels."""
         self.cfg.load_in_8bit = False
         self.cfg.load_in_4bit = True
         self.cfg.adapter = "qlora"
@@ -121,8 +119,7 @@ class TestModelsUtils:
         ].llm_int8_skip_modules == ["out_proj", "lm_head"]
 
     def test_qlora_leaves_skip_modules_unset_for_other_architectures(self):
-        """Architectures without the fused-kernel constraint keep transformers'
-        own default, which is computed from the model at load time."""
+        """Other architectures keep transformers' own default."""
         self.cfg.load_in_8bit = False
         self.cfg.load_in_4bit = True
         self.cfg.adapter = "qlora"
@@ -136,7 +133,7 @@ class TestModelsUtils:
         )
 
     def test_bnb_config_kwargs_still_overrides_the_skip_modules(self):
-        """``bnb_config_kwargs`` is applied last and stays authoritative."""
+        """bnb_config_kwargs is applied last and stays authoritative."""
         self.cfg.load_in_8bit = False
         self.cfg.load_in_4bit = True
         self.cfg.adapter = "qlora"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes #3951.

`nemotron_h` joins `falcon_h1` in the bitsandbytes 4-bit skip list, and that list now also carries `lm_head`.

## Motivation and Context

### 1. `out_proj` must not be packed

The Mamba2 mixer hands the fused kernel the raw weight tensor rather than calling the module, so a bnb-packed `out_proj` reaches `F.linear` as 4-bit storage. In transformers 5.15.0 the call site is literally the same line in all three hybrid architectures:

```
models/falcon_h1/modeling_falcon_h1.py:699:                outproj_weight=self.out_proj.weight,
models/nemotron_h/modeling_nemotron_h.py:456:                outproj_weight=self.out_proj.weight,
models/granitemoehybrid/modeling_granitemoehybrid.py:593:                outproj_weight=self.out_proj.weight,
```

`_set_quantization_config` guarded only `falcon_h1`, even though `nemotron_h` is already named eight lines above it (in the `bnb_4bit_quant_storage` list) and is paired with `falcon_h1` everywhere else in the tree — `multipack.SUPPORTED_MULTIPACK_MODEL_TYPES`, `ChatTemplate`, and the `mamba_utils` packing patches. So `examples/nemotron-h/nano-30b-a3b-qlora.yaml` with `load_in_4bit: true` loads fine and then dies at step 0.

### 2. Setting the skip list at all disables the default that protects the head

This is why the fix is not simply `["out_proj"]`. `llm_int8_skip_modules` **replaces** rather than extends — `HfQuantizer.get_modules_to_not_convert` (`transformers/quantizers/base.py`) only computes the automatic list when the caller passed `None`:

```python
if skip_modules is None or add_default_skips:
    modules_to_not_convert = get_keys_to_not_convert(model)
else:
    modules_to_not_convert = []
```

and the 4-bit quantizer calls it without `add_default_skips` (only the AWQ quantizer passes it). `get_keys_to_not_convert` is what keeps the output head — and, for tied models, the embedding it shares storage with — out of 4-bit. The reporter hit exactly this when they added `out_proj` by hand and had to add `lm_head` back to get a run that trains.

That makes today's `falcon_h1` entry a latent instance of the same hole, and `falcon_h1` ties `lm_head.weight` to `model.embed_tokens.weight`, so it is the more exposed of the two. Both entries now list `["out_proj", "lm_head"]`.

`bnb_config_kwargs` is still applied afterwards, so a user-supplied `llm_int8_skip_modules` remains authoritative.

### Deliberately not in this PR

- **`granitemoehybrid`** — same fused call site above, and `patch_manager` already special-cases it, but it has no in-tree example or config and was not part of the report. Happy to add it in this PR if you want it.
- **The `load_in_8bit` branch** — `jamba` (`["mamba"]`) and `falcon_h1` (`["out_proj"]`) drop the default head protection there for the same reason. Left alone because #3951 is about 4-bit QLoRA and the 8-bit path deserves its own look.

## How has this been tested?

Three new cases in `tests/test_loaders.py`, alongside the existing `test_set_quantization_config`. They exercise the real `_set_quantization_config` and assert on the real `BitsAndBytesConfig`; no model download and no GPU.

Resolved skip list produced by `_set_quantization_config` for `adapter: qlora` + `load_in_4bit: true`:

| `model_config_type` | before | after |
| --- | --- | --- |
| `falcon_h1` | `['out_proj']` | `['out_proj', 'lm_head']` |
| `nemotron_h` | `None` ← the bug | `['out_proj', 'lm_head']` |
| `llama` | `None` | `None` (unchanged) |
| `nemotron_h` + `bnb_config_kwargs: {llm_int8_skip_modules: [out_proj]}` | `['out_proj']` | `['out_proj']` (override still wins) |

The two new architecture cases fail on `main` and pass with this change; the other two pass on both, pinning the behaviour that must not move. `ruff check` and `ruff format --check` are clean on both files.

Not tested end-to-end: I have no Blackwell/24GB box for `NVIDIA-Nemotron-3.5-Lightning-30B-A3B`, so the step-0 crash itself is verified only through the mechanism above and the reporter's run.

## AI Usage Disclaimer

Yes — Claude Code, AI-assisted and human reviewed.

## Types of changes

Bug fix (non-breaking change which fixes an issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QLoRA 4-bit quantization support for Falcon-H1 and Nemotron-H models.
  * Prevented quantization of modules that require full-precision weights for these fused architectures.
  * Preserved explicitly provided quantization settings across supported model types.

* **Tests**
  * Added coverage for fused and non-fused Mamba2 architectures and custom quantization overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->