### PR TITLE
bump bnb 0.50.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "mistral-common==1.11.5",
 
     # Platform-specific (Linux only)
-    "bitsandbytes==0.50.0 ; sys_platform != 'darwin'",
+    "bitsandbytes==0.50.2 ; sys_platform != 'darwin'",
     "triton>=3.4.0 ; sys_platform != 'darwin'",
     "xformers>=0.0.33.post2 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
     "liger-kernel==0.8.0 ; sys_platform != 'darwin'",


### PR DESCRIPTION


# Description
bump bnb 0.50.2


## How has this been tested?

ci should be green 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux and non-macOS `bitsandbytes` dependency to version 0.50.2 for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->