### PR TITLE
fix(perplexity): stop scoring padding in batched references

### DIFF
--- a/src/axolotl/utils/callbacks/perplexity.py
+++ b/src/axolotl/utils/callbacks/perplexity.py
@@ -53,6 +53,8 @@ class Perplexity:
         )
         input_ids: Tensor = references_tokenized["input_ids"]  # type: ignore
         input_ids = input_ids.to(model.device)
+        attention_mask: Tensor = references_tokenized["attention_mask"]  # type: ignore
+        attention_mask = attention_mask.to(model.device)
 
         sequence_length = input_ids.size(1)
 
@@ -64,12 +66,17 @@ class Perplexity:
             end_loc = min(begin_loc + self.max_seq_len, sequence_length)
             trg_len = end_loc - prev_end_loc
             input_ids_slice = input_ids[:, begin_loc:end_loc]
+            attention_mask_slice = attention_mask[:, begin_loc:end_loc]
             labels_slice = input_ids_slice.clone()
             labels_slice[:, :-trg_len] = -100
+            # Padding is not part of the text being measured.
+            labels_slice[attention_mask_slice == 0] = -100
 
             with torch.no_grad():
                 outputs: CausalLMOutput = model(
-                    input_ids=input_ids_slice, labels=labels_slice
+                    input_ids=input_ids_slice,
+                    attention_mask=attention_mask_slice,
+                    labels=labels_slice,
                 )
 
             losses.append(outputs.loss)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -45,3 +45,42 @@ def test_perplexity_short(model, metric):
     result = metric.compute(model, [sample_text])
     ppl = result["score"]
     assert round(ppl, 2) == 10.33
+
+
+def test_batched_references_are_not_inflated_by_padding(model, metric):
+    """Scoring several references at once pads the batch to the longest one.
+
+    Those pad positions are not part of any reference, so the pooled score must
+    still sit between the scores of the individual texts.
+    """
+    long_text = "Once upon a time, there was a little car named Beep. Beep loved to go fast and play in the sun. Beep was a healthy car because he always had good fuel. Good fuel made Beep happy and strong."
+    short_text = "Once upon a time, there was a little car named Beep."
+
+    alone_long = metric.compute(model, [long_text])["score"]
+    alone_short = metric.compute(model, [short_text])["score"]
+    batched = metric.compute(model, [long_text, short_text])["score"]
+
+    assert min(alone_long, alone_short) <= batched <= max(alone_long, alone_short)
+
+
+def test_padding_is_never_scored(model, metric, tokenizer):
+    """Pad positions must be masked out of the labels, and the mask must reach
+    the model so it does not attend across them."""
+    seen = []
+    forward = model.forward
+
+    def capture(*args, **kwargs):
+        seen.append(kwargs)
+        return forward(*args, **kwargs)
+
+    model.forward = capture
+    try:
+        metric.compute(model, ["a b c d e f g h i j k l", "a b"])
+    finally:
+        model.forward = forward
+
+    assert seen, "model was never called"
+    for kwargs in seen:
+        assert kwargs.get("attention_mask") is not None
+        labels = kwargs["labels"]
+        assert (labels[kwargs["attention_mask"] == 0] == -100).all()


### PR DESCRIPTION
# Description

`Perplexity.compute` tokenizes with `padding=True`, then discards the `attention_mask` and never masks pad positions out of the labels:

```python
references_tokenized = self.tokenizer(
    references, return_tensors="pt", padding=True, truncation=True
)
input_ids: Tensor = references_tokenized["input_ids"]
...
labels_slice = input_ids_slice.clone()
labels_slice[:, :-trg_len] = -100

outputs = model(input_ids=input_ids_slice, labels=labels_slice)
```

Only the sliding-window prefix is masked. Padding is not. So with more than one reference of differing length the model attends across pad positions and is then scored on predicting them, and the number returned is not the perplexity of the text.

The fix keeps the `attention_mask`, slices it alongside `input_ids`, sets pad positions to `-100` in the labels, and passes the mask to the model.

## Motivation and Context

Perplexity here is a scorer, so a wrong value does not surface as a crash. It surfaces as a confident number that is not the quantity it claims to be. The size of the error tracks how much padding the batch happens to carry, so it is not a fixed offset a user could calibrate away.

No open issue; found while reading the callback.

## How has this been tested?

`HuggingFaceTB/SmolLM2-135M`, the model `tests/test_perplexity.py` already uses, with the TinyStories text from `test_perplexity_longer_than_stride` and the shorter one from `test_perplexity_short`. `Perplexity(tokenizer, max_seq_len=512)`, as the tests construct it:

| | current | with the fix |
|---|---|---|
| long text alone | 7.406 | 7.406 |
| short text alone | 10.334 | 10.334 |
| **both together** | **423.049** | **7.560** |

Each text scores between 7 and 11 on its own. Passed together, current `main` reports 423. The batch is 2 x 382 and 356 of the 762 scored targets, 46.7%, are padding.

Both existing tests pass a single reference, so no padding is involved and neither pinned value moves: 7.406 and 10.334 round to the 7.41 and 10.33 they assert, on both branches.

> **Correction.** The table above replaces the one this description opened with, which read 7.663 / 268.425 / 7.956. Those came from an earlier run I did not repeat against the exact strings the repo's tests use, and 7.663 is visibly inconsistent with this repo's own pinned 7.41. Every figure here was produced by calling `Perplexity.compute` on a clean checkout of `main` and on this branch. The correction makes the reported error larger, not smaller.

## Tests added

Two, both in `tests/test_perplexity.py`, both failing on `main`.

`test_batched_references_are_not_inflated_by_padding` asserts the pooled score of two references lies between their individual scores: 7.406 < 7.560 < 10.334 holds here, and 423.049 does not.

`test_padding_is_never_scored` wraps the model's `forward` and asserts the `attention_mask` reaches the model and every pad position is `-100` in the labels.

Verified in both directions: 4 pass with the fix, and the two new ones fail without it while the two existing ones still pass.

## AI Usage Disclaimer

Yes. Claude was used throughout: reading the callback, drafting the patch and the tests, and writing this description. The figures in the table were produced by running the scorer on both branches rather than estimated.

## Types of changes

Bug fix (non-breaking change which fixes an issue).
