### PR TITLE
fix(fsdp2): train every LoRA shard under cpu_ram_efficient_loading; init dist before load for EP

### DIFF
--- a/src/axolotl/loaders/model.py
+++ b/src/axolotl/loaders/model.py
@@ -48,6 +48,7 @@ from axolotl.loaders.utils import (
     get_linear_embedding_layers,
     get_module_class_from_name,
     load_model_config,
+    materialize_trainable_meta_params,
 )
 from axolotl.model_support import get_model_support, resolve_model_support
 from axolotl.models.mamba import fix_mamba_attn_for_loss
@@ -58,6 +59,7 @@ from axolotl.utils.distributed import (
     build_parallelism_config,
     get_device_count,
     get_device_type,
+    init_distributed_state,
 )
 from axolotl.utils.fp32_norms import (
     _matches_norm_class,
@@ -201,6 +203,7 @@ class ModelLoader:
         PLUGIN_MANAGER.pre_lora_load(self.cfg, self.model)
         lora_config = self._load_adapters()
         PLUGIN_MANAGER.post_lora_load(self.cfg, self.model)
+        self._materialize_trainable_meta_params()
 
         # Apply remaining patches and finalize
         self._apply_post_lora_load_setup(skip_move_to_device)
@@ -525,6 +528,16 @@ class ModelLoader:
                 )
 
         return lora_config
+
+    def _materialize_trainable_meta_params(self):
+        """Non-rank-0 loads onto meta and PEFT follows the base layer's device; the optimizer is
+        built before `accelerator.prepare`, which remaps its params by `data_ptr()` (0 on meta)."""
+        if (
+            self.cfg.fsdp_config
+            and self.cfg.fsdp_config.cpu_ram_efficient_loading
+            and int(os.getenv("LOCAL_RANK", "0")) != 0
+        ):
+            materialize_trainable_meta_params(self.model)
 
     def _keep_no_placement_params_on_cpu(self):
         """Stop the offloaded ``_no_placement_params`` being pulled back into VRAM.
@@ -956,6 +969,9 @@ class ModelLoader:
         if self.is_fsdp_enabled:
             if self.cfg.fsdp_config.cpu_ram_efficient_loading:
                 skip_move_to_device = True
+                # transformers' non-rank-0 meta gate needs an initialized process group; the
+                # mesh build normally provides one, pure EP builds no mesh (no-op if already up)
+                init_distributed_state()
                 # Don't delete device_map for QLoRA + FSDP - it was set correctly in
                 # _set_device_map
                 if (

--- a/src/axolotl/loaders/utils.py
+++ b/src/axolotl/loaders/utils.py
@@ -228,6 +228,74 @@ def ensure_dtype(model: PreTrainedModel, dtype: torch.dtype = torch.bfloat16):
             module.to(dtype)
 
 
+def _cpu_storage_like(tensor: torch.Tensor) -> torch.Tensor | None:
+    """Real CPU storage matching a plain tensor's shape/dtype, or ``None`` for an opaque subclass."""
+    if type(tensor) not in (torch.Tensor, torch.nn.Parameter):
+        return None
+    try:
+        return torch.zeros_like(tensor, device="cpu")
+    except (NotImplementedError, RuntimeError):
+        # some dtypes (e.g. float4_e2m1fn_x2) have no CPU fill kernel
+        return torch.empty_like(tensor, device="cpu")
+
+
+def materialize_trainable_meta_params(model: torch.nn.Module) -> list[str]:
+    """Gives meta-device trainable params real CPU storage, because accelerate's FSDP2 prepare keys
+    its optimizer parameter remap on `data_ptr()` and every meta tensor reports 0."""
+    from torch.distributed.tensor import DTensor
+
+    replacements: dict[int, torch.nn.Parameter] = {}
+    materialized: list[str] = []
+
+    for name, param in model.named_parameters():
+        if not (param.requires_grad and param.is_meta):
+            continue
+
+        if isinstance(param, DTensor):
+            cpu_local = _cpu_storage_like(param._local_tensor)
+            storage = (
+                None
+                if cpu_local is None
+                else DTensor.from_local(
+                    cpu_local,
+                    param.device_mesh,
+                    param.placements,
+                    run_check=False,
+                    shape=param.shape,
+                    stride=param.stride(),
+                )
+            )
+            kind = f"DTensor over {type(param._local_tensor).__name__}"
+        else:
+            storage = _cpu_storage_like(param)
+            kind = type(param).__name__
+
+        if storage is None:
+            LOG.warning(
+                f"{name} ({kind}) is trainable but on meta and cannot be materialized on "
+                "CPU; accelerate's FSDP2 optimizer remap may not reach it"
+            )
+            continue
+        replacements[id(param)] = torch.nn.Parameter(storage)
+        materialized.append(name)
+
+    if not materialized:
+        return materialized
+
+    # meta -> cpu is not a compatible shallow copy, so `.data =` raises and the object is swapped
+    for module in model.modules():
+        for attr, param in module._parameters.items():
+            if param is not None and id(param) in replacements:
+                module._parameters[attr] = replacements[id(param)]
+
+    LOG.info(
+        f"materialized {len(materialized)} trainable meta params on CPU "
+        "for FSDP2 optimizer mapping"
+    )
+
+    return materialized
+
+
 def get_linear_embedding_layers(model_type: str) -> list[str]:
     """Returns layer names of linear embeddings needed for LoRA based on model type."""
     if model_type == "gpt_neox":

--- a/src/axolotl/loaders/utils.py
+++ b/src/axolotl/loaders/utils.py
@@ -246,6 +246,7 @@ def materialize_trainable_meta_params(model: torch.nn.Module) -> list[str]:
 
     replacements: dict[int, torch.nn.Parameter] = {}
     materialized: list[str] = []
+    skipped: list[str] = []
 
     for name, param in model.named_parameters():
         if not (param.requires_grad and param.is_meta):
@@ -271,13 +272,18 @@ def materialize_trainable_meta_params(model: torch.nn.Module) -> list[str]:
             kind = type(param).__name__
 
         if storage is None:
-            LOG.warning(
-                f"{name} ({kind}) is trainable but on meta and cannot be materialized on "
-                "CPU; accelerate's FSDP2 optimizer remap may not reach it"
-            )
+            skipped.append(f"{name} ({kind})")
             continue
         replacements[id(param)] = torch.nn.Parameter(storage)
         materialized.append(name)
+
+    # only non-rank-0 has anything to do here, where LOG's main-process default drops every line
+    if skipped:
+        LOG.warning(
+            f"{len(skipped)} trainable params are on meta and cannot be materialized on "
+            f"CPU; accelerate's FSDP2 optimizer remap may not reach them: {skipped[:5]}",
+            main_process_only=False,
+        )
 
     if not materialized:
         return materialized
@@ -290,7 +296,8 @@ def materialize_trainable_meta_params(model: torch.nn.Module) -> list[str]:
 
     LOG.info(
         f"materialized {len(materialized)} trainable meta params on CPU "
-        "for FSDP2 optimizer mapping"
+        "for FSDP2 optimizer mapping",
+        main_process_only=False,
     )
 
     return materialized

--- a/src/axolotl/monkeypatch/accelerate/fsdp2.py
+++ b/src/axolotl/monkeypatch/accelerate/fsdp2.py
@@ -789,7 +789,11 @@ def patch_move_missing_keys_meta_for_fsdp():
     Caller MUST restrict this to frozen-base (adapter) runs: leaving base params on meta on
     non-rank-0 deadlocks the FSDP2 optimizer-state all-gather at checkpoint save for a FULL
     fine-tune (rank-0 real DTensors vs non-rank-0 meta). LoRA/qLoRA carry no base optimizer state,
-    so the gather never touches these params."""
+    so the gather never touches these params.
+
+    Trainable params created after the load (the adapters) must NOT stay on meta on non-rank-0 —
+    accelerate keys its FSDP2 optimizer param remap on ``data_ptr()``, which is 0 for every meta
+    tensor; see ``axolotl.loaders.utils.materialize_trainable_meta_params``."""
     from transformers import PreTrainedModel
     from transformers.integrations import (
         is_deepspeed_zero3_enabled,

--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -31,6 +31,7 @@ from axolotl.contribs.lgpl import (  # pylint: disable = no-name-in-module
 )
 from axolotl.integrations.base import PluginManager
 from axolotl.loaders import ModelLoader, load_processor, load_tokenizer
+from axolotl.loaders.utils import materialize_trainable_meta_params
 from axolotl.telemetry.errors import send_errors
 from axolotl.telemetry.manager import TelemetryManager
 from axolotl.utils.ctx_managers.sequence_parallel import SequenceParallelContextManager
@@ -108,6 +109,8 @@ def setup_model_and_tokenizer(
     # Apply freezing if specified
     if cfg.unfrozen_parameters:
         freeze_layers_except(model, cfg.unfrozen_parameters)
+        # unfreezing can promote base params the loader left on meta (non-rank-0) to trainable
+        materialize_trainable_meta_params(model)
         if any(
             any(embed in param for embed in ["lm_head", "embed_tokens"])
             for param in cfg.unfrozen_parameters

--- a/tests/e2e/multigpu/_cpu_ram_efficient_load_probe.py
+++ b/tests/e2e/multigpu/_cpu_ram_efficient_load_probe.py
@@ -1,0 +1,88 @@
+"""Launch-only probe for ``fsdp_config.cpu_ram_efficient_loading``: build the model the way
+``axolotl train`` does but skip dataset preparation, whose rank checks initialize the process
+group as a side effect and would mask a loader that forgets to. Then run the trainer's
+``accelerator.prepare(model, optimizer)`` and record what every rank ends up holding. Dumps
+per-rank facts as JSON to ``$CPU_RAM_LOAD_PROBE_DIR/rank<LOCAL_RANK>.json`` for the outer test.
+
+Usage: ``accelerate launch --num_processes 2 <this file> <config.yaml>``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+
+def _weight_checksums(model: torch.nn.Module) -> list[float]:
+    """Per-param sums of the gathered weights, in ``named_parameters`` order (collective)."""
+    from torch.distributed.tensor import DTensor
+
+    sums = []
+    for name, param in model.named_parameters():
+        # EP-sharded base experts legitimately differ per rank; everything else must match rank 0
+        if ".experts." in name and "lora_" not in name:
+            continue
+        full = param.full_tensor() if isinstance(param, DTensor) else param
+        sums.append(float(full.detach().float().sum()))
+    return sums
+
+
+def main() -> None:
+    from accelerate import Accelerator
+
+    from axolotl.cli.config import load_cfg
+    from axolotl.train import setup_model_and_tokenizer
+
+    cfg = load_cfg(sys.argv[1])
+    dist_initialized_before_load = dist.is_initialized()
+    model, _tokenizer, _peft_config, _processor = setup_model_and_tokenizer(cfg)
+
+    params = list(model.named_parameters())
+    facts = {
+        "local_rank": int(os.environ.get("LOCAL_RANK", "0")),
+        "dist_initialized_before_load": dist_initialized_before_load,
+        "meta_buffers": [n for n, b in model.named_buffers() if b.is_meta],
+        "trainable_meta_params": [
+            n for n, p in params if p.requires_grad and p.is_meta
+        ],
+        "num_meta_params": sum(p.is_meta for _, p in params),
+        "num_params": len(params),
+    }
+
+    # Same order as transformers' Trainer under FSDP2: optimizer first, then prepare both.
+    optimizer = torch.optim.AdamW(
+        [p for p in model.parameters() if p.requires_grad], lr=1e-3
+    )
+    model, optimizer = Accelerator().prepare(model, optimizer)
+
+    slots = [p for group in optimizer.param_groups for p in group["params"]]
+    trainable_ids = {id(p) for p in model.parameters() if p.requires_grad}
+    facts.update(
+        {
+            "optimizer_slots": len(slots),
+            "optimizer_distinct_params": len({id(p) for p in slots}),
+            "optimizer_params_are_model_trainable": {id(p) for p in slots}
+            == trainable_ids,
+            "meta_params_after_prepare": [
+                n for n, p in model.named_parameters() if p.is_meta
+            ],
+            "weight_checksums": _weight_checksums(model),
+        }
+    )
+
+    out_dir = Path(os.environ["CPU_RAM_LOAD_PROBE_DIR"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"rank{facts['local_rank']}.json").write_text(
+        json.dumps(facts, indent=2)
+    )
+    if dist.is_initialized():
+        dist.barrier()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/multigpu/test_fsdp2.py
+++ b/tests/e2e/multigpu/test_fsdp2.py
@@ -1,5 +1,7 @@
 """Test module for FSDP2 multi-GPU functionality."""
 
+import json
+import os
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,7 @@ from transformers.testing_utils import get_torch_dist_unique_port
 from axolotl.utils.dict import DictDefault
 
 from tests.e2e.utils import (
+    check_lora_b_fully_trained,
     check_tensorboard_loss_decreased,
     require_torch_2_7_0,
     requires_flash_attn,
@@ -182,6 +185,301 @@ class TestFSDP2:
         )
 
         verify_training_success(temp_dir)
+        check_lora_b_fully_trained(temp_dir)
+
+    @require_torch_2_7_0
+    @pytest.mark.parametrize(
+        "save_only_model, unfrozen_parameters",
+        [
+            pytest.param(False, None, id="optimizer_state_save"),
+            pytest.param(True, None, id="model_only_save"),
+            # unfreezing runs after the loader; base params it promotes must get storage too
+            pytest.param(
+                False,
+                [".+lora_.+", "^.+layers.0.input_layernorm.weight$"],
+                id="unfrozen_parameters",
+            ),
+        ],
+    )
+    def test_lora_sft_cpu_ram_efficient_loading(
+        self, temp_dir, save_only_model, unfrozen_parameters
+    ):
+        cfg = DictDefault(
+            {
+                "base_model": "axolotl-ai-co/tiny-qwen2-129m",
+                "sequence_len": 2048,
+                "val_set_size": 0.01,
+                "datasets": [
+                    {
+                        "path": "tatsu-lab/alpaca",
+                        "type": "alpaca",
+                        "split": "train[:3%]",
+                    },
+                ],
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.0,
+                "lora_target_linear": True,
+                "num_epochs": 1,
+                "max_steps": 80,
+                "warmup_steps": 5,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-3,
+                "optimizer": "adamw_torch_fused",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "fsdp_version": 2,
+                "fsdp_config": {
+                    "offload_params": False,
+                    "cpu_ram_efficient_loading": True,
+                    "transformer_layer_cls_to_wrap": "Qwen2DecoderLayer",
+                    "state_dict_type": "FULL_STATE_DICT",
+                    "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+                    "reshard_after_forward": True,
+                },
+                "use_tensorboard": True,
+                "seed": 42,
+                "sample_packing": True,
+                "pad_to_sequence_len": True,
+                "bf16": True,
+                "save_only_model": save_only_model,
+                "unfrozen_parameters": unfrozen_parameters,
+                # explicitly disable LORA kernels, as they may be auto-enabled
+                "lora_mlp_kernel": False,
+                "lora_qkv_kernel": False,
+                "lora_o_kernel": False,
+            }
+        )
+
+        # write cfg to yaml file
+        Path(temp_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+            fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+        execute_subprocess_async(
+            [
+                "axolotl",
+                "train",
+                str(Path(temp_dir) / "config.yaml"),
+                "--num-processes",
+                "2",
+                "--main-process-port",
+                f"{get_torch_dist_unique_port()}",
+            ]
+        )
+
+        verify_training_success(temp_dir)
+        check_lora_b_fully_trained(temp_dir)
+
+    @require_torch_2_7_0
+    def test_lora_sft_cpu_ram_efficient_loading_expert_parallel(self, temp_dir):
+        # ep == world_size builds no device mesh, so nothing else initializes the process
+        # group before the load; the loader must do it or non-rank-0 buffers stay on meta
+        cfg = DictDefault(
+            {
+                "base_model": "axolotl-ai-co/tiny-mixtral-30m",
+                "plugins": [
+                    "axolotl.integrations.expert_parallel.ExpertParallelPlugin",
+                ],
+                "expert_parallel_size": 2,
+                "experts_implementation": "grouped_mm",
+                "sequence_len": 1024,
+                "val_set_size": 0.01,
+                "datasets": [
+                    {
+                        "path": "tatsu-lab/alpaca",
+                        "type": "alpaca",
+                        "split": "train[:3%]",
+                    },
+                ],
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.0,
+                "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
+                "lora_target_parameters": [
+                    "mlp.experts.gate_up_proj",
+                    "mlp.experts.down_proj",
+                ],
+                "num_epochs": 1,
+                "max_steps": 80,
+                "warmup_steps": 5,
+                "micro_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-3,
+                "optimizer": "adamw_torch_fused",
+                "lr_scheduler": "cosine",
+                "flash_attention": True,
+                "fsdp_version": 2,
+                "fsdp_config": {
+                    "offload_params": False,
+                    "cpu_ram_efficient_loading": True,
+                    "transformer_layer_cls_to_wrap": "MixtralDecoderLayer",
+                    "state_dict_type": "FULL_STATE_DICT",
+                    "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+                    "reshard_after_forward": True,
+                },
+                "use_tensorboard": True,
+                "seed": 42,
+                "sample_packing": True,
+                "pad_to_sequence_len": True,
+                "bf16": True,
+                # a LoRA-shard regression then fails on the occupancy check, not a save-time hang
+                "save_only_model": True,
+                "lora_mlp_kernel": False,
+                "lora_qkv_kernel": False,
+                "lora_o_kernel": False,
+            }
+        )
+
+        # write cfg to yaml file
+        Path(temp_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+            fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+        execute_subprocess_async(
+            [
+                "axolotl",
+                "train",
+                str(Path(temp_dir) / "config.yaml"),
+                "--num-processes",
+                "2",
+                "--main-process-port",
+                f"{get_torch_dist_unique_port()}",
+            ]
+        )
+
+        verify_training_success(temp_dir)
+        check_lora_b_fully_trained(temp_dir)
+
+    @require_torch_2_7_0
+    @pytest.mark.parametrize(
+        "base_model, layer_cls, expert_parallel",
+        [
+            pytest.param(
+                "axolotl-ai-co/tiny-qwen2-129m", "Qwen2DecoderLayer", False, id="dense"
+            ),
+            pytest.param(
+                "axolotl-ai-co/tiny-mixtral-30m", "MixtralDecoderLayer", False, id="moe"
+            ),
+            # ep == world_size builds no device mesh, so the loader itself must initialize the
+            # process group or transformers leaves non-rank-0 buffers on meta
+            pytest.param(
+                "axolotl-ai-co/tiny-mixtral-30m",
+                "MixtralDecoderLayer",
+                True,
+                id="moe_expert_parallel",
+            ),
+        ],
+    )
+    def test_cpu_ram_efficient_loading_load_probe(
+        self, temp_dir, base_model, layer_cls, expert_parallel
+    ):
+        """Launch-only: load + accelerator.prepare, no dataset prep (its rank checks would
+        initialize the process group first) and no training; asserts every rank holds real
+        storage and the optimizer was remapped onto its own sharded params."""
+        cfg = DictDefault(
+            {
+                "base_model": base_model,
+                "sequence_len": 512,
+                "datasets": [
+                    {
+                        "path": "tatsu-lab/alpaca",
+                        "type": "alpaca",
+                        "split": "train[:1%]",
+                    },
+                ],
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.0,
+                "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
+                "micro_batch_size": 1,
+                "num_epochs": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 1e-3,
+                "fsdp_version": 2,
+                "fsdp_config": {
+                    "offload_params": False,
+                    "cpu_ram_efficient_loading": True,
+                    "transformer_layer_cls_to_wrap": layer_cls,
+                    "state_dict_type": "FULL_STATE_DICT",
+                    "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+                },
+                "bf16": True,
+                "lora_mlp_kernel": False,
+                "lora_qkv_kernel": False,
+                "lora_o_kernel": False,
+            }
+        )
+        if "mixtral" in base_model:
+            cfg["lora_target_parameters"] = [
+                "mlp.experts.gate_up_proj",
+                "mlp.experts.down_proj",
+            ]
+            cfg["experts_implementation"] = "grouped_mm"
+        if expert_parallel:
+            cfg["plugins"] = [
+                "axolotl.integrations.expert_parallel.ExpertParallelPlugin",
+            ]
+            cfg["expert_parallel_size"] = 2
+
+        Path(temp_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(temp_dir) / "config.yaml", "w", encoding="utf-8") as fout:
+            fout.write(yaml.dump(cfg.to_dict(), Dumper=yaml.Dumper))
+
+        probe_dir = Path(temp_dir) / "probe"
+        env = dict(os.environ, CPU_RAM_LOAD_PROBE_DIR=str(probe_dir))
+        execute_subprocess_async(
+            [
+                "accelerate",
+                "launch",
+                "--num_processes",
+                "2",
+                "--main_process_port",
+                f"{get_torch_dist_unique_port()}",
+                str(Path(__file__).parent / "_cpu_ram_efficient_load_probe.py"),
+                str(Path(temp_dir) / "config.yaml"),
+            ],
+            env=env,
+        )
+
+        facts = {
+            rank: json.loads((probe_dir / f"rank{rank}.json").read_text())
+            for rank in (0, 1)
+        }
+        for rank, f in facts.items():
+            assert not f["meta_buffers"], (
+                f"rank {rank} buffers left on meta: {f['meta_buffers']}"
+            )
+            assert not f["trainable_meta_params"], (
+                f"rank {rank} trainable params left on meta: {f['trainable_meta_params']}"
+            )
+            assert not f["meta_params_after_prepare"], (
+                f"rank {rank} params still on meta after prepare: "
+                f"{f['meta_params_after_prepare']}"
+            )
+            # the bug signature: every optimizer slot collapsed onto one param
+            assert f["optimizer_distinct_params"] == f["optimizer_slots"], (
+                f"rank {rank} optimizer holds {f['optimizer_distinct_params']} distinct params "
+                f"across {f['optimizer_slots']} slots; accelerate keyed its FSDP2 remap on "
+                "data_ptr() and meta params collapsed onto one key"
+            )
+            assert f["optimizer_params_are_model_trainable"], (
+                f"rank {rank} optimizer params are not the model's trainable params"
+            )
+            assert f["weight_checksums"] == facts[0]["weight_checksums"], (
+                f"rank {rank} weights differ from rank 0 after the broadcast"
+            )
+        assert facts[0]["num_meta_params"] == 0
+        # the non-rank-0 base model must still be on meta, or the CPU-RAM saving is gone
+        assert 0 < facts[1]["num_meta_params"] < facts[1]["num_params"]
+        # the probe only proves anything if nothing else initialized the process group first
+        assert not facts[1]["dist_initialized_before_load"]
 
     @require_torch_2_7_0
     def test_lora_sft_kernels(self, temp_dir):

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 import torch
 from packaging import version
+from safetensors.torch import load_file
 from tbparse import SummaryReader
 
 from axolotl.utils.dict import DictDefault
@@ -337,3 +338,28 @@ def check_model_output_exists(temp_dir: str, cfg: DictDefault) -> None:
         assert (Path(temp_dir) / "model.safetensors").exists()
     else:
         assert (Path(temp_dir) / "adapter_model.safetensors").exists()
+
+
+def check_lora_b_fully_trained(temp_dir: str) -> None:
+    """Assert every row of every saved ``lora_B`` was trained.
+
+    ``lora_B`` starts at exactly zero, so a row that is still all-zero was never stepped.
+    Under FSDP each rank owns a contiguous row slice, so a partially trained adapter shows
+    up as an occupancy fraction of exactly ``1/world_size``.
+    """
+    adapter_path = Path(temp_dir) / "adapter_model.safetensors"
+    adapter = load_file(str(adapter_path))
+
+    lora_b_keys = [key for key in adapter if "lora_B" in key]
+    assert lora_b_keys, (
+        f"No lora_B tensors found in {adapter_path} - the occupancy check below would "
+        f"pass vacuously. Keys present: {sorted(adapter)[:10]}"
+    )
+
+    for key in lora_b_keys:
+        tensor = adapter[key]
+        occupancy = (tensor != 0).any(dim=1).float().mean().item()
+        assert occupancy == 1.0, (
+            f"{key}: only {occupancy} of rows are nonzero, expected 1.0 - "
+            f"a 1/world_size occupancy means only rank 0's FSDP shard was trained"
+        )

--- a/tests/loaders/test_materialize_trainable_meta_params.py
+++ b/tests/loaders/test_materialize_trainable_meta_params.py
@@ -8,7 +8,6 @@ optimizer slot collapses onto one param and their LoRA shards never get stepped,
 exactly ``1/world_size`` of each ``lora_B``'s rows nonzero in the saved adapter.
 """
 
-import logging
 import os
 import types
 from unittest.mock import patch
@@ -149,32 +148,24 @@ class TestMaterializeDTensorParams:
         assert keys["sharded"] != 0
 
 
-def test_unsupported_tensor_subclass_is_skipped_and_warned(caplog):
-    # axolotl's LOG propagates to the root logger, so caplog sees it directly; fall
-    # back to patching LOG.warning if a future logging change breaks that propagation.
+def test_unsupported_tensor_subclass_is_skipped_and_warned():
     model = torch.nn.Module()
     model.packed = _Packed(torch.empty(2, 2, device="meta"))
     assert model.packed.requires_grad
     assert model.packed.is_meta
 
-    with caplog.at_level(logging.WARNING, logger="axolotl.loaders.utils"):
+    with patch.object(utils_mod.LOG, "warning") as mock_warning:
         materialized = materialize_trainable_meta_params(model)
 
     assert materialized == []
     assert model.packed.is_meta
     assert type(model.packed) is _Packed
 
-    if caplog.records:
-        messages = [r.getMessage() for r in caplog.records]
-        assert any("packed" in m and "_Packed" in m for m in messages)
-    else:
-        with patch.object(utils_mod.LOG, "warning") as mock_warning:
-            model2 = torch.nn.Module()
-            model2.packed = _Packed(torch.empty(2, 2, device="meta"))
-            materialize_trainable_meta_params(model2)
-            mock_warning.assert_called_once()
-            message = mock_warning.call_args[0][0]
-            assert "packed" in message and "_Packed" in message
+    mock_warning.assert_called_once()
+    message = mock_warning.call_args[0][0]
+    assert "packed" in message and "_Packed" in message
+    # the helper only runs on non-rank-0, so the main-process default would drop this
+    assert mock_warning.call_args[1]["main_process_only"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/loaders/test_materialize_trainable_meta_params.py
+++ b/tests/loaders/test_materialize_trainable_meta_params.py
@@ -1,0 +1,218 @@
+"""Regression tests for ``materialize_trainable_meta_params``.
+
+With ``fsdp_config.cpu_ram_efficient_loading`` under LoRA, non-rank-0 base params stay on
+meta and PEFT lands the freshly created adapter params there too. accelerate's
+``Accelerator._prepare_fsdp2`` then remaps the optimizer's params onto the new sharded
+DTensors by ``data_ptr()``, and every meta tensor reports 0 — so on those ranks every
+optimizer slot collapses onto one param and their LoRA shards never get stepped, leaving
+exactly ``1/world_size`` of each ``lora_B``'s rows nonzero in the saved adapter.
+"""
+
+import logging
+import os
+import types
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+from accelerate import Accelerator
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
+
+import axolotl.loaders.utils as utils_mod
+from axolotl.loaders.utils import materialize_trainable_meta_params
+
+
+class _MixedDeviceModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.trainable_meta = torch.nn.Parameter(torch.empty(4, 3, device="meta"))
+        self.frozen_meta = torch.nn.Parameter(
+            torch.empty(4, 3, device="meta"), requires_grad=False
+        )
+        self.trainable_cpu = torch.nn.Parameter(torch.randn(4, 3))
+
+
+class _NestedMetaAdapter(torch.nn.Module):
+    """Nested like a real PEFT adapter: the params hang off submodules, not the root."""
+
+    def __init__(self):
+        super().__init__()
+        self.lora_A = torch.nn.Linear(4, 8, bias=False, device="meta")
+        self.lora_B = torch.nn.Linear(8, 4, bias=False, device="meta")
+
+
+class _Packed(torch.nn.Parameter):
+    """Stand-in for an opaque tensor subclass (bnb Params4bit, torchao NVFP4Tensor, ...)."""
+
+
+class _DTensorModel(torch.nn.Module):
+    def __init__(self, mesh):
+        super().__init__()
+        local = torch.empty(4, 3, device="meta")
+        dtensor = DTensor.from_local(local, mesh, [Shard(0)], run_check=False)
+        self.sharded = torch.nn.Parameter(dtensor)
+
+
+def _accelerate_data_ptr_keys(model: torch.nn.Module) -> dict[str, int]:
+    return Accelerator._get_named_parameters(  # pylint: disable=protected-access
+        types.SimpleNamespace(fp8_backend=None), model, drop_refs=True
+    )
+
+
+def test_materializes_trainable_meta_params_only():
+    model = _MixedDeviceModel()
+    cpu_param = model.trainable_cpu
+    cpu_data_ptr = model.trainable_cpu.data_ptr()
+
+    materialized = materialize_trainable_meta_params(model)
+
+    assert materialized == ["trainable_meta"]
+    assert model.trainable_meta.device.type == "cpu"
+    assert not model.trainable_meta.is_meta
+    assert torch.equal(model.trainable_meta.detach(), torch.zeros(4, 3))
+    assert model.trainable_meta.requires_grad
+
+    # frozen base params staying on meta is the CPU-RAM saving this whole path exists for
+    assert model.frozen_meta.is_meta
+    assert not model.frozen_meta.requires_grad
+
+    assert model.trainable_cpu is cpu_param
+    assert model.trainable_cpu.data_ptr() == cpu_data_ptr
+
+
+def test_second_call_is_a_no_op():
+    model = _MixedDeviceModel()
+
+    assert materialize_trainable_meta_params(model) == ["trainable_meta"]
+    assert materialize_trainable_meta_params(model) == []
+
+
+def test_data_ptr_keys_collide_on_meta_and_separate_after():
+    """Pins the accelerate mechanism the helper works around."""
+    model = _NestedMetaAdapter()
+
+    before = _accelerate_data_ptr_keys(model)
+    assert before["lora_A.weight"] == before["lora_B.weight"] == 0, (
+        "accelerate's Accelerator._prepare_fsdp2 keys its FSDP2 optimizer param remap on "
+        f"data_ptr(), and every meta tensor reports 0 — got {before}. If this assertion "
+        "fails, accelerate fixed the collision upstream and "
+        "materialize_trainable_meta_params may be droppable."
+    )
+
+    assert sorted(materialize_trainable_meta_params(model)) == [
+        "lora_A.weight",
+        "lora_B.weight",
+    ]
+
+    after = _accelerate_data_ptr_keys(model)
+    assert after["lora_A.weight"] != after["lora_B.weight"], (
+        "each trainable param needs its own data_ptr() once materialized on CPU — "
+        f"got {after}. accelerate's data_ptr-keyed FSDP2 optimizer remap otherwise maps "
+        "every slot onto the same param and those ranks' LoRA shards are never stepped."
+    )
+    assert 0 not in after.values()
+
+
+class TestMaterializeDTensorParams:
+    """Single-process gloo mesh, like TestShardingSingleRank in test_expert_parallel.py."""
+
+    def setup_method(self):
+        if not dist.is_initialized():
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "29561")
+            os.environ.setdefault("RANK", "0")
+            os.environ.setdefault("WORLD_SIZE", "1")
+            dist.init_process_group(backend="gloo", rank=0, world_size=1)
+
+    def teardown_method(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_materializes_dtensor_local_shard_in_place(self):
+        mesh = init_device_mesh("cpu", (1,))
+        model = _DTensorModel(mesh)
+        placements_before = model.sharded.placements
+        mesh_before = model.sharded.device_mesh
+
+        materialized = materialize_trainable_meta_params(model)
+
+        assert materialized == ["sharded"]
+        assert isinstance(model.sharded, DTensor)
+        assert not model.sharded.is_meta
+        assert model.sharded.placements == placements_before
+        assert model.sharded.device_mesh is mesh_before
+        assert model.sharded._local_tensor.device.type == "cpu"
+
+        keys = _accelerate_data_ptr_keys(model)
+        assert keys["sharded"] != 0
+
+
+def test_unsupported_tensor_subclass_is_skipped_and_warned(caplog):
+    # axolotl's LOG propagates to the root logger, so caplog sees it directly; fall
+    # back to patching LOG.warning if a future logging change breaks that propagation.
+    model = torch.nn.Module()
+    model.packed = _Packed(torch.empty(2, 2, device="meta"))
+    assert model.packed.requires_grad
+    assert model.packed.is_meta
+
+    with caplog.at_level(logging.WARNING, logger="axolotl.loaders.utils"):
+        materialized = materialize_trainable_meta_params(model)
+
+    assert materialized == []
+    assert model.packed.is_meta
+    assert type(model.packed) is _Packed
+
+    if caplog.records:
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("packed" in m and "_Packed" in m for m in messages)
+    else:
+        with patch.object(utils_mod.LOG, "warning") as mock_warning:
+            model2 = torch.nn.Module()
+            model2.packed = _Packed(torch.empty(2, 2, device="meta"))
+            materialize_trainable_meta_params(model2)
+            mock_warning.assert_called_once()
+            message = mock_warning.call_args[0][0]
+            assert "packed" in message and "_Packed" in message
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bfloat16,
+        torch.float16,
+        torch.float8_e4m3fn,
+        torch.float8_e8m0fnu,
+    ],
+)
+def test_dtype_is_preserved(dtype):
+    model = torch.nn.Module()
+    model.p = torch.nn.Parameter(
+        torch.empty(4, 3, device="meta", dtype=dtype), requires_grad=True
+    )
+
+    materialized = materialize_trainable_meta_params(model)
+
+    assert materialized == ["p"]
+    assert model.p.device.type == "cpu"
+    assert model.p.dtype == dtype
+    assert model.p.data_ptr() != 0
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float4_e2m1fn_x2"), reason="torch build lacks float4_e2m1fn_x2"
+)
+def test_fp4_dtype_falls_back_to_empty_like():
+    model = torch.nn.Module()
+    model.p = torch.nn.Parameter(
+        torch.empty(4, 3, device="meta", dtype=torch.float4_e2m1fn_x2),
+        requires_grad=True,
+    )
+
+    materialized = materialize_trainable_meta_params(model)
+
+    assert materialized == ["p"]
+    assert model.p.device.type == "cpu"
+    assert model.p.dtype == torch.float4_e2m1fn_x2
+    assert model.p.data_ptr() != 0


### PR DESCRIPTION
# Description

Fixes #3772 (#3779 did not properly fix this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FSDP2 CPU-efficient model loading across distributed ranks.
  * Ensured trainable parameters are correctly initialized before optimizer setup, including adapter and selectively unfrozen parameters.
  * Improved compatibility with expert-parallel training and varied tensor data types.

* **Tests**
  * Added coverage for distributed loading, optimizer setup, adapter training, and parameter materialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->