### PR TITLE
fix: sonicmoe use upstream kernel

### DIFF
--- a/src/axolotl/integrations/kernels/README.md
+++ b/src/axolotl/integrations/kernels/README.md
@@ -131,13 +131,9 @@ NVFP4 for `deepseek_v4` is supported via ScatterMoE with `use_dsv4_kernels` (its
 
 ### Epilogue check (why `gpt_oss` is No on SonicMoE)
 
-`@use_experts_implementation` installs `_apply_gate` as the model's declared expert epilogue, and every transformers experts backend calls it except SonicMoE, which selects a fused epilogue from `config.hidden_act` instead. The kernel offers only `swiglu`/`geglu`/`reglu`: no clamp, no sigmoid scaling factor, no `(up + 1)` bias. `GptOssConfig.hidden_act` is `"silu"`, so `gpt_oss` resolved to plain SwiGLU with no error. On `openai/gpt-oss-20b` that measured 10.4% top-1 agreement and teacher-forced NLL 2.30 -> 8.12 against the correct epilogue. It now raises at model load, pointing at `expert_backend: scattermoe`.
+SonicMoE picks its fused epilogue from `config.hidden_act`, which cannot express a clamped or otherwise non-plain GLU. `GptOssConfig.hidden_act` is `"silu"`, so `gpt_oss` silently ran plain SwiGLU (10.4% top-1 agreement, teacher-forced NLL 2.30 -> 8.12 on `openai/gpt-oss-20b`).
 
-The check is numeric -- the declared `_apply_gate` is probed against the epilogue the chosen path would compute -- rather than a `gpt_oss` special case, because the same trap is live for any architecture with a clamped or otherwise non-plain GLU (`deepseek_v4` and, upstream, `minimax_m3_vl` / `openai_privacy_filter`), and `hidden_act` cannot be the signal even in principle: `MiniMaxM3VLTextConfig` overwrites the checkpoint's `"swigluoai"` with `"silu"` because the field must be a real `ACT2FN` key. The SonicMoE NVFP4 path applies `limit`, so it additionally accepts clamped SwiGLU.
-
-### Blackwell (sm_120) note
-
-`use_sonicmoe` runs on consumer Blackwell (sm_120): the `kernels-community/sonic-moe` prebuilt bundles quack 0.6.1 (on nvidia-cutlass-dsl 4.6.0), which carries the sm_120 GEMM. NVFP4 experts on sm_120 take the dequant path (no native W4A4: `fp4_cute` is SM100/SM110-only).
+Axolotl now probes each model's declared `_apply_gate` numerically at load and raises if the chosen path cannot reproduce it, pointing at `expert_backend: scattermoe`.
 
 ## Feature comparison
 

--- a/src/axolotl/integrations/kernels/README.md
+++ b/src/axolotl/integrations/kernels/README.md
@@ -123,11 +123,17 @@ Any model whose `Experts` class is decorated with `@use_experts_implementation` 
 | `ernie4_5_moe`    |    Yes    |   Yes    |  -  |  -  |
 | `hunyuan_v1_moe`  |    Yes    |   Yes    |  -  |  -  |
 | `gemma4_text`     |    Yes    |   Yes    | Yes |  -  |
-| `gpt_oss`         |    Yes    |   Yes    |  -  |  -  |
+| `gpt_oss`         |    Yes    |   No     |  -  |  -  |
 
 NVFP4 for `deepseek_v4` is supported via ScatterMoE with `use_dsv4_kernels` (its own fused-kernel path), so it is not a row above.
 
-`gpt_oss` carries the decorator with `is_concatenated=False, is_transposed=True, has_bias=True` and uses a sigmoid-GLU activation with clamping. Both forwards read these flags off `self` and dispatch accordingly: the ScatterMoE forward handles the transposed/interleaved/biased layout and clamped sigmoid-GLU via its Triton path (no weight transpose, interleaved gate/up, per-expert bias folded into the grouped GEMM); the SonicMoE forward uses the upstream CUTLASS kernel.
+`gpt_oss` carries the decorator with `is_concatenated=False, is_transposed=True, has_bias=True` and uses a clamped sigmoid-GLU activation. The ScatterMoE forward handles the transposed/interleaved/biased layout and that epilogue via its Triton path (no weight transpose, interleaved gate/up, per-expert bias folded into the grouped GEMM).
+
+### Epilogue check (why `gpt_oss` is No on SonicMoE)
+
+`@use_experts_implementation` installs `_apply_gate` as the model's declared expert epilogue, and every transformers experts backend calls it except SonicMoE, which selects a fused epilogue from `config.hidden_act` instead. The kernel offers only `swiglu`/`geglu`/`reglu`: no clamp, no sigmoid scaling factor, no `(up + 1)` bias. `GptOssConfig.hidden_act` is `"silu"`, so `gpt_oss` resolved to plain SwiGLU with no error. On `openai/gpt-oss-20b` that measured 10.4% top-1 agreement and teacher-forced NLL 2.30 -> 8.12 against the correct epilogue. It now raises at model load, pointing at `expert_backend: scattermoe`.
+
+The check is numeric -- the declared `_apply_gate` is probed against the epilogue the chosen path would compute -- rather than a `gpt_oss` special case, because the same trap is live for any architecture with a clamped or otherwise non-plain GLU (`deepseek_v4` and, upstream, `minimax_m3_vl` / `openai_privacy_filter`), and `hidden_act` cannot be the signal even in principle: `MiniMaxM3VLTextConfig` overwrites the checkpoint's `"swigluoai"` with `"silu"` because the field must be a real `ACT2FN` key. The SonicMoE NVFP4 path applies `limit`, so it additionally accepts clamped SwiGLU.
 
 ### Blackwell (sm_120) note
 

--- a/src/axolotl/integrations/kernels/README.md
+++ b/src/axolotl/integrations/kernels/README.md
@@ -137,7 +137,7 @@ The check is numeric -- the declared `_apply_gate` is probed against the epilogu
 
 ### Blackwell (sm_120) note
 
-`use_sonicmoe` runs on consumer Blackwell (sm_120) when the loaded `sonic-moe` kernel bundles quack 0.6.1 (on nvidia-cutlass-dsl 4.6.0). The upstream `kernels-community/sonic-moe` prebuilt may still bundle quack 0.3.11 (no sm_120 GEMM) until the rebuild lands; point at a quack 0.6.1 build or use `use_scattermoe`. NVFP4 experts on sm_120 take the dequant path (no native W4A4: `fp4_cute` is SM100/SM110-only).
+`use_sonicmoe` runs on consumer Blackwell (sm_120): the `kernels-community/sonic-moe` prebuilt bundles quack 0.6.1 (on nvidia-cutlass-dsl 4.6.0), which carries the sm_120 GEMM. NVFP4 experts on sm_120 take the dequant path (no native W4A4: `fp4_cute` is SM100/SM110-only).
 
 ## Feature comparison
 

--- a/src/axolotl/integrations/kernels/args.py
+++ b/src/axolotl/integrations/kernels/args.py
@@ -285,7 +285,9 @@ class KernelsArgs(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_use_kernels(cls, data):
-        if data.get("use_kernels") is not True:
+        """Default `use_kernels` on, honoring an explicit opt-out: the experts backend is
+        registered independently of kernelize, whose hub-kernel swap can shadow it."""
+        if data.get("use_kernels") is None:
             LOG.warning(
                 "`use_kernels` must be set to True to use this. Automatically setting it to True."
             )

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/epilogue.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/epilogue.py
@@ -1,0 +1,129 @@
+"""Verify the epilogue sonicmoe will compute against the one the model declares.
+
+`@use_experts_implementation` installs `_apply_gate` as the model's declared expert
+epilogue, and every transformers experts backend calls it except `sonicmoe`, which
+resolves the epilogue from `config.hidden_act` instead. A model whose epilogue that
+string cannot describe (gpt_oss, deepseek_v4) runs silently-wrong math rather than
+raising.
+
+The check is numeric rather than a model allowlist: an allowlist rots as new
+architectures land, and `hidden_act` is not a usable signal even in principle
+(MiniMaxM3VLTextConfig overwrites the checkpoint's "swigluoai" with "silu" because
+it has to be a real ACT2FN key).
+"""
+
+from __future__ import annotations
+
+import torch
+
+_PROBE_WIDTH = 16
+# Per instance, not per class: `_apply_gate` closes over `self.limit` / `self.alpha`.
+_VERDICT_ATTR = "_sonicmoe_epilogue_verdict"
+
+
+def _describe(experts_module) -> str:
+    cls = type(experts_module).__name__
+    parts = []
+    for attr in ("limit", "alpha", "swiglu_alpha", "swiglu_limit"):
+        val = getattr(experts_module, attr, None)
+        if val is not None:
+            parts.append(f"{attr}={val}")
+    return f"{cls}({', '.join(parts)})" if parts else cls
+
+
+def _mismatch(experts_module, act: str, *, concat: bool, limit: float | None) -> bool:
+    """True if ``(act, limit, concat)`` fails to reproduce ``_apply_gate``."""
+    from .nvfp4 import gated_activation
+
+    # Span past the clamp so a missing clamp cannot pass by luck.
+    scale = 3.0 * (limit if limit is not None else 2.0)
+    x = torch.randn(256, _PROBE_WIDTH, dtype=torch.float32) * scale
+    try:
+        want = experts_module._apply_gate(x)
+        got = gated_activation(x, act, concat=concat, limit=limit)
+    except Exception:  # noqa: BLE001
+        # Either side failing means an epilogue that also fails in eager, or an activation
+        # outside `gated_activation`'s superset of upstream's ACT_MAP. Both raise later
+        # with a better message than this check could give.
+        return False
+    return want.shape != got.shape or not torch.allclose(
+        want, got, atol=1e-5, rtol=1e-4
+    )
+
+
+def check_epilogue(
+    experts_module, act: str, *, concat: bool, limit: float | None, path: str
+) -> None:
+    """Raise if ``path`` would not reproduce the module's declared ``_apply_gate``.
+
+    Skipped under `torch.compile` (Dynamo folds the branch away): the probe is
+    data-dependent and would break the single-graph guarantee. Real runs are covered
+    eagerly by `check_model_epilogues` at plugin setup.
+    """
+    if torch.compiler.is_compiling():
+        return
+    # No declared epilogue means nothing to contradict.
+    if not hasattr(experts_module, "_apply_gate"):
+        return
+
+    # `__func__` because attribute access rebuilds the bound method object each time.
+    gate_fn = experts_module._apply_gate
+    key = (getattr(gate_fn, "__func__", gate_fn), act, limit, concat, path)
+    cached = getattr(experts_module, _VERDICT_ATTR, None)
+    if cached is not None and cached[0] == key:
+        if cached[1]:
+            raise ValueError(cached[1])
+        return
+
+    reason = None
+    if _mismatch(experts_module, act, concat=concat, limit=limit):
+        from transformers.integrations.moe import _default_apply_gate
+
+        computed = f"{act!r}" + (
+            f" with clamp(+/-{limit})" if limit is not None else " with no clamp"
+        )
+        declares = (
+            "The model declares a custom `_apply_gate`"
+            if getattr(type(experts_module), "_apply_gate", None)
+            is not _default_apply_gate
+            else "The model's `_apply_gate` disagrees with the resolved activation"
+        )
+        reason = (
+            f"sonicmoe would compute the wrong expert math for {_describe(experts_module)}. "
+            f"{declares}, but the sonicmoe {path} path computes {computed}, and the "
+            f"fused kernel has no activation that can express this epilogue.\n"
+            "Use `expert_backend: scattermoe` (which implements these epilogues), or "
+            "drop the kernel expert backend to fall back to the built-in "
+            "implementation."
+        )
+    setattr(experts_module, _VERDICT_ATTR, (key, reason))
+    if reason:
+        raise ValueError(reason)
+
+
+def check_model_epilogues(model) -> int:
+    """Eagerly probe every experts module in ``model``. Returns the number checked.
+
+    Runs at plugin setup so an unrepresentable epilogue fails before training starts
+    rather than mid-forward.
+    """
+    from .nvfp4 import is_nvfp4_param, resolve_gated_activation
+
+    checked = 0
+    for module in model.modules():
+        if not hasattr(module, "_apply_gate") or not hasattr(module, "gate_up_proj"):
+            continue
+        # `_apply_gate` is not the contract for non-gated experts (the backends call
+        # `act_fn` directly), and the forward already rejects them by `has_gate`.
+        if not getattr(module, "has_gate", True):
+            continue
+        nvfp4 = is_nvfp4_param(module.gate_up_proj)
+        check_epilogue(
+            module,
+            resolve_gated_activation(module.config),
+            concat=getattr(module, "is_concatenated", True),
+            limit=getattr(module, "limit", None) if nvfp4 else None,
+            path="NVFP4 grouped" if nvfp4 else "dense",
+        )
+        checked += 1
+    return checked

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -80,7 +80,6 @@ def _resolve_weights_and_lora(experts_module):
 _ACT_ALIASES = {
     "gelu_pytorch_tanh": "gelu",
     "gelu_tanh": "gelu",
-    "gelu_new": "gelu",
 }
 
 

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -1,8 +1,8 @@
 """LoRA-aware sonicmoe experts forward for the transformers ExpertsInterface.
 
-Dense experts wrap upstream ``_sonicmoe_wrapper``, materializing expert LoRA via
-``MoELoRAMaterialize`` before the CUTLASS call. NVFP4 experts (which that kernel
-cannot read) take the grouped dequant path in ``nvfp4_lora`` instead.
+Dense experts materialize expert LoRA via ``MoELoRAMaterialize`` and hand the result
+to upstream's ``sonicmoe_experts_forward`` through a facade. NVFP4 experts (which the
+CUTLASS kernel cannot read) take the grouped dequant path in ``nvfp4_lora`` instead.
 """
 
 from __future__ import annotations
@@ -75,6 +75,64 @@ def _resolve_weights_and_lora(experts_module):
     return w1, b1, w2, b2, lora_w1, lora_w2
 
 
+# sonic-moe's GEGLU epilogue is itself tanh-approximate (quack ``activation.geglu``), so these
+# map onto it exactly. Without this Gemma resolves to no ``hidden_act`` and silently runs SwiGLU.
+_ACT_ALIASES = {
+    "gelu_pytorch_tanh": "gelu",
+    "gelu_tanh": "gelu",
+    "gelu_new": "gelu",
+}
+
+
+class _FacadeConfig:
+    __slots__ = ("hidden_act",)
+
+    def __init__(self, hidden_act: str):
+        self.hidden_act = hidden_act
+
+
+class _LoRAExpertsFacade:
+    """Stand-in module exposing ``W_eff`` where upstream reads the raw expert weights.
+
+    Upstream reads all of these as plain attributes, so reusing its forward beats
+    duplicating the unwrap, permute and kernel call. Activation resolves via
+    ``resolve_gated_activation`` because Gemma stores its own under ``hidden_activation``,
+    where upstream's ``hidden_act`` lookup silently yields SwiGLU.
+
+    Must stay a plain class: ``SimpleNamespace`` is constructed inside the compiled region
+    and Dynamo cannot trace its ``__new__``, which breaks ``fullgraph=True``.
+    """
+
+    __slots__ = (
+        "config",
+        "down_proj",
+        "down_proj_bias",
+        "gate_up_proj",
+        "gate_up_proj_bias",
+        "has_bias",
+        "has_gate",
+        "is_concatenated",
+        "is_transposed",
+        "num_experts",
+    )
+
+    def __init__(self, experts_module, w1, b1, w2, b2):
+        from .nvfp4 import resolve_gated_activation
+
+        act = resolve_gated_activation(experts_module.config)
+
+        self.has_gate = True
+        self.gate_up_proj = w1
+        self.down_proj = w2
+        self.has_bias = b1 is not None or b2 is not None
+        self.gate_up_proj_bias = b1
+        self.down_proj_bias = b2
+        self.is_transposed = getattr(experts_module, "is_transposed", False)
+        self.is_concatenated = getattr(experts_module, "is_concatenated", True)
+        self.num_experts = experts_module.num_experts
+        self.config = _FacadeConfig(_ACT_ALIASES.get(act, act))
+
+
 def sonicmoe_experts_forward_with_lora(
     self,
     hidden_states: torch.Tensor,
@@ -87,6 +145,8 @@ def sonicmoe_experts_forward_with_lora(
     into W_eff first). NVFP4 experts, which the opaque CUTLASS kernel cannot
     read, take the grouped reference path (dequant base + fused low-rank LoRA).
     """
+    from transformers.integrations.sonicmoe import sonicmoe_experts_forward
+
     from .nvfp4 import is_nvfp4_param
 
     if not getattr(self, "has_gate", True):
@@ -122,51 +182,17 @@ def sonicmoe_experts_forward_with_lora(
             lora_w2,
         )
 
-    from transformers.integrations.sonicmoe import _sonicmoe_wrapper
-
-    device = hidden_states.device
-    num_top_k = top_k_index.size(-1)
-    num_tokens = hidden_states.size(0)
-
-    # sonic-moe requires int32 token indices sorted ascending.
-    token_idx = (
-        torch.arange(num_tokens, device=device)
-        .unsqueeze(1)
-        .expand(-1, num_top_k)
-        .reshape(-1)
-        .int()
-    )
-    router_scores = top_k_weights.reshape(-1).to(hidden_states.dtype)
-    expert_ids = top_k_index.reshape(-1).int()
-
     # Materialize W_eff = W + scaling * (B @ A) per expert. No-op when no LoRA.
     if lora_w1 is not None:
         w1 = MoELoRAMaterialize.apply(w1, *lora_w1)
     if lora_w2 is not None:
         w2 = MoELoRAMaterialize.apply(w2, *lora_w2)
 
-    # Match upstream layout expectations:
-    #   is_transposed=False: gate_up [E, 2*I, H] / down [E, H, I] -> permute(1, 2, 0)
-    #   is_transposed=True:  gate_up [E, H, 2*I] / down [E, I, H] -> permute(2, 1, 0)
-    perm = (2, 1, 0) if getattr(self, "is_transposed", False) else (1, 2, 0)
-    w1 = w1.permute(*perm)
-    w2 = w2.permute(*perm)
-
-    act_name = getattr(self.config, "hidden_act", "silu").lower()
-
-    return _sonicmoe_wrapper(
-        hidden_states=hidden_states,
-        router_scores=router_scores,
-        expert_ids=expert_ids,
-        token_idx=token_idx,
-        w1=w1,
-        b1=b1,
-        w2=w2,
-        b2=b2,
-        act_name=act_name,
-        num_experts=self.num_experts,
-        concat_layout=getattr(self, "is_concatenated", True),
-        is_inference_mode_enabled=not torch.is_grad_enabled(),
+    return sonicmoe_experts_forward(
+        _LoRAExpertsFacade(self, w1, b1, w2, b2),
+        hidden_states,
+        top_k_index,
+        top_k_weights,
     )
 
 
@@ -253,33 +279,10 @@ def _sonicmoe_nvfp4_forward(
     )
 
 
-def redirect_sonicmoe_kernel_repo() -> None:
-    """Point transformers' ``sonic-moe`` hub kernel at our org build (quack 0.6.1 on cutlass-dsl
-    4.6.0); the upstream ``kernels-community/sonic-moe`` prebuilt still bundles an older quack that
-    breaks on cutlass-dsl 4.6.0. No-op if the hub mapping is absent (e.g. CPU / no kernels)."""
-    try:
-        from transformers.integrations import hub_kernels
-    except ImportError:
-        return
-    mapping = getattr(hub_kernels, "_HUB_KERNEL_MAPPING", None)
-    if isinstance(mapping, dict) and "sonic-moe" in mapping:
-        mapping["sonic-moe"] = {
-            "repo_id": "axolotl-ai-co/sonic-moe",
-            "revision": "main",
-        }
-        # Our repo is outside kernels-community, which the lazy expert-kernel load blocks unless
-        # this global is set. The loader's context-managed allow only covers model init, not the
-        # forward-time load, so set it directly (harmless: sonicmoe is an explicit opt-in).
-        hub_kernels.ALLOW_ALL_KERNELS = True
-
-
 def register_sonicmoe_experts() -> None:
     """Register the LoRA-aware ``"sonicmoe"`` forward, overriding upstream. Idempotent."""
     from transformers.integrations.moe import ALL_EXPERTS_FUNCTIONS
 
-    # Any caller (plugin, e2e tests) must load our sonic-moe build, not the stale upstream prebuilt;
-    # the kernel loads lazily on first forward, so redirect before that, at registration time.
-    redirect_sonicmoe_kernel_repo()
     ALL_EXPERTS_FUNCTIONS.register("sonicmoe", sonicmoe_experts_forward_with_lora)
 
     # Route PEFT target_parameters expert LoRA past the parametrization merge (which cannot

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -116,9 +116,13 @@ class _LoRAExpertsFacade:
     )
 
     def __init__(self, experts_module, w1, b1, w2, b2):
+        from .epilogue import check_epilogue
         from .nvfp4 import resolve_gated_activation
 
         act = resolve_gated_activation(experts_module.config)
+        concat = getattr(experts_module, "is_concatenated", True)
+        # The fused kernel has no clamp, so the dense path can only ever compute limit=None.
+        check_epilogue(experts_module, act, concat=concat, limit=None, path="dense")
 
         self.has_gate = True
         self.gate_up_proj = w1
@@ -127,7 +131,7 @@ class _LoRAExpertsFacade:
         self.gate_up_proj_bias = b1
         self.down_proj_bias = b2
         self.is_transposed = getattr(experts_module, "is_transposed", False)
-        self.is_concatenated = getattr(experts_module, "is_concatenated", True)
+        self.is_concatenated = concat
         self.num_experts = experts_module.num_experts
         # Unaliased names pass through as-is, not to a default, so upstream still raises
         # on activations the kernel has no epilogue for.
@@ -237,6 +241,7 @@ def _sonicmoe_nvfp4_forward(
     in-kernel W4A4 grouped GEMM (``fp4_cute``); elsewhere it is dequantized to
     dense per matmul (``dequant``).
     """
+    from .epilogue import check_epilogue
     from .nvfp4 import resolve_gated_activation
     from .nvfp4_lora import grouped_moe_reference_forward
 
@@ -255,6 +260,12 @@ def _sonicmoe_nvfp4_forward(
             "(EP-sharded base with global-id routing/LoRA is unfinished and untested)"
         )
 
+    act = resolve_gated_activation(self.config)
+    limit = getattr(self, "limit", None)
+    concat = getattr(self, "is_concatenated", True)
+    # `gated_activation` honors `limit`, so this path additionally accepts clamped SwiGLU.
+    check_epilogue(self, act, concat=concat, limit=limit, path="NVFP4 grouped")
+
     lora1 = (lora_w1[0], lora_w1[1]) if lora_w1 is not None else None
     lora2 = (lora_w2[0], lora_w2[1]) if lora_w2 is not None else None
     scaling1 = lora_w1[2] if lora_w1 is not None else 1.0
@@ -271,10 +282,10 @@ def _sonicmoe_nvfp4_forward(
         lora1,
         lora2,
         self.num_experts,
-        act=resolve_gated_activation(self.config),
+        act=act,
         backend=_select_nvfp4_backend(w1, w2),
-        limit=getattr(self, "limit", None),
-        concat=getattr(self, "is_concatenated", True),
+        limit=limit,
+        concat=concat,
         scaling1=scaling1,
         scaling2=scaling2,
     )

--- a/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
+++ b/src/axolotl/integrations/kernels/libs/sonicmoe/experts.py
@@ -129,6 +129,8 @@ class _LoRAExpertsFacade:
         self.is_transposed = getattr(experts_module, "is_transposed", False)
         self.is_concatenated = getattr(experts_module, "is_concatenated", True)
         self.num_experts = experts_module.num_experts
+        # Unaliased names pass through as-is, not to a default, so upstream still raises
+        # on activations the kernel has no epilogue for.
         self.config = _FacadeConfig(_ACT_ALIASES.get(act, act))
 
 

--- a/src/axolotl/integrations/kernels/plugin.py
+++ b/src/axolotl/integrations/kernels/plugin.py
@@ -173,7 +173,6 @@ class KernelsPlugin(BasePlugin):
                 register_sonicmoe_experts,
             )
 
-            # register_sonicmoe_experts() redirects the sonic-moe hub kernel to our build.
             register_sonicmoe_experts()
             if not ep_active:
                 cfg.experts_implementation = "sonicmoe"

--- a/src/axolotl/integrations/kernels/plugin.py
+++ b/src/axolotl/integrations/kernels/plugin.py
@@ -230,6 +230,12 @@ class KernelsPlugin(BasePlugin):
             adapter.pre_lora_load(cfg, model)
 
     def post_model_load(self, cfg, model):
+        if cfg.use_sonicmoe:
+            from axolotl.integrations.kernels.libs.sonicmoe.epilogue import (
+                check_model_epilogues,
+            )
+
+            check_model_epilogues(model)
         for adapter in self._adapters(cfg):
             adapter.post_model_load(cfg, model)
 

--- a/tests/e2e/integrations/test_sonicmoe_lora.py
+++ b/tests/e2e/integrations/test_sonicmoe_lora.py
@@ -85,13 +85,21 @@ def _build_sonic_model():
     return AutoModelForCausalLM.from_config(config).cuda().bfloat16()
 
 
-def _apply_lora(model, target_modules):
+def _apply_lora(model, target_modules=None, target_parameters=None):
+    """Wrap ``model`` in LoRA.
+
+    Expert weights are ``nn.Parameter`` on the Experts module, so they need
+    ``target_parameters``; the router ``gate`` is a real ``nn.Linear`` and uses
+    ``target_modules``. ``target_modules=[]`` rather than ``None`` keeps PEFT from
+    falling back to its per-architecture default (q_proj/v_proj).
+    """
     from peft import LoraConfig, get_peft_model
 
     lora_config = LoraConfig(
         r=8,
         lora_alpha=16,
-        target_modules=target_modules,
+        target_modules=target_modules if target_modules is not None else [],
+        target_parameters=target_parameters,
         lora_dropout=0.0,
         bias="none",
     )
@@ -104,7 +112,7 @@ class TestSonicMoELoRATraining:
     def test_loss_decreases(self):
         input_ids = torch.randint(0, 1000, (2, 32), device="cuda")
         model = _build_sonic_model()
-        model = _apply_lora(model, ["gate_up_proj", "down_proj"])
+        model = _apply_lora(model, target_parameters=["gate_up_proj", "down_proj"])
 
         optimizer = torch.optim.AdamW(
             [p for p in model.parameters() if p.requires_grad], lr=1e-3
@@ -127,7 +135,7 @@ class TestSonicMoELoRATraining:
     def test_base_weights_frozen(self):
         input_ids = torch.randint(0, 1000, (2, 32), device="cuda")
         model = _build_sonic_model()
-        model = _apply_lora(model, ["gate_up_proj", "down_proj"])
+        model = _apply_lora(model, target_parameters=["gate_up_proj", "down_proj"])
 
         frozen_before = {
             name: param.data.clone()
@@ -151,7 +159,7 @@ class TestSonicMoELoRATraining:
     def test_lora_adapters_receive_gradients(self):
         input_ids = torch.randint(0, 1000, (1, 16), device="cuda")
         model = _build_sonic_model()
-        model = _apply_lora(model, ["gate_up_proj", "down_proj"])
+        model = _apply_lora(model, target_parameters=["gate_up_proj", "down_proj"])
 
         lora_params = [
             p for n, p in model.named_parameters() if "lora_" in n and p.requires_grad
@@ -181,7 +189,7 @@ class TestSonicMoELoRATraining:
     def test_lora_adapters_update(self):
         input_ids = torch.randint(0, 1000, (2, 32), device="cuda")
         model = _build_sonic_model()
-        model = _apply_lora(model, ["gate_up_proj", "down_proj"])
+        model = _apply_lora(model, target_parameters=["gate_up_proj", "down_proj"])
 
         lora_before = {
             name: param.data.clone()
@@ -213,7 +221,7 @@ class TestSonicMoEGateOnlyLoRA:
     def test_gate_only_lora_loss_decreases(self):
         input_ids = torch.randint(0, 1000, (2, 32), device="cuda")
         model = _build_sonic_model()
-        model = _apply_lora(model, ["gate"])
+        model = _apply_lora(model, target_modules=["gate"])
 
         optimizer = torch.optim.AdamW(
             [p for p in model.parameters() if p.requires_grad], lr=1e-3

--- a/tests/e2e/integrations/test_sonicmoe_lora.py
+++ b/tests/e2e/integrations/test_sonicmoe_lora.py
@@ -153,6 +153,17 @@ class TestSonicMoELoRATraining:
         model = _build_sonic_model()
         model = _apply_lora(model, ["gate_up_proj", "down_proj"])
 
+        lora_params = [
+            p for n, p in model.named_parameters() if "lora_" in n and p.requires_grad
+        ]
+
+        # lora_B is zero-initialized and dL/dA is proportional to B, so lora_A gets an
+        # exactly-zero gradient on the first backward. Step once to move B off zero.
+        model(input_ids, labels=input_ids).loss.backward()
+        optimizer = torch.optim.SGD(lora_params, lr=1e-2)
+        optimizer.step()
+        optimizer.zero_grad()
+
         out = model(input_ids, labels=input_ids)
         out.loss.backward()
 

--- a/tests/integrations/kernels/test_kernels_config_intent.py
+++ b/tests/integrations/kernels/test_kernels_config_intent.py
@@ -214,3 +214,20 @@ def test_merged_dsv4_lora_target_linear_rejected():
     Merged = _merged_cls()
     with pytest.raises(pydantic.ValidationError, match="lora_target_linear"):
         Merged.model_validate(_minimal(use_dsv4_kernels=True, lora_target_linear=True))
+
+
+def test_merged_use_kernels_explicit_false_is_honored():
+    # An explicit opt-out must survive: it is the only way to get the experts backend
+    # without kernelize, whose hub-kernel swap shadows it on some archs.
+    Merged = _merged_cls()
+    m = Merged.model_validate(_minimal(use_kernels=False, expert_backend="scattermoe"))
+    assert m.use_kernels is False
+    assert m.use_scattermoe is True
+    assert m.experts_implementation == "scattermoe"
+
+
+def test_merged_use_kernels_unset_defaults_on():
+    Merged = _merged_cls()
+    cfg = _minimal(expert_backend="scattermoe")
+    del cfg["use_kernels"]
+    assert Merged.model_validate(cfg).use_kernels is True

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -289,10 +289,8 @@ class TestFacadeActivationResolution:
 
 
 class TestEpilogueCheck:
-    """sonicmoe selects its fused epilogue from `hidden_act` and never calls
-    `_apply_gate`, so models declaring an epilogue the kernel cannot express must be
-    rejected instead of silently running plain SwiGLU.
-    """
+    """sonicmoe picks its epilogue from `hidden_act` and never calls `_apply_gate`, so an
+    epilogue the kernel cannot express must raise rather than silently run SwiGLU."""
 
     @staticmethod
     def _experts(model_type, cls_name, **overrides):
@@ -359,19 +357,15 @@ class TestEpilogueCheck:
         self._check(experts, limit=experts.limit, path="NVFP4 grouped")
 
     def test_sigmoid_glu_rejected_on_nvfp4_path(self):
-        """The clamp alone is not enough: a sigmoid-GLU also needs alpha and (up + 1).
-
-        `minimax_m3_vl` is a fixture, not a supported model: it is the only upstream
-        sigmoid-GLU arch with `is_transposed=False`, so it is the only one that reaches
-        this path rather than the layout guard above it.
-        """
+        """`minimax_m3_vl` is a fixture, not a supported model: it is the only upstream
+        sigmoid-GLU arch with `is_transposed=False`, so the only one reaching this path."""
         experts = self._experts("minimax_m3_vl", "MiniMaxM3VLExperts")
         with pytest.raises(ValueError, match="wrong expert math"):
             self._check(experts, limit=experts.limit, path="NVFP4 grouped")
 
     def test_verdict_is_per_instance(self):
-        """`_apply_gate` closes over instance state, so a class-keyed cache would hand
-        one module's verdict to another that computes something else."""
+        """`_apply_gate` closes over instance state, so a class-keyed cache would leak
+        one module's verdict to another."""
         ok = self._experts("qwen3_moe", "Qwen3MoeExperts")
         self._check(ok, limit=None, path="dense")
 

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -286,3 +286,96 @@ class TestFacadeActivationResolution:
             SimpleNamespace(hidden_act="silu"),
         ):
             assert self._facade_act(config) in ACT_MAP
+
+
+class TestEpilogueCheck:
+    """sonicmoe selects its fused epilogue from `hidden_act` and never calls
+    `_apply_gate`, so models declaring an epilogue the kernel cannot express must be
+    rejected instead of silently running plain SwiGLU.
+    """
+
+    @staticmethod
+    def _experts(model_type, cls_name, **overrides):
+        import importlib
+
+        from transformers import AutoConfig
+
+        config = AutoConfig.for_model(model_type)
+        config = getattr(config, "text_config", config)
+        for key, value in overrides.items():
+            setattr(config, key, value)
+        config._experts_implementation = None
+        module = importlib.import_module(
+            f"transformers.models.{model_type}.modeling_{model_type}"
+        )
+        with torch.device("meta"):
+            return getattr(module, cls_name)(config)
+
+    @staticmethod
+    def _check(experts, *, limit, path):
+        from axolotl.integrations.kernels.libs.sonicmoe.epilogue import check_epilogue
+        from axolotl.integrations.kernels.libs.sonicmoe.nvfp4 import (
+            resolve_gated_activation,
+        )
+
+        check_epilogue(
+            experts,
+            resolve_gated_activation(experts.config),
+            concat=getattr(experts, "is_concatenated", True),
+            limit=limit,
+            path=path,
+        )
+
+    @pytest.mark.parametrize(
+        "model_type,cls_name,overrides",
+        [
+            ("qwen3_moe", "Qwen3MoeExperts", {}),
+            (
+                "gemma4",
+                "Gemma4TextExperts",
+                {"num_experts": 8, "moe_intermediate_size": 64},
+            ),
+        ],
+    )
+    def test_representable_epilogues_pass(self, model_type, cls_name, overrides):
+        experts = self._experts(model_type, cls_name, **overrides)
+        self._check(experts, limit=None, path="dense")
+
+    @pytest.mark.parametrize(
+        "model_type,cls_name",
+        [
+            ("gpt_oss", "GptOssExperts"),
+            ("deepseek_v4", "DeepseekV4Experts"),
+        ],
+    )
+    def test_custom_apply_gate_rejected_on_dense_path(self, model_type, cls_name):
+        experts = self._experts(model_type, cls_name)
+        with pytest.raises(ValueError, match="wrong expert math"):
+            self._check(experts, limit=None, path="dense")
+
+    def test_clamped_swiglu_accepted_on_nvfp4_path(self):
+        """DeepSeek-V4 is plain SwiGLU plus a clamp, which `gated_activation` honors."""
+        experts = self._experts("deepseek_v4", "DeepseekV4Experts")
+        self._check(experts, limit=experts.limit, path="NVFP4 grouped")
+
+    def test_sigmoid_glu_rejected_on_nvfp4_path(self):
+        """The clamp alone is not enough: a sigmoid-GLU also needs alpha and (up + 1).
+
+        `minimax_m3_vl` is a fixture, not a supported model: it is the only upstream
+        sigmoid-GLU arch with `is_transposed=False`, so it is the only one that reaches
+        this path rather than the layout guard above it.
+        """
+        experts = self._experts("minimax_m3_vl", "MiniMaxM3VLExperts")
+        with pytest.raises(ValueError, match="wrong expert math"):
+            self._check(experts, limit=experts.limit, path="NVFP4 grouped")
+
+    def test_verdict_is_per_instance(self):
+        """`_apply_gate` closes over instance state, so a class-keyed cache would hand
+        one module's verdict to another that computes something else."""
+        ok = self._experts("qwen3_moe", "Qwen3MoeExperts")
+        self._check(ok, limit=None, path="dense")
+
+        bad = self._experts("qwen3_moe", "Qwen3MoeExperts")
+        bad._apply_gate = lambda gate_up: gate_up.chunk(2, dim=-1)[0]
+        with pytest.raises(ValueError, match="wrong expert math"):
+            self._check(bad, limit=None, path="dense")

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -267,6 +267,14 @@ class TestFacadeActivationResolution:
         assert self._facade_act(SimpleNamespace(hidden_act="gelu")) == "gelu"
         assert self._facade_act(SimpleNamespace(hidden_act="relu")) == "relu"
 
+    def test_unaliased_activation_still_raises_upstream(self):
+        """The `.get(act, act)` fallback must not coerce unknown names to a default."""
+        from transformers.integrations.sonicmoe import ACT_MAP
+
+        assert (
+            self._facade_act(SimpleNamespace(hidden_act="quadratic_glu")) not in ACT_MAP
+        )
+
     def test_resolved_name_is_accepted_by_upstream(self):
         """Upstream raises on anything outside its ACT_MAP, so aliases must land in it."""
         from transformers.integrations.sonicmoe import ACT_MAP

--- a/tests/integrations/test_sonicmoe.py
+++ b/tests/integrations/test_sonicmoe.py
@@ -235,3 +235,46 @@ class TestExpertsClassMetadata:
             sonicmoe_experts_forward_with_lora(
                 fake_self, hidden, top_k_index, top_k_weights
             )
+
+
+class TestFacadeActivationResolution:
+    """The facade must hand upstream an activation name its ACT_MAP accepts.
+
+    Gemma4 declares ``hidden_activation="gelu_pytorch_tanh"`` and has no ``hidden_act``
+    key at all, so reading ``hidden_act`` alone silently yields SwiGLU on a GeGLU model.
+    """
+
+    @staticmethod
+    def _facade_act(config):
+        from axolotl.integrations.kernels.libs.sonicmoe.experts import (
+            _LoRAExpertsFacade,
+        )
+
+        module = SimpleNamespace(config=config, num_experts=8)
+        facade = _LoRAExpertsFacade(module, torch.zeros(1), None, torch.zeros(1), None)
+        return facade.config.hidden_act
+
+    def test_gemma4_resolves_to_geglu(self):
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+        config = Gemma4TextConfig()
+        assert not hasattr(config, "hidden_act")
+        assert config.hidden_activation == "gelu_pytorch_tanh"
+        assert self._facade_act(config) == "gelu"
+
+    def test_hidden_act_models_unchanged(self):
+        assert self._facade_act(SimpleNamespace(hidden_act="silu")) == "silu"
+        assert self._facade_act(SimpleNamespace(hidden_act="gelu")) == "gelu"
+        assert self._facade_act(SimpleNamespace(hidden_act="relu")) == "relu"
+
+    def test_resolved_name_is_accepted_by_upstream(self):
+        """Upstream raises on anything outside its ACT_MAP, so aliases must land in it."""
+        from transformers.integrations.sonicmoe import ACT_MAP
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+        for config in (
+            Gemma4TextConfig(),
+            SimpleNamespace(hidden_activation="gelu_tanh"),
+            SimpleNamespace(hidden_act="silu"),
+        ):
+            assert self._facade_act(config) in ACT_MAP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Supersedes #3947 , credit to `OnePunchMonk` for initial report.

This solution is more future proof, avoids re-creating the shim that's removed upstream, would raise error if they change attribute upstream.

Misc:
- Respect use_kernels: False
- Clarified proper model support and raise if unsupported

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran on 1xH100 to verify and run E2E

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SonicMoE expert execution across supported activation configurations.
  - Preserved compatibility for LoRA-enhanced expert paths, including grouped quantized processing.
  - Improved LoRA training behavior so expert and gate configurations receive the expected gradient updates.

- **Tests**
  - Added coverage for activation-name handling and upstream compatibility.
  - Expanded end-to-end validation for SonicMoE LoRA training scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->