### PR TITLE
fix: vLLM serve model revision and trust_remote_code forwarding

### DIFF
--- a/src/axolotl/cli/merge_lora.py
+++ b/src/axolotl/cli/merge_lora.py
@@ -118,6 +118,7 @@ def _do_merge_lora_efficient(*, cfg: DictDefault) -> None:
         trust_remote_code=bool(getattr(cfg, "trust_remote_code", False)),
         dequant=bool(getattr(cfg, "merge_dequant", False)),
         override_quantizer=bool(getattr(cfg, "merge_override_quantizer", False)),
+        revision=cfg.revision_of_model,
     )
 
     LOG.debug("Memory-efficient LoRA merge completed successfully!")

--- a/src/axolotl/cli/utils/lora_merge.py
+++ b/src/axolotl/cli/utils/lora_merge.py
@@ -1944,6 +1944,7 @@ def merge_lora_sharded_efficient(
     trust_remote_code: bool = False,
     dequant: bool = False,
     override_quantizer: bool = False,
+    revision: Optional[str] = None,
 ) -> None:
     """
     Memory-efficient LoRA merging that processes shards individually
@@ -1988,7 +1989,9 @@ def merge_lora_sharded_efficient(
     nvfp4_scale_mode = _resolve_nvfp4_scale_mode(lora_config_dict, override_quantizer)
 
     if "/" in str(base_model_path) and not base_model_path.exists():
-        base_model_path = Path(snapshot_download(str(base_model_path)))
+        base_model_path = Path(
+            snapshot_download(str(base_model_path), revision=revision)
+        )
 
     meta_model = _build_meta_model(base_model_path, trust_remote_code=trust_remote_code)
 

--- a/src/axolotl/cli/vllm_serve.py
+++ b/src/axolotl/cli/vllm_serve.py
@@ -87,6 +87,7 @@ def do_vllm_serve(
     enforce_eager = bool(raw_enforce_eager) if raw_enforce_eager is not None else False
     base_kwargs = dict(
         model=model,
+        revision=cfg.revision_of_model,
         tensor_parallel_size=tensor_parallel_size,
         data_parallel_size=data_parallel_size,
         host=host,

--- a/src/axolotl/cli/vllm_serve.py
+++ b/src/axolotl/cli/vllm_serve.py
@@ -88,6 +88,7 @@ def do_vllm_serve(
     base_kwargs = dict(
         model=model,
         revision=cfg.revision_of_model,
+        trust_remote_code=bool(cfg.trust_remote_code),
         tensor_parallel_size=tensor_parallel_size,
         data_parallel_size=data_parallel_size,
         host=host,

--- a/tests/cli/test_cli_vllm_serve.py
+++ b/tests/cli/test_cli_vllm_serve.py
@@ -22,6 +22,7 @@ def stub_serve(monkeypatch):
     cfg = DictDefault(
         {
             "base_model": "dummy-model",
+            "revision_of_model": "test-revision",
             "vllm": {
                 "serve_module": name,
                 "enable_prefix_caching": True,
@@ -58,3 +59,15 @@ def test_vllm_serve_bool_precedence(cli_runner, tmp_path, stub_serve, flags, exp
     script_args = stub_serve.main.call_args.args[0]
     assert script_args.enable_prefix_caching is expected
     assert script_args.enable_reasoning is expected
+
+
+def test_vllm_serve_forwards_model_revision(cli_runner, tmp_path, stub_serve):
+    config = tmp_path / "config.yml"
+    config.write_text("base_model: dummy-model\n")
+
+    result = cli_runner.invoke(cli, ["vllm-serve", str(config)])
+    assert result.exit_code == 0, result.output
+
+    stub_serve.main.assert_called_once()
+    script_args = stub_serve.main.call_args.args[0]
+    assert script_args.revision == "test-revision"

--- a/tests/cli/test_cli_vllm_serve.py
+++ b/tests/cli/test_cli_vllm_serve.py
@@ -23,6 +23,7 @@ def stub_serve(monkeypatch):
         {
             "base_model": "dummy-model",
             "revision_of_model": "test-revision",
+            "trust_remote_code": True,
             "vllm": {
                 "serve_module": name,
                 "enable_prefix_caching": True,
@@ -71,3 +72,15 @@ def test_vllm_serve_forwards_model_revision(cli_runner, tmp_path, stub_serve):
     stub_serve.main.assert_called_once()
     script_args = stub_serve.main.call_args.args[0]
     assert script_args.revision == "test-revision"
+
+
+def test_vllm_serve_forwards_trust_remote_code(cli_runner, tmp_path, stub_serve):
+    config = tmp_path / "config.yml"
+    config.write_text("base_model: dummy-model\n")
+
+    result = cli_runner.invoke(cli, ["vllm-serve", str(config)])
+    assert result.exit_code == 0, result.output
+
+    stub_serve.main.assert_called_once()
+    script_args = stub_serve.main.call_args.args[0]
+    assert script_args.trust_remote_code is True


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

- Forward `revision_of_model` to the vLLM server as its `revision` argument. 
- Add CLI regression coverage that verifies the configured revision reaches the serve module.


<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3959.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Ruff format and lint checks
- Added `test_vllm_serve_forwards_model_revision`

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

Yes. OpenAI Codex

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * vLLM server launches now use the configured model revision, ensuring the intended model version is served.

* **Tests**
  * Added coverage to verify that the configured model revision is correctly passed to the serving process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->