### PR TITLE
docs: document S3-compatible endpoints for dataset loading

### DIFF
--- a/docs/dataset_loading.qmd
+++ b/docs/dataset_loading.qmd
@@ -204,6 +204,18 @@ We assume you have credentials setup and not using anonymous access. If you want
 
 Other environment variables that can be set can be found in [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables)
 
+#### S3-compatible endpoints
+
+Keep the `s3://` prefix and set `AWS_ENDPOINT_URL` to the store's endpoint. Works with MinIO, [Tigris](https://www.tigrisdata.com), Cloudflare R2, and other S3-compatible stores.
+
+Example for Tigris:
+
+```bash
+export AWS_ENDPOINT_URL=https://t3.storage.dev
+export AWS_ACCESS_KEY_ID=tid_your_access_key_id
+export AWS_SECRET_ACCESS_KEY=tsec_your_secret_access_key
+```
+
 #### GCS
 
 Prepend the path with `gs://` or `gcs://`.

--- a/docs/dataset_loading.qmd
+++ b/docs/dataset_loading.qmd
@@ -206,14 +206,10 @@ Other environment variables that can be set can be found in [boto3 docs](https:/
 
 #### S3-compatible endpoints
 
-Keep the `s3://` prefix and set `AWS_ENDPOINT_URL` to the store's endpoint. Works with MinIO, [Tigris](https://www.tigrisdata.com), Cloudflare R2, and other S3-compatible stores.
-
-Example for Tigris:
-
 ```bash
-export AWS_ENDPOINT_URL=https://t3.storage.dev
-export AWS_ACCESS_KEY_ID=tid_your_access_key_id
-export AWS_SECRET_ACCESS_KEY=tsec_your_secret_access_key
+export AWS_ENDPOINT_URL=
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
 ```
 
 #### GCS


### PR DESCRIPTION
Description
Adds a short "S3-compatible endpoints" subsection to docs/dataset_loading.qmd explaining that setting AWS_ENDPOINT_URL lets you load datasets from MinIO, Tigris, Cloudflare R2, or any other S3-compatible store. Includes a Tigris example.

Why?
dataset_loading.qmd documents S3, GCS, Azure, OCI, and HTTPS but doesn't mention S3-compatible object stores. Users on MinIO / Tigris / R2 currently have to figure out that s3fs respects AWS_ENDPOINT_URL via boto3 themselves.

How has this been tested?
Docs-only change; no code paths modified. Content was reviewed by a human and fact-checked before submission.

@davidmyriel co-author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for loading datasets from S3-compatible storage endpoints.
  * Documented endpoint configuration using `AWS_ENDPOINT_URL` while retaining the `s3://` path format.
  * Included an example using Tigris credentials and noted compatibility with MinIO, Cloudflare R2, and similar services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->