### PR TITLE
fix(chat_template): do not split thinking on a turn with no content

### DIFF
--- a/src/axolotl/prompt_strategies/chat_template.py
+++ b/src/axolotl/prompt_strategies/chat_template.py
@@ -1109,8 +1109,14 @@ class ChatTemplateStrategy(PromptTokenizingStrategy):
 
         # TODO handle reasoning_content with split_thinking
         # if the role is assistant that we want to use reasoning_content
-        if self.split_thinking and transformed_message["role"] == "assistant":
-            content = transformed_message["content"]
+        content = transformed_message.get("content")
+        if (
+            self.split_thinking
+            and transformed_message.get("role") == "assistant"
+            # a tool call turn carries no content, and multimodal content is a
+            # list of parts, neither of which has thinking tags to split
+            and isinstance(content, str)
+        ):
             thinking_pairs = [
                 ("<think>", "</think>"),
                 ("<reasoning>", "</reasoning>"),

--- a/tests/prompt_strategies/test_chat_templates_thinking.py
+++ b/tests/prompt_strategies/test_chat_templates_thinking.py
@@ -55,6 +55,43 @@ def messages_w_reasoning_fixture():
     )
 
 
+@pytest.fixture(name="messages_w_tool_call")
+def messages_w_tool_call_fixture():
+    """An assistant tool call turn, which carries no content.
+
+    ``content: null`` is what the OpenAI format emits for a tool call, and the
+    key is absent altogether once the message property mapping skips the None.
+    """
+    return Dataset.from_list(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "what is the weather in Paris?"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city": "Paris"}',
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "tool", "content": "22C, sunny"},
+                    {
+                        "role": "assistant",
+                        "content": "<think>lorem</think>\nwelcome",
+                    },
+                ]
+            }
+        ]
+    )
+
+
 class TestSplitThinking:
     """
     test class to make sure datasets with reasoning content conforms to the chat_template strategy
@@ -122,3 +159,55 @@ class TestSplitThinking:
             assert input_ids == expected_input_ids, (
                 f"Input IDs mismatch: {input_ids} != {expected_input_ids}"
             )
+
+    def test_tool_call_turn_without_content(
+        self, messages_w_tool_call, qwen3_tokenizer
+    ):
+        """A contentless assistant turn must not break the thinking split.
+
+        The split reads the assistant content, and an OpenAI tool call turn has
+        none, so the same conversation tokenizes with split_thinking off and
+        raised KeyError with it on.
+        """
+        strategy = load(
+            qwen3_tokenizer,
+            DictDefault(
+                {
+                    "train_on_inputs": False,
+                    "sequence_len": 512,
+                }
+            ),
+            DictDefault(
+                {
+                    "chat_template": "qwen3",
+                    "message_field_role": "role",
+                    "message_field_content": "content",
+                    "message_property_mappings": {
+                        "role": "role",
+                        "content": "content",
+                    },
+                    "roles": {
+                        "user": ["user"],
+                        "assistant": ["assistant"],
+                        "system": ["system"],
+                        "tool": ["tool"],
+                    },
+                    "field_messages": "messages",
+                    "split_thinking": True,
+                }
+            ),
+        )
+
+        conversation = messages_w_tool_call[0]
+        thread = strategy.get_conversation_thread(conversation)
+
+        # the tool call survives, and carries no content to split
+        assert thread[1]["role"] == "assistant"
+        assert "content" not in thread[1]
+        assert thread[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+        # the later assistant turn still splits normally
+        assert thread[3]["reasoning_content"] == "lorem"
+        assert thread[3]["content"] == "welcome"
+
+        assert len(strategy.tokenize_prompt(conversation)["input_ids"]) > 0


### PR DESCRIPTION
# Description

`ChatTemplateStrategy.transform_message` reads the assistant content unconditionally once `split_thinking` is on:

```python
if self.split_thinking and transformed_message["role"] == "assistant":
    content = transformed_message["content"]
```

An OpenAI-format tool call turn carries `"content": null`, and the loop just above this drops properties whose value is `None`, so the key is not in `transformed_message` at all and the lookup raises `KeyError: 'content'` during preprocessing.

Multimodal content reaches the same branch as a list of parts rather than a string, where `"<think>" in content` is a list membership test and never matches. Guarding on `isinstance(content, str)` covers both.

## Motivation and Context

`split_thinking` and tool-calling data are a natural combination: reasoning models that call tools. Today enabling the first on a dataset containing the second stops preprocessing with a `KeyError`, and the traceback points at a content key the user never wrote, because the `null` they did write was removed one loop earlier.

Related but separate: #3824 reports the DPO `chat_template` strategy dropping `tool_calls`, with #3825 open against it. This is the SFT strategy and a different line.

## How has this been tested?

The `qwen3` chat template, with one conversation whose second turn is an assistant tool call:

```python
{"role": "user", "content": "What's the weather in Paris?"},
{"role": "assistant", "content": None, "tool_calls": [
    {"id": "c1", "type": "function",
     "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'}}]},
{"role": "tool", "content": "22C, sunny"},
{"role": "assistant", "content": "<think>tool says sunny</think>\nIt is 22C and sunny."},
```

| | `get_conversation_thread` | `tokenize_prompt` |
|---|---|---|
| `split_thinking: false` | ok | 98 ids |
| `split_thinking: true`, current | `KeyError: 'content'` | not reached |
| `split_thinking: true`, with the fix | ok | 98 ids |

Nothing about the dataset changes between the rows. The id counts match because the thinking split is a round trip through this template: the tags come out of `content` and the template puts them back.

Also checked directly against `transform_message`, where `"content": null` and an absent `content` key both raised before and both pass now, and the ordinary `<think>...</think>` message still splits into `reasoning_content: "lorem"` and `content: "welcome"`.

## Tests added

`test_tool_call_turn_without_content` in the existing `tests/prompt_strategies/test_chat_templates_thinking.py`. It asserts the tool call turn survives with its function name intact and no content key, that the later assistant turn still splits, and that the conversation tokenizes. It fails on `main` with `KeyError: 'content'`.

`test_splits_think` is unchanged and passes on both branches.

## AI Usage Disclaimer

Yes. Claude was used throughout: reading the strategy, drafting the patch and the test, and writing this description. The table was produced by running the strategy on both branches rather than estimated.

## Types of changes

Bug fix (non-breaking change which fixes an issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed chat processing for assistant tool-call messages without text content.
  - Preserved multimodal message content without incorrectly applying thinking-content splitting.
  - Ensured subsequent assistant reasoning and response content continues to be processed correctly.

- **Tests**
  - Added coverage for tool-call conversations and successful tokenization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->