### PR TITLE
fix: raise deprecation error for flash_attn_fuse_qkv

### DIFF
--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -85,6 +85,12 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         None,
     ),
     (
+        ("--flash-attn-fuse-qkv/--no-flash-attn-fuse-qkv",),
+        None,
+        None,
+        None,
+    ),
+    (
         ("--overrides-of-model-config",),
         None,
         None,

--- a/src/axolotl/utils/schemas/deprecated.py
+++ b/src/axolotl/utils/schemas/deprecated.py
@@ -25,6 +25,7 @@ class DeprecatedParameters(BaseModel):
     rpo_alpha: float | None = None
     s2_attention: bool | None = None
     flash_attn_rms_norm: bool | None = None
+    flash_attn_fuse_qkv: bool | None = None
 
     @field_validator("max_packed_sequence_len")
     @classmethod
@@ -139,6 +140,13 @@ class DeprecatedParameters(BaseModel):
         if flash_attn_rms_norm:
             raise DeprecationWarning("`flash_attn_rms_norm` is no longer supported.")
         return flash_attn_rms_norm
+
+    @field_validator("flash_attn_fuse_qkv")
+    @classmethod
+    def validate_flash_attn_fuse_qkv(cls, flash_attn_fuse_qkv):
+        if flash_attn_fuse_qkv:
+            raise DeprecationWarning("`flash_attn_fuse_qkv` is no longer supported.")
+        return flash_attn_fuse_qkv
 
 
 class RemappedParameters(BaseModel):

--- a/tests/patched/test_validation.py
+++ b/tests/patched/test_validation.py
@@ -684,6 +684,21 @@ class TestValidation(BaseValidation):
         ):
             validate_config(cfg)
 
+    def test_deprecated_flash_attn_fuse_qkv(self, minimal_cfg):
+        cfg = (
+            DictDefault(
+                {
+                    "flash_attn_fuse_qkv": True,
+                }
+            )
+            | minimal_cfg
+        )
+        with pytest.raises(
+            DeprecationWarning,
+            match=r"`flash_attn_fuse_qkv` is no longer supported",
+        ):
+            validate_config(cfg)
+
     def test_packing(self, minimal_cfg):
         cfg = (
             DictDefault(


### PR DESCRIPTION
# Description

`flash_attn_fuse_qkv` is a config option that no longer does anything. It used to select a monkeypatched attention `forward()` (see `src/axolotl/monkeypatch/llama_attn_hijack_flash.py` / `mistral_attn_hijack_flash.py`) that fused Q/K/V projections, but that patch predates recent `transformers` attention signature changes and the option was silently orphaned — setting it in a YAML config today does nothing at all (pydantic ignores the unrecognized/unused field), which is worse than an error since it looks like it's still supported.

This adds `flash_attn_fuse_qkv` to `DeprecatedParameters` in `src/axolotl/utils/schemas/deprecated.py`, following the exact same pattern already used for the sibling `flash_attn_rms_norm` and `s2_attention` options: a `field_validator` that raises a `DeprecationWarning` with a clear message when the option is set to a truthy value.

## Motivation and Context

Fixes #2650.

The issue reporter hit a hard crash (`TypeError: flashattn_forward() got an unexpected keyword argument 'cache_position'`) when using `flash_attn_fuse_qkv` against a recent `transformers` version. The maintainer (@NanoCode012) suggested adding a deprecation error for the config option rather than trying to keep the old monkeypatch working.

**That crash is no longer reachable, and the current failure mode is a silent one.** `97e86c6d4` ("drop old patches and code that are no longer needed", #3007, 2025-08-06) deleted `flashattn_forward` from both `llama_attn_hijack_flash.py` and `mistral_attn_hijack_flash.py`, the `if self.cfg.flash_attn_fuse_qkv:` branch in `patch_manager.py`, and the field itself from `utils/schemas/config.py`. `grep -rn flash_attn_fuse_qkv src/` on `main` returns nothing.

Re-validated on `main` at `917a3d04` with `transformers` 5.15.0, running the issue's config with `flash_attn_fuse_qkv: true`:

```
validate_config: ACCEPTED (no error raised)
warnings emitted mentioning fuse_qkv: []
cfg.flash_attn_fuse_qkv in the validated config: <dropped>
```

The option is accepted, silently discarded during validation, and training proceeds with ordinary unfused attention — no crash and no warning, just quietly different behaviour from what the YAML says. This PR turns that into a clear, actionable `DeprecationWarning` at config-validation time, same as the other retired flash-attention options.

## How has this been tested?

Added `test_deprecated_flash_attn_fuse_qkv` to `tests/patched/test_validation.py`, mirroring the existing `test_deprecated_packing` test for `max_packed_sequence_len`.

- Before the fix: the test fails with `Failed: DID NOT RAISE DeprecationWarning` (config validation silently accepts `flash_attn_fuse_qkv: true`).
- After the fix: the test passes.

Ran:
- `pytest tests/patched/test_validation.py -q` → 75 passed, 1 skipped
- `pytest -m "not slow" -n4 --dist loadfile --ignore=tests/e2e tests/` → 529 passed, 51 skipped, 1 pre-existing failure unrelated to this change (`test_chat_templates_advanced.py`, a parallel-worker crash reproducible on a clean checkout of this branch's base with no changes) and several pre-existing `DeprecationWarning`-as-error collection errors from `click`/`typer` version skew in `tests/test_ebft_kernels.py` / `tests/utils/test_grpo_rw_fnc.py`, also present without this change.
- `pre-commit run --all-files` → all hooks pass, including `check-cli-config-options` (regenerated `src/axolotl/cli/config_options.py` via `axolotl generate-cli-config-options`).

This is a pure config-validation change (no model/GPU code paths touched), verified CPU-only.

## AI Usage Disclaimer

Yes — AI-assisted (Claude Code). Issue triage, diagnosis, patch, and tests were produced with AI assistance and reviewed before submitting.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate)

N/A

## Social Handles (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added CLI support for enabling or disabling fused QKV attention.
  * Marked `flash_attn_fuse_qkv` as deprecated; enabling it now displays a deprecation warning.
* **Bug Fixes**
  * Improved validation to clearly identify use of the unsupported configuration option.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->