### PR TITLE
fix(callbacks): strip the padded prompt width from generated eval text

### DIFF
--- a/src/axolotl/utils/callbacks/__init__.py
+++ b/src/axolotl/utils/callbacks/__init__.py
@@ -526,19 +526,20 @@ def causal_lm_bench_eval_callback_factory(trainer: Trainer, tokenizer):
                                 **prompt_encoding, generation_config=generation_config
                             )
 
+                            # Every row of the output starts with the *padded*
+                            # prompt, and re-tokenizing the decoded prompt may have
+                            # added special tokens, so the number of leading
+                            # positions to drop is the width of this batch rather
+                            # than the length of any one unpadded prompt.
+                            prompt_width = prompt_encoding["input_ids"].shape[1]
+
                             del prompt_encoding
 
                         prediction_all_tokens = predictions["sequences"].cpu().tolist()
-                        prediction_without_prompt_tokens_list = []
-                        for prompt_token_ids, prediction_tokens in zip(
-                            prompt_token_ids_list, prediction_all_tokens, strict=False
-                        ):
-                            prediction_without_prompt_tokens = prediction_tokens[
-                                len(prompt_token_ids) :
-                            ]
-                            prediction_without_prompt_tokens_list.append(
-                                prediction_without_prompt_tokens
-                            )
+                        prediction_without_prompt_tokens_list = [
+                            prediction_tokens[prompt_width:]
+                            for prediction_tokens in prediction_all_tokens
+                        ]
 
                         predicted_texts = tokenizer.batch_decode(
                             prediction_without_prompt_tokens_list,

--- a/tests/test_causal_lm_bench_eval_callback.py
+++ b/tests/test_causal_lm_bench_eval_callback.py
@@ -20,7 +20,7 @@ COMPLETION = " Paris."
 
 @fixture()
 def tokenizer():
-    tokenizer_ = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    tokenizer_ = AutoTokenizer.from_pretrained(MODEL_NAME)
     tokenizer_.add_special_tokens({"pad_token": "<|endoftext|>"})
     # generation pads on the left, which is what makes the prompt prefix in the
     # generated rows wider than the individual prompts
@@ -30,9 +30,7 @@ def tokenizer():
 
 @fixture()
 def model():
-    model_ = AutoModelForCausalLM.from_pretrained(
-        MODEL_NAME, trust_remote_code=True, dtype="float32"
-    )
+    model_ = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype="float32")
     model_.eval()
     return model_
 

--- a/tests/test_causal_lm_bench_eval_callback.py
+++ b/tests/test_causal_lm_bench_eval_callback.py
@@ -1,0 +1,140 @@
+"""unit tests for the causal LM generation eval callback"""
+
+import torch
+from accelerate import Accelerator
+from pytest import fixture
+from transformers.models.auto.modeling_auto import AutoModelForCausalLM
+from transformers.models.auto.tokenization_auto import AutoTokenizer
+
+from axolotl.utils.callbacks import causal_lm_bench_eval_callback_factory
+
+MODEL_NAME = "HuggingFaceTB/SmolLM2-135M"
+
+LONG_PROMPT = (
+    "Question: What is the capital city of France, and why did it become "
+    "the capital?\nAnswer:"
+)
+SHORT_PROMPT = "Hi."
+COMPLETION = " Paris."
+
+
+@fixture()
+def tokenizer():
+    tokenizer_ = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)
+    tokenizer_.add_special_tokens({"pad_token": "<|endoftext|>"})
+    # generation pads on the left, which is what makes the prompt prefix in the
+    # generated rows wider than the individual prompts
+    tokenizer_.padding_side = "left"
+    return tokenizer_
+
+
+@fixture()
+def model():
+    model_ = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME, trust_remote_code=True, dtype="float32"
+    )
+    model_.eval()
+    return model_
+
+
+class StubTrainer:
+    """Minimal stand-in for the pieces of Trainer the callback touches."""
+
+    def __init__(self, model):
+        self.model_wrapped = model
+        self.accelerator = Accelerator()
+        self.logged: dict = {}
+
+    def log(self, logs):
+        self.logged.update(logs)
+
+
+class CapturingMetric:
+    """Stands in for an ``evaluate`` metric so the predictions are observable."""
+
+    name = "capture"
+
+    def __init__(self):
+        self.predictions: list[str] | None = None
+        self.references: list[str] | None = None
+
+    def _feature_names(self):
+        return ["predictions", "references", "sources"]
+
+    def compute(self, predictions=None, references=None, sources=None):
+        self.predictions = predictions
+        self.references = references
+        return {"score": 0.0}
+
+
+class Cfg(dict):
+    """Attribute access over a plain dict, as the callback reads cfg.<name>."""
+
+    __getattr__ = dict.get
+
+
+def _eval_batch(tokenizer, prompts, completion):
+    """One right-padded eval batch, prompt tokens masked out of the labels."""
+    rows = [
+        (
+            tokenizer(prompt, add_special_tokens=False)["input_ids"],
+            tokenizer(completion, add_special_tokens=False)["input_ids"],
+        )
+        for prompt in prompts
+    ]
+    width = max(
+        len(prompt_ids) + len(completion_ids) for prompt_ids, completion_ids in rows
+    )
+
+    input_ids = []
+    labels = []
+    for prompt_ids, completion_ids in rows:
+        padding = width - len(prompt_ids) - len(completion_ids)
+        input_ids.append(
+            prompt_ids + completion_ids + [tokenizer.pad_token_id] * padding
+        )
+        labels.append([-100] * len(prompt_ids) + completion_ids + [-100] * padding)
+
+    return {
+        "input_ids": torch.tensor(input_ids),
+        "labels": torch.tensor(labels),
+    }
+
+
+def _run_callback(model, tokenizer, prompts):
+    metric = CapturingMetric()
+    callback_cls = causal_lm_bench_eval_callback_factory(StubTrainer(model), tokenizer)
+    callback = callback_cls(
+        Cfg(device="cpu", eval_max_new_tokens=8, eval_causal_lm_metrics=[])
+    )
+    callback.metrics = {"capture": metric}
+    callback.on_evaluate(
+        None, None, "control", None, [_eval_batch(tokenizer, prompts, COMPLETION)]
+    )
+    return metric
+
+
+def test_prompt_is_not_prepended_to_the_prediction(model, tokenizer):
+    """A short prompt in a padded batch must not leak into its own prediction.
+
+    ``generate`` returns rows that begin with the padded prompt, so dropping only
+    as many tokens as the unpadded prompt has leaves the prompt itself at the
+    front of the prediction that is then scored.
+    """
+    metric = _run_callback(model, tokenizer, [LONG_PROMPT, SHORT_PROMPT])
+
+    assert metric.predictions is not None
+    assert len(metric.predictions) == 2
+    for prompt, prediction in zip(
+        [LONG_PROMPT, SHORT_PROMPT], metric.predictions, strict=True
+    ):
+        assert prompt not in prediction
+
+
+def test_single_prompt_batch_is_unaffected(model, tokenizer):
+    """With one prompt there is no padding, so nothing about this path changes."""
+    metric = _run_callback(model, tokenizer, [SHORT_PROMPT])
+
+    assert metric.predictions is not None
+    assert len(metric.predictions) == 1
+    assert SHORT_PROMPT not in metric.predictions[0]


### PR DESCRIPTION
# Description

`CausalLMBenchEvalCallback` decodes each example's prompt, re-tokenizes the batch with `padding=True`, calls `generate`, and then removes the prompt from each generated row:

```python
prompt_encoding = tokenizer(prompt_texts, padding=True, return_tensors="pt").to(device)
predictions = unwrapped_model.generate(**prompt_encoding, generation_config=generation_config)
...
for prompt_token_ids, prediction_tokens in zip(prompt_token_ids_list, prediction_all_tokens):
    prediction_without_prompt_tokens = prediction_tokens[len(prompt_token_ids):]
```

`len(prompt_token_ids)` is the length of that example's **unpadded** prompt. Every row of `generate`'s output begins with the **padded** prompt, so any example shorter than the longest one in its batch keeps part of its own prompt at the front of the text that is then passed to the metric.

Re-tokenizing the decoded prompt can shift the same slice a second way, independent of padding. `prompt_texts` come from `batch_decode(..., skip_special_tokens=True)` and are fed back through the tokenizer with `add_special_tokens` left at its default, so a tokenizer that adds BOS makes the prompt one position wider than the ids the callback kept. With the TinyLlama (Llama) tokenizer, `"The capital of France is"` is 5 ids without special tokens and occupies 6 positions after re-tokenization, so the recorded prediction starts one token early even in a batch of one.

`prompt_encoding["input_ids"].shape[1]` is the number of leading positions the prompt actually occupies. It is correct for both padding sides and with or without added special tokens.

## Motivation and Context

The affected values are `eval_*` metric scores, so this does not fail loudly. It reports a number. Since the leaked text is the prompt, and the prompt is also what is passed as `sources`, the contamination systematically favours overlap-based metrics rather than adding noise, and the amount leaked depends on how much padding each eval batch happens to carry.

No open issue; found while reading the callback.

## How has this been tested?

`HuggingFaceTB/SmolLM2-135M`, the model `tests/test_perplexity.py` already uses, driven through the real callback on CPU with a left-padding tokenizer. One batch, two prompts, `eval_max_new_tokens=8`:

| prompt | current | with the fix |
|---|---|---|
| long | `' Paris is the capital of France. It'` | `' Paris is the capital of France. It'` |
| short (`"Hi."`) | `"Hi. I'm not sure what you mean by"` | `" I'm not sure what you mean by"` |

The long prompt is the longest in the batch, so it is unaffected. The short one carries its whole prompt into the prediction.

The special-token half was checked separately with the TinyLlama tokenizer: unpadded lengths `[5, 2]`, re-tokenized batch width 6, and `convert_ids_to_tokens` on the first row gives `['<s>', 'The', 'capital', 'of', 'France', 'is']`.

## Tests added

`tests/test_causal_lm_bench_eval_callback.py` builds the callback with a stub trainer and a capturing metric object in place of an `evaluate` metric, so the predictions the callback would have scored are observable, and runs `on_evaluate` over a single hand-built batch.

`test_prompt_is_not_prepended_to_the_prediction` asserts no prediction contains its own prompt. It fails on `main`.

`test_single_prompt_batch_is_unaffected` covers the one-prompt case where there is no padding. It passes either way and is there so the first test's failure is attributable to the padding, not to the harness.

Verified in both directions: 2 pass with the fix, and reverting the slice fails the first while the second still passes.

## AI Usage Disclaimer

Yes. Claude was used throughout: reading the callback, drafting the patch and the tests, and writing this description. The predictions in the table were produced by running the callback on both branches rather than estimated.

## Types of changes

Bug fix (non-breaking change which fixes an issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated evaluation outputs for right-padded batches so predictions no longer include leftover prompt tokens from padding.
  - Preserved correct behavior for single-prompt evaluation batches.

- **Tests**
  - Added coverage for padded multi-prompt batches and single-prompt batches during evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->