### PR TITLE
Add Qwen3.8-Flash-Next example config and MoE registration

### DIFF
--- a/examples/qwen3.8-flash-next/README.md
+++ b/examples/qwen3.8-flash-next/README.md
@@ -1,0 +1,38 @@
+# Finetune Qwen3.8-Flash-Next with Axolotl
+
+[Qwen3.8-Flash-Next](https://huggingface.co/collections/Qwen/qwen38-flash-next) is a large hybrid-attention MoE model combining Gated DeltaNet linear attention with periodic full attention, a sparse-attention indexer, and multi-token prediction, plus a vision tower for image-text-to-text inputs.
+
+This guide shows how to fine-tune the text path with Axolotl using QLoRA.
+
+## Getting started
+
+1. Install Axolotl following the [installation guide](https://docs.axolotl.ai/docs/installation.html).
+
+2. Install [Cut Cross Entropy](https://docs.axolotl.ai/docs/custom_integrations.html#cut-cross-entropy) to reduce training VRAM usage.
+
+3. Run the finetuning example:
+
+```bash
+axolotl train examples/qwen3.8-flash-next/qwen3.8-flash-next-qlora.yaml
+```
+
+## TIPS
+
+- This config trains on text-only conversation data; no `pixel_values` are supplied, so the vision tower is not exercised.
+- Uncomment the `linear_attn.*` entries in `lora_target_modules` to also adapt the Gated DeltaNet projections.
+- Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
+- The dataset format follows the OpenAI Messages format as seen [here](https://docs.axolotl.ai/docs/dataset-formats/conversation.html#chat_template).
+
+## Optimization Guides
+
+- [Multi-GPU Training](https://docs.axolotl.ai/docs/multi-gpu.html)
+- [Multi-Node Training](https://docs.axolotl.ai/docs/multi-node.html)
+- [LoRA Optimizations](https://docs.axolotl.ai/docs/lora_optims.html)
+
+## Related Resources
+
+- [Qwen3.8-Flash-Next Collection](https://huggingface.co/collections/Qwen/qwen38-flash-next)
+- [Axolotl Docs](https://docs.axolotl.ai)
+- [Axolotl Website](https://axolotl.ai)
+- [Axolotl GitHub](https://github.com/axolotl-ai-cloud/axolotl)
+- [Axolotl Discord](https://discord.gg/7m9sfhzaf3)

--- a/examples/qwen3.8-flash-next/qwen3.8-flash-next-qlora.yaml
+++ b/examples/qwen3.8-flash-next/qwen3.8-flash-next-qlora.yaml
@@ -1,0 +1,84 @@
+base_model: Qwen/Qwen3.8-Flash-Next
+
+# Automatically upload checkpoint and final model to HF
+# hub_model_id: username/custom_model_name
+
+plugins:
+  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
+strict: false
+
+# Qwen3.8-Flash-Next ships its own chat template on the tokenizer.
+chat_template: tokenizer_default
+
+load_in_8bit: false
+load_in_4bit: true
+
+quantize_moe_experts: true
+
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+
+dataset_prepared_path: last_run_prepared
+val_set_size: 0.1
+output_dir: ./outputs/lora-out
+
+adapter: qlora
+lora_model_dir:
+
+sequence_len: 2048
+sample_packing: true
+
+lora_r: 16
+lora_alpha: 8
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - shared_expert.up_proj
+  - shared_expert.down_proj
+  - shared_expert.gate_proj
+  - shared_expert_gate
+  # Uncomment below to also target the linear-attention (Gated DeltaNet) projections.
+  # - linear_attn.in_proj_qkv
+  # - linear_attn.in_proj_z
+  # - linear_attn.out_proj
+
+# lora_target_parameters:
+#   - mlp.experts.gate_up_proj
+#   - mlp.experts.down_proj
+
+lora_mlp_kernel: false
+lora_qkv_kernel: false
+lora_o_kernel: false
+
+wandb_project:
+wandb_entity:
+wandb_watch:
+wandb_name:
+wandb_log_model:
+
+gradient_accumulation_steps: 2
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+bf16: auto
+tf32: false
+
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+resume_from_checkpoint:
+logging_steps: 1
+attn_implementation: flash_attention_2
+
+warmup_ratio: 0.1
+evals_per_epoch: 1
+saves_per_epoch: 1
+
+# save_first_step: true  # uncomment this to validate checkpoint saving works with your config

--- a/src/axolotl/common/architectures.py
+++ b/src/axolotl/common/architectures.py
@@ -13,6 +13,7 @@ MOE_ARCH_BLOCK = {
     "qwen2_moe": "Qwen2MoeSparseMoeBlock",
     "qwen3_moe": "Qwen3MoeSparseMoeBlock",
     "qwen3_5_moe": "Qwen3_5MoeSparseMoeBlock",
+    "qwen4_exp_text": "Qwen4ExpTextSparseMoeBlock",
     "qwen3_vl_moe": "Qwen3VLMoeTextSparseMoeBlock",
     "deepseek_v2": "DeepseekV2MoE",
     "deepseek_v3": "DeepseekV3MoE",


### PR DESCRIPTION
## Summary

- Registers `qwen4_exp_text` → `Qwen4ExpTextSparseMoeBlock` in `MOE_ARCH_BLOCK` so axolotl's MoE-aware logic (layer offloading, etc.) recognizes `Qwen/Qwen3.8-Flash-Next`.
- Adds `examples/qwen3.8-flash-next/` with a QLoRA example config and README, modeled on the existing `examples/qwen3-next/` and `examples/qwen3.8/` configs.

`transformers==5.16.1` (already pinned in `setup.py`) ships native modeling code for `qwen4_exp` (`Qwen4ExpForConditionalGeneration`, `Qwen4ExpTextSparseMoeBlock`, etc.), so — consistent with how every recent Qwen release has been onboarded (qwen3, qwen3_moe, qwen3_5, qwen3_next, qwen3_vl) — no new modeling code is needed here, just registration/config glue.

No monkeypatch is added in this PR. None of the existing Qwen monkeypatches were written speculatively either; per `docs/agents/new_model_support.md` and git history (`e198b1d`), they're added reactively once a real training run surfaces a concrete bug.

Closes #3955

## Test plan

- [x] New YAML parses (`yaml.safe_load`)
- [x] `architectures.py` syntax verified
- [ ] `axolotl preprocess examples/qwen3.8-flash-next/qwen3.8-flash-next-qlora.yaml` — not run (no local install/hardware for this 180B-param model)
- [ ] End-to-end training run — not run (no GPU hardware available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Qwen4 experimental text sparse Mixture-of-Experts architecture.
  - Added a ready-to-use QLoRA fine-tuning example for Qwen3.8-Flash-Next, including 4-bit quantization, sample packing, flash attention, and gradient checkpointing.
- **Documentation**
  - Added setup instructions, training guidance, configuration details, optimization tips, and related resources for the new fine-tuning example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->