### PR TITLE
fix(cli): pass revision_of_model to vllm-serve

### DIFF
--- a/src/axolotl/cli/vllm_serve.py
+++ b/src/axolotl/cli/vllm_serve.py
@@ -87,6 +87,7 @@ def do_vllm_serve(
     enforce_eager = bool(raw_enforce_eager) if raw_enforce_eager is not None else False
     base_kwargs = dict(
         model=model,
+        revision=cfg.revision_of_model,
         tensor_parallel_size=tensor_parallel_size,
         data_parallel_size=data_parallel_size,
         host=host,

--- a/tests/cli/test_cli_vllm_serve.py
+++ b/tests/cli/test_cli_vllm_serve.py
@@ -58,3 +58,36 @@ def test_vllm_serve_bool_precedence(cli_runner, tmp_path, stub_serve, flags, exp
     script_args = stub_serve.main.call_args.args[0]
     assert script_args.enable_prefix_caching is expected
     assert script_args.enable_reasoning is expected
+
+
+def test_vllm_serve_passes_model_revision(cli_runner, tmp_path, monkeypatch):
+    """`revision_of_model` must reach vLLM's `ScriptArguments.revision`, the same
+    way it reaches the model/tokenizer/processor loaders.
+
+    Regression for the bug where `do_vllm_serve` built `base_kwargs` without a
+    `revision` entry, so `revision_of_model` was silently ignored and vLLM always
+    served the default branch.
+    """
+    name = "axolotl_stub_serve_revision"
+    module = types.ModuleType(name)
+    module.main = MagicMock()
+    monkeypatch.setitem(sys.modules, name, module)
+
+    cfg = DictDefault(
+        {
+            "base_model": "dummy-model",
+            "revision_of_model": "abc123",
+            "vllm": {"serve_module": name},
+        }
+    )
+    monkeypatch.setattr("axolotl.cli.vllm_serve.load_cfg", lambda *_, **__: cfg)
+
+    config = tmp_path / "config.yml"
+    config.write_text("base_model: dummy-model\n")
+
+    result = cli_runner.invoke(cli, ["vllm-serve", str(config)])
+    assert result.exit_code == 0, result.output
+
+    module.main.assert_called_once()
+    script_args = module.main.call_args.args[0]
+    assert script_args.revision == "abc123"


### PR DESCRIPTION
# Description

`axolotl vllm-serve` never forwarded the top-level `revision_of_model` config
value to vLLM. `do_vllm_serve()` builds `base_kwargs` for
`ScriptArguments`/`LoRAScriptArguments` from the config, but the dict never
included `revision`, so `ScriptArguments.revision` stayed at its default
(`None`) regardless of what the user set in `revision_of_model`. vLLM would
then always resolve the model's default HF Hub branch.

This is inconsistent with the rest of the loading pipeline: the model,
tokenizer, and processor loaders already read `cfg.revision_of_model` and
pass it through as `revision`.

The fix passes `revision=cfg.revision_of_model` into `base_kwargs`, the same
way the other loaders do.

## Motivation and Context

Fixes #3959.

`revision_of_model` is documented and used by the model/tokenizer/processor
loading code paths, so users reasonably expect `vllm-serve` to honor it too.
Silently ignoring it means vLLM can load an unexpected model revision (e.g.
`main`) with no warning.

## How has this been tested?

- Added `test_vllm_serve_passes_model_revision` in
  `tests/cli/test_cli_vllm_serve.py`, following the existing
  `test_vllm_serve_bool_precedence` pattern (stubs the serve module, drives
  the real Click CLI, asserts on the `ScriptArguments` passed to `main`).
- Verified the new test fails without the fix
  (`AssertionError: assert None == 'abc123'`) and passes with it.
- `pytest tests/cli/test_cli_vllm_serve.py -v` — 3 passed.
- `pre-commit run --files src/axolotl/cli/vllm_serve.py tests/cli/test_cli_vllm_serve.py` — all hooks passed (ruff, ruff format, mypy, bandit).
- CPU-only environment (no GPU available); did not run the real vLLM server end-to-end, only the CLI/config wiring covered by the test above.

## AI Usage Disclaimer

Yes — this PR was authored with the assistance of Claude (Anthropic), used
for investigating the issue, writing the fix and the regression test, and
running the verification steps described above. All changes were reviewed
by me before submitting.

## Screenshots (if appropriate)

N/A (CLI/config wiring change, no UI).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * vLLM serving now uses the configured model revision when launching both standard and LoRA deployments.
  * Ensures the requested model version is passed correctly to the serving process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->