### PR TITLE
fix: nightly test failing (fla bump, kernel nightly install, peft api change)

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Override with nightly HF packages
         run: |
-          uv pip install "kernels>=0.15.2,<0.16"
           uv pip install --no-deps \
+            "kernels @ git+https://github.com/huggingface/kernels.git@main#subdirectory=kernels" \
             "transformers @ git+https://github.com/huggingface/transformers.git@main" \
             "peft @ git+https://github.com/huggingface/peft.git@main" \
             "accelerate @ git+https://github.com/huggingface/accelerate.git@main" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ dependencies = [
     "torchao==0.17.0 ; sys_platform != 'darwin' and platform_machine != 'aarch64'",
 
     # Architecture-specific
-    "fla-core==0.4.1 ; platform_machine != 'aarch64'",
-    "flash-linear-attention==0.4.1 ; platform_machine != 'aarch64'",
+    "fla-core==0.5.2 ; platform_machine != 'aarch64'",
+    "flash-linear-attention==0.5.2 ; platform_machine != 'aarch64'",
 ]
 
 [project.optional-dependencies]

--- a/src/axolotl/monkeypatch/moe_quant.py
+++ b/src/axolotl/monkeypatch/moe_quant.py
@@ -184,6 +184,7 @@ def patch_peft_target_parameters_matching():
     ):
         original_targets = list(peft_config.target_parameters)
         expanded = set(original_targets)
+        targeted_parameter_names: list[str] = []
 
         # Expand short suffixes to full paths for parametrized modules.
         for module_name, module in model.named_modules():
@@ -286,7 +287,7 @@ def patch_peft_target_parameters_matching():
                         key.endswith(f".{t}") for t in target_names_set
                     ):
                         create_and_replace_param(module_name, key, param_name)
-                        self.targeted_parameter_names.append(key)
+                        targeted_parameter_names.append(key)
             else:
                 unwrapped_module_name = strip_base_layer_from_name(module_name)
                 for param_name, _ in module.named_parameters(recurse=False):
@@ -295,7 +296,11 @@ def patch_peft_target_parameters_matching():
                         key.endswith(f".{t}") for t in target_names_set
                     ):
                         create_and_replace_param(module_name, key, param_name)
-                        self.targeted_parameter_names.append(key)
+                        targeted_parameter_names.append(key)
+
+        # PEFT <=0.20 reads the attribute, newer PEFT uses the return value.
+        self.targeted_parameter_names.extend(targeted_parameter_names)
+        return targeted_parameter_names
 
     BaseTuner._inject_parameters = _patched_inject_parameters
 

--- a/tests/core/test_builders_rl.py
+++ b/tests/core/test_builders_rl.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from datasets import Dataset
@@ -140,7 +140,9 @@ def rand_reward_func(prompts, completions) -> list[float]:
         try:
             builder = HFRLTrainerBuilder(grpo_cfg, model, tokenizer)
             training_arguments, _ = builder._build_training_arguments(100)
-            builder.train_dataset = MagicMock()
+            builder.train_dataset = Dataset.from_dict(
+                {"prompt": [[{"role": "user", "content": "Question?"}]] * 8}
+            )
 
             self._test_common_training_arguments(training_arguments, rl=grpo_cfg.rl)
             # GRPO specific

--- a/tests/monkeypatch/test_qwen4_exp_modeling_patch.py
+++ b/tests/monkeypatch/test_qwen4_exp_modeling_patch.py
@@ -10,6 +10,25 @@ from transformers.models.qwen4_exp.configuration_qwen4_exp import (  # noqa: E40
     Qwen4ExpTextConfig,
 )
 
+
+def _torch_reference(dispatcher):
+    """Unwrap a transformers hub-kernel ``Func`` back to its torch implementation."""
+    (cell,) = type(dispatcher).forward.__closure__
+    return cell.cell_contents.__wrapped__
+
+
+@pytest.fixture(autouse=True)
+def _torch_gated_delta_rule(monkeypatch):
+    """Keep the stock forward on torch: fla's kernels need a GPU.
+
+    transformers resolves these kernels at import time on package availability alone,
+    with no device check, so a CPU runner with flash-linear-attention installed
+    dispatches into Triton and dies.
+    """
+    for name in ("torch_chunk_gated_delta_rule", "torch_recurrent_gated_delta_rule"):
+        monkeypatch.setattr(qwen4_exp, name, _torch_reference(getattr(qwen4_exp, name)))
+
+
 HIDDEN = 32
 INDEX_HEAD_DIM = 16
 DOC_LENS = [7, 11, 5]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

We have a few nightly test failing https://github.com/axolotl-ai-cloud/axolotl/actions/runs/33823250877/job/100870338475

- FLA got nested imported upstream in main transformers. This breaks on our current FLA version. This bump should contain their latest change which has a guard.
- Kernel nightly had a hardcoded range which was wrong
- PEFT contract change for target parameters. Made BC now.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## AI Usage Disclaimer

<!--- Was AI (e.g., ChatGPT, Claude, Copilot) used to generate or assist with this PR? -->
<!--- Please indicate: No / Yes (specify which tool and to what extent) -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

## Social Handles (Optional)

<!-- Thanks for submitting a bugfix or enhancement. -->
<!-- We'd love to show our thanks to you on Twitter & Discord if you provide your handle -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with updated machine-learning tooling and nightly package versions.
  - Enhanced parameter handling across supported training configurations, including compatibility with multiple PEFT versions.

- **Tests**
  - Strengthened reinforcement learning workflow validation using realistic conversational training data.
  - Updated nightly test coverage to validate the latest development packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->