### PR TITLE
fix(trainer): stop forcing model_accepts_loss_kwargs=False for every model (breaks gradient accumulation)

### DIFF
--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -111,22 +111,36 @@ class AxolotlTrainer(
         super().__init__(*_args, **kwargs)
 
         # Gemma4 (and similar multimodal models) declare **kwargs in forward() for
-        # extra inputs like mm_token_type_ids.  HF Trainer interprets VAR_KEYWORD as
-        # "the model handles num_items_in_batch internally" and skips the loss ÷
-        # gradient_accumulation_steps normalisation, which inflates the *logged* loss
-        # (the gradient itself is still correct). Override to False when the model
-        # doesn't actually consume num_items_in_batch.
+        # extra inputs like mm_token_type_ids. HF Trainer interprets VAR_KEYWORD as
+        # "the model handles num_items_in_batch internally". Override to False only
+        # when the model's loss really does not consume num_items_in_batch.
+        #
+        # Setting this flag False is not cosmetic: transformers then skips counting
+        # items per accumulation window, each micro-batch loss becomes a mean over
+        # its own supervised tokens, and the step reduces to a mean of micro-batch
+        # means rather than (sum of token losses / total tokens). When micro-batches
+        # carry different numbers of supervised tokens the gradient direction moves,
+        # not just the logged loss.
         if self.model_accepts_loss_kwargs:
             model_to_check = self.accelerator.unwrap_model(self.model)
-            if hasattr(model_to_check, "base_model"):  # PEFT wrapper
-                model_to_check = model_to_check.base_model
-            if hasattr(model_to_check, "model"):
-                model_to_check = model_to_check.model
-            fwd = getattr(model_to_check, "forward", None)
-            if fwd is not None:
+            # Unwrap PEFT explicitly. Do NOT walk `.base_model` / `.model`
+            # generically: `base_model` is a property on every PreTrainedModel
+            # (it returns `getattr(self, self.base_model_prefix, self)`), so the
+            # old walk descended from LlamaForCausalLM into LlamaModel, i.e. the
+            # module that never computes the loss at all.
+            if hasattr(model_to_check, "get_base_model"):
+                model_to_check = model_to_check.get_base_model()
+
+            # `num_items_in_batch` is consumed by the model's loss_function, not
+            # named in forward() (forward takes it via **kwargs). Inspecting
+            # forward() therefore never finds it and forced the flag to False for
+            # every model, silently reverting the transformers>=4.46 gradient
+            # accumulation fix back to a mean-of-micro-batch-means.
+            loss_fn = getattr(model_to_check, "loss_function", None)
+            if loss_fn is not None:
                 import inspect
 
-                params = inspect.signature(fwd).parameters
+                params = inspect.signature(loss_fn).parameters
                 if "num_items_in_batch" not in params:
                     self.model_accepts_loss_kwargs = False
 

--- a/src/axolotl/core/trainers/base.py
+++ b/src/axolotl/core/trainers/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import gc
+import inspect
 import json
 import math
 import os
@@ -61,6 +62,36 @@ from axolotl.utils.samplers import MultipackBatchSampler, get_dataset_lengths
 from axolotl.utils.schemas.fp8 import DEFAULT_FP8_RECIPE
 
 LOG = get_logger(__name__)
+
+
+def model_loss_accepts_num_items_in_batch(model) -> bool:
+    """Whether ``model``'s loss function consumes ``num_items_in_batch``.
+
+    ``num_items_in_batch`` is a parameter of the model's ``loss_function``; it is
+    never named in ``forward()``, which receives it through ``**kwargs``. Inspecting
+    ``forward()`` therefore never finds it.
+
+    PEFT wrappers are unwrapped via ``get_base_model()``. We deliberately do not walk
+    ``.base_model`` / ``.model`` generically: ``base_model`` is a property on every
+    ``PreTrainedModel`` (it returns ``getattr(self, self.base_model_prefix, self)``),
+    so such a walk descends from e.g. ``LlamaForCausalLM`` into ``LlamaModel``, the
+    module that never computes a loss at all.
+    """
+    if hasattr(model, "get_base_model"):
+        model = model.get_base_model()
+
+    loss_fn = getattr(model, "loss_function", None)
+    if loss_fn is None:
+        return True
+
+    try:
+        params = inspect.signature(loss_fn).parameters
+    except (TypeError, ValueError):
+        # Un-introspectable callable: leave the transformers default alone.
+        return True
+
+    return "num_items_in_batch" in params
+
 
 REDUCTION_FNS = {
     "mean": torch.mean,
@@ -123,26 +154,8 @@ class AxolotlTrainer(
         # not just the logged loss.
         if self.model_accepts_loss_kwargs:
             model_to_check = self.accelerator.unwrap_model(self.model)
-            # Unwrap PEFT explicitly. Do NOT walk `.base_model` / `.model`
-            # generically: `base_model` is a property on every PreTrainedModel
-            # (it returns `getattr(self, self.base_model_prefix, self)`), so the
-            # old walk descended from LlamaForCausalLM into LlamaModel, i.e. the
-            # module that never computes the loss at all.
-            if hasattr(model_to_check, "get_base_model"):
-                model_to_check = model_to_check.get_base_model()
-
-            # `num_items_in_batch` is consumed by the model's loss_function, not
-            # named in forward() (forward takes it via **kwargs). Inspecting
-            # forward() therefore never finds it and forced the flag to False for
-            # every model, silently reverting the transformers>=4.46 gradient
-            # accumulation fix back to a mean-of-micro-batch-means.
-            loss_fn = getattr(model_to_check, "loss_function", None)
-            if loss_fn is not None:
-                import inspect
-
-                params = inspect.signature(loss_fn).parameters
-                if "num_items_in_batch" not in params:
-                    self.model_accepts_loss_kwargs = False
+            if not model_loss_accepts_num_items_in_batch(model_to_check):
+                self.model_accepts_loss_kwargs = False
 
         self.train_data_collator = self.data_collator
         self._tkps_prev_trainable: float | None = None

--- a/tests/core/trainers/test_loss_kwargs_detection.py
+++ b/tests/core/trainers/test_loss_kwargs_detection.py
@@ -11,6 +11,7 @@ from transformers.loss.loss_utils import (
     ForTokenClassification,
 )
 
+from axolotl.core.trainers import base as base_module
 from axolotl.core.trainers.base import model_loss_accepts_num_items_in_batch
 
 
@@ -101,8 +102,20 @@ class TestDetection:
 
         assert model_loss_accepts_num_items_in_batch(Model()) is True
 
-    def test_uninspectable_loss_left_alone(self):
+    @pytest.mark.parametrize("exc", [ValueError, TypeError])
+    def test_uninspectable_loss_left_alone(self, monkeypatch, exc):
+        """The fallback for a callable whose signature cannot be retrieved.
+
+        Which builtins expose a signature varies by CPython version, so rather
+        than pick one and hope, force the failure the fallback exists for.
+        """
+
+        def raises(*_args, **_kwargs):
+            raise exc("no signature found")
+
+        monkeypatch.setattr(base_module.inspect, "signature", raises)
+
         class Model:
-            loss_function = print  # builtin, no retrievable signature
+            loss_function = staticmethod(ForCausalLMLoss)
 
         assert model_loss_accepts_num_items_in_batch(Model()) is True

--- a/tests/core/trainers/test_loss_kwargs_detection.py
+++ b/tests/core/trainers/test_loss_kwargs_detection.py
@@ -1,0 +1,108 @@
+"""Tests for detection of whether a model's loss consumes ``num_items_in_batch``."""
+
+# pylint: disable=missing-class-docstring,too-few-public-methods
+
+import inspect
+
+import pytest
+from transformers.loss.loss_utils import (
+    ForCausalLMLoss,
+    ForSequenceClassificationLoss,
+    ForTokenClassification,
+)
+
+from axolotl.core.trainers.base import model_loss_accepts_num_items_in_batch
+
+
+class TestRealTransformersLossSignatures:
+    """Pin the upstream signatures the detection depends on.
+
+    If transformers changes which losses take ``num_items_in_batch`` these fail
+    loudly, which is the intent: the detection would then be making the wrong
+    call for those model types and needs revisiting.
+    """
+
+    def test_causal_lm_loss_takes_num_items_in_batch(self):
+        params = inspect.signature(ForCausalLMLoss).parameters
+        assert "num_items_in_batch" in params
+
+    @pytest.mark.parametrize(
+        "loss_fn", [ForSequenceClassificationLoss, ForTokenClassification]
+    )
+    def test_non_causal_losses_do_not_take_num_items_in_batch(self, loss_fn):
+        params = inspect.signature(loss_fn).parameters
+        assert "num_items_in_batch" not in params
+
+
+class TestDetection:
+    def test_causal_lm_loss_is_accepted(self):
+        class Model:
+            loss_function = staticmethod(ForCausalLMLoss)
+
+        assert model_loss_accepts_num_items_in_batch(Model()) is True
+
+    @pytest.mark.parametrize(
+        "loss_fn", [ForSequenceClassificationLoss, ForTokenClassification]
+    )
+    def test_losses_without_the_kwarg_are_forced_off(self, loss_fn):
+        """The case the maintainer asked about.
+
+        A sequence- or token-classification model's loss genuinely does not take
+        ``num_items_in_batch``, so the flag must be forced False for it.
+        """
+
+        class Model:
+            loss_function = staticmethod(loss_fn)
+
+        assert model_loss_accepts_num_items_in_batch(Model()) is False
+
+    def test_peft_wrapper_is_unwrapped(self):
+        class Inner:
+            loss_function = staticmethod(ForSequenceClassificationLoss)
+
+        class PeftLike:
+            # A PEFT wrapper's own loss_function would resolve to the causal
+            # default; only the wrapped model's loss is authoritative.
+            loss_function = staticmethod(ForCausalLMLoss)
+
+            def get_base_model(self):
+                return Inner()
+
+        assert model_loss_accepts_num_items_in_batch(PeftLike()) is False
+
+    def test_does_not_descend_through_base_model_property(self):
+        """Regression test for the bug this replaced.
+
+        ``base_model`` is a property on every ``PreTrainedModel``, so walking
+        ``.base_model`` / ``.model`` generically descended from the causal-LM
+        head into the bare backbone, which has no loss at all, and the flag was
+        forced False for every model.
+        """
+
+        class Backbone:
+            """Stands in for e.g. LlamaModel: computes no loss."""
+
+        class CausalLM:
+            loss_function = staticmethod(ForCausalLMLoss)
+
+            @property
+            def base_model(self):
+                return Backbone()
+
+            @property
+            def model(self):
+                return Backbone()
+
+        assert model_loss_accepts_num_items_in_batch(CausalLM()) is True
+
+    def test_model_without_loss_function_left_alone(self):
+        class Model:
+            pass
+
+        assert model_loss_accepts_num_items_in_batch(Model()) is True
+
+    def test_uninspectable_loss_left_alone(self):
+        class Model:
+            loss_function = print  # builtin, no retrievable signature
+
+        assert model_loss_accepts_num_items_in_batch(Model()) is True


### PR DESCRIPTION
## What

`AxolotlTrainer.__init__` (`src/axolotl/core/trainers/base.py`, L113-131) tries to detect whether the model's `forward()` accepts `num_items_in_batch`, and sets `self.model_accepts_loss_kwargs = False` if it does not. The detection can never succeed, so the flag is forced `False` for essentially every model, silently reverting the transformers >= 4.46 gradient accumulation fix.

Two independent reasons the check cannot pass:

**1. `base_model` is not PEFT-only.** The code walks `.base_model` to unwrap PEFT. But `base_model` is a property on *every* `PreTrainedModel`:

```python
@property
def base_model(self) -> nn.Module:
    return getattr(self, self.base_model_prefix, self)
```

So for a plain `LlamaForCausalLM` the walk descends into `LlamaModel`, the inner module that never computes a loss.

**2. `num_items_in_batch` is not a named parameter of `forward()`.** It arrives through `**kwargs` and is consumed by `self.loss_function` (`ForCausalLMLoss`). So even on the right module, `inspect.signature(forward)` never lists it.

Net effect: the condition is unsatisfiable, the flag goes `False`, transformers stops counting items per accumulation window, and each micro-batch loss becomes a mean over its own supervised tokens. The optimizer step then computes a **mean of micro-batch means** instead of `sum(token losses) / total supervised tokens`.

## The in-code comment is not correct

The comment being replaced says the mis-normalisation inflates the *logged* loss and that "the gradient itself is still correct". Measured directly on `HuggingFaceM4/tiny-random-LlamaForCausalLM`, `gradient_accumulation_steps=2`, comparing the accumulated gradient against the correctly token-weighted gradient:

| supervised tokens per micro-batch | cosine(grad, correct) | grad norm ratio |
|---|---|---|
| [8, 8] | 1.000 | 1.000 |
| [6, 10] | 0.969 | 1.009 |
| [4, 12] | 0.867 | 1.203 |
| [2, 13] | 0.683 | 1.342 |
| [1, 15] | 0.492 | 1.760 |

Error is exactly zero when micro-batches carry equal supervised-token counts and grows with the imbalance. So it is invisible on uniform-length data and worst under completion-only masking (`train_on_inputs: false`) on mixed-length conversations, and under sample packing.

## Also worth flagging

`src/axolotl/monkeypatch/gemma4_loss_kwargs.py` already sets this flag back to `True` for Gemma 4, and its own docstring says `False` "wrongly makes the Trainer withhold `num_items_in_batch` and mis-normalize the loss under gradient accumulation". This block in `base.py` then flips it straight back for that same model.

## Fix

- Unwrap PEFT explicitly with `get_base_model()` rather than walking `.base_model`, so plain `PreTrainedModel`s are left alone.
- Inspect `loss_function`, which is what actually receives `num_items_in_batch`.
- Correct the comment.

## Verification and its limits

Verified by direct gradient comparison, which is the table above, not by the test suite: the relevant tests need a GPU and I do not have one. A tiny-random model on CPU reproduces the effect, so I am happy to add a CPU-runnable regression test if maintainers want one in-tree, and equally happy to be told the detection should be written a different way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training compatibility for models and adapters with custom loss functions.
  * Preserved support for batch-size information when the model’s loss function accepts it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->