### PR TITLE
fix: pin flash-attn2 hub kernel to v2, v3 breaks GQA backward

### DIFF
--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -1165,10 +1165,10 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         "Sync steps for the reference model.",
     ),
     (
-        ("--trl.scale-rewards/--no-trl.scale-rewards",),
+        ("--trl.scale-rewards",),
         "trl__scale_rewards",
         None,
-        "Whether to scale rewards by their standard deviation.",
+        "How to scale rewards by their standard deviation. One of 'group' (per prompt-group, GRPO default), 'batch' (whole batch), or 'none'. Booleans are accepted for back-compat (True->'group', False->'none').",
     ),
     (
         ("--trl.temperature",),
@@ -1247,6 +1247,60 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         "trl__mask_truncated_completions",
         None,
         "Whether to exclude truncated completions from loss calculation.",
+    ),
+    (
+        ("--trl.entropy-coef",),
+        "trl__entropy_coef",
+        "float",
+        "Static entropy regularization coefficient for GRPO, adding an entropy bonus to encourage exploration.",
+    ),
+    (
+        ("--trl.use-adaptive-entropy/--no-trl.use-adaptive-entropy",),
+        "trl__use_adaptive_entropy",
+        None,
+        "Enable adaptive entropy regularization (Skywork-OR1 style), adjusting entropy_coef toward entropy_target.",
+    ),
+    (
+        ("--trl.entropy-target",),
+        "trl__entropy_target",
+        "float",
+        "Target entropy when use_adaptive_entropy is enabled.",
+    ),
+    (
+        ("--trl.entropy-coef-delta",),
+        "trl__entropy_coef_delta",
+        "float",
+        "Step size for adjusting entropy_coef toward entropy_target.",
+    ),
+    (
+        ("--trl.entropy-coef-min",),
+        "trl__entropy_coef_min",
+        "float",
+        "Lower bound for the adaptive entropy_coef.",
+    ),
+    (
+        ("--trl.entropy-coef-max",),
+        "trl__entropy_coef_max",
+        "float",
+        "Upper bound for the adaptive entropy_coef.",
+    ),
+    (
+        ("--trl.vllm-importance-sampling-clip-min",),
+        "trl__vllm_importance_sampling_clip_min",
+        "float",
+        "Lower clip bound for the vLLM/training importance-sampling ratio.",
+    ),
+    (
+        ("--trl.vllm-importance-sampling-clip-max",),
+        "trl__vllm_importance_sampling_clip_max",
+        "float",
+        "Upper clip bound for the vLLM/training importance-sampling ratio.",
+    ),
+    (
+        ("--trl.log-multimodal/--no-trl.log-multimodal",),
+        "trl__log_multimodal",
+        None,
+        "Whether to log multimodal content (images, videos) alongside completions. Disable to reduce log size.",
     ),
     (
         ("--trl.vllm-enable-sleep-mode/--no-trl.vllm-enable-sleep-mode",),

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -375,6 +375,12 @@ class PatchManager:
 
     def _apply_flash_attention_patches(self):
         """Apply patches related to Flash Attention."""
+        from axolotl.monkeypatch.attention.fa2_hub_kernel import (
+            patch_fa2_hub_kernel_version,
+        )
+
+        patch_fa2_hub_kernel_version()
+
         if self.cfg.attn_implementation == "xformers":
             from axolotl.monkeypatch.attention import register_xformers_attn
 

--- a/src/axolotl/monkeypatch/attention/fa2_hub_kernel.py
+++ b/src/axolotl/monkeypatch/attention/fa2_hub_kernel.py
@@ -1,0 +1,50 @@
+"""Pin the ``kernels-community/flash-attn2`` hub kernel to a working major version."""
+
+from axolotl.utils.logging import get_logger
+
+LOG = get_logger(__name__)
+
+# transformers 5.16 resolves `flash_attention_2` to hub kernel v3, whose stable-ABI CUDA
+# builds fail the backward pass for every GQA/MQA model; v2 is the newest major with
+# working CUDA builds on torch 2.11-2.13.
+# https://github.com/huggingface/kernels-community/issues/1085
+FA2_HUB_KERNEL_VERSION = 2
+_BROKEN_FA2_HUB_KERNEL_VERSION = 3
+
+
+def patch_fa2_hub_kernel_version() -> None:
+    """Resolve ``flash_attention_2`` to hub kernel v2 instead of the broken v3."""
+    from transformers.integrations import hub_kernels
+
+    mapping = getattr(hub_kernels, "_FLASH_ATTN_KERNEL_VERSION_MAPPING", None)
+    # Leave anything but the known-bad v3 alone so an upstream bump isn't clobbered.
+    if mapping is None or mapping.get(2) != _BROKEN_FA2_HUB_KERNEL_VERSION:
+        return
+
+    mapping[2] = FA2_HUB_KERNEL_VERSION
+    LOG.info(
+        "Pinned the flash-attn2 hub kernel to v%d; v%d's stable-ABI build fails the "
+        "backward pass for GQA/MQA models.",
+        FA2_HUB_KERNEL_VERSION,
+        _BROKEN_FA2_HUB_KERNEL_VERSION,
+    )
+
+
+def is_fa2_hub_kernel_available() -> bool:
+    """Whether the pinned flash-attn2 hub kernel has a build for this torch."""
+    from transformers.utils import is_kernels_available
+
+    if not is_kernels_available():
+        return False
+
+    from kernels import get_kernel
+    from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
+
+    try:
+        get_kernel(
+            FLASH_ATTN_KERNEL_FALLBACK["flash_attention_2"],
+            version=FA2_HUB_KERNEL_VERSION,
+        )
+    except Exception:
+        return False
+    return True

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -1388,12 +1388,18 @@ class SystemValidationMixin:
             is_flash_attn_3_available,
         )
 
-        # kernels_fallback_ok mirrors runtime resolution: the flash-attn package OR a
-        # kernels-hub binary matching this torch build.
+        # Mirror runtime resolution: the flash-attn package OR a kernels-hub binary
+        # matching this torch build.
         if self.attn_implementation == "flash_attention_3":
             available = is_flash_attn_3_available(kernels_fallback_ok=True)
         else:
-            available = is_flash_attn_2_available(kernels_fallback_ok=True)
+            # transformers probes the hub at v1 but loads a different major, so ask
+            # about the version we actually pin instead.
+            from axolotl.monkeypatch.attention.fa2_hub_kernel import (
+                is_fa2_hub_kernel_available,
+            )
+
+            available = is_flash_attn_2_available() or is_fa2_hub_kernel_available()
         if not available:
             raise ValueError(
                 f"attn_implementation: {self.attn_implementation} is set, but no "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,15 @@ def _apply_transformers_test_shims():
 def pytest_configure(config):  # pylint: disable=unused-argument
     _apply_transformers_test_shims()
 
+    # Tests that call `from_pretrained` directly never reach PatchManager, and
+    # `lazy_import_flash_attention` caches by implementation string, so the first FA2
+    # load in a worker pins the kernel major for every later test in that process.
+    from axolotl.monkeypatch.attention.fa2_hub_kernel import (
+        patch_fa2_hub_kernel_version,
+    )
+
+    patch_fa2_hub_kernel_version()
+
 
 # A device-side assert / illegal access poisons the process-wide CUDA context, so
 # every later GPU test errors at setup. Abort the session instead of cascading.

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -49,7 +49,13 @@ def flash_attn_available() -> bool:
     try:
         from transformers.utils import is_flash_attn_2_available
 
-        return is_flash_attn_2_available(kernels_fallback_ok=True)
+        from axolotl.monkeypatch.attention.fa2_hub_kernel import (
+            is_fa2_hub_kernel_available,
+        )
+
+        # transformers probes the hub at v1, which has no build for newer torch; ask
+        # about the version we pin or these tests silently skip instead of running.
+        return is_flash_attn_2_available() or is_fa2_hub_kernel_available()
     except Exception:  # pylint: disable=broad-except
         return False
 

--- a/tests/utils/schemas/validation/test_flash_attn_availability.py
+++ b/tests/utils/schemas/validation/test_flash_attn_availability.py
@@ -17,11 +17,17 @@ class TestFlashAttnAvailabilityValidator:
     def _force_availability(monkeypatch, value: bool):
         import transformers.utils
 
+        from axolotl.monkeypatch.attention import fa2_hub_kernel
+
         monkeypatch.setattr(
             transformers.utils, "is_flash_attn_2_available", lambda **_: value
         )
         monkeypatch.setattr(
             transformers.utils, "is_flash_attn_3_available", lambda **_: value
+        )
+        # FA2 has a second opinion; leaving it live would hit the hub from a unit test.
+        monkeypatch.setattr(
+            fa2_hub_kernel, "is_fa2_hub_kernel_available", lambda: value
         )
 
     def test_fa2_unavailable_raises(self, min_base_cfg, monkeypatch):
@@ -43,6 +49,20 @@ class TestFlashAttnAvailabilityValidator:
         cfg = min_base_cfg | DictDefault(flash_attention=True)
         with pytest.raises(ValueError, match="no\\s+flash-attn build is available"):
             validate_config(cfg)
+
+    def test_fa2_falls_back_to_pinned_hub_kernel(self, min_base_cfg, monkeypatch):
+        """transformers probes the hub at v1; a v2-only build must still count."""
+        import transformers.utils
+
+        from axolotl.monkeypatch.attention import fa2_hub_kernel
+
+        monkeypatch.setattr(
+            transformers.utils, "is_flash_attn_2_available", lambda **_: False
+        )
+        monkeypatch.setattr(fa2_hub_kernel, "is_fa2_hub_kernel_available", lambda: True)
+        cfg = min_base_cfg | DictDefault(attn_implementation="flash_attention_2")
+        validated = validate_config(cfg)
+        assert validated.attn_implementation == "flash_attention_2"
 
     def test_fa2_available_passes(self, min_base_cfg, monkeypatch):
         self._force_availability(monkeypatch, True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

`v3` in flash attn kernel mapping is breaking our CI runs.

Reported to upstream HF however, we'll patch here to fix our CIs. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flash Attention 2 compatibility by using a stable kernel version when the newer version is unavailable or problematic.
  * Flash Attention 2 availability checks now recognize supported hub kernels and current hardware configurations more reliably.
  * Prevented valid Flash Attention 2 setups from being incorrectly reported as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->