### PR TITLE
fix(loaders): skip quantizing out_proj for nemotron_h under bitsandbytes

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -764,8 +764,11 @@ class ModelLoader:
                 # for some reason, this causes the loss to be off by an order of magnitude
                 # but deepspeed needs this still in bfloat16
                 bnb_config["bnb_4bit_quant_storage"] = torch.float32
-            if self.cfg.model_config_type == "falcon_h1":
-                # output projection cannot be quantized for Falcon-H1 models
+            if self.cfg.model_config_type in ["falcon_h1", "nemotron_h"]:
+                # output projection cannot be quantized: the fused mamba
+                # kernel for these architectures reads `out_proj.weight`
+                # directly instead of calling the module, so it must stay
+                # unquantized
                 bnb_config["llm_int8_skip_modules"] = ["out_proj"]
 
             if self.cfg.bnb_config_kwargs:
@@ -781,8 +784,11 @@ class ModelLoader:
             # Exclude mamba blocks from int8 quantization for jamba
             if self.cfg.model_config_type == "jamba":
                 bnb_config["llm_int8_skip_modules"] = ["mamba"]
-            if self.cfg.model_config_type == "falcon_h1":
-                # output projection cannot be quantized for Falcon-H1 models
+            if self.cfg.model_config_type in ["falcon_h1", "nemotron_h"]:
+                # output projection cannot be quantized: the fused mamba
+                # kernel for these architectures reads `out_proj.weight`
+                # directly instead of calling the module, so it must stay
+                # unquantized
                 bnb_config["llm_int8_skip_modules"] = ["out_proj"]
             self.model_kwargs["quantization_config"] = BitsAndBytesConfig(
                 **bnb_config,

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -102,6 +102,29 @@ class TestModelsUtils:
                 is True
             )
 
+    @pytest.mark.parametrize("model_config_type", ["falcon_h1", "nemotron_h"])
+    @pytest.mark.parametrize("load_in_8bit", [True, False])
+    @pytest.mark.parametrize("load_in_4bit", [True, False])
+    def test_quantization_config_skips_out_proj_for_mamba_hybrid_models(
+        self, model_config_type, load_in_8bit, load_in_4bit
+    ):
+        """`out_proj` must be excluded from bnb quantization for architectures
+        whose fused mamba kernel reads `out_proj.weight` directly (falcon_h1,
+        nemotron_h) -- quantizing it silently corrupts the mamba block.
+        """
+        self.cfg.model_config_type = model_config_type
+        self.cfg.load_in_8bit = load_in_8bit
+        self.cfg.load_in_4bit = load_in_4bit
+        self.cfg.adapter = "qlora" if load_in_4bit else "lora"
+
+        self.model_loader._set_quantization_config()
+
+        if (self.cfg.adapter == "qlora" and load_in_4bit) or (
+            self.cfg.adapter == "lora" and load_in_8bit
+        ):
+            quantization_config = self.model_loader.model_kwargs["quantization_config"]
+            assert quantization_config.llm_int8_skip_modules == ["out_proj"]
+
     def test_message_property_mapping(self):
         """Test message property mapping configuration validation"""
         from axolotl.utils.schemas.datasets import SFTDataset


### PR DESCRIPTION
# Description

`axolotl` already skips bitsandbytes quantization of `out_proj` for
Falcon-H1 models (`model_config_type == "falcon_h1"`), because Falcon-H1's
fused mamba kernel reads `out_proj.weight` directly instead of calling the
module, so a quantized `out_proj` silently corrupts the mamba block.

`nemotron_h` uses the same mamba2 kernel family and has the identical
constraint (the fused path calls `F.linear(out, outproj_weight)` on the raw
weight), but the `model_config_type` check only ever matched `"falcon_h1"`.
As a result, `load_in_4bit: true` / `load_in_8bit: true` on a `nemotron_h`
model (e.g. the in-tree `examples/nemotron-h/nano-30b-a3b-qlora.yaml`)
bitsandbytes-packs `out_proj`, and the first training step crashes inside
the mamba kernel.

This extends both the 4-bit (qlora) and 8-bit (lora) skip-module checks to
also match `nemotron_h`, mirroring the existing `falcon_h1` handling.

## Motivation and Context

Fixes #3951.

The workaround today is `bnb_config_kwargs: {llm_int8_skip_modules:
["out_proj"]}`, but passing that manually *replaces* the default skip list
that protects `lm_head`, so users following the workaround silently lose the
`lm_head` protection too. Defaulting the skip for `nemotron_h` (like
`falcon_h1` already does) fixes the shipped example out of the box and
avoids that second footgun.

## How has this been tested?

- Added `test_quantization_config_skips_out_proj_for_mamba_hybrid_models` in
  `tests/test_loaders.py`, parametrized over `falcon_h1`/`nemotron_h` and
  the 4-bit/8-bit paths, following the existing
  `test_set_quantization_config` pattern in the same file (constructs a real
  `ModelLoader` against a tiny HF model and calls
  `_set_quantization_config()` directly — no GPU or actual quantized load
  required).
- Verified the new test fails for the `nemotron_h` cases without the fix
  (`assert None == ['out_proj']`) and passes for both architectures with it.
- `pytest tests/test_loaders.py -v` — 40 passed (no regressions).
- `pre-commit run --files src/axolotl/loaders/model.py tests/test_loaders.py` — all hooks passed (ruff, ruff format, mypy, bandit).
- CPU-only environment (no GPU available); did not run an actual 4-bit/8-bit
  model load or training step on real `nemotron_h` weights, only the
  `BitsAndBytesConfig` construction path covered by the test above.

## AI Usage Disclaimer

Yes — this PR was authored with the assistance of Claude (Anthropic), used
for investigating the issue, writing the fix and the regression test, and
running the verification steps described above. All changes were reviewed
by me before submitting.

## Screenshots (if appropriate)

N/A (quantization config change, no UI).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA and QLoRA compatibility for Nemotron-H hybrid models by excluding the required output projection from quantization.
  * Applied the same compatibility behavior consistently across 4-bit and 8-bit configurations.

* **Tests**
  * Added coverage for Falcon H1 and Nemotron-H models across supported quantization modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->