### PR TITLE
fix: load mistral tokenizer test fixtures offline to avoid HF rate

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,6 +407,34 @@ def download_muse_glimmer_tokenizer_fixture():
     )
 
 
+# mistral-common tokenizers live in tekken.json, which `*token*` does not match
+@pytest.fixture(scope="session")
+def download_magistral_tokenizer_fixture():
+    snapshot_download_w_retry(
+        "mistralai/Magistral-Small-2506",
+        repo_type="model",
+        allow_patterns=["tekken.json"],
+    )
+
+
+@pytest.fixture(scope="session")
+def download_devstral_tokenizer_fixture():
+    snapshot_download_w_retry(
+        "mistralai/Devstral-Small-2505",
+        repo_type="model",
+        allow_patterns=["tekken.json"],
+    )
+
+
+@pytest.fixture(scope="session")
+def download_devstral_1_1_tokenizer_fixture():
+    snapshot_download_w_retry(
+        "mistralai/Devstral-Small-2507",
+        repo_type="model",
+        allow_patterns=["tekken.json"],
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def download_phi_35_mini_model_fixture():
     # download the tokenizer only

--- a/tests/prompt_strategies/conftest.py
+++ b/tests/prompt_strategies/conftest.py
@@ -164,24 +164,33 @@ def fixture_muse_glimmer_tokenizer(
     return tokenizer
 
 
-@pytest.fixture(name="magistral_tokenizer")
-def fixture_magistral_tokenizer():
+@pytest.fixture(name="magistral_tokenizer", scope="session")
+@enable_hf_offline
+def fixture_magistral_tokenizer(
+    download_magistral_tokenizer_fixture,
+):
     from axolotl.utils.mistral import HFMistralTokenizer
 
     tokenizer = HFMistralTokenizer.from_pretrained("mistralai/Magistral-Small-2506")
     return tokenizer
 
 
-@pytest.fixture(name="devstral_tokenizer")
-def fixture_devstral_tokenizer():
+@pytest.fixture(name="devstral_tokenizer", scope="session")
+@enable_hf_offline
+def fixture_devstral_tokenizer(
+    download_devstral_tokenizer_fixture,
+):
     from axolotl.utils.mistral import HFMistralTokenizer
 
     tokenizer = HFMistralTokenizer.from_pretrained("mistralai/Devstral-Small-2505")
     return tokenizer
 
 
-@pytest.fixture(name="devstral_1_1_tokenizer")
-def fixture_devstral_1_1_tokenizer():
+@pytest.fixture(name="devstral_1_1_tokenizer", scope="session")
+@enable_hf_offline
+def fixture_devstral_1_1_tokenizer(
+    download_devstral_1_1_tokenizer_fixture,
+):
     from axolotl.utils.mistral import HFMistralTokenizer
 
     tokenizer = HFMistralTokenizer.from_pretrained("mistralai/Devstral-Small-2507")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Some CI failing due to HF rate limiting. This tries to reduce that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable test fixtures for downloading tokenizer files for Magistral and Devstral model variants.
  * Updated tokenizer test fixtures to share downloads across the test session and support offline execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->