### PR TITLE
fix: match AsyncGRPOTrainer._get_per_token_logps_and_entropies to TRL…

### DIFF
--- a/src/axolotl/core/trainers/grpo/async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/async_trainer.py
@@ -1598,6 +1598,21 @@ class AsyncGRPOTrainer(GRPOTrainer):
         else:
             forward_kwargs = {}
 
+        # Recover LFM2-VL tile counts; the full processor drops row/column metadata.
+        num_tiles = None
+        if images is not None and "spatial_shapes" in forward_kwargs:
+            image_info = self.processing_class.image_processor(
+                images=images, return_tensors="pt", return_row_col_info=True
+            )
+            tiles_per_image = image_info["image_rows"] * image_info["image_cols"]
+            if self.processing_class.image_processor.use_thumbnail:
+                tiles_per_image = tiles_per_image + (tiles_per_image > 1).to(
+                    tiles_per_image.dtype
+                )
+            num_tiles = [
+                group.sum().item() for group in torch.split(tiles_per_image, num_images)
+            ]
+
         # Extend token_type_ids / mm_token_type_ids for completion tokens
         for ttid_key in ("token_type_ids", "mm_token_type_ids"):
             if ttid_key in forward_kwargs:
@@ -1640,13 +1655,17 @@ class AsyncGRPOTrainer(GRPOTrainer):
             output["tool_mask"] = tool_mask
         if images is not None:
             output["num_images"] = num_images
+        if num_tiles is not None:
+            output["num_tiles"] = num_tiles
         for k in (
             "pixel_values",
             "image_grid_thw",
             "pixel_attention_mask",
+            "spatial_shapes",
             "image_sizes",
             "token_type_ids",
             "mm_token_type_ids",
+            "image_position_ids",
         ):
             if k in forward_kwargs:
                 output[k] = forward_kwargs[k]
@@ -1762,13 +1781,16 @@ class AsyncGRPOTrainer(GRPOTrainer):
             "pixel_values",
             "image_grid_thw",
             "pixel_attention_mask",
+            "spatial_shapes",
             "image_sizes",
             "token_type_ids",
             "mm_token_type_ids",
+            "image_position_ids",
         ):
             if key in data:
                 forward_kwargs[key] = data[key]
         num_images = data.get("num_images")
+        num_tiles = data.get("num_tiles")
 
         # --- Launch rewards in parallel with logprobs ---
         self._launch_reward_workers(inputs, prompts, completions, completion_ids_list)
@@ -1810,6 +1832,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         logits_to_keep,
                         logprob_batch_size,
                         num_images=num_images,
+                        num_tiles=num_tiles,
                         **forward_kwargs,
                     )
                 data["old_per_token_logps"] = old_per_token_logps
@@ -1826,6 +1849,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         logits_to_keep,
                         batch_size,
                         num_images=num_images,
+                        num_tiles=num_tiles,
                         **forward_kwargs,
                     )
                 else:
@@ -1844,6 +1868,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                             logits_to_keep,
                             batch_size,
                             num_images=num_images,
+                            num_tiles=num_tiles,
                             **forward_kwargs,
                         )
                 data["ref_per_token_logps"] = ref_logps
@@ -2146,9 +2171,11 @@ class AsyncGRPOTrainer(GRPOTrainer):
             "pixel_values",
             "image_grid_thw",
             "pixel_attention_mask",
+            "spatial_shapes",
             "image_sizes",
             "token_type_ids",
             "mm_token_type_ids",
+            "image_position_ids",
         ):
             if key in data:
                 val = data[key]
@@ -2167,6 +2194,13 @@ class AsyncGRPOTrainer(GRPOTrainer):
             and len(num_images) == len(data["prompt_ids"])
         ):
             num_images = num_images[s_start:s_end]
+        num_tiles = data.get("num_tiles")
+        if (
+            num_tiles is not None
+            and hasattr(num_tiles, "__getitem__")
+            and len(num_tiles) == len(data["prompt_ids"])
+        ):
+            num_tiles = num_tiles[s_start:s_end]
 
         # --- Launch rewards in parallel with logprobs ---
         self._launch_reward_workers(inputs, prompts, completions, completion_ids_list)
@@ -2203,6 +2237,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         logits_to_keep,
                         logprob_batch_size,
                         num_images=num_images,
+                        num_tiles=num_tiles,
                         **forward_kwargs,
                     )
                 if "old_per_token_logps" not in data:
@@ -2253,6 +2288,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         logits_to_keep,
                         batch_size,
                         num_images=num_images,
+                        num_tiles=num_tiles,
                         **forward_kwargs,
                     )
                 else:
@@ -2271,6 +2307,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                             logits_to_keep,
                             batch_size,
                             num_images=num_images,
+                            num_tiles=num_tiles,
                             **forward_kwargs,
                         )
                 if "ref_per_token_logps" not in data:
@@ -2924,8 +2961,9 @@ class AsyncGRPOTrainer(GRPOTrainer):
         all_aux_losses = []
         with autocast_ctx:
             for start in range(0, input_ids.size(0), batch_size):
-                input_ids_batch = input_ids[start : start + batch_size]
-                attention_mask_batch = attention_mask[start : start + batch_size]
+                end = min(start + batch_size, input_ids.size(0))
+                input_ids_batch = input_ids[start:end]
+                attention_mask_batch = attention_mask[start:end]
 
                 # Build model inputs
                 model_inputs = {
@@ -2944,15 +2982,15 @@ class AsyncGRPOTrainer(GRPOTrainer):
                     )
                     row_start, row_end = (
                         cum_rows[start].item(),
-                        cum_rows[start + batch_size].item(),
+                        cum_rows[end].item(),
                     )
                     model_inputs["pixel_values"] = pixel_values[row_start:row_end]
                     cum_imgs = torch.tensor([0] + num_images).cumsum(0)
-                    img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
+                    img_start, img_end = cum_imgs[start], cum_imgs[end]
                     model_inputs["image_grid_thw"] = image_grid_thw[img_start:img_end]
                 elif image_position_ids is not None and pixel_values is not None:
                     cum_imgs = torch.tensor([0] + num_images).cumsum(0)
-                    img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
+                    img_start, img_end = cum_imgs[start], cum_imgs[end]
                     model_inputs["pixel_values"] = pixel_values[img_start:img_end]
                     model_inputs["image_position_ids"] = image_position_ids[
                         img_start:img_end
@@ -2962,7 +3000,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                     cum_tiles = torch.tensor([0] + num_tiles).cumsum(0)
                     tile_start, tile_end = (
                         cum_tiles[start],
-                        cum_tiles[start + batch_size],
+                        cum_tiles[end],
                     )
                     model_inputs["pixel_values"] = pixel_values[tile_start:tile_end]
                     model_inputs["pixel_attention_mask"] = pixel_attention_mask[
@@ -3086,9 +3124,12 @@ class AsyncGRPOTrainer(GRPOTrainer):
                 "image_grid_thw",
                 "num_images",
                 "pixel_attention_mask",
+                "spatial_shapes",
+                "num_tiles",
                 "image_sizes",
                 "token_type_ids",
                 "mm_token_type_ids",
+                "image_position_ids",
             )
             if k in inputs and inputs[k] is not None
         }
@@ -3097,6 +3138,10 @@ class AsyncGRPOTrainer(GRPOTrainer):
             getattr(self.args, "batch_flattening", False)
             and not forward_kwargs
             and not self.is_fsdp_enabled
+            # The flattened forward pass doesn't request router logits, so it
+            # can't produce an aux_loss — fall back to the padded path instead
+            # of silently dropping the MoE load-balancing loss.
+            and not self.aux_loss_enabled
         )
 
         if can_flatten:
@@ -3110,14 +3155,18 @@ class AsyncGRPOTrainer(GRPOTrainer):
                     compute_entropy=True,
                 )
             )
+            aux_loss = None
         else:
-            per_token_logps, entropies, _ = self._get_per_token_logps_and_entropies(
-                model,
-                input_ids,
-                attention_mask,
-                logits_to_keep,
-                compute_entropy=True,
-                **forward_kwargs,
+            per_token_logps, entropies, aux_loss = (
+                self._get_per_token_logps_and_entropies(
+                    model,
+                    input_ids,
+                    attention_mask,
+                    logits_to_keep,
+                    compute_entropy=True,
+                    compute_aux_loss=self.aux_loss_enabled,
+                    **forward_kwargs,
+                )
             )
         if self.top_entropy_quantile < 1.0:
             entropy_mask = self.get_high_entropy_mask(
@@ -3247,6 +3296,12 @@ class AsyncGRPOTrainer(GRPOTrainer):
             loss = (per_token_loss * mask.sum(1, keepdim=True)).mean() / normalizer
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}")
+
+        if self.aux_loss_enabled:
+            loss = loss + self.router_aux_loss_coef * aux_loss / normalizer
+            self._metrics[mode]["aux_loss"].append(
+                self.accelerator.gather(aux_loss).nanmean().item()
+            )
 
         # --- Metrics ---
         completion_token_count = mask.sum().clamp(min=1.0)

--- a/src/axolotl/core/trainers/grpo/async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/async_trainer.py
@@ -1803,7 +1803,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         prompt_mask=prompt_mask,
                     )
                 else:
-                    old_per_token_logps, _ = self._get_per_token_logps_and_entropies(
+                    old_per_token_logps, _, _ = self._get_per_token_logps_and_entropies(
                         self.model,
                         prompt_completion_ids,
                         attention_mask,
@@ -1819,7 +1819,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
             # Reference model logprobs
             if self.beta != 0.0:
                 if self.ref_model is not None:
-                    ref_logps, _ = self._get_per_token_logps_and_entropies(
+                    ref_logps, _, _ = self._get_per_token_logps_and_entropies(
                         self.ref_model,
                         prompt_completion_ids,
                         attention_mask,
@@ -1837,7 +1837,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         else None
                     )
                     with use_adapter(unwrapped, adapter_name=adapter_name):
-                        ref_logps, _ = self._get_per_token_logps_and_entropies(
+                        ref_logps, _, _ = self._get_per_token_logps_and_entropies(
                             self.model,
                             prompt_completion_ids,
                             attention_mask,
@@ -2196,7 +2196,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         prompt_mask=chunk_prompt_mask,
                     )
                 else:
-                    old_logps, _ = self._get_per_token_logps_and_entropies(
+                    old_logps, _, _ = self._get_per_token_logps_and_entropies(
                         self.model,
                         prompt_completion_ids,
                         attention_mask,
@@ -2246,7 +2246,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
             # Reference logprobs
             if self.beta != 0.0:
                 if self.ref_model is not None:
-                    ref_logps, _ = self._get_per_token_logps_and_entropies(
+                    ref_logps, _, _ = self._get_per_token_logps_and_entropies(
                         self.ref_model,
                         prompt_completion_ids,
                         attention_mask,
@@ -2264,7 +2264,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                         else None
                     )
                     with use_adapter(unwrapped, adapter_name=adapter_name):
-                        ref_logps, _ = self._get_per_token_logps_and_entropies(
+                        ref_logps, _, _ = self._get_per_token_logps_and_entropies(
                             self.model,
                             prompt_completion_ids,
                             attention_mask,
@@ -2877,15 +2877,23 @@ class AsyncGRPOTrainer(GRPOTrainer):
         logits_to_keep,
         batch_size=None,
         compute_entropy=False,
+        compute_aux_loss=False,
         pixel_values=None,
         image_grid_thw=None,
         num_images=None,
         pixel_attention_mask=None,
+        spatial_shapes=None,
+        num_tiles=None,
         image_sizes=None,
         token_type_ids=None,
         mm_token_type_ids=None,
-    ) -> tuple[Any, torch.Tensor | None]:
-        """Compute log-probs and (optionally) entropies for each token.
+        image_position_ids=None,
+    ) -> tuple[Any, torch.Tensor | None, torch.Tensor | None]:
+        """Compute log-probs, (optionally) entropies, and (optionally) the MoE aux loss.
+
+        Signature/behavior mirrors ``trl.GRPOTrainer._get_per_token_logps_and_entropies``
+        (needed because TRL's base ``_generate_and_score_completions``/``_compute_loss``
+        call this method polymorphically with these kwargs).
 
         When running under no_grad (scoring path), bypasses accelerate's
         ConvertOutputsToFp32 wrapper to avoid a fp32 copy of the
@@ -2913,6 +2921,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
         batch_size = batch_size or input_ids.size(0)
         all_logps = []
         all_entropies = []
+        all_aux_losses = []
         with autocast_ctx:
             for start in range(0, input_ids.size(0), batch_size):
                 input_ids_batch = input_ids[start : start + batch_size]
@@ -2941,11 +2950,30 @@ class AsyncGRPOTrainer(GRPOTrainer):
                     cum_imgs = torch.tensor([0] + num_images).cumsum(0)
                     img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
                     model_inputs["image_grid_thw"] = image_grid_thw[img_start:img_end]
+                elif image_position_ids is not None and pixel_values is not None:
+                    cum_imgs = torch.tensor([0] + num_images).cumsum(0)
+                    img_start, img_end = cum_imgs[start], cum_imgs[start + batch_size]
+                    model_inputs["pixel_values"] = pixel_values[img_start:img_end]
+                    model_inputs["image_position_ids"] = image_position_ids[
+                        img_start:img_end
+                    ]
+                elif spatial_shapes is not None and pixel_values is not None:
+                    # LFM2-VL tensors are tile-indexed.
+                    cum_tiles = torch.tensor([0] + num_tiles).cumsum(0)
+                    tile_start, tile_end = (
+                        cum_tiles[start],
+                        cum_tiles[start + batch_size],
+                    )
+                    model_inputs["pixel_values"] = pixel_values[tile_start:tile_end]
+                    model_inputs["pixel_attention_mask"] = pixel_attention_mask[
+                        tile_start:tile_end
+                    ]
+                    model_inputs["spatial_shapes"] = spatial_shapes[tile_start:tile_end]
                 elif pixel_values is not None:
                     model_inputs["pixel_values"] = pixel_values[
                         start : start + batch_size
                     ]
-                if pixel_attention_mask is not None:
+                if pixel_attention_mask is not None and spatial_shapes is None:
                     model_inputs["pixel_attention_mask"] = pixel_attention_mask[
                         start : start + batch_size
                     ]
@@ -2967,7 +2995,14 @@ class AsyncGRPOTrainer(GRPOTrainer):
 
                 model_inputs["use_cache"] = False
 
-                logits = model(**model_inputs).logits
+                # MoE models: request router logits so the model returns `outputs.aux_loss`.
+                # VLM wrappers honor this only as a forward kwarg (not from the model
+                # config), so it must be passed here.
+                if compute_aux_loss:
+                    model_inputs["output_router_logits"] = True
+
+                outputs = model(**model_inputs)
+                logits = outputs.logits
                 completion_ids = input_ids_batch[:, -logits_to_keep:]
                 # FP8 models produce NaN logits at positions where
                 # attention_mask=0 (padding). Replace NaN with 0 so
@@ -2998,9 +3033,13 @@ class AsyncGRPOTrainer(GRPOTrainer):
                             entropies = entropy_from_logits(logits)
                         all_entropies.append(entropies)
 
+                if compute_aux_loss:
+                    all_aux_losses.append(outputs.aux_loss)
+
         logps = torch.cat(all_logps, dim=0)
         entropies = torch.cat(all_entropies, dim=0) if compute_entropy else None
-        return logps, entropies
+        aux_loss = torch.stack(all_aux_losses).mean() if compute_aux_loss else None
+        return logps, entropies, aux_loss
 
     # ------------------------------------------------------------------
     # Loss override (adds IS ratio + OPSM)
@@ -3072,7 +3111,7 @@ class AsyncGRPOTrainer(GRPOTrainer):
                 )
             )
         else:
-            per_token_logps, entropies = self._get_per_token_logps_and_entropies(
+            per_token_logps, entropies, _ = self._get_per_token_logps_and_entropies(
                 model,
                 input_ids,
                 attention_mask,

--- a/src/axolotl/core/trainers/grpo/fast_async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/fast_async_trainer.py
@@ -586,7 +586,7 @@ class FastAsyncGRPOTrainer(AsyncGRPOTrainer):
                             ):
                                 if fk in data:
                                     r_fwd_kwargs[fk] = data[fk]
-                            r_logps, _ = self._get_per_token_logps_and_entropies(
+                            r_logps, _, _ = self._get_per_token_logps_and_entropies(
                                 self.model,
                                 r_ids,
                                 r_mask,

--- a/src/axolotl/core/trainers/grpo/fast_async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/fast_async_trainer.py
@@ -580,9 +580,12 @@ class FastAsyncGRPOTrainer(AsyncGRPOTrainer):
                                 "pixel_values",
                                 "image_grid_thw",
                                 "pixel_attention_mask",
+                                "spatial_shapes",
+                                "num_tiles",
                                 "image_sizes",
                                 "token_type_ids",
                                 "mm_token_type_ids",
+                                "image_position_ids",
                             ):
                                 if fk in data:
                                     r_fwd_kwargs[fk] = data[fk]

--- a/src/axolotl/core/trainers/grpo/fast_async_trainer.py
+++ b/src/axolotl/core/trainers/grpo/fast_async_trainer.py
@@ -42,6 +42,74 @@ from axolotl.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _slice_multimodal_kwargs(data: dict, start: int, end: int) -> dict:
+    """Slice full-batch multimodal fields in ``data`` down to sample range
+    ``[start, end)``.
+
+    ``pixel_values``/``image_grid_thw``/``pixel_attention_mask``/
+    ``spatial_shapes``/``image_position_ids`` are indexed by image/tile
+    count, not sample count, so a naive ``data[key][start:end]`` pulls the
+    wrong rows whenever ``start > 0`` — mirrors the cumulative-offset
+    branches in ``AsyncGRPOTrainer._get_per_token_logps_and_entropies``,
+    which otherwise treats ``start=0`` as relative to whatever slice it's
+    handed.
+    """
+    kwargs: dict = {}
+    num_images = data.get("num_images")
+    num_tiles = data.get("num_tiles")
+    pixel_values = data.get("pixel_values")
+
+    if num_images is not None and pixel_values is not None and "image_grid_thw" in data:
+        image_grid_thw = data["image_grid_thw"]
+        rows_per_image = image_grid_thw.prod(dim=-1)
+        rows_per_sample = torch.split(rows_per_image, num_images)
+        rows_per_sample = torch.stack([s.sum() for s in rows_per_sample])
+        cum_rows = torch.cat(
+            [
+                torch.tensor([0], device=rows_per_sample.device),
+                rows_per_sample.cumsum(0),
+            ]
+        )
+        row_start, row_end = cum_rows[start].item(), cum_rows[end].item()
+        kwargs["pixel_values"] = pixel_values[row_start:row_end]
+        cum_imgs = torch.tensor([0] + num_images).cumsum(0)
+        img_start, img_end = cum_imgs[start], cum_imgs[end]
+        kwargs["image_grid_thw"] = image_grid_thw[img_start:img_end]
+        kwargs["num_images"] = num_images[start:end]
+    elif (
+        num_images is not None
+        and pixel_values is not None
+        and "image_position_ids" in data
+    ):
+        cum_imgs = torch.tensor([0] + num_images).cumsum(0)
+        img_start, img_end = cum_imgs[start], cum_imgs[end]
+        kwargs["pixel_values"] = pixel_values[img_start:img_end]
+        kwargs["image_position_ids"] = data["image_position_ids"][img_start:img_end]
+        kwargs["num_images"] = num_images[start:end]
+    elif (
+        num_tiles is not None and pixel_values is not None and "spatial_shapes" in data
+    ):
+        cum_tiles = torch.tensor([0] + num_tiles).cumsum(0)
+        tile_start, tile_end = cum_tiles[start], cum_tiles[end]
+        kwargs["pixel_values"] = pixel_values[tile_start:tile_end]
+        if "pixel_attention_mask" in data:
+            kwargs["pixel_attention_mask"] = data["pixel_attention_mask"][
+                tile_start:tile_end
+            ]
+        kwargs["spatial_shapes"] = data["spatial_shapes"][tile_start:tile_end]
+        kwargs["num_tiles"] = num_tiles[start:end]
+    elif pixel_values is not None:
+        kwargs["pixel_values"] = pixel_values[start:end]
+        if "pixel_attention_mask" in data:
+            kwargs["pixel_attention_mask"] = data["pixel_attention_mask"][start:end]
+
+    for fk in ("image_sizes", "token_type_ids", "mm_token_type_ids"):
+        if fk in data:
+            kwargs[fk] = data[fk][start:end]
+
+    return kwargs
+
+
 # ---------------------------------------------------------------------------
 # Extended config
 # ---------------------------------------------------------------------------
@@ -575,20 +643,9 @@ class FastAsyncGRPOTrainer(AsyncGRPOTrainer):
                                 dim=1,
                             )
                             r_logits_to_keep = data["completion_ids"].size(1)
-                            r_fwd_kwargs = {}
-                            for fk in (
-                                "pixel_values",
-                                "image_grid_thw",
-                                "pixel_attention_mask",
-                                "spatial_shapes",
-                                "num_tiles",
-                                "image_sizes",
-                                "token_type_ids",
-                                "mm_token_type_ids",
-                                "image_position_ids",
-                            ):
-                                if fk in data:
-                                    r_fwd_kwargs[fk] = data[fk]
+                            r_fwd_kwargs = _slice_multimodal_kwargs(
+                                data, r_start, r_end
+                            )
                             r_logps, _, _ = self._get_per_token_logps_and_entropies(
                                 self.model,
                                 r_ids,

--- a/tests/core/test_async_grpo.py
+++ b/tests/core/test_async_grpo.py
@@ -1,7 +1,9 @@
 """Unit tests for async GRPO"""
 
+import types
 import unittest
-from unittest.mock import MagicMock
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -406,6 +408,433 @@ class TestMaybeSyncVllmWeightsIntervalDefault(unittest.TestCase):
         trainer.state.global_step = 4
         AsyncGRPOTrainer._maybe_sync_vllm_weights(trainer)
         trainer._sync_lora_adapter.assert_called_once()
+
+
+class _StopEarly(Exception):
+    """Raised by a mocked call to short-circuit a large method right after
+    capturing the kwargs it was invoked with."""
+
+
+def _capture_and_stop():
+    """Returns (captured_kwargs_dict, side_effect_fn) for mocking
+    ``_get_per_token_logps_and_entropies``: records the kwargs of the first
+    call, then aborts the enclosing method via ``_StopEarly`` so tests don't
+    need to stub out the rest of a large scoring/loss method."""
+    captured: dict = {}
+
+    def _side_effect(*_args, **kwargs):
+        captured.update(kwargs)
+        raise _StopEarly()
+
+    return captured, _side_effect
+
+
+class TestMultimodalTileFieldPropagation(unittest.TestCase):
+    """spatial_shapes / num_tiles / image_position_ids (TRL 1.9's LFM2-VL /
+    tile-indexed VLM fields) must reach ``_get_per_token_logps_and_entropies``
+    from every async GRPO scoring path, not just the low-level method
+    signature."""
+
+    def _make_async_trainer(self):
+        from axolotl.core.trainers.grpo.async_trainer import AsyncGRPOTrainer
+
+        trainer = AsyncGRPOTrainer.__new__(AsyncGRPOTrainer)
+        trainer.accelerator = MagicMock()
+        trainer.accelerator.device = torch.device("cpu")
+        trainer.accelerator.num_processes = 1
+        trainer.model = MagicMock()
+        trainer.model.is_gradient_checkpointing = False
+        trainer.is_fsdp_enabled = False
+        trainer.use_vllm = True
+        trainer.vllm_importance_sampling_correction = True
+        trainer.beta = 0.0
+        trainer.aux_loss_enabled = False
+        trainer.num_generations = 2
+        trainer.num_iterations = 1
+        trainer.pad_token_id = 0
+        trainer.eos_token_id = 1
+        trainer.mask_truncated_completions = False
+        trainer.tools = None
+        trainer.chat_template_kwargs = {}
+        trainer._launch_reward_workers = MagicMock()
+        trainer.args = types.SimpleNamespace(
+            per_device_train_batch_size=2,
+            batch_flattening=False,
+            gradient_accumulation_steps=1,
+            steps_per_generation=1,
+            gradient_checkpointing_kwargs=None,
+        )
+        return trainer
+
+    def test_generate_only_forwards_tile_fields(self):
+        """_generate_only must (a) recover num_tiles the way TRL does for
+        tile-indexed VLMs, and (b) preserve spatial_shapes/image_position_ids
+        into the deferred rollout output."""
+        from axolotl.core.trainers.grpo.async_trainer import AsyncGRPOTrainer
+
+        trainer = self._make_async_trainer()
+
+        images = [["img_a"], ["img_b", "img_c"]]  # num_images == [1, 2]
+        inputs = [
+            {"prompt": "p1", "images": images[0]},
+            {"prompt": "p2", "images": images[1]},
+        ]
+        trainer._generate = MagicMock(
+            return_value=(
+                [[1, 2, 3], [1, 2]],  # prompt_ids_list
+                [[4, 5], [4, 5, 6]],  # completion_ids_list
+                None,  # tool_mask_list
+                ["a", "b"],  # completions
+                2,  # num_items_in_batch
+                None,  # sampling_per_token_logps_list
+                None,  # extra_fields
+            )
+        )
+        trainer.processing_class = MagicMock()
+        trainer.processing_class.return_value = {
+            "spatial_shapes": torch.zeros(3, 2),
+            "pixel_values": torch.zeros(3, 4, 4),
+            "image_position_ids": torch.zeros(2, 5),
+        }
+        trainer.processing_class.image_processor.use_thumbnail = False
+        trainer.processing_class.image_processor.return_value = {
+            "image_rows": torch.tensor([1, 1, 1]),
+            "image_cols": torch.tensor([2, 3, 4]),
+        }
+
+        with (
+            patch(
+                "axolotl.core.trainers.grpo.async_trainer.apply_chat_template",
+                return_value={"prompt": "TEXT"},
+            ),
+            patch(
+                "axolotl.core.trainers.grpo.async_trainer.is_conversational",
+                return_value=True,
+            ),
+            patch(
+                "axolotl.core.trainers.grpo.async_trainer.prepare_multimodal_messages",
+                side_effect=lambda p, _il: p,
+            ),
+        ):
+            output = AsyncGRPOTrainer._generate_only(trainer, inputs)
+
+        # image_rows * image_cols == [2, 3, 4]; split by num_images=[1, 2] → [2], [3, 4]
+        self.assertEqual(output["num_tiles"], [2, 7])
+        self.assertIn("spatial_shapes", output)
+        self.assertIn("image_position_ids", output)
+
+    def test_compute_deferred_scores_forwards_tile_fields(self):
+        trainer = self._make_async_trainer()
+        captured, side_effect = _capture_and_stop()
+        trainer._get_per_token_logps_and_entropies = MagicMock(side_effect=side_effect)
+
+        rollout = {
+            "_deferred_inputs": [{}, {}],
+            "_deferred_prompts": ["p1", "p2"],
+            "_deferred_completions": ["c1", "c2"],
+            "_deferred_completion_ids_list": [[1], [1]],
+            "_pending_policy_logps": True,
+            "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(2, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+            "completion_mask": torch.ones(2, 4, dtype=torch.long),
+            "spatial_shapes": torch.zeros(2, 2),
+            "image_position_ids": torch.zeros(2, 5),
+            "num_tiles": [2, 3],
+        }
+
+        with self.assertRaises(_StopEarly):
+            trainer._compute_deferred_scores(rollout)
+
+        self.assertEqual(captured["num_tiles"], [2, 3])
+        self.assertIn("spatial_shapes", captured)
+        self.assertIn("image_position_ids", captured)
+
+    def test_compute_streaming_group_scores_forwards_tile_fields(self):
+        trainer = self._make_async_trainer()
+        captured, side_effect = _capture_and_stop()
+        trainer._get_per_token_logps_and_entropies = MagicMock(side_effect=side_effect)
+
+        data = {
+            "prompt_ids": torch.zeros(4, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(4, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(4, 3, dtype=torch.long),
+            "completion_mask": torch.ones(4, 4, dtype=torch.long),
+            "spatial_shapes": torch.zeros(4, 2),
+            "image_position_ids": torch.zeros(4, 5),
+            "num_tiles": [2, 3, 4, 5],
+        }
+
+        with self.assertRaises(_StopEarly):
+            trainer._compute_streaming_group_scores(
+                data,
+                s_start=0,
+                s_end=2,
+                inputs=[{}, {}],
+                prompts=["p1", "p2"],
+                completions=["c1", "c2"],
+                completion_ids_list=[[1], [1]],
+                is_last_chunk=True,
+            )
+
+        # num_tiles is a per-sample list (like num_images) — sliced to the chunk
+        self.assertEqual(captured["num_tiles"], [2, 3])
+        self.assertIn("spatial_shapes", captured)
+        self.assertIn("image_position_ids", captured)
+
+    def test_compute_loss_forwards_tile_fields(self):
+        trainer = self._make_async_trainer()
+        captured, side_effect = _capture_and_stop()
+        trainer._get_per_token_logps_and_entropies = MagicMock(side_effect=side_effect)
+
+        inputs = {
+            "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(2, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+            "completion_mask": torch.ones(2, 4, dtype=torch.long),
+            "spatial_shapes": torch.zeros(2, 2),
+            "num_tiles": [2, 3],
+            "image_position_ids": torch.zeros(2, 5),
+        }
+
+        with self.assertRaises(_StopEarly):
+            trainer._compute_loss(trainer.model, inputs)
+
+        self.assertEqual(captured["num_tiles"], [2, 3])
+        self.assertIn("spatial_shapes", captured)
+        self.assertIn("image_position_ids", captured)
+
+    def test_fast_async_replay_recompute_forwards_tile_fields(self):
+        from axolotl.core.trainers.grpo.fast_async_trainer import (
+            FastAsyncGRPOTrainer,
+        )
+        from axolotl.core.trainers.grpo.replay_buffer import ReplayBuffer
+
+        trainer = FastAsyncGRPOTrainer.__new__(FastAsyncGRPOTrainer)
+        trainer.model = MagicMock()
+        trainer.model.is_gradient_checkpointing = False
+        trainer.args = types.SimpleNamespace(gradient_checkpointing_kwargs=None)
+        trainer.reward_funcs = [MagicMock()]
+        trainer._replay_recompute_logps = True
+        trainer._replay_buffer = ReplayBuffer(max_size=2)
+        trainer._replay_buffer.add(
+            1.0,
+            {
+                "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+                "completion_ids": torch.zeros(2, 4, dtype=torch.long),
+                "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+                "completion_mask": torch.ones(2, 4, dtype=torch.long),
+                "old_per_token_logps": torch.zeros(2, 4),
+            },
+        )
+        captured, side_effect = _capture_and_stop()
+        trainer._get_per_token_logps_and_entropies = MagicMock(side_effect=side_effect)
+
+        # One group (num_generations=2) with zero reward variance → "no signal" →
+        # triggers replacement from the replay buffer + old_per_token_logps recompute.
+        data = {
+            "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(2, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+            "completion_mask": torch.ones(2, 4, dtype=torch.long),
+            "old_per_token_logps": torch.zeros(2, 4),
+            "spatial_shapes": torch.zeros(2, 2),
+            "image_position_ids": torch.zeros(2, 5),
+            "num_tiles": [2, 3],
+        }
+        rewards_per_func = torch.zeros(2, 1)
+        advantages = torch.zeros(2)
+
+        with self.assertRaises(_StopEarly):
+            FastAsyncGRPOTrainer._post_advantage_hook(
+                trainer,
+                data,
+                rewards_per_func,
+                advantages,
+                inputs=[{}, {}],
+                num_generations=2,
+                mode="train",
+            )
+
+        self.assertIn("spatial_shapes", captured)
+        self.assertIn("num_tiles", captured)
+        self.assertIn("image_position_ids", captured)
+
+
+class TestGetPerTokenLogpsMultimodalTailBatch(unittest.TestCase):
+    """A batch_size that doesn't evenly divide the sample count must not
+    overflow the cumulative image/tile index tensors on the last chunk."""
+
+    def _make_trainer(self):
+        from axolotl.core.trainers.grpo.async_trainer import AsyncGRPOTrainer
+
+        trainer = AsyncGRPOTrainer.__new__(AsyncGRPOTrainer)
+        trainer.is_fsdp_enabled = False
+        trainer.accelerator = MagicMock()
+        trainer.accelerator.unwrap_model = lambda m, keep_fp32_wrapper=True: m
+        trainer.use_liger_kernel = False
+        trainer.temperature = 1.0
+        trainer.model_kwarg_keys = set()
+        return trainer
+
+    @staticmethod
+    def _fake_model(seq_len, vocab_size):
+        def _call(**kwargs):
+            n = kwargs["input_ids"].size(0)
+            out = MagicMock()
+            out.logits = torch.randn(n, seq_len, vocab_size)
+            return out
+
+        return _call
+
+    def test_image_position_ids_tail_batch_does_not_overflow(self):
+        trainer = self._make_trainer()
+        B, L, V = 5, 6, 10  # batch_size=2 -> last chunk start=4, start+batch_size=6 > B
+        logits_to_keep = 3
+        num_images = [1, 1, 1, 1, 1]
+
+        logps, _entropies, _aux = trainer._get_per_token_logps_and_entropies(
+            self._fake_model(L, V),
+            torch.randint(0, V, (B, L)),
+            torch.ones(B, L, dtype=torch.long),
+            logits_to_keep,
+            batch_size=2,
+            num_images=num_images,
+            pixel_values=torch.randn(5, 3, 4, 4),
+            image_position_ids=torch.randn(5, 2),
+        )
+        self.assertEqual(logps.shape, (B, logits_to_keep))
+
+    def test_spatial_shapes_tail_batch_does_not_overflow(self):
+        trainer = self._make_trainer()
+        B, L, V = 5, 6, 10
+        logits_to_keep = 3
+        num_tiles = [1, 1, 1, 1, 1]
+
+        logps, _entropies, _aux = trainer._get_per_token_logps_and_entropies(
+            self._fake_model(L, V),
+            torch.randint(0, V, (B, L)),
+            torch.ones(B, L, dtype=torch.long),
+            logits_to_keep,
+            batch_size=2,
+            num_tiles=num_tiles,
+            pixel_values=torch.randn(5, 3, 4, 4),
+            pixel_attention_mask=torch.ones(5, 4, 4, dtype=torch.long),
+            spatial_shapes=torch.randn(5, 2),
+        )
+        self.assertEqual(logps.shape, (B, logits_to_keep))
+
+    def test_image_grid_thw_tail_batch_does_not_overflow(self):
+        trainer = self._make_trainer()
+        B, L, V = 5, 6, 10
+        logits_to_keep = 3
+        num_images = [1, 1, 1, 1, 1]
+
+        logps, _entropies, _aux = trainer._get_per_token_logps_and_entropies(
+            self._fake_model(L, V),
+            torch.randint(0, V, (B, L)),
+            torch.ones(B, L, dtype=torch.long),
+            logits_to_keep,
+            batch_size=2,
+            num_images=num_images,
+            pixel_values=torch.randn(5, 4),
+            image_grid_thw=torch.tensor([[1, 1, 1]] * 5),
+        )
+        self.assertEqual(logps.shape, (B, logits_to_keep))
+
+
+class TestComputeLossAuxLoss(unittest.TestCase):
+    """MoE router aux loss must be requested, added to the policy loss with
+    ``router_aux_loss_coef``, and logged — matching stock TRL's
+    ``GRPOTrainer._compute_loss`` behavior."""
+
+    def _make_trainer(self, aux_loss_enabled, batch_flattening=False):
+        from axolotl.core.trainers.grpo.async_trainer import AsyncGRPOTrainer
+
+        trainer = AsyncGRPOTrainer.__new__(AsyncGRPOTrainer)
+        trainer.is_fsdp_enabled = False
+        trainer.aux_loss_enabled = aux_loss_enabled
+        trainer.router_aux_loss_coef = 0.01
+        trainer.top_entropy_quantile = 1.0
+        trainer.beta = 0.0
+        trainer.loss_type = "grpo"
+        trainer.epsilon_low = 0.2
+        trainer.epsilon_high = 0.2
+        trainer.use_vllm = False
+        trainer.off_policy_mask_threshold = None
+        trainer.current_gradient_accumulation_steps = 1
+        trainer.args = types.SimpleNamespace(
+            batch_flattening=batch_flattening, delta=None
+        )
+        trainer.model = MagicMock()
+        trainer.model.training = True
+        trainer._metrics = defaultdict(lambda: defaultdict(list))
+        trainer.accelerator = MagicMock()
+        trainer.accelerator.gather = lambda x: x
+        return trainer
+
+    def _make_inputs(self):
+        return {
+            "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+            "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(2, 3, dtype=torch.long),
+            "completion_mask": torch.ones(2, 3, dtype=torch.long),
+            "advantages": torch.ones(2, 1),
+        }
+
+    def test_aux_loss_added_to_policy_loss_when_enabled(self):
+        trainer = self._make_trainer(aux_loss_enabled=True)
+        aux_loss = torch.tensor(2.0)
+        trainer._get_per_token_logps_and_entropies = MagicMock(
+            return_value=(torch.zeros(2, 3), torch.zeros(2, 3), aux_loss)
+        )
+
+        loss_with_aux = trainer._compute_loss(trainer.model, self._make_inputs())
+
+        # compute_aux_loss must be requested from the low-level scoring call
+        _, call_kwargs = trainer._get_per_token_logps_and_entropies.call_args
+        self.assertTrue(call_kwargs["compute_aux_loss"])
+
+        # Baseline without aux loss: same setup, aux_loss_enabled=False
+        trainer_no_aux = self._make_trainer(aux_loss_enabled=False)
+        trainer_no_aux._get_per_token_logps_and_entropies = MagicMock(
+            return_value=(torch.zeros(2, 3), torch.zeros(2, 3), None)
+        )
+        loss_without_aux = trainer_no_aux._compute_loss(
+            trainer_no_aux.model, self._make_inputs()
+        )
+        _, call_kwargs_no_aux = (
+            trainer_no_aux._get_per_token_logps_and_entropies.call_args
+        )
+        self.assertFalse(call_kwargs_no_aux["compute_aux_loss"])
+
+        # router_aux_loss_coef * aux_loss must be added on top of the policy loss
+        self.assertAlmostEqual(
+            (loss_with_aux - loss_without_aux).item(),
+            trainer.router_aux_loss_coef * aux_loss.item(),
+            places=5,
+        )
+        self.assertIn("aux_loss", trainer._metrics["train"])
+        self.assertNotIn("aux_loss", trainer_no_aux._metrics["train"])
+
+    def test_flattened_path_disabled_when_aux_loss_enabled(self):
+        """batch_flattening's fast path can't produce an aux_loss; it must be
+        skipped (not silently drop the MoE loss) whenever aux_loss is needed."""
+        trainer = self._make_trainer(aux_loss_enabled=True, batch_flattening=True)
+        aux_loss = torch.tensor(1.5)
+        trainer._get_per_token_logps_and_entropies = MagicMock(
+            return_value=(torch.zeros(2, 3), torch.zeros(2, 3), aux_loss)
+        )
+        trainer._get_per_token_logps_and_entropies_flattened = MagicMock(
+            side_effect=AssertionError(
+                "flattened path must not be used when aux_loss_enabled"
+            )
+        )
+
+        trainer._compute_loss(trainer.model, self._make_inputs())
+
+        trainer._get_per_token_logps_and_entropies.assert_called_once()
+        trainer._get_per_token_logps_and_entropies_flattened.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/core/test_async_grpo.py
+++ b/tests/core/test_async_grpo.py
@@ -632,15 +632,17 @@ class TestMultimodalTileFieldPropagation(unittest.TestCase):
 
         # One group (num_generations=2) with zero reward variance → "no signal" →
         # triggers replacement from the replay buffer + old_per_token_logps recompute.
+        # 2 samples, uneven tiles-per-sample [2, 3] -> 5 tiles total (LFM2-VL-style).
         data = {
             "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
             "completion_ids": torch.zeros(2, 4, dtype=torch.long),
             "prompt_mask": torch.ones(2, 3, dtype=torch.long),
             "completion_mask": torch.ones(2, 4, dtype=torch.long),
             "old_per_token_logps": torch.zeros(2, 4),
-            "spatial_shapes": torch.zeros(2, 2),
-            "image_position_ids": torch.zeros(2, 5),
             "num_tiles": [2, 3],
+            "pixel_values": torch.zeros(5, 3, 4, 4),
+            "pixel_attention_mask": torch.ones(5, 4, 4),
+            "spatial_shapes": torch.zeros(5, 2),
         }
         rewards_per_func = torch.zeros(2, 1)
         advantages = torch.zeros(2)
@@ -658,7 +660,7 @@ class TestMultimodalTileFieldPropagation(unittest.TestCase):
 
         self.assertIn("spatial_shapes", captured)
         self.assertIn("num_tiles", captured)
-        self.assertIn("image_position_ids", captured)
+        self.assertEqual(captured["num_tiles"], [2, 3])
 
 
 class TestGetPerTokenLogpsMultimodalTailBatch(unittest.TestCase):
@@ -835,6 +837,145 @@ class TestComputeLossAuxLoss(unittest.TestCase):
 
         trainer._get_per_token_logps_and_entropies.assert_called_once()
         trainer._get_per_token_logps_and_entropies_flattened.assert_not_called()
+
+
+class TestSliceMultimodalKwargs(unittest.TestCase):
+    """_slice_multimodal_kwargs must slice image/tile-indexed tensors by
+    cumulative image/tile offset, not by naive sample-range slicing."""
+
+    def test_image_position_ids_path_uses_image_offset_not_sample_offset(self):
+        from axolotl.core.trainers.grpo.fast_async_trainer import (
+            _slice_multimodal_kwargs,
+        )
+
+        # 4 samples, uneven images-per-sample: [1, 2, 1, 1] -> 5 images total
+        num_images = [1, 2, 1, 1]
+        pixel_values = torch.arange(5).float().unsqueeze(1).repeat(1, 3)
+        image_position_ids = torch.arange(5).float().unsqueeze(1).repeat(1, 2)
+        data = {
+            "num_images": num_images,
+            "pixel_values": pixel_values,
+            "image_position_ids": image_position_ids,
+        }
+
+        # samples [1:3) own images at rows [1:4) (sample 0 -> row 0,
+        # sample 1 -> rows 1-2, sample 2 -> row 3) — NOT rows [1:3).
+        out = _slice_multimodal_kwargs(data, 1, 3)
+        self.assertEqual(out["num_images"], [2, 1])
+        torch.testing.assert_close(out["pixel_values"], pixel_values[1:4])
+        torch.testing.assert_close(out["image_position_ids"], image_position_ids[1:4])
+
+    def test_spatial_shapes_path_uses_tile_offset_not_sample_offset(self):
+        from axolotl.core.trainers.grpo.fast_async_trainer import (
+            _slice_multimodal_kwargs,
+        )
+
+        # 3 samples, uneven tiles-per-sample: [2, 1, 3] -> 6 tiles total
+        num_tiles = [2, 1, 3]
+        pixel_values = torch.arange(6).float().unsqueeze(1).repeat(1, 3)
+        spatial_shapes = torch.arange(6).float().unsqueeze(1).repeat(1, 2)
+        pixel_attention_mask = torch.ones(6, 4)
+        data = {
+            "num_tiles": num_tiles,
+            "pixel_values": pixel_values,
+            "spatial_shapes": spatial_shapes,
+            "pixel_attention_mask": pixel_attention_mask,
+        }
+
+        # samples [1:3) own tile rows [2:6), not [1:3)
+        out = _slice_multimodal_kwargs(data, 1, 3)
+        self.assertEqual(out["num_tiles"], [1, 3])
+        torch.testing.assert_close(out["pixel_values"], pixel_values[2:6])
+        torch.testing.assert_close(out["spatial_shapes"], spatial_shapes[2:6])
+        torch.testing.assert_close(
+            out["pixel_attention_mask"], pixel_attention_mask[2:6]
+        )
+
+    def test_sample_indexed_fields_use_plain_sample_slice(self):
+        from axolotl.core.trainers.grpo.fast_async_trainer import (
+            _slice_multimodal_kwargs,
+        )
+
+        data = {
+            "image_sizes": torch.arange(4).unsqueeze(1),
+            "token_type_ids": torch.arange(8).view(4, 2),
+        }
+        out = _slice_multimodal_kwargs(data, 1, 3)
+        torch.testing.assert_close(out["image_sizes"], data["image_sizes"][1:3])
+        torch.testing.assert_close(out["token_type_ids"], data["token_type_ids"][1:3])
+
+
+class TestFastAsyncReplayRecomputeImageOffset(unittest.TestCase):
+    """Regression test for the replay-recompute call site: a replayed group
+    with r_start > 0 must receive the images belonging to *its* samples,
+    not the first N images of the full batch."""
+
+    def test_replay_recompute_uses_correct_image_offset_for_r_start_gt_0(self):
+        from axolotl.core.trainers.grpo.fast_async_trainer import (
+            FastAsyncGRPOTrainer,
+        )
+        from axolotl.core.trainers.grpo.replay_buffer import ReplayBuffer
+
+        trainer = FastAsyncGRPOTrainer.__new__(FastAsyncGRPOTrainer)
+        trainer.model = MagicMock()
+        trainer.model.is_gradient_checkpointing = False
+        trainer.args = types.SimpleNamespace(gradient_checkpointing_kwargs=None)
+        trainer.reward_funcs = [MagicMock()]
+        trainer._replay_recompute_logps = True
+        trainer._replay_buffer = ReplayBuffer(max_size=2)
+        trainer._replay_buffer.add(
+            1.0,
+            {
+                "prompt_ids": torch.zeros(2, 3, dtype=torch.long),
+                "completion_ids": torch.zeros(2, 4, dtype=torch.long),
+                "prompt_mask": torch.ones(2, 3, dtype=torch.long),
+                "completion_mask": torch.ones(2, 4, dtype=torch.long),
+                "old_per_token_logps": torch.zeros(2, 4),
+            },
+        )
+        captured, side_effect = _capture_and_stop()
+        trainer._get_per_token_logps_and_entropies = MagicMock(side_effect=side_effect)
+
+        # 4 samples / 2 groups of num_generations=2. Uneven images-per-sample
+        # [1, 2, 1, 1] -> 5 images total, so a naive data[key][r_start:r_end]
+        # slice would silently return the wrong (group 0's) images.
+        num_images = [1, 2, 1, 1]
+        pixel_values = torch.arange(5).float().unsqueeze(1).repeat(1, 3)
+        image_position_ids = torch.arange(5).float().unsqueeze(1).repeat(1, 2)
+        data = {
+            "prompt_ids": torch.zeros(4, 3, dtype=torch.long),
+            "completion_ids": torch.zeros(4, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(4, 3, dtype=torch.long),
+            "completion_mask": torch.ones(4, 4, dtype=torch.long),
+            "old_per_token_logps": torch.zeros(4, 4),
+            "num_images": num_images,
+            "pixel_values": pixel_values,
+            "image_position_ids": image_position_ids,
+        }
+        # Group 0 (samples 0-1) has reward signal -> kept as-is.
+        # Group 1 (samples 2-3) has zero variance -> replaced from the replay
+        # buffer, triggering recompute for r_start=2, r_end=4.
+        rewards_per_func = torch.tensor([[0.0], [1.0], [0.5], [0.5]])
+        advantages = torch.zeros(4)
+
+        with self.assertRaises(_StopEarly):
+            FastAsyncGRPOTrainer._post_advantage_hook(
+                trainer,
+                data,
+                rewards_per_func,
+                advantages,
+                inputs=[{}, {}, {}, {}],
+                num_generations=2,
+                mode="train",
+            )
+
+        # Samples [2:4) own images at rows [3:5) (sample 0 -> row 0,
+        # sample 1 -> rows 1-2, sample 2 -> row 3, sample 3 -> row 4).
+        self.assertEqual(captured["num_images"], [1, 1])
+        torch.testing.assert_close(captured["pixel_values"], pixel_values[3:5])
+        torch.testing.assert_close(
+            captured["image_position_ids"], image_position_ids[3:5]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/e2e/solo/test_batch_flattening.py
+++ b/tests/e2e/solo/test_batch_flattening.py
@@ -209,7 +209,7 @@ def test_scoring_correctness():
     print(f"  Padding ratio: {1 - total_real / total_padded:.1%}")
 
     with torch.no_grad():
-        logps_pad, _ = trainer._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer._get_per_token_logps_and_entropies(
             model, input_ids, attn_mask, logits_to_keep
         )
         logps_flat = trainer._get_per_token_logps_flattened(
@@ -245,7 +245,7 @@ def test_training_loss_correctness():
 
     # Padded path (with grad)
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        logps_pad, _ = trainer._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer._get_per_token_logps_and_entropies(
             model, input_ids, attn_mask, logits_to_keep
         )
 
@@ -285,13 +285,13 @@ def test_gradient_correctness():
     trainer_pad = make_mock_trainer(model_pad)
 
     with torch.no_grad():
-        old_logps, _ = trainer_pad._get_per_token_logps_and_entropies(
+        old_logps, _, _ = trainer_pad._get_per_token_logps_and_entropies(
             model_pad, input_ids, attn_mask, logits_to_keep
         )
 
     model_pad.zero_grad()
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        logps_pad, _ = trainer_pad._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer_pad._get_per_token_logps_and_entropies(
             model_pad, input_ids, attn_mask, logits_to_keep
         )
     # Simple GRPO-style loss
@@ -388,7 +388,7 @@ def test_variable_completion_lengths():
     print(f"  Padding ratio: {1 - total_real / total_padded:.1%}")
 
     with torch.no_grad():
-        logps_pad, _ = trainer._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer._get_per_token_logps_and_entropies(
             model, input_ids, attn_mask, max_compl
         )
         logps_flat = trainer._get_per_token_logps_flattened(
@@ -454,7 +454,7 @@ def test_prompt_mask_edge_case():
 
     with torch.no_grad():
         # Padded reference (always correct since it uses logits_to_keep slicing)
-        logps_pad, _ = trainer._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer._get_per_token_logps_and_entropies(
             model, input_ids, attention_mask, logits_to_keep
         )
 
@@ -525,7 +525,7 @@ def test_training_flattened_gradients():
     ref_model = setup_model()
     ref_trainer = make_mock_trainer(ref_model)
     with torch.no_grad():
-        old_logps, _ = ref_trainer._get_per_token_logps_and_entropies(
+        old_logps, _, _ = ref_trainer._get_per_token_logps_and_entropies(
             ref_model, input_ids, attn_mask, logits_to_keep
         )
     del ref_model
@@ -538,7 +538,7 @@ def test_training_flattened_gradients():
     trainer_pad = make_mock_trainer(model_pad)
     model_pad.zero_grad()
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        logps_pad, _ = trainer_pad._get_per_token_logps_and_entropies(
+        logps_pad, _, _ = trainer_pad._get_per_token_logps_and_entropies(
             model_pad, input_ids, attn_mask, logits_to_keep
         )
     ratio_pad = torch.exp(logps_pad - old_logps.detach())


### PR DESCRIPTION
… 1.9 signature (#3971)

<!--- Provide a general summary of your changes in the Title above -->

# Description

`AsyncGRPOTrainer._get_per_token_logps_and_entropies` (`src/axolotl/core/trainers/grpo/async_trainer.py`) still had the pre-TRL-1.9 signature: 2 positional/keyword args short (`compute_aux_loss`, `spatial_shapes`, `num_tiles`, `image_position_ids`) and a 2-tuple return instead of a 3-tuple `(logps, entropies, aux_loss)`.

Updated the override to match `trl.GRPOTrainer._get_per_token_logps_and_entropies` (TRL 1.9.0) exactly: added the missing kwargs (including the tile-indexed LFM2-VL branch and MoE `output_router_logits`/`aux_loss` handling), and changed the return type to a 3-tuple. Updated all 8 internal call sites in `async_trainer.py`, `fast_async_trainer.py`, and `tests/e2e/solo/test_batch_flattening.py` to unpack 3 values instead of 2.

## Motivation and Context

Fixes #3971.

When both `use_data_producer: true` and `async_prefetch: true` are set, the first (synchronous warmup) rollout calls TRL's unmodified base `_generate_and_score_completions`, which polymorphically calls `self._get_per_token_logps_and_entropies(...)` with the new TRL 1.9 kwargs. Since axolotl's override didn't accept them, this crashed with:

TypeError: AsyncGRPOTrainer._get_per_token_logps_and_entropies() got an unexpected keyword argument 'num_tiles'


## How has this been tested?

- Verified the new override's signature matches `trl.GRPOTrainer._get_per_token_logps_and_entropies` exactly via `inspect.signature` (same parameter names/order, both return `tuple[Tensor, Tensor | None, Tensor | None]`).
- `pytest tests/core/test_async_grpo.py` and the broader `tests/core/` + `tests/integrations/test_nemo_gym.py` CPU suite: all pass except 2 pre-existing failures unrelated to this change (`ModuleNotFoundError: triton` in this environment, confirmed present on `main` before this change too).
- `tests/e2e/solo/test_batch_flattening.py` (GPU/flash-attn only, not runnable in this environment) collects cleanly (6 tests) after updating its call sites to the new 3-tuple return.
- Ran `pre-commit run --files` (ruff, ruff-format, mypy, bandit at CI-pinned versions) on all 3 changed files — all pass.
- Not tested against a live GRPO run with `use_data_producer` + `async_prefetch` + vLLM server (requires multi-GPU setup).

## AI Usage Disclaimer

Yes Claude Code was used to investigate the issue, implement the fix, and run the test/lint checks described above.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Social Handles (Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved training support for multimodal inputs, including image positions and tile-indexed data.
  * Added optional auxiliary-loss handling for mixture-of-experts models.
  * Enhanced scoring and loss calculations to provide log-probabilities and entropy information.

* **Bug Fixes**
  * Updated asynchronous and replayed training flows to correctly process the expanded scoring results.

* **Tests**
  * Updated batch-flattening coverage for the enhanced training outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->