### PR TITLE
feat(vLLM colocate for grpo)

### DIFF
--- a/docs/agents/grpo.md
+++ b/docs/agents/grpo.md
@@ -20,7 +20,7 @@ Terminal 1 (GPU 0)                    Terminal 2 (GPU 1)
 
 1. A YAML config with `rl: grpo`
 2. A reward module (Python file with reward functions)
-3. A running vLLM server (`axolotl vllm-serve config.yaml`)
+3. A vLLM backend: a running server (`axolotl vllm-serve config.yaml`, `vllm_mode: server`), or `vllm_mode: colocate` to host the engine on the training GPU (single-GPU; engine options come from the `vllm:` block)
 
 ## Reward Function Signature
 

--- a/docs/grpo.qmd
+++ b/docs/grpo.qmd
@@ -522,7 +522,7 @@ All GRPO-specific options live under the `trl:` key in your config. Standard tra
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `use_vllm` | bool | `false` | Enable vLLM for generation |
-| `vllm_mode` | `"server"` or `"colocate"` | `null` | vLLM deployment mode |
+| `vllm_mode` | `"server"` or `"colocate"` | `null` | vLLM deployment mode. `colocate` hosts the engine on the training GPU (single-GPU); engine options come from the `vllm:` block, see [Colocate Mode](vllm_serving.qmd#sec-colocate-mode) |
 | `vllm_server_host` | str | `"0.0.0.0"` | vLLM server hostname |
 | `vllm_server_port` | int | `8000` | vLLM server port |
 | `vllm_server_timeout` | int | `null` | Timeout (seconds) for vLLM responses |

--- a/docs/vllm_serving.qmd
+++ b/docs/vllm_serving.qmd
@@ -14,7 +14,7 @@ execute:
 
 GRPO (Group Relative Policy Optimization) trains a language model by generating completions, scoring them with reward functions, and updating the policy to favor higher-reward outputs. The generation step is the bottleneck: producing thousands of tokens per training step with the policy model is slow using standard HuggingFace generation.
 
-Axolotl uses [vLLM](https://github.com/vllm-project/vllm) as a high-throughput generation backend. vLLM runs as a separate process (either on a dedicated GPU or colocated on the training GPU) and serves completions via an HTTP API. The trainer sends prompts to vLLM, receives completions, scores them, and performs gradient updates.
+Axolotl uses [vLLM](https://github.com/vllm-project/vllm) as a high-throughput generation backend. In server mode, vLLM runs as a separate process on dedicated GPUs and serves completions via an HTTP API. In [colocate mode](#sec-colocate-mode), the trainer process hosts a vLLM engine on its own GPU, so a single GPU is enough. Either way, the trainer sends prompts to vLLM, receives completions, scores them, and performs gradient updates.
 
 ```
 ┌──────────────────────┐       HTTP        ┌──────────────────────┐
@@ -98,20 +98,37 @@ Due to how TRL maps vLLM device indices, the vLLM instance should use the **last
 
 ## Colocate Mode {#sec-colocate-mode}
 
-Colocate mode runs vLLM on the same GPU as the trainer. This is useful when you only have a single GPU.
+Colocate mode runs a vLLM engine inside the trainer process, on the same GPU. No `axolotl vllm-serve` process is needed, so this is the way to run GRPO on a single GPU.
 
 ```yaml
+base_model: Qwen/Qwen2.5-1.5B-Instruct
+rl: grpo
+adapter: lora
+
 trl:
   use_vllm: true
   vllm_mode: colocate
   vllm_enable_sleep_mode: true
+  num_generations: 8
+  max_completion_length: 512
+  reward_funcs:
+    - rewards.accuracy_reward
+
+vllm:
+  gpu_memory_utilization: 0.3   # fraction reserved for vLLM; the rest is for training
+  max_model_len: 2048           # prompt + completion budget for the engine
+  enforce_eager: true           # disable CUDA graphs if vLLM's custom all-reduce errors
 ```
+
+The `vllm:` block configures the colocated engine. `gpu_memory_utilization`, `tensor_parallel_size`, and `max_model_len` map to TRL's `vllm_gpu_memory_utilization`, `vllm_tensor_parallel_size`, and `vllm_max_model_length`; `enforce_eager`, `enable_prefix_caching`, and `dtype` are passed straight to the engine. When `gpu_memory_utilization` is unset, colocate mode uses TRL's default of 0.3 rather than the 0.9 used by `vllm-serve`, since the training process shares the GPU. `tensor_parallel_size` must divide the number of training processes.
 
 With `vllm_enable_sleep_mode: true`, vLLM offloads its VRAM allocation when not actively generating, freeing memory for training. When the trainer needs new completions, vLLM wakes up and reclaims VRAM.
 
 ::: {.callout-warning}
 Colocate mode is significantly slower than server mode because generation and training cannot overlap. The GPU alternates between the two workloads. This mode is practical only for smaller models (up to ~3B on a 24 GB GPU).
 :::
+
+Colocate mode uses the standard GRPO trainer. It cannot be combined with `context_parallel_size > 1`, with `vllm_lora_sync`, or with the async trainer (`async_prefetch` / `use_data_producer`) when training an adapter; config validation rejects those combinations.
 
 **When to use colocate mode:**
 
@@ -253,7 +270,7 @@ curl http://localhost:8000/health
 
 ### vLLM Server Options (`vllm:` section)
 
-These control the vLLM server process started by `axolotl vllm-serve`.
+These control the vLLM server process started by `axolotl vllm-serve`, and the colocated engine in [colocate mode](#sec-colocate-mode).
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -262,7 +279,7 @@ These control the vLLM server process started by `axolotl vllm-serve`.
 | `device` | str | `auto` | Device to use for vLLM |
 | `tensor_parallel_size` | int | `None` | Number of GPUs for tensor parallelism |
 | `data_parallel_size` | int | `None` | Number of data parallel replicas |
-| `gpu_memory_utilization` | float | `0.9` | Fraction of GPU memory for vLLM (0.0-1.0) |
+| `gpu_memory_utilization` | float | `None` | Fraction of GPU memory for vLLM (0.0-1.0). Defaults to 0.9 for `vllm-serve` and 0.3 in colocate mode |
 | `dtype` | str | `auto` | Data type (`auto`, `float16`, `bfloat16`) |
 | `max_model_len` | int | `None` | Maximum model context length. Set explicitly if the default is too large for your GPU |
 | `enable_prefix_caching` | bool | `None` | Enable prefix caching for repeated prompt prefixes |

--- a/src/axolotl/cli/config_options.py
+++ b/src/axolotl/cli/config_options.py
@@ -1452,7 +1452,7 @@ AXOLOTL_CONFIG_CLI_OPTIONS = (
         ("--vllm.gpu-memory-utilization",),
         "vllm__gpu_memory_utilization",
         "float",
-        "GPU memory utilization for VLLM",
+        "GPU memory utilization for VLLM. Defaults to 0.9 for `vllm-serve` and to TRL's 0.3 in colocate mode, leaving the rest of the GPU for training.",
     ),
     (
         ("--vllm.dtype",),

--- a/src/axolotl/cli/vllm_serve.py
+++ b/src/axolotl/cli/vllm_serve.py
@@ -61,7 +61,7 @@ def do_vllm_serve(
     host = cli_args.get("host") or cfg.vllm.host
     port = cli_args.get("port") or cfg.vllm.port
     gpu_memory_utilization = (
-        cli_args.get("gpu_memory_utilization") or cfg.vllm.gpu_memory_utilization
+        cli_args.get("gpu_memory_utilization") or cfg.vllm.gpu_memory_utilization or 0.9
     )
     dtype = cli_args.get("dtype") or cfg.vllm.dtype
     max_model_len = cli_args.get("max_model_len") or cfg.vllm.max_model_len

--- a/src/axolotl/core/trainers/ebft/__init__.py
+++ b/src/axolotl/core/trainers/ebft/__init__.py
@@ -130,22 +130,25 @@ class EBFTStrategy:
                     kwargs["use_vllm"] = trl.use_vllm
                     if trl.vllm_mode:
                         kwargs["vllm_mode"] = trl.vllm_mode
+                    vllm_cfg = cfg.vllm
                     if trl.vllm_mode == "colocate":
-                        kwargs["vllm_enable_sleep_mode"] = trl.vllm_enable_sleep_mode
-                        vllm_cfg = cfg.vllm
-                        if vllm_cfg:
-                            kwargs["vllm_gpu_memory_utilization"] = (
-                                vllm_cfg.gpu_memory_utilization
+                        if trl.vllm_enable_sleep_mode is not None:
+                            kwargs["vllm_enable_sleep_mode"] = (
+                                trl.vllm_enable_sleep_mode
                             )
-                            kwargs["vllm_tensor_parallel_size"] = (
-                                vllm_cfg.tensor_parallel_size
-                            )
-                    kwargs["vllm_server_host"] = trl.vllm_server_host or (
-                        trl.vllm.host if trl.vllm else None
+                        from axolotl.core.trainers.grpo import GRPOStrategy
+
+                        kwargs.update(GRPOStrategy.get_colocate_vllm_kwargs(vllm_cfg))
+                    server_host = trl.vllm_server_host or (
+                        vllm_cfg.host if vllm_cfg else None
                     )
-                    kwargs["vllm_server_port"] = trl.vllm_server_port or (
-                        trl.vllm.port if trl.vllm else None
+                    if server_host:
+                        kwargs["vllm_server_host"] = server_host
+                    server_port = trl.vllm_server_port or (
+                        vllm_cfg.port if vllm_cfg else None
                     )
+                    if server_port:
+                        kwargs["vllm_server_port"] = server_port
                     if trl.vllm_server_timeout:
                         kwargs["vllm_server_timeout"] = trl.vllm_server_timeout
 

--- a/src/axolotl/core/trainers/grpo/__init__.py
+++ b/src/axolotl/core/trainers/grpo/__init__.py
@@ -56,6 +56,24 @@ class GRPOStrategy:
         return AxolotlGRPOConfig
 
     @classmethod
+    def get_colocate_vllm_kwargs(cls, vllm_cfg: VllmConfig | None) -> dict[str, Any]:
+        """Map the `vllm:` block onto TRL's colocate engine args.
+
+        Unset values are omitted so TRL's colocate defaults apply (notably 0.3 GPU
+        memory utilization, which leaves room for training on the shared GPU).
+        """
+        kwargs: dict[str, Any] = {}
+        if not vllm_cfg:
+            return kwargs
+        if vllm_cfg.gpu_memory_utilization is not None:
+            kwargs["vllm_gpu_memory_utilization"] = vllm_cfg.gpu_memory_utilization
+        if vllm_cfg.tensor_parallel_size is not None:
+            kwargs["vllm_tensor_parallel_size"] = vllm_cfg.tensor_parallel_size
+        if vllm_cfg.max_model_len is not None:
+            kwargs["vllm_max_model_length"] = vllm_cfg.max_model_len
+        return kwargs
+
+    @classmethod
     def set_training_args_kwargs(cls, cfg: DictDefault) -> dict[str, Any]:
         grpo_args_kwargs: dict[str, Any] = {}
 
@@ -70,15 +88,17 @@ class GRPOStrategy:
             if trl.vllm_mode:
                 grpo_args_kwargs["vllm_mode"] = trl.vllm_mode
             if trl.vllm_mode == "colocate":
-                grpo_args_kwargs["vllm_enable_sleep_mode"] = trl.vllm_enable_sleep_mode  # type: ignore[attr-defined]
-                grpo_args_kwargs["vllm_gpu_memory_utilization"] = (
-                    vllm_cfg.gpu_memory_utilization
-                )
-                grpo_args_kwargs["vllm_tensor_parallel_size"] = (
-                    vllm_cfg.tensor_parallel_size
-                )
-            grpo_args_kwargs["vllm_server_host"] = trl.vllm_server_host or trl.vllm.host  # type: ignore[attr-defined]
-            grpo_args_kwargs["vllm_server_port"] = trl.vllm_server_port or trl.vllm.port  # type: ignore[attr-defined]
+                if trl.vllm_enable_sleep_mode is not None:
+                    grpo_args_kwargs["vllm_enable_sleep_mode"] = (
+                        trl.vllm_enable_sleep_mode
+                    )
+                grpo_args_kwargs.update(cls.get_colocate_vllm_kwargs(vllm_cfg))
+            server_host = trl.vllm_server_host or (vllm_cfg.host if vllm_cfg else None)
+            if server_host:
+                grpo_args_kwargs["vllm_server_host"] = server_host
+            server_port = trl.vllm_server_port or (vllm_cfg.port if vllm_cfg else None)
+            if server_port:
+                grpo_args_kwargs["vllm_server_port"] = server_port
             if trl.vllm_server_timeout:
                 grpo_args_kwargs["vllm_server_timeout"] = trl.vllm_server_timeout
             if trl.vllm_guided_decoding_regex:

--- a/src/axolotl/loaders/patch_manager.py
+++ b/src/axolotl/loaders/patch_manager.py
@@ -1182,9 +1182,17 @@ class PatchManager:
             and getattr(self.cfg, "trl", None)
             and getattr(self.cfg.trl, "use_vllm", False)
         ):
-            from axolotl.monkeypatch.trainer.trl_vllm import patch_trl_vllm
+            from axolotl.monkeypatch.trainer.trl_vllm import (
+                colocate_vllm_engine_kwargs,
+                patch_trl_vllm,
+                patch_vllm_colocate_engine_kwargs,
+            )
 
             patch_trl_vllm()
+            if getattr(self.cfg.trl, "vllm_mode", None) == "colocate":
+                patch_vllm_colocate_engine_kwargs(
+                    colocate_vllm_engine_kwargs(getattr(self.cfg, "vllm", None))
+                )
 
     def _apply_trl_trainer_utils_patches(self):
         """Replace trl.trainer.utils.{selective_log_softmax, entropy_from_logits} with Triton kernels."""

--- a/src/axolotl/monkeypatch/trainer/trl_vllm.py
+++ b/src/axolotl/monkeypatch/trainer/trl_vllm.py
@@ -5,10 +5,12 @@ Adds:
 - extract_logprobs: NaN→0.0 fix (prevents downstream NaN propagation)
 - VLLMGeneration: weight_sync_chunk_size + batched sync path for non-FSDP/non-ZeRO
 - split_tensor_dict / shuffle_sequence_dict: scalar type handling (int/float/bool passthrough)
+- LLM (colocate): forward `vllm:` engine args TRL has no config field for (enforce_eager, ...)
 """
 
 import math
 from functools import wraps
+from typing import Any
 
 import torch
 from torch import nn
@@ -302,3 +304,40 @@ def patch_trl_vllm():
     trl.trainer.utils.split_tensor_dict = _patched_split_tensor_dict
     trl.trainer.utils.shuffle_sequence_dict = _patched_shuffle_sequence_dict
     LOG.info("Patched split_tensor_dict and shuffle_sequence_dict for scalar types")
+
+
+def colocate_vllm_engine_kwargs(vllm_cfg) -> dict[str, Any]:
+    """`vllm:` options that only reach a colocated engine via the LLM() call itself."""
+    kwargs: dict[str, Any] = {}
+    if not vllm_cfg:
+        return kwargs
+    if vllm_cfg.enforce_eager is not None:
+        kwargs["enforce_eager"] = vllm_cfg.enforce_eager
+    if vllm_cfg.enable_prefix_caching is not None:
+        kwargs["enable_prefix_caching"] = vllm_cfg.enable_prefix_caching
+    if vllm_cfg.dtype and vllm_cfg.dtype != "auto":
+        kwargs["dtype"] = vllm_cfg.dtype
+    return kwargs
+
+
+def patch_vllm_colocate_engine_kwargs(engine_kwargs: dict[str, Any]) -> None:
+    """Merge extra engine kwargs into the LLM() call VLLMGeneration makes in colocate mode.
+
+    TRL hardcodes that call, so this is the only way for e.g. `enforce_eager` (needed
+    to avoid vLLM's custom all-reduce CUDA errors on some setups) to reach the engine.
+    """
+    if not engine_kwargs:
+        return
+    import trl.generation.vllm_generation as vllm_generation
+
+    base_llm = getattr(vllm_generation, "LLM", None)
+    if base_llm is None:
+        return
+    base_llm = getattr(base_llm, "__wrapped__", base_llm)
+
+    @wraps(base_llm, updated=())
+    def _llm_with_engine_kwargs(*args, **kwargs):
+        return base_llm(*args, **{**kwargs, **engine_kwargs})
+
+    vllm_generation.LLM = _llm_with_engine_kwargs
+    LOG.info(f"Forwarding extra engine kwargs to colocated vLLM: {engine_kwargs}")

--- a/src/axolotl/utils/schemas/validation.py
+++ b/src/axolotl/utils/schemas/validation.py
@@ -2044,6 +2044,32 @@ class GRPOVllmValidationMixin:
             self.trl.vllm_mode = "server"
         return self
 
+    @model_validator(mode="after")
+    def check_vllm_colocate_compat(self):
+        trl = self.trl
+        if not (trl and trl.use_vllm and trl.vllm_mode == "colocate"):
+            return self
+        if (getattr(self, "context_parallel_size", None) or 1) > 1:
+            raise ValueError(
+                "`vllm_mode: colocate` is not supported with `context_parallel_size > 1`. "
+                "Use `vllm_mode: server` with a dedicated vLLM GPU."
+            )
+        if trl.vllm_lora_sync:
+            raise ValueError(
+                "`vllm_lora_sync: true` requires `vllm_mode: server` (adapters are pushed "
+                "over HTTP to the vLLM server). In colocate mode, remove `vllm_lora_sync`; "
+                "weights are merged and loaded into the colocated engine directly."
+            )
+        if (trl.async_prefetch or trl.use_data_producer) and getattr(
+            self, "adapter", None
+        ):
+            raise ValueError(
+                "`vllm_mode: colocate` with an adapter is not supported by the async GRPO "
+                "trainer (`async_prefetch` / `use_data_producer`): its LoRA weight sync only "
+                "targets a vLLM server. Remove those options or use `vllm_mode: server`."
+            )
+        return self
+
 
 class ValidationMixin(
     DatasetValidationMixin,

--- a/src/axolotl/utils/schemas/vllm.py
+++ b/src/axolotl/utils/schemas/vllm.py
@@ -23,8 +23,11 @@ class VllmConfig(BaseModel):
         json_schema_extra={"description": "Data parallel size for VLLM"},
     )
     gpu_memory_utilization: float | None = Field(
-        default=0.9,
-        json_schema_extra={"description": "GPU memory utilization for VLLM"},
+        default=None,
+        json_schema_extra={
+            "description": "GPU memory utilization for VLLM. Defaults to 0.9 for `vllm-serve` "
+            "and to TRL's 0.3 in colocate mode, leaving the rest of the GPU for training."
+        },
     )
     dtype: str | None = Field(
         default="auto",

--- a/tests/core/test_grpo_colocate.py
+++ b/tests/core/test_grpo_colocate.py
@@ -1,0 +1,83 @@
+"""Unit tests for GRPO colocate-mode vLLM wiring."""
+
+from axolotl.core.trainers.grpo import GRPOStrategy
+from axolotl.utils.dict import DictDefault
+
+
+def _cfg(trl: dict, vllm: dict | None = None) -> DictDefault:
+    return DictDefault(
+        {
+            "rl": "grpo",
+            "context_parallel_size": 1,
+            "trl": {"use_vllm": True, "max_completion_length": 64, **trl},
+            "vllm": vllm if vllm is not None else {},
+        }
+    )
+
+
+class TestColocateTrainingArgs:
+    """GRPOStrategy maps the `vllm:` block onto TRL's colocate engine args."""
+
+    def test_colocate_forwards_vllm_block(self):
+        kwargs = GRPOStrategy.set_training_args_kwargs(
+            _cfg(
+                {"vllm_mode": "colocate", "vllm_enable_sleep_mode": True},
+                {
+                    "gpu_memory_utilization": 0.4,
+                    "tensor_parallel_size": 2,
+                    "max_model_len": 4096,
+                },
+            )
+        )
+        assert kwargs["vllm_mode"] == "colocate"
+        assert kwargs["vllm_enable_sleep_mode"] is True
+        assert kwargs["vllm_gpu_memory_utilization"] == 0.4
+        assert kwargs["vllm_tensor_parallel_size"] == 2
+        assert kwargs["vllm_max_model_length"] == 4096
+
+    def test_colocate_unset_options_fall_through_to_trl_defaults(self):
+        kwargs = GRPOStrategy.set_training_args_kwargs(_cfg({"vllm_mode": "colocate"}))
+        for key in (
+            "vllm_gpu_memory_utilization",
+            "vllm_tensor_parallel_size",
+            "vllm_max_model_length",
+            "vllm_enable_sleep_mode",
+        ):
+            assert key not in kwargs
+
+    def test_server_mode_does_not_forward_engine_options(self):
+        kwargs = GRPOStrategy.set_training_args_kwargs(
+            _cfg(
+                {"vllm_mode": "server"},
+                {"gpu_memory_utilization": 0.9, "max_model_len": 4096},
+            )
+        )
+        assert "vllm_gpu_memory_utilization" not in kwargs
+        assert "vllm_max_model_length" not in kwargs
+
+    def test_server_host_port_fall_back_to_vllm_block(self):
+        kwargs = GRPOStrategy.set_training_args_kwargs(
+            _cfg(
+                {
+                    "vllm_mode": "server",
+                    "vllm_server_host": None,
+                    "vllm_server_port": None,
+                },
+                {"host": "10.0.0.5", "port": 9000},
+            )
+        )
+        assert kwargs["vllm_server_host"] == "10.0.0.5"
+        assert kwargs["vllm_server_port"] == 9000
+
+    def test_server_host_port_unset_left_to_trl_default(self):
+        kwargs = GRPOStrategy.set_training_args_kwargs(
+            _cfg(
+                {
+                    "vllm_mode": "server",
+                    "vllm_server_host": None,
+                    "vllm_server_port": None,
+                }
+            )
+        )
+        assert "vllm_server_host" not in kwargs
+        assert "vllm_server_port" not in kwargs

--- a/tests/core/test_trl_vllm_colocate_patch.py
+++ b/tests/core/test_trl_vllm_colocate_patch.py
@@ -1,0 +1,57 @@
+"""Unit tests for forwarding `vllm:` engine args to a colocated vLLM engine."""
+
+import pytest
+
+from axolotl.utils.dict import DictDefault
+
+# The monkeypatch package imports triton at package level (GPU-only dependency).
+trl_vllm = pytest.importorskip("axolotl.monkeypatch.trainer.trl_vllm")
+colocate_vllm_engine_kwargs = trl_vllm.colocate_vllm_engine_kwargs
+patch_vllm_colocate_engine_kwargs = trl_vllm.patch_vllm_colocate_engine_kwargs
+
+
+class TestColocateEngineKwargs:
+    """Engine options TRL has no config field for reach LLM() via the monkeypatch."""
+
+    def test_engine_kwargs_from_vllm_block(self):
+        assert colocate_vllm_engine_kwargs(
+            DictDefault({"enforce_eager": True, "dtype": "auto"})
+        ) == {"enforce_eager": True}
+        assert colocate_vllm_engine_kwargs(
+            DictDefault({"enable_prefix_caching": False, "dtype": "bfloat16"})
+        ) == {"enable_prefix_caching": False, "dtype": "bfloat16"}
+        assert colocate_vllm_engine_kwargs(None) == {}
+        assert colocate_vllm_engine_kwargs(DictDefault({})) == {}
+
+    def test_patch_merges_engine_kwargs_into_llm_call(self, monkeypatch):
+        vllm_generation = pytest.importorskip("trl.generation.vllm_generation")
+
+        calls = []
+
+        class FakeLLM:
+            """Stand-in for vllm.LLM that records constructor kwargs."""
+
+            def __init__(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(vllm_generation, "LLM", FakeLLM, raising=False)
+
+        patch_vllm_colocate_engine_kwargs({"enforce_eager": True})
+        vllm_generation.LLM(model="m", gpu_memory_utilization=0.3)
+        assert calls[-1] == {
+            "model": "m",
+            "gpu_memory_utilization": 0.3,
+            "enforce_eager": True,
+        }
+
+        # Re-patching replaces rather than stacks the previous engine kwargs.
+        patch_vllm_colocate_engine_kwargs({"dtype": "bfloat16"})
+        vllm_generation.LLM(model="m")
+        assert calls[-1] == {"model": "m", "dtype": "bfloat16"}
+
+    def test_patch_noop_without_engine_kwargs(self, monkeypatch):
+        vllm_generation = pytest.importorskip("trl.generation.vllm_generation")
+        sentinel = object()
+        monkeypatch.setattr(vllm_generation, "LLM", sentinel, raising=False)
+        patch_vllm_colocate_engine_kwargs({})
+        assert vllm_generation.LLM is sentinel


### PR DESCRIPTION

# Description
#2752 
vlm colocate mode so GRPO runs on single gpu 

## Motivation and Context
#2752

## How has this been tested?
tests locally added e2e + manual validation 


## AI Usage Disclaimer
claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for standalone and colocated vLLM backends, including configuration, defaults, engine options, and compatibility requirements.
  - Clarified that colocated mode can run on a single training GPU and documented its configuration limits.

- **Enhancements**
  - Colocated vLLM now forwards supported engine settings from the `vllm:` configuration block.
  - vLLM Serve now defaults GPU memory utilization to 0.9 when unspecified.

- **Bug Fixes**
  - Improved fallback handling for vLLM server host and port settings.
  - Added validation for unsupported colocated-mode combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->