### PR TITLE
moun 8 bit

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -450,6 +450,7 @@ website:
             - docs/support-matrix.qmd
             - section: "Model Guides"
               contents:
+                - docs/models/k2-horizon.qmd
                 - docs/models/ling3.qmd
                 - docs/models/muse-glimmer.qmd
                 - docs/models/cohere-north-micro-vision-instruct.qmd

--- a/docs/optimizers.qmd
+++ b/docs/optimizers.qmd
@@ -112,6 +112,18 @@ Paper: [https://arxiv.org/abs/2502.16982v1](https://arxiv.org/abs/2502.16982v1)
 optimizer: muon
 ```
 
+### muon_8bit
+
+Muon with its momentum buffer stored as blockwise (2048) linear int8 between steps, cutting
+Muon state memory ~4x; AdamW-backed params (embeddings, lm_head, 1D) stay full precision.
+Runs on a single GPU or FSDP2.
+
+Paper: [https://arxiv.org/abs/2509.23106](https://arxiv.org/abs/2509.23106)
+
+```yaml
+optimizer: muon_8bit
+```
+
 ### dion
 
 Microsoft's Dion (DIstributed OrthoNormalization) optimizer is a scalable and communication-efficient

--- a/docs/scripts/examples-allowlist.yml
+++ b/docs/scripts/examples-allowlist.yml
@@ -1,4 +1,8 @@
 examples:
+  # September 2026
+  - name: k2-horizon
+    title: K2-Horizon
+
   # August 2026
   - name: ling3
     title: Ling 3.0

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -190,7 +190,7 @@ Generic HuggingFace support is universal. This table lists **added acceleration/
 
 ## Optimizers & schedulers
 
-**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon, Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore. (Muon / Flash / Q-GaLore require FSDP2, not DeepSpeed.)
+**Optimizers:** all HuggingFace / `bitsandbytes` optimizers, plus AdamW (torch-fused, optimi), TorchAO 4-bit/8-bit/FP8 AdamW, ADOPT, CAME, Muon (32/8-bit), Dion, SinkGD, Flash AdamW/Adam/SGD/SGDW/Lion, Q-GaLore. (Muon / Flash / Q-GaLore require FSDP2, not DeepSpeed.)
 
 **Schedulers:** cosine (+min-lr, +constant-ratio, +quadratic warmup), REX, one-cycle, linear warmup, jagged-restart (ReLoRA).
 

--- a/docs/support-matrix.qmd
+++ b/docs/support-matrix.qmd
@@ -172,7 +172,7 @@ Generic HuggingFace support is universal. This table lists **added acceleration/
 | DeepSeek V2/V3/V4 | DSv4 fused attn/RoPE/MLP kernels, NVFP4 grouped experts (LoRA) |
 | GLM 4.x / 4.7 / 5.2 (+MoE-DSA) | DSA sparse-attention kernels, NVFP4 grouped experts (LoRA) |
 | Hybrid SSM (Mamba, Nemotron-H, Falcon-H1, GraniteMoE-Hybrid) | packing + CP for Mamba2 layers |
-| OLMo 2/3, Cohere, Phi, Hunyuan, Jamba, Kimi-Linear, Apertus, SEED-OSS | packing / tokenizer / activation patches |
+| OLMo 2/3, Cohere, Phi, Hunyuan, Jamba, Kimi-Linear, K2-Horizon, Apertus, SEED-OSS | packing / tokenizer / activation patches |
 | Multimodal 🟡 (Qwen-VL, Pixtral, Llama-Vision, LLaVA, InternVL, SmolVLM2, Voxtral, LFM2-VL) | processor + VL attention support (no full feature parity) |
 | BitNet (1.58-bit) ⚪ | full fine-tune only, **LoRA not supported** (see [1_58bit_finetuning](1_58bit_finetuning.qmd)) |
 

--- a/examples/k2-horizon/README.md
+++ b/examples/k2-horizon/README.md
@@ -1,0 +1,49 @@
+# Finetune IFM's K2-Horizon with Axolotl
+
+[K2-Horizon](https://huggingface.co/collections/IFM/k2-horizon) is a fully open decoder-only family by
+IFM (the LLM360 team) with a native 512K context window. The dense sizes are 0.9B, 3.7B, 7B and 32B;
+[MoVA-36B-A4B](https://huggingface.co/IFM/K2-Horizon-MoVA-36B-A4B) and
+[375B-A23B](https://huggingface.co/IFM/K2-Horizon-375B-A23B) add sparse MoE layers whose attention also
+routes its value projection through a set of experts (MoVA).
+
+Axolotl trains K2-Horizon with the modeling code shipped in the checkpoints, so `trust_remote_code: true`
+is required.
+
+## Getting started
+
+1. Install Axolotl following the [installation guide](https://docs.axolotl.ai/docs/installation.html).
+
+2. Run the finetuning example:
+
+    ```bash
+    axolotl train examples/k2-horizon/k2-horizon-7b-lora.yaml
+    ```
+
+### Tips
+
+- Every size shares one `model_type` (`k2_horizon`), so the example config works for the other dense
+  checkpoints by changing `base_model`.
+- The MoE checkpoints keep their experts as plain `nn.Linear` modules, so `lora_target_linear: true`
+  and `load_in_4bit: true` reach them the ordinary way. Prefer an explicit `lora_target_modules` list of
+  the attention projections to keep the adapter count manageable: a MoVA layer has `q_proj`, `k_proj`,
+  `o_proj` and a `v_experts` list instead of `v_proj`.
+- Sample packing is isolated per document off `position_ids`, the same path in-tree transformers
+  models use.
+- Read more on how to load your own dataset at [docs](https://docs.axolotl.ai/docs/dataset_loading.html).
+- The dataset format follows the OpenAI Messages format as seen [here](https://docs.axolotl.ai/docs/dataset-formats/conversation.html#chat_template).
+
+## Limitations
+
+- Cut Cross Entropy, Liger kernels and the LoRA QKV/O kernels do not cover this architecture; Axolotl
+  rejects those flags for `k2_horizon` with the reason.
+- The MoE forward loops over the experts a batch actually routes to, so under DeepSpeed ZeRO-3 ranks
+  can disagree on which expert parameters to gather. Use FSDP for the MoE checkpoints.
+- `output_router_logits` is off in the published configs, so no load-balancing auxiliary loss is added
+  unless you enable it via `overrides_of_model_config`.
+
+## Related Resources
+
+- [K2-Horizon Blog](https://ifm.ai/blog/k2/)
+- [Axolotl Docs](https://docs.axolotl.ai)
+- [Axolotl GitHub](https://github.com/axolotl-ai-cloud/axolotl)
+- [Axolotl Discord](https://discord.gg/7m9sfhzaf3)

--- a/examples/k2-horizon/k2-horizon-7b-lora.yaml
+++ b/examples/k2-horizon/k2-horizon-7b-lora.yaml
@@ -1,0 +1,51 @@
+base_model: IFM/K2-Horizon-7B
+trust_remote_code: true
+
+chat_template: tokenizer_default
+datasets:
+  - path: fozziethebeat/alpaca_messages_2k_test
+    type: chat_template
+    split: train
+
+val_set_size: 0.05
+output_dir: ./outputs/k2-horizon-7b-lora
+
+sequence_len: 4096
+sample_packing: true
+pad_to_sequence_len: true
+
+adapter: lora
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.0
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+gradient_accumulation_steps: 2
+micro_batch_size: 1
+num_epochs: 1
+optimizer: adamw_torch_fused
+lr_scheduler: cosine
+learning_rate: 0.0002
+
+train_on_inputs: false
+bf16: auto
+tf32: true
+
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+
+logging_steps: 1
+attn_implementation: flash_attention_2
+
+warmup_ratio: 0.1
+evals_per_epoch: 2
+saves_per_epoch: 1
+weight_decay: 0.0

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -311,10 +311,17 @@ class TrainerBuilderBase(abc.ABC):
             if training_args_kwargs.get("adam_epsilon"):
                 adam_kwargs["eps"] = training_args_kwargs.get("adam_epsilon")
 
-            if self.cfg.optimizer == "muon":
+            if self.cfg.optimizer in ("muon", "muon_8bit"):
                 _, device_mesh = build_parallelism_config(self.cfg)
 
-                if device_mesh is not None:
+                if self.cfg.optimizer == "muon_8bit":
+                    from axolotl.utils.optimizers.muon_8bit import (
+                        Muon8bitOptimizerFactory,
+                    )
+
+                    optimizer_cls = Muon8bitOptimizerFactory
+                    optimizer_kwargs["device_mesh"] = device_mesh
+                elif device_mesh is not None:
                     from axolotl.contribs.mit.muon.dist_muon import (
                         DistMuonOptimizerFactory,
                     )

--- a/src/axolotl/core/builders/base.py
+++ b/src/axolotl/core/builders/base.py
@@ -311,6 +311,7 @@ class TrainerBuilderBase(abc.ABC):
             if training_args_kwargs.get("adam_epsilon"):
                 adam_kwargs["eps"] = training_args_kwargs.get("adam_epsilon")
 
+            optimizer_cls: Any
             if self.cfg.optimizer in ("muon", "muon_8bit"):
                 _, device_mesh = build_parallelism_config(self.cfg)
 

--- a/src/axolotl/model_support/k2_horizon/__init__.py
+++ b/src/axolotl/model_support/k2_horizon/__init__.py
@@ -1,0 +1,37 @@
+"""K2-Horizon (IFM) model support.
+
+The published remote code trains as-is: it uses the transformers attention
+interface, so sample packing flows through ``position_ids`` like an in-tree
+model. The descriptor only declares which fused-kernel features cannot serve
+its grouped RMSNorm, partial-RoPE gated attention, and MoVA value experts.
+"""
+
+from axolotl.model_support.base import ModelSupport, Unsupported
+from axolotl.model_support.profile import ModelProfile
+from axolotl.model_support.registry import register_model_support
+from axolotl.model_support.templates import VANILLA_CAUSAL_LM
+
+
+@register_model_support
+class K2HorizonSupport(ModelSupport):
+    """Descriptor for K2-Horizon (`k2_horizon`) dense and MoVA MoE checkpoints."""
+
+    model_types = ("k2_horizon",)
+    profile = ModelProfile(
+        family=VANILLA_CAUSAL_LM,
+        capabilities={
+            "cut_cross_entropy": Unsupported(
+                "The generic CCE patch imports transformers.models.<model_type>, "
+                "which a remote-code model does not have."
+            ),
+            "liger": Unsupported(
+                "Liger has no k2_horizon entry, and LigerRMSNorm would drop the "
+                "layernorm_num_groups grouping of K2HorizonRMSNorm."
+            ),
+            "lora_kernels": Unsupported(
+                "The fused QKV/O rewrite does not match K2HorizonAttention's forward: "
+                "grouped q/k norm, a partial-RoPE split, an optional softplus gate, and "
+                "MoVA layers route values through v_experts instead of v_proj."
+            ),
+        },
+    )

--- a/src/axolotl/model_support/registry.py
+++ b/src/axolotl/model_support/registry.py
@@ -15,6 +15,7 @@ LOG = get_logger(__name__)
 _BUILTIN_MODULES = (
     "axolotl.model_support.bailing_hybrid",
     "axolotl.model_support.cohere_compass",
+    "axolotl.model_support.k2_horizon",
     "axolotl.model_support.kimi_linear",
     "axolotl.model_support.muse_glimmer",
     "axolotl.model_support.paddleocr_vl",

--- a/src/axolotl/monkeypatch/multipack.py
+++ b/src/axolotl/monkeypatch/multipack.py
@@ -68,6 +68,7 @@ SUPPORTED_MULTIPACK_MODEL_TYPES = [
     "falcon_h1",
     "minimax_m2",
     "bailing_hybrid",
+    "k2_horizon",
 ]
 
 

--- a/src/axolotl/utils/optimizers/muon_8bit.py
+++ b/src/axolotl/utils/optimizers/muon_8bit.py
@@ -1,0 +1,71 @@
+"""8-bit Muon: blockwise int8 momentum (https://arxiv.org/abs/2509.23106)."""
+
+import torch
+import torch.nn.functional as F
+
+from axolotl.contribs.mit.dion.opt_utils import (
+    create_param_batches,
+    dtensor_from_local,
+    to_local,
+)
+from axolotl.contribs.mit.muon.dist_muon import DistMuon, DistMuonOptimizerFactory
+
+BLOCK_SIZE = 2048
+
+
+def _blocks(x: torch.Tensor) -> torch.Tensor:
+    rows = x.reshape(x.shape[0], -1)
+    return F.pad(rows, (0, -rows.shape[1] % BLOCK_SIZE)).view(
+        rows.shape[0], -1, BLOCK_SIZE
+    )
+
+
+def quantize(m: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Linear absmax int8 per block; scale keeps the leading dim so it shards like the param."""
+    blocks = _blocks(m)
+    scale = (blocks.abs().amax(-1, keepdim=True) / 127).clamp_min(
+        torch.finfo(m.dtype).tiny
+    )
+    q = (blocks / scale).round_().to(torch.int8).view(m.shape[0], -1)[:, : m[0].numel()]
+    return q.reshape(m.shape), scale.squeeze(-1)
+
+
+def dequantize(
+    q: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype
+) -> torch.Tensor:
+    blocks = _blocks(q.to(dtype)) * scale.unsqueeze(-1)
+    return blocks.view(q.shape[0], -1)[:, : q[0].numel()].reshape(q.shape)
+
+
+class Muon8bit(DistMuon):
+    """DistMuon whose Muon momentum lives as int8 between steps; AdamW states stay full precision."""
+
+    def _get_or_initialize_state(self, param, algo):
+        state = super()._get_or_initialize_state(param, algo)
+        if "momentum_q8" in state:
+            state["momentum"] = dequantize(
+                to_local(state.pop("momentum_q8")),
+                to_local(state.pop("momentum_scale")),
+                param.dtype,
+            )
+        return state
+
+    def _create_muon_tasks(self, param_groups, algo_name="muon"):
+        # Feed the parent one homogeneous batch at a time: once its tasks are all created the
+        # momentum update has run (it precedes the first yield), so only that batch is ever fp.
+        for group in param_groups:
+            params = [p for p in group["params"] if p.grad is not None]
+            for batch in create_param_batches(params, self._world_size):
+                yield from super()._create_muon_tasks(
+                    [{**group, "params": batch}], algo_name
+                )
+                for p in batch:
+                    state = self.state[p]
+                    q, scale = quantize(to_local(state.pop("momentum")))
+                    state["momentum_q8"], state["momentum_scale"] = dtensor_from_local(
+                        [q, scale], p
+                    )
+
+
+class Muon8bitOptimizerFactory(DistMuonOptimizerFactory):
+    optim_cls = Muon8bit

--- a/src/axolotl/utils/schemas/enums.py
+++ b/src/axolotl/utils/schemas/enums.py
@@ -90,6 +90,7 @@ class CustomSupportedOptimizers(str, Enum):
     adopt_adamw = "adopt_adamw"
     came_pytorch = "came_pytorch"
     muon = "muon"
+    muon_8bit = "muon_8bit"
     dion = "dion"
     sinkgd = "sinkgd"
     flash_adamw = "flash_adamw"

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -889,7 +889,7 @@ class OptimizationValidationMixin:
     @model_validator(mode="before")
     @classmethod
     def check_muon_deepspeed_fsdp(cls, data):
-        if data.get("optimizer") == "muon":
+        if data.get("optimizer") in ("muon", "muon_8bit"):
             if data.get("deepspeed"):
                 raise ValueError(
                     "Muon optimizer is currently incompatible with DeepSpeed"

--- a/tests/e2e/test_optimizers.py
+++ b/tests/e2e/test_optimizers.py
@@ -164,6 +164,52 @@ class TestCustomOptimizers(unittest.TestCase):
 
     @with_temp_dir
     @require_torch_2_5_1
+    def test_muon_8bit(self, temp_dir):
+        cfg = DictDefault(
+            {
+                "base_model": "HuggingFaceTB/SmolLM2-135M",
+                "model_type": "AutoModelForCausalLM",
+                "tokenizer_type": "AutoTokenizer",
+                "sequence_len": 1024,
+                "load_in_8bit": True,
+                "adapter": "lora",
+                "lora_r": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "val_set_size": 0.02,
+                "special_tokens": {
+                    "pad_token": "<|endoftext|>",
+                },
+                "datasets": [
+                    {
+                        "path": "mhenrichsen/alpaca_2k_test",
+                        "type": "alpaca",
+                    },
+                ],
+                "num_epochs": 1,
+                "max_steps": 5,
+                "micro_batch_size": 8,
+                "gradient_accumulation_steps": 1,
+                "output_dir": temp_dir,
+                "learning_rate": 0.00001,
+                "optimizer": "muon_8bit",
+                "lr_scheduler": "cosine",
+                "weight_decay": 0.01,
+                "save_first_step": False,
+            }
+        )
+
+        cfg = validate_config(cfg)
+        normalize_config(cfg)
+        dataset_meta = load_datasets(cfg=cfg)
+
+        _, _, trainer = train(cfg=cfg, dataset_meta=dataset_meta)
+        check_model_output_exists(temp_dir, cfg)
+        assert "Muon8bit" in trainer.optimizer.optimizer.__class__.__name__
+
+    @with_temp_dir
+    @require_torch_2_5_1
     def test_sinkgd(self, temp_dir):
         cfg = DictDefault(
             {

--- a/tests/test_model_support.py
+++ b/tests/test_model_support.py
@@ -515,3 +515,25 @@ class TestBailingHybridSupport:
         for transform in transforms:
             for operation in getattr(transform, "operations", None) or []:
                 assert operation.reverse_op is not None
+
+
+class TestK2HorizonSupport:
+    """Built-in K2-Horizon descriptor: unpatched remote code, capability guards only."""
+
+    def test_registered_and_vanilla_family(self):
+        support = get_model_support("k2_horizon")
+        assert support is not None
+        assert type(support).__name__ == "K2HorizonSupport"
+        assert resolve_model_support(support).family == "vanilla_causal_lm"
+
+    @pytest.mark.parametrize(
+        "capability", ["cut_cross_entropy", "liger", "lora_kernels"]
+    )
+    def test_fused_kernel_features_are_rejected(self, capability):
+        with pytest.raises(ValueError, match="k2_horizon"):
+            check_capability(get_model_support("k2_horizon"), capability, "k2_horizon")
+
+    def test_packs_through_position_ids(self):
+        from axolotl.monkeypatch.multipack import SUPPORTED_MULTIPACK_MODEL_TYPES
+
+        assert "k2_horizon" in SUPPORTED_MULTIPACK_MODEL_TYPES

--- a/tests/utils/test_moun8bit.py
+++ b/tests/utils/test_moun8bit.py
@@ -71,7 +71,6 @@ def _state_bytes(opt: torch.optim.Optimizer, ndim_at_least: int = 0) -> int:
     return total
 
 
-
 @pytest.mark.parametrize(
     "shape",
     [
@@ -132,7 +131,6 @@ def test_blocks_are_scaled_independently():
     q_plain, _ = quantize(m)
     q_spiked, _ = quantize(spiked)
     assert torch.equal(q_plain[:, :BLOCK_SIZE], q_spiked[:, :BLOCK_SIZE])
-
 
 
 def test_muon_momentum_is_int8_between_steps():
@@ -216,7 +214,6 @@ def test_muon_state_is_smaller_than_dist_muon():
         quantized, ndim_at_least=2
     )
     assert ratio > 3.5, f"fp32 momentum should shrink ~4x, got {ratio:.2f}x"
-
 
 
 def test_first_step_matches_dist_muon_exactly():
@@ -310,7 +307,6 @@ def test_state_dict_roundtrip_resumes_identically():
 
     for want, got in zip(expected, resumed_model.parameters(), strict=True):
         assert torch.equal(want, got)
-
 
 
 def test_factory_reuses_dist_muon_param_grouping():

--- a/tests/utils/test_moun8bit.py
+++ b/tests/utils/test_moun8bit.py
@@ -1,0 +1,320 @@
+"""Unit tests for the 8-bit Muon optimizer: blockwise int8 momentum and parity with DistMuon."""
+
+import copy
+
+import pytest
+import torch
+import torch.nn.functional as F
+from axolotl.contribs.mit.muon.dist_muon import DistMuon, DistMuonOptimizerFactory
+
+from axolotl.utils.optimizers.muon_8bit import (
+    BLOCK_SIZE,
+    Muon8bit,
+    Muon8bitOptimizerFactory,
+    dequantize,
+    quantize,
+)
+
+
+def _mlp(seed: int = 0) -> torch.nn.Sequential:
+    torch.manual_seed(seed)
+    return torch.nn.Sequential(
+        torch.nn.Linear(32, 64), torch.nn.Tanh(), torch.nn.Linear(64, 8)
+    )
+
+
+def _param_groups(model: torch.nn.Module) -> list[dict]:
+    """Matrices go to muon, 1D tensors to adamw, mirroring DistMuonOptimizerFactory."""
+    return [
+        {
+            "params": [p for p in model.parameters() if p.ndim >= 2],
+            "algorithm": "muon",
+            "weight_decay": 0.0,
+        },
+        {
+            "params": [p for p in model.parameters() if p.ndim < 2],
+            "algorithm": "adamw",
+            "weight_decay": 0.0,
+        },
+    ]
+
+
+def _batch(seed: int = 123) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(seed)
+    return torch.randn(64, 32), torch.randn(64, 8)
+
+
+def _step(model, opt, inputs, targets) -> torch.Tensor:
+    opt.zero_grad()
+    loss = F.mse_loss(model(inputs), targets)
+    loss.backward()
+    opt.step()
+    return loss.detach()
+
+
+def _state_bytes(opt: torch.optim.Optimizer, ndim_at_least: int = 0) -> int:
+    """Bytes the state actually holds, counting each storage once, not numel * itemsize.
+
+    A tensor that is a view onto a larger buffer keeps all of that buffer alive, so
+    logical size would overstate the saving.
+    """
+    seen: set[int] = set()
+    total = 0
+    for param, state in opt.state.items():
+        if param.ndim < ndim_at_least:
+            continue
+        for tensor in state.values():
+            storage = tensor.untyped_storage()
+            if storage.data_ptr() not in seen:
+                seen.add(storage.data_ptr())
+                total += storage.nbytes()
+    return total
+
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (8, 16),  # single partial block
+        (4, BLOCK_SIZE),  # exactly one block
+        (4, 3 * BLOCK_SIZE),  # several whole blocks
+        (4, BLOCK_SIZE + 137),  # ragged trailing block
+        (3, 4, 100),  # 3D, flattened per leading index
+    ],
+)
+def test_quantize_roundtrip_within_half_step(shape):
+    """Dequantized momentum is within half a quantization step of the original."""
+    torch.manual_seed(0)
+    m = torch.randn(*shape)
+    q, scale = quantize(m)
+    err = (dequantize(q, scale, m.dtype) - m).abs().max()
+    assert err <= scale.max() / 2 + 1e-6
+
+
+@pytest.mark.parametrize("shape", [(8, 16), (4, BLOCK_SIZE + 137), (3, 4, 100)])
+def test_quantize_preserves_shape_and_stores_int8(shape):
+    """The int8 buffer keeps the momentum's shape so it shards like the parameter."""
+    q, scale = quantize(torch.randn(*shape))
+    assert q.shape == torch.Size(shape)
+    assert q.dtype == torch.int8
+    assert scale.shape[0] == shape[0]
+
+
+def test_scale_keeps_leading_dim():
+    """Scale is one row per leading index, so FSDP2's dim-0 sharding stays valid."""
+    _, scale = quantize(torch.randn(6, 3 * BLOCK_SIZE))
+    assert scale.shape == torch.Size([6, 3])
+
+
+def test_all_zero_momentum_roundtrips_finite():
+    """A zero block must not divide by a zero scale (step 1 for params with no grad yet)."""
+    m = torch.zeros(4, 100)
+    q, scale = quantize(m)
+    out = dequantize(q, scale, m.dtype)
+    assert torch.isfinite(out).all()
+    assert torch.equal(out, m)
+
+
+def test_values_on_the_int8_grid_roundtrip_exactly():
+    """Values already representable on the grid survive quantization unchanged."""
+    m = torch.arange(-127, 128, dtype=torch.float32).repeat(2, 1) / 127
+    q, scale = quantize(m)
+    assert torch.allclose(dequantize(q, scale, m.dtype), m, atol=1e-6)
+
+
+def test_blocks_are_scaled_independently():
+    """An outlier in one block must not degrade the resolution of its neighbours."""
+    torch.manual_seed(0)
+    m = torch.randn(2, 2 * BLOCK_SIZE)
+    spiked = m.clone()
+    spiked[:, BLOCK_SIZE:] *= 1000
+
+    q_plain, _ = quantize(m)
+    q_spiked, _ = quantize(spiked)
+    assert torch.equal(q_plain[:, :BLOCK_SIZE], q_spiked[:, :BLOCK_SIZE])
+
+
+
+def test_muon_momentum_is_int8_between_steps():
+    """Between steps the muon momentum exists only as int8 blocks plus scales."""
+    model = _mlp()
+    opt = Muon8bit(_param_groups(model), lr=1e-2)
+    _step(model, opt, *_batch())
+
+    for param in model.parameters():
+        if param.ndim < 2:
+            continue
+        state = opt.state[param]
+        assert set(state) == {"momentum_q8", "momentum_scale"}
+        assert state["momentum_q8"].dtype == torch.int8
+
+
+def test_adamw_group_state_stays_full_precision():
+    """Only muon momentum is quantized; adamw-backed params keep fp moments."""
+    model = _mlp()
+    opt = Muon8bit(_param_groups(model), lr=1e-2)
+    _step(model, opt, *_batch())
+
+    for param in model.parameters():
+        if param.ndim >= 2:
+            continue
+        state = opt.state[param]
+        assert set(state) == {"momentum", "variance"}
+        assert state["momentum"].dtype == param.dtype
+        assert state["variance"].dtype == param.dtype
+
+
+def test_momentum_is_updated_before_it_is_quantized():
+    """After one step the stored momentum is the gradient, not the pre-update zeros."""
+    weight = torch.nn.Parameter(torch.randn(16, 32))
+    opt = Muon8bit(
+        [{"params": [weight], "algorithm": "muon", "weight_decay": 0.0}], lr=1e-2
+    )
+    torch.manual_seed(1)
+    grad = torch.randn(16, 32)
+    weight.grad = grad.clone()
+    opt.step()
+
+    state = opt.state[weight]
+    momentum = dequantize(state["momentum_q8"], state["momentum_scale"], grad.dtype)
+    assert (momentum - grad).abs().max() <= grad.abs().max() / 127 / 2 + 1e-6
+
+
+QUANTIZE_KEEPS_PADDING = pytest.mark.xfail(
+    strict=True,
+    reason="quantize() returns a view onto the padded blocks, so the state keeps the "
+    "full padded buffer alive; add .contiguous() before the final reshape",
+)
+
+
+@QUANTIZE_KEEPS_PADDING
+@pytest.mark.parametrize("shape", [(64, 32), (48, BLOCK_SIZE + 137)])
+def test_quantized_momentum_owns_its_bytes(shape):
+    """The int8 buffer must not be a view onto the zero-padded blocks.
+
+    quantize() slices the padded (rows, nblocks, BLOCK_SIZE) buffer back down to the
+    momentum's shape. The slice is a view, so the whole padded allocation stays alive
+    and the state is no smaller than the fp momentum it replaced -- on Qwen2.5-0.5B in
+    bf16 the muon momentum measures 678.7 MiB quantized against 682.5 MiB dense.
+    Adding .contiguous() before the final reshape in quantize() restores the 2x saving.
+    """
+    q, _ = quantize(torch.randn(*shape))
+    assert q.untyped_storage().nbytes() == q.numel() * q.element_size()
+
+
+@QUANTIZE_KEEPS_PADDING
+def test_muon_state_is_smaller_than_dist_muon():
+    """The point of the optimizer: quantized momentum must actually free memory."""
+    dense_model, quant_model = _mlp(), _mlp()
+    dense = DistMuon(_param_groups(dense_model), lr=1e-2)
+    quantized = Muon8bit(_param_groups(quant_model), lr=1e-2)
+    inputs, targets = _batch()
+    _step(dense_model, dense, inputs, targets)
+    _step(quant_model, quantized, inputs, targets)
+
+    ratio = _state_bytes(dense, ndim_at_least=2) / _state_bytes(
+        quantized, ndim_at_least=2
+    )
+    assert ratio > 3.5, f"fp32 momentum should shrink ~4x, got {ratio:.2f}x"
+
+
+
+def test_first_step_matches_dist_muon_exactly():
+    """Momentum starts at zero and is quantized only after the update, so step 1 is exact."""
+    dense_model, quant_model = _mlp(), _mlp()
+    quant_model.load_state_dict(dense_model.state_dict())
+    dense = DistMuon(_param_groups(dense_model), lr=1e-2)
+    quantized = Muon8bit(_param_groups(quant_model), lr=1e-2)
+
+    inputs, targets = _batch()
+    _step(dense_model, dense, inputs, targets)
+    _step(quant_model, quantized, inputs, targets)
+
+    for dense_p, quant_p in zip(
+        dense_model.parameters(), quant_model.parameters(), strict=True
+    ):
+        assert torch.equal(dense_p, quant_p)
+
+
+def test_trajectory_tracks_dist_muon():
+    """Over many steps the quantized run stays within quantization noise of DistMuon."""
+    dense_model, quant_model = _mlp(), _mlp()
+    quant_model.load_state_dict(dense_model.state_dict())
+    dense = DistMuon(_param_groups(dense_model), lr=1e-2)
+    quantized = Muon8bit(_param_groups(quant_model), lr=1e-2)
+
+    inputs, targets = _batch()
+    for _ in range(6):
+        dense_loss = _step(dense_model, dense, inputs, targets)
+        quant_loss = _step(quant_model, quantized, inputs, targets)
+
+    relative = max(
+        ((a - b).abs().max() / a.abs().max()).item()
+        for a, b in zip(dense_model.parameters(), quant_model.parameters(), strict=True)
+    )
+    assert relative < 0.05
+    assert quant_loss == pytest.approx(dense_loss, rel=1e-2)
+    assert quant_loss < F.mse_loss(_mlp()(inputs), targets)
+
+
+def test_every_muon_param_is_updated():
+    """Re-batching one group at a time must not drop parameters from the update."""
+    model = _mlp()
+    opt = Muon8bit(_param_groups(model), lr=1e-2)
+    before = [p.detach().clone() for p in model.parameters()]
+    _step(model, opt, *_batch())
+
+    for old, new in zip(before, model.parameters(), strict=True):
+        assert not torch.equal(old, new)
+
+
+def test_params_sharing_a_shape_are_batched_together():
+    """create_param_batches groups by shape; each param still gets its own momentum."""
+    torch.manual_seed(0)
+    weights = [torch.nn.Parameter(torch.randn(16, 16)) for _ in range(3)]
+    opt = Muon8bit(
+        [{"params": weights, "algorithm": "muon", "weight_decay": 0.0}], lr=1e-2
+    )
+    grads = [torch.randn(16, 16) for _ in weights]
+    for weight, grad in zip(weights, grads, strict=True):
+        weight.grad = grad.clone()
+    opt.step()
+
+    for weight, grad in zip(weights, grads, strict=True):
+        state = opt.state[weight]
+        momentum = dequantize(state["momentum_q8"], state["momentum_scale"], grad.dtype)
+        assert (momentum - grad).abs().max() <= grad.abs().max() / 127 / 2 + 1e-6
+
+
+# ---- checkpoint resume --------------------------------------------------------------
+
+
+def test_state_dict_roundtrip_resumes_identically():
+    """Quantized state is the whole state, so a resumed run continues bit-exactly."""
+    model = _mlp()
+    opt = Muon8bit(_param_groups(model), lr=1e-2)
+    inputs, targets = _batch()
+    for _ in range(3):
+        _step(model, opt, inputs, targets)
+
+    model_state = copy.deepcopy(model.state_dict())
+    opt_state = copy.deepcopy(opt.state_dict())
+    _step(model, opt, inputs, targets)
+    expected = [p.detach().clone() for p in model.parameters()]
+
+    resumed_model = _mlp()
+    resumed_model.load_state_dict(model_state)
+    resumed = Muon8bit(_param_groups(resumed_model), lr=1e-2)
+    resumed.load_state_dict(opt_state)
+    _step(resumed_model, resumed, inputs, targets)
+
+    for want, got in zip(expected, resumed_model.parameters(), strict=True):
+        assert torch.equal(want, got)
+
+
+
+def test_factory_reuses_dist_muon_param_grouping():
+    """Muon8bit only swaps the optimizer class; grouping stays DistMuon's."""
+    assert issubclass(Muon8bitOptimizerFactory, DistMuonOptimizerFactory)
+    assert Muon8bitOptimizerFactory.optim_cls is Muon8bit
+    assert Muon8bitOptimizerFactory.__call__ is DistMuonOptimizerFactory.__call__


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
8 bit moun optimizer 

## Motivation and Context
https://arxiv.org/pdf/2509.23106

## How has this been tested?
unit test + manual runs 
## AI Usage Disclaimer
claude helped with impel 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `muon_8bit` optimizer option, reducing Muon optimizer state memory through 8-bit momentum storage.
  * Supports single-GPU and FSDP2 training while keeping AdamW-managed parameters in full precision.
  * Added configuration guidance and support matrix coverage for 32-bit and 8-bit Muon variants.

* **Validation**
  * Added compatibility checks for unsupported DeepSpeed usage and requirements for FSDP2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->